### PR TITLE
Phase 6F: fmt adversarial comments and mutation fuzzing — 51,000 inputs, three root causes, and a formatter that reports a syntax error in a file that has none

### DIFF
--- a/docs/dev/fmt.md
+++ b/docs/dev/fmt.md
@@ -198,6 +198,28 @@ program source.
   `core.autocrlf=true` checkout — exactly the Windows configuration those cases
   exist to cover — leaving the test asserting nothing.
 
+* **`tests/scheme/fmt/fmt-adversarial.sh`** — comment placement where the
+  layout engine has a decision to make (between `define` and its name, after a
+  dotted `.`, inside a `case` datum list, `#|` inside a `;` and vice versa, a
+  comment as a file's only content, one with no trailing newline, …). Each case
+  asserts all three of: `fmt` accepts it, every comment survives in order, and a
+  second pass changes nothing. Plus the parser-depth property — an input deeper
+  than any reader accepts must be *rejected*, not fatal.
+
+* **`tools/fmt_fuzz.py`** — the fuzzer those cases came from, run on demand.
+  Not in `run-all.sh`: a useful run takes minutes, past that suite's 60 s
+  per-file budget. Four modes over the repo's own corpus — random byte
+  mutation, whitespace-run resizing (which must not change the output at all),
+  comment and blank-line insertion, and an exhaustive comment × blank-line
+  grid. Nothing is written over a corpus file: every mutant reaches `fmt` on
+  stdin. Run it when changing `fmt.zig` or `fmt_print.zig`.
+
+  Why a fuzzer earns its keep here specifically: the round-trip guard proves
+  the *program* is unchanged, and comments are not part of the program, so
+  comment handling and idempotence are exactly the two properties nothing else
+  checks. Both of the bugs the first campaign found live there
+  (kaappi#2142, kaappi#2143), along with a parser-depth crash (kaappi#2141).
+
 ## CI adoption
 
 Ecosystem repos can gate formatting in CI with the check form:

--- a/tests/scheme/fmt/fmt-adversarial.sh
+++ b/tests/scheme/fmt/fmt-adversarial.sh
@@ -155,6 +155,35 @@ case_ "vector after an identifier, spaced"           '(a b #(1) d)\n'
 # case_ "datum comment glued to an identifier"         '(list a#;(b) c)\n'
 # case_ "vector glued to an identifier"                '(a b#(1) d)\n'
 
+# ── Fit-to-width is measured in bytes, not columns (kaappi#2149) ────────────
+
+# assert_one_line <label> <source>
+#   fmt.md: "A form that fits within max_width (80) columns is put on one line."
+assert_one_line() {
+    local label="$1" src="$2" lines
+    printf '%b' "$src" > "$TMP/w.scm"
+    lines="$("$KAAPPI" fmt < "$TMP/w.scm" | wc -l | tr -d ' ')"
+    if [[ "$lines" -eq 1 ]]; then
+        pass "$label"
+    else
+        fail "$label" "broke a 75-column form into $lines lines"
+    fi
+}
+
+# 12 five-character identifiers: 75 columns either way, 75 bytes vs 135.
+ascii12=""
+wide12=""
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    ascii12="$ascii12 aaaaa"
+    wide12="$wide12 λλλλλ"
+done
+
+assert_one_line "width: a 75-column ASCII form stays on one line" "(f$ascii12)\n"
+
+# FAIL: #2149 (computeMeasure returns node.text.len, so every non-ASCII lexeme
+# counts double or triple against an 80-column budget)
+# assert_one_line "width: a 75-column Unicode form stays on one line" "(f$wide12)\n"
+
 # ── Parser depth: a deep input is rejected, never fatal (kaappi#2141) ────────
 
 # repeat <byte> <count> — a portable "print this byte N times" with no seq,

--- a/tests/scheme/fmt/fmt-adversarial.sh
+++ b/tests/scheme/fmt/fmt-adversarial.sh
@@ -188,7 +188,13 @@ assert_one_line "width: a 75-column ASCII form stays on one line" "(f$ascii12)\n
 
 # repeat <byte> <count> — a portable "print this byte N times" with no seq,
 # no python and no shell loop.
-repeat() { head -c "$2" /dev/zero | tr '\0' "$1"; }
+# `head -c` is a GNU/FreeBSD extension, NOT POSIX. OpenBSD's head answers
+# `head: unknown option -- c` and prints nothing, so the generated file came out
+# empty, `fmt` accepted it, and the assertion below failed on that leg alone.
+# Same shape as the no-GNU-regex rule in tests/scheme/CLAUDE.md: it passes on
+# macOS, Linux and FreeBSD, and fails only on the strict leg.
+# `printf '%*s'` is POSIX and needs no external file.
+repeat() { printf "%${2}s" '' | tr ' ' "$1"; }
 
 # assert_clean_reject <label> <path>
 #   The input is deeper than any reader accepts (`kaappi` itself answers

--- a/tests/scheme/fmt/fmt-adversarial.sh
+++ b/tests/scheme/fmt/fmt-adversarial.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+# `kaappi fmt` — adversarial comment placement and parser-depth robustness.
+#
+# `fmt`'s round-trip guard re-reads both texts with the real reader and compares
+# datums, so it can never let the *program* change. Comments are not datums, so
+# it is structurally blind to them: a comment that moves, is duplicated, or is
+# dropped passes the guard unnoticed. Idempotence — `fmt(fmt(x)) == fmt(x)` —
+# is the other property the guard cannot see. This suite is those two blind
+# spots, driven by cases where the layout engine has a decision to make.
+#
+# Each case asserts three things at once: `fmt` accepts it, every comment
+# marker (`C1`, `C2`, …) survives in the same order, and a second pass is a
+# no-op. Cases are one line each; the corpus-wide properties live in fmt.sh,
+# and exact input→output layout lives in src/tests_fmt.zig.
+#
+# The generator that found the failures below is `tools/fmt_fuzz.py` — it is
+# deliberately *not* run here (it takes minutes; this file takes ~2 seconds).
+# See kaappi#2141, kaappi#2142, kaappi#2143.
+
+set -uo pipefail
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+case "$KAAPPI" in
+    /*) : ;;
+    *) KAAPPI="$PWD/$KAAPPI" ;;
+esac
+
+PASS=0
+FAIL=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1 — $2"; FAIL=$((FAIL + 1)); }
+
+markers() { grep -o 'C[0-9][0-9]*' "$1" | tr '\n' ' '; }
+
+# case <label> <source-with-\n-escapes>
+#
+# fmt accepts it, the comment markers survive in order, and a second pass
+# changes nothing.
+case_() {
+    local label="$1" src="$2" status=0
+    printf '%b' "$src" > "$TMP/a.scm"
+    "$KAAPPI" fmt < "$TMP/a.scm" > "$TMP/b.scm" 2> "$TMP/err" || status=$?
+    if [[ "$status" -ne 0 ]]; then
+        fail "$label" "fmt exit $status: $(cat "$TMP/err")"
+        return
+    fi
+    local want got
+    want="$(markers "$TMP/a.scm")"
+    got="$(markers "$TMP/b.scm")"
+    if [[ "$want" != "$got" ]]; then
+        fail "$label" "comments [$want] came out as [$got]"
+        return
+    fi
+    status=0
+    "$KAAPPI" fmt < "$TMP/b.scm" > "$TMP/c.scm" 2> "$TMP/err" || status=$?
+    if [[ "$status" -ne 0 ]]; then
+        fail "$label" "second pass exit $status: $(cat "$TMP/err")"
+        return
+    fi
+    if ! cmp -s "$TMP/b.scm" "$TMP/c.scm"; then
+        fail "$label" "not idempotent: [$(tr '\n' '~' < "$TMP/b.scm")] then [$(tr '\n' '~' < "$TMP/c.scm")]"
+        return
+    fi
+    pass "$label"
+}
+
+# ── Comments where the layout engine must make a decision ───────────────────
+
+case_ "comment between define and its name"          '(define ; C1\n  x 1)\n'
+case_ "comment on its own line before the name"      '(define\n  ; C1\n  x 1)\n'
+case_ "comment inside a let binding list"            '(let ((a 1) ; C1\n      (b 2)) ; C2\n  (+ a b))\n'
+case_ "own-line comments inside a binding list"      '(let (; C1\n      (a 1)\n      ; C2\n      (b 2))\n  (+ a b))\n'
+case_ "comment between last form and close paren"    '(begin\n  (a)\n  ; C1\n  )\n'
+case_ "trailing comment before the close paren"      '(begin (a) ; C1\n)\n'
+case_ "comment after a dotted pair's dot"            '(a . ; C1\n   b)\n'
+case_ "comment before a dotted pair's dot"           '(a ; C1\n   . b)\n'
+case_ "comment inside a quasiquote unquote"          '`(a ,(f ; C1\n       x) b)\n'
+case_ "comment between unquote and its datum"        '`(a , ; C1\n  b)\n'
+case_ "comment in a case clause datum list"          "(case x\n  ((1 2 ; C1\n    3) 'lo)\n  (else 'hi))\n"
+case_ "comment before a #; datum comment"            '(list ; C1\n  #;(dead) alive)\n'
+case_ "comment after a #; datum comment"             '(list #;(dead) ; C1\n  alive)\n'
+case_ "comment between #; and its datum"             '(list #; ; C1\n  (dead) alive)\n'
+case_ "nested block comments"                        '#| outer C1 #| inner C2 |# tail C3 |#\n(a)\n'
+case_ "; inside a block comment is not a comment"    '#| C1 ; C2 still in the block |#\n(a)\n'
+case_ "#| inside a line comment never opens"         '; C1 #| never opens\n(a)\n'
+case_ "|# inside a line comment never closes"        '; C1 |# never closes\n(a)\n'
+case_ "comment is the whole file"                    '; C1 only\n'
+case_ "line comment with no trailing newline"        '(a)\n; C1 no newline'
+case_ "block comment with no trailing newline"       '(a)\n#| C1 |#'
+case_ "comment is the only child of a list"          '( ; C1\n)\n'
+case_ "block comment is the only child of a list"    '(#| C1 |#)\n'
+case_ "comment between operator and first argument"  '(f ; C1\n  a b)\n'
+case_ "block comment riding the head line"           '(define #| C1 |# x 1)\n'
+case_ "block comment between let and its bindings"   '(let #| C1 |# ((a 1)) a)\n'
+case_ "two block comments on one line"               '(f a #| C1 |# #| C2 |# b)\n'
+case_ "line comment after a block comment"           '(f a #| C1 |# ; C2\n  b)\n'
+case_ "comment inside an empty vector"               '#( ; C1\n)\n'
+case_ "comment between vector elements"              '#(1 ; C1\n  2 3)\n'
+case_ "comment inside a bytevector"                  '#u8(1 ; C1\n    2)\n'
+case_ "comment between quote and its datum"          "'; C1\nx\n"
+case_ "blank line then a comment in a body"          '(define (f)\n  (a)\n\n  ; C1\n  (b))\n'
+case_ "comment then a blank line in a body"          '(define (f)\n  (a)\n  ; C1\n\n  (b))\n'
+case_ "comment trailing a top-level form"            '(a) ; C1\n(b)\n'
+case_ "comment forces a form that would fit inline"  '(f a ; C1\n  b)\n'
+case_ "line comment past 80 columns"                 '(f a) ; C1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n'
+case_ "comment in a deeply nested tail"              '(a (b (c (d ; C1\n  e))))\n'
+case_ "comment after the last binding"               '(let ((a 1) ; C1\n      )\n  a)\n'
+case_ "datum comment over a whole define"            '#;(define x 1)\n(define y 2)\n'
+case_ "datum comment targeting a block comment"      '#; #| C1 |# (dead)\n(alive)\n'
+case_ "nested datum comments"                        '(list #;#;(a) (b) c)\n'
+case_ "comments between do's distinguished forms"    '(do ((i 0 (+ i 1))) ; C1\n    ((= i 3)) ; C2\n  (f i))\n'
+case_ "comment first, operator after it"             '(; C1\n f a)\n'
+case_ "comment inside syntax-rules literals"         '(syntax-rules (; C1\n               lit)\n  ((_ x) x))\n'
+case_ "comment between cond clauses"                 '(cond ((a) 1)\n      ; C1\n      ((b) 2))\n'
+case_ "comment at the end of a cond clause"          '(cond ((a) 1 ; C1\n       ))\n'
+case_ "carriage return inside a block comment"       '#| C1\rC2 |#\n(a)\n'
+case_ "comment containing a close paren"             '(f a ; C1 )\n  b)\n'
+case_ "comment containing an open paren"             '(f a ; C1 (\n  b)\n'
+case_ "comment containing a double quote"            '(f a ; C1 "\n  b)\n'
+case_ "block comment containing a double quote"      '(f a #| C1 " |# b)\n'
+case_ "a semicolon inside a string is not a comment" '(f "; C1 not a comment")\n'
+
+# ── Blank-line grouping around head-line comments (kaappi#2142) ──────────────
+#
+# These three are the discriminating controls for #2142: same blank, same
+# comment, only the position differs — and all three are stable. The unstable
+# one is disabled below.
+
+case_ "blank before the first argument, no comment"  '(f\n\n   a b)\n'
+case_ "blank one item after a head-line comment"     '(f #|c|# a\n\n   b)\n'
+case_ "blank after a head-line line comment"         '(f ; c\n\n   a b)\n'
+case_ "blank before a define body, not its name"     '(define #|c|# x\n\n  1)\n'
+
+# FAIL: #2142 (hasBodyBlank indexes children; the printer counts non-comments,
+# so a head-line-riding block comment shifts them out of step — pass 1 drops
+# the blank it forced a break for, pass 2 then collapses the form inline)
+# case_ "blank before an arg displaced by a comment"   '(f #|c|#\n\n   a b)\n'
+# case_ "blank before a name displaced by a comment"   '(define #|c|#\n\n  x 1)\n'
+
+# ── Lexeme boundaries the reader and fmt must agree on (kaappi#2143) ─────────
+#
+# Enabled: the space-separated spellings, which are the discriminating controls.
+
+case_ "block comment after an identifier, spaced"    '(a b #|c|# d)\n'
+case_ "datum comment after an identifier, spaced"    '(list a #;(b) c)\n'
+case_ "vector after an identifier, spaced"           '(a b #(1) d)\n'
+
+# FAIL: #2143 (fmt.Lexer.scanAtom runs to the next delimiter; Reader.readSymbol
+# stops at the first non-subsequent, so a glued `#`-led lexeme splits
+# differently — `kaappi ast` reads all three of these without complaint)
+# case_ "block comment glued to an identifier"         '(a b#|c|# d)\n'
+# case_ "datum comment glued to an identifier"         '(list a#;(b) c)\n'
+# case_ "vector glued to an identifier"                '(a b#(1) d)\n'
+
+# ── Parser depth: a deep input is rejected, never fatal (kaappi#2141) ────────
+
+# repeat <byte> <count> — a portable "print this byte N times" with no seq,
+# no python and no shell loop.
+repeat() { head -c "$2" /dev/zero | tr '\0' "$1"; }
+
+# assert_clean_reject <label> <path>
+#   The input is deeper than any reader accepts (`kaappi` itself answers
+#   `read error[KP1009]: nesting too deep` at 1025), so `fmt` must decline it —
+#   but with an exit code, not a signal. Anything >= 128 is a crash.
+assert_clean_reject() {
+    local label="$1" path="$2" status=0
+    "$KAAPPI" fmt < "$path" > /dev/null 2>&1 || status=$?
+    if [[ "$status" -eq 1 ]]; then
+        pass "$label"
+    elif [[ "$status" -ge 128 ]]; then
+        fail "$label" "died on a signal (exit $status), not a clean rejection"
+    else
+        fail "$label" "expected exit 1, got $status"
+    fi
+}
+
+{ repeat '(' 300000; repeat ')' 300000; echo; } > "$TMP/deep-list.scm"
+assert_clean_reject "depth: 300000 nested lists rejected cleanly" "$TMP/deep-list.scm"
+
+# FAIL: #2141 (max_nesting is checked in parseList only; parsePrefixTarget
+# recurses unguarded, so a long prefix chain overflows the native stack —
+# ~158000 on an 8 MB stack, and every prefix kind reaches it)
+# { repeat "'" 300000; echo x; } > "$TMP/deep-quote.scm"
+# assert_clean_reject "depth: 300000 quote prefixes rejected cleanly" "$TMP/deep-quote.scm"
+
+echo ""
+echo "fmt-adversarial: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/tools/fmt_fuzz.py
+++ b/tools/fmt_fuzz.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Fuzz `kaappi fmt` against the repo's own Scheme corpus.
+
+`fmt` guards every write with a real-reader `equal?` round-trip, so it can
+never change a program. Two things that guard structurally cannot see are what
+this fuzzer looks for:
+
+  * **Comments.** The reader discards them, so a comment that moves, is
+    duplicated, or is dropped passes the round-trip unnoticed.
+  * **Idempotence.** `fmt(fmt(x)) == fmt(x)` is a separate property; a
+    formatter can be `equal?`-preserving and still oscillate between layouts.
+
+It is **not** part of `run-all.sh` — a useful run takes minutes, well past that
+suite's 60 s per-file budget. The cases it has already found are pinned as fast
+regression tests in `tests/scheme/fmt/fmt-adversarial.sh`; run this when
+changing `src/fmt.zig` or `src/fmt_print.zig`, or to look for new ones.
+
+    tools/fmt_fuzz.py byte  30000        # random byte mutation
+    tools/fmt_fuzz.py ws     4000        # whitespace-run resizing
+    tools/fmt_fuzz.py cmt    6000        # comment / blank-line insertion
+    tools/fmt_fuzz.py blank                # exhaustive comment x blank grid
+    tools/fmt_fuzz.py all                  # a moderate run of each
+
+Modes
+  byte   Flip, delete, insert, replace, duplicate and truncate bytes. Most
+         mutants are unreadable — that is expected. The interesting outcomes
+         are a crash, a hang, non-idempotence, or `fmt` disagreeing with the
+         real reader about whether the file is even readable.
+  ws     Resize runs of spaces and tabs outside strings and comments, never
+         adding or removing a newline. `docs/dev/fmt.md`: "Layout depends only
+         on the program's content and its comments, **not** on the input's own
+         line breaks". Oracle: `fmt(mutant)` byte-identical to `fmt(original)`.
+  cmt    Insert `;`, `#| |#`, `#;` comments and blank lines at token
+         boundaries. Oracle: idempotence, every comment marker surviving in
+         order, and `fmt`'s own guard. `--glue` additionally inserts them with
+         no separating space, which reproduces kaappi#2143 in bulk.
+  blank  Not random: every (comment position x blank position) pair over a
+         grid of head forms. This is what mapped kaappi#2142's 58 shapes.
+
+Buckets, and what each means
+
+  clean          fmt accepted it and every oracle held
+  rejected       fmt refused, and so does the real reader — expected
+  crash          fmt died on a signal or printed a panic        -> BUG
+  hang           fmt did not finish inside the timeout          -> BUG
+  nonidem        the second pass differs from the first         -> BUG
+  comment_lost   a comment marker vanished or moved             -> BUG
+  ws_drift       whitespace changed the layout                  -> BUG
+  reader_split   fmt reported a syntax error the reader does not -> BUG
+  guard_trip     fmt's round-trip guard refused a file the reader reads
+                 fine — fmt's output would have been a different program
+
+Nothing is ever written over a corpus file: every mutant goes to `fmt` on
+stdin, and the copies kept for the reader cross-check live in a `mktemp` dir
+that is removed on exit.
+"""
+
+import argparse
+import os
+import random
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ProcessPoolExecutor
+
+TIMEOUT = 30
+MAX_CORPUS_BYTES = 20000
+
+KAAPPI = os.environ.get("KAAPPI", "zig-out/bin/kaappi")
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Worker processes are spawned (not forked) on macOS and Windows, so the
+# scratch directory has to travel in the environment rather than in a global.
+SCRATCH_VAR = "KAAPPI_FMT_FUZZ_SCRATCH"
+
+
+def scratch():
+    return os.environ[SCRATCH_VAR]
+
+BUG_BUCKETS = ("crash", "hang", "nonidem", "comment_lost", "ws_drift",
+               "reader_split", "guard_trip")
+
+MUTATION_BYTES = bytes(b"()[]{}'`,@#|;\"\\ \n\r\t.0123456789abcdefxu8=e"
+                       b"\x00\x7f\xff\xc3\xa9")
+
+
+def run_fmt(data):
+    p = subprocess.run([KAAPPI, "fmt"], input=data, capture_output=True,
+                       timeout=TIMEOUT)
+    return p.returncode, p.stdout, p.stderr
+
+
+def reader_accepts(data, tag):
+    """Does the real reader read this? `kaappi ast` reads and prints datums and
+    executes nothing, so it answers exactly that question."""
+    path = os.path.join(scratch(), "probe%s.scm" % tag)
+    with open(path, "wb") as f:
+        f.write(data)
+    try:
+        p = subprocess.run([KAAPPI, "ast", path], capture_output=True,
+                           timeout=TIMEOUT)
+    except subprocess.TimeoutExpired:
+        return False
+    return p.returncode == 0
+
+
+def crashed(rc, err):
+    return rc < 0 or rc >= 128 or b"panic" in err or b"error at address" in err
+
+
+def corpus():
+    out = subprocess.run(["git", "ls-files", "*.scm", "*.sld"], cwd=REPO,
+                         capture_output=True, check=True).stdout.decode().split()
+    files = []
+    for rel in out:
+        try:
+            data = open(os.path.join(REPO, rel), "rb").read()
+        except OSError:
+            continue
+        if 0 < len(data) <= MAX_CORPUS_BYTES:
+            files.append((rel, data))
+    return files
+
+
+# ── where it is legal to insert ─────────────────────────────────────────────
+
+def safe_points(src):
+    """Byte offsets outside strings, |symbols|, character literals and
+    comments, at a whitespace or paren byte — where inserting whitespace or a
+    comment cannot land inside a lexeme."""
+    pts = []
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i:i + 1]
+        if c in (b'"', b"|"):
+            close, i = c, i + 1
+            while i < n:
+                if src[i:i + 1] == b"\\":
+                    i += 2
+                    continue
+                i += 1
+                if src[i - 1:i] == close:
+                    break
+            continue
+        if c == b";":
+            while i < n and src[i:i + 1] != b"\n":
+                i += 1
+            continue
+        if src[i:i + 2] == b"#|":
+            depth, i = 1, i + 2
+            while i + 1 < n and depth:
+                if src[i:i + 2] == b"#|":
+                    depth, i = depth + 1, i + 2
+                elif src[i:i + 2] == b"|#":
+                    depth, i = depth - 1, i + 2
+                else:
+                    i += 1
+            continue
+        if src[i:i + 2] == b"#\\":
+            i += 3
+            while i < n and src[i:i + 1].isalnum():
+                i += 1
+            continue
+        if src[i:i + 2] == b'#"':
+            i += 2
+            while i < n and src[i:i + 1] != b'"':
+                i += 1
+            i += 1
+            continue
+        if c in (b" ", b"\t", b"\n", b"(", b")"):
+            pts.append(i)
+        i += 1
+    return pts
+
+
+# ── mode: byte ──────────────────────────────────────────────────────────────
+
+def mutate_bytes(rng, src):
+    b = bytearray(src)
+    for _ in range(rng.randint(1, 6)):
+        if not b:
+            break
+        op, i = rng.randrange(7), rng.randrange(len(b))
+        if op == 0:
+            b[i] ^= 1 << rng.randrange(8)
+        elif op == 1:
+            del b[i]
+        elif op == 2:
+            b.insert(i, rng.choice(MUTATION_BYTES))
+        elif op == 3:
+            b[i] = rng.choice(MUTATION_BYTES)
+        elif op == 4:
+            b[i:i] = b[i:min(len(b), i + rng.randint(1, 64))]
+        elif op == 5:
+            del b[i:min(len(b), i + rng.randint(1, 64))]
+        else:
+            del b[i:]
+    return bytes(b)
+
+
+def job_byte(args):
+    idx, seed, rel, src = args
+    rng = random.Random((seed << 20) ^ idx)
+    mut = mutate_bytes(rng, src)
+    return check_mutant(idx, rel, mut, want_markers=False)
+
+
+# ── mode: ws ────────────────────────────────────────────────────────────────
+
+WS_RUN = re.compile(rb"[ \t]+")
+
+
+def mutate_ws(rng, src):
+    ok = set(safe_points(src))
+    out, i, n, changed = bytearray(), 0, len(src), 0
+    while i < n:
+        m = WS_RUN.match(src, i)
+        if m and i in ok and rng.random() < 0.4:
+            out += bytes(rng.choice(b" \t") for _ in range(rng.randint(1, 6)))
+            changed, i = changed + 1, m.end()
+            continue
+        out += src[i:i + 1]
+        i += 1
+    return bytes(out), changed
+
+
+def job_ws(args):
+    idx, seed, rel, src = args
+    rng = random.Random((seed << 20) ^ idx)
+    try:
+        rc0, base, _ = run_fmt(src)
+    except subprocess.TimeoutExpired:
+        return ("hang", rel, b"formatting the original", b"")
+    if rc0 != 0:
+        return ("skipped", rel, b"", b"")
+    mut, changed = mutate_ws(rng, base)
+    if changed == 0:
+        return ("skipped", rel, b"", b"")
+    try:
+        rc, out, err = run_fmt(mut)
+    except subprocess.TimeoutExpired:
+        return ("hang", rel, b"", b"")
+    if crashed(rc, err):
+        return ("crash", rel, err[:400], b"")
+    if rc != 0:
+        return ("rejected", rel, err[:200], b"")
+    if out != base:
+        return ("ws_drift", rel, base[:300], out[:300])
+    return ("clean", rel, b"", b"")
+
+
+# ── mode: cmt ───────────────────────────────────────────────────────────────
+
+INSERTS = [b" ; C%d\n", b" #| C%d |#", b" #|\nC%d\n|#", b" #;C%d ",
+           b"\n; C%d\n", b"\n\n; C%d\n", b"\n\n", b"  ", b"\n"]
+
+# Same comments with the leading space removed, so they glue to the preceding
+# identifier. Off by default (`--glue`): every one of them lands in a bug
+# bucket for kaappi#2143, which would drown out anything new.
+GLUED = [b"#| C%d |#", b"#;C%d ", b"; C%d\n"]
+
+GLUE_VAR = "KAAPPI_FMT_FUZZ_GLUE"
+
+
+def mutate_cmt(rng, src, base_id):
+    pts = safe_points(src)
+    if not pts:
+        return src, 0
+    table = INSERTS + (GLUED if os.environ.get(GLUE_VAR) else [])
+    picks = sorted(rng.sample(pts, min(rng.randint(1, 5), len(pts))), reverse=True)
+    out, n = bytearray(src), 0
+    for p in picks:
+        tmpl = rng.choice(table)
+        n += 1
+        out[p:p] = tmpl % (base_id + n) if b"%d" in tmpl else tmpl
+    return bytes(out), n
+
+
+def job_cmt(args):
+    idx, seed, rel, src = args
+    rng = random.Random((seed << 20) ^ idx)
+    mut, n = mutate_cmt(rng, src, idx * 100)
+    if n == 0:
+        return ("skipped", rel, b"", b"")
+    return check_mutant(idx, rel, mut, want_markers=True)
+
+
+# ── shared verdict ──────────────────────────────────────────────────────────
+
+def markers(b):
+    return re.findall(rb"\bC\d+\b", b)
+
+
+def check_mutant(idx, rel, mut, want_markers):
+    try:
+        rc, out, err = run_fmt(mut)
+    except subprocess.TimeoutExpired:
+        return ("hang", rel, b"", b"")
+    if crashed(rc, err):
+        return ("crash", rel, err[:400], b"")
+    if rc != 0:
+        if not reader_accepts(mut, str(idx % 64)):
+            return ("rejected", rel, err[:200], b"")
+        keep(rel, idx, mut)
+        if b"internal error" in err:
+            return ("guard_trip", rel, err[:200], b"")
+        return ("reader_split", rel, err[:200], b"")
+    try:
+        rc2, out2, err2 = run_fmt(out)
+    except subprocess.TimeoutExpired:
+        return ("hang", rel, b"second pass", b"")
+    if crashed(rc2, err2):
+        return ("crash", rel, b"second pass: " + err2[:400], b"")
+    if rc2 != 0 or out2 != out:
+        keep(rel, idx, mut)
+        return ("nonidem", rel, out[:400], out2[:400])
+    if want_markers and markers(mut) != markers(out):
+        keep(rel, idx, mut)
+        return ("comment_lost", rel, b" ".join(markers(mut))[:200],
+                b" ".join(markers(out))[:200])
+    return ("clean", rel, b"", b"")
+
+
+def keep(rel, idx, mut):
+    """Save a mutant worth reducing by hand."""
+    name = "%s_%d.scm" % (os.path.basename(rel), idx)
+    with open(os.path.join(scratch(), "found", name), "wb") as f:
+        f.write(mut)
+
+
+# ── mode: blank ─────────────────────────────────────────────────────────────
+
+BLANK_HEADS = ["f", "cond", "and", "define", "lambda", "let", "let*", "letrec",
+               "when", "unless", "begin", "case", "do", "guard", "syntax-rules",
+               "case-lambda", "receive", "define-values", "define-record-type",
+               "parameterize"]
+
+
+def blank_grid():
+    """Every (comment position, blank position) pair over a grid of head forms.
+    Not random: this is a complete enumeration of one small shape."""
+    for head in BLANK_HEADS:
+        for nargs in (2, 3, 4):
+            items = [head] + ["a", "b", "c", "d"][:nargs]
+            for ci in range(1, len(items) + 1):
+                toks = items[:ci] + ["#|c|#"] + items[ci:]
+                for bi in range(1, len(toks)):
+                    parts = [toks[0]]
+                    for i, t in enumerate(toks[1:], 1):
+                        parts.append(("\n\n  " if i == bi else " ") + t)
+                    yield head, "(" + "".join(parts) + ")\n"
+
+
+def job_blank(args):
+    idx, seed, head, src = args
+    return check_mutant(idx, head, src.encode(), want_markers=False)
+
+
+# ── driver ──────────────────────────────────────────────────────────────────
+
+MODES = {"byte": job_byte, "ws": job_ws, "cmt": job_cmt, "blank": job_blank}
+
+
+def run_mode(mode, n, seed, workers):
+    if mode == "blank":
+        jobs = [(i, seed, head, src) for i, (head, src) in enumerate(blank_grid())]
+    else:
+        rng = random.Random(seed)
+        files = corpus()
+        if not files:
+            sys.exit("no corpus files found under %s" % REPO)
+        jobs = [(i, seed, *rng.choice(files)) for i in range(n)]
+
+    buckets, found = {}, []
+    with ProcessPoolExecutor(max_workers=workers) as ex:
+        for kind, rel, a, b in ex.map(MODES[mode], jobs, chunksize=8):
+            buckets[kind] = buckets.get(kind, 0) + 1
+            if kind in BUG_BUCKETS:
+                found.append((kind, rel, a, b))
+
+    print("\n=== %s: %d inputs, seed %d ===" % (mode, len(jobs), seed))
+    for k in sorted(buckets):
+        mark = "  <-- BUG" if k in BUG_BUCKETS else ""
+        print("  %-13s %6d%s" % (k, buckets[k], mark))
+    if found:
+        print("  kept for reduction: %s/found/" % scratch())
+    for kind, rel, a, b in found[:20]:
+        print("  %-13s %s\n      %r\n      %r" % (kind, rel, a[:200], b[:200]))
+    return len(found)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("mode", choices=list(MODES) + ["all"])
+    ap.add_argument("n", nargs="?", type=int, default=2000,
+                    help="mutants to generate (ignored by 'blank')")
+    ap.add_argument("--seed", type=int, default=1)
+    ap.add_argument("--jobs", type=int, default=os.cpu_count() or 4)
+    ap.add_argument("--keep", action="store_true",
+                    help="do not delete the scratch dir on exit")
+    ap.add_argument("--glue", action="store_true",
+                    help="cmt mode: also insert comments with no separating "
+                         "space, which reproduces kaappi#2143 and swamps "
+                         "everything else")
+    args = ap.parse_args()
+
+    if not os.access(KAAPPI, os.X_OK):
+        sys.exit("no kaappi binary at %s (set $KAAPPI or run zig build)" % KAAPPI)
+
+    if args.glue:
+        os.environ[GLUE_VAR] = "1"
+    os.environ[SCRATCH_VAR] = tempfile.mkdtemp(prefix="kaappi-fmt-fuzz-")
+    os.makedirs(os.path.join(scratch(), "found"), exist_ok=True)
+    try:
+        modes = list(MODES) if args.mode == "all" else [args.mode]
+        bugs = 0
+        for m in modes:
+            bugs += run_mode(m, args.n, args.seed, args.jobs)
+        print("\n%d input(s) in a bug bucket" % bugs)
+        return 1 if bugs else 0
+    finally:
+        if args.keep:
+            print("scratch kept: %s" % scratch())
+        else:
+            shutil.rmtree(scratch(), ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Phase 6F of the systematic audit v2 (#1890). A survey unit: no `fmt` behaviour
changes here, only tests, a fuzzer, and four issues.

## The premise

`fmt` guards every write with a real-reader `equal?` round-trip, so it can never
change a program. Two things that guard is *structurally* blind to are the whole
of this unit:

* **Comments are not datums.** The reader discards them, so a comment that
  moves, is duplicated, or is dropped passes the round-trip unnoticed.
* **Idempotence is a separate property.** A formatter can be
  `equal?`-preserving and still oscillate between two layouts.

Phase 6 reconnaissance called `fmt` "genuinely robust", and on the evidence
below that is largely right — but not unqualified.

## What was run

| campaign | inputs | outcome |
|---|--:|---|
| byte mutation over the repo's 912 `.scm`/`.sld` files | 34 300 | 0 crash, 0 hang, 0 non-idempotent, 0 comment loss; 3 refusals, all one cause |
| whitespace-run resizing (must not change the output at all) | 4 700 | 0 drift |
| comment/blank insertion, space-separated | 7 000 | 0 in any bug bucket |
| comment/blank insertion, glued to the preceding token | 4 000 | 604 refusals, **100 % one cause** |
| exhaustive comment × blank-line grid, 20 head forms | 1 000 | 58 non-idempotent, one cause |
| adversarial comment placement, hand-written | 53 | all pass |
| **total** | **~51 000** | **3 root causes** |

A fourth, #2149, came from hand-probing rather than fuzzing.

Headline run (30 000 byte mutants, seed 42): 19 907 rejected, 10 090 formatted
clean, 3 guard trips, **0 crashes, 0 hangs, 0 non-idempotent, 0 comment loss**.
`fmt` survives a real fuzzing campaign — every bug below needed either a
mutator that knew what a comment was, or an input no random mutation reaches.

Every mutant went to `fmt` on **stdin**; no corpus file was ever rewritten,
verified by `git status` before and after each run.

## Found

**#2141 — `fmt` stack-overflows on a long reader-prefix chain.** `max_nesting`
is checked in `parseList` and nowhere else; `nodeFromTok` → `parsePrefixTarget`
→ `nodeFromTok` recurses unguarded, so ~158 000 `'` in a row is a SIGBUS
(exit 134) on an 8 MB stack — from `kaappi fmt --check` too, the documented CI
gate. All six prefix kinds reach it (`'`, `` ` ``, `,`, `,@`, `#;`, `#N=`).
Two discriminating controls: 300 000 nested **lists** give a clean
`syntax error: nesting too deep`, and the real reader answers
`read error[KP1009]: nesting too deep` at depth 1025 — the same number `fmt`
writes down and half-enforces.

**#2142 — `fmt` is not idempotent when a block comment rides the head line.**
`hasBodyBlank` decides which children are body items **by index**
(`n + 1` for body style, `2` for call style); `emitBodyStyle`/`emitCallStyle`
decide by **counting non-comment items**, and a same-line comment rides without
incrementing the count. One `#|c|#` between the operator and the first head-line
datum shifts everything one index right, so pass 1 forces a break for a blank it
then drops, and pass 2 collapses the form inline:

```text
(f #|c|#          fmt      (f #|c|# a       fmt      (f #|c|# a b)
                  --->              b)      --->
   a b)
```

The concrete harm: `kaappi fmt x.scm` followed by `kaappi fmt --check x.scm`
exits 1 — on the file `fmt` itself just wrote. `fmt.md` § *Idempotence* states
the lockstep this violates, in those words. Three discriminating controls (no
comment / blank one item later / a *line* comment instead) are all stable and
are committed **enabled**. `begin` and `case-lambda` are immune, which is the
tell: they are the two table entries with `n = 0`.

**#2143 — `fmt` refuses legal Scheme where a `#`-led lexeme is glued to an
identifier.** `fmt.zig:146` says its `isDelimiter` "mirrors
`reader.Reader.isDelimiter` so the formatter carves the same lexemes the real
reader does" — but `isDelimiter` is not what ends an identifier in the reader.
`readSymbol` stops at the first non-⟨subsequent⟩ byte; `scanAtom` runs to the
next ⟨delimiter⟩. `#` is neither, so:

```console
$ printf '(list a#;(b) c)\n' > x.scm && kaappi ast x.scm
(list a c)
$ kaappi fmt x.scm
kaappi fmt: x.scm: syntax error: unterminated list
```

`fmt` reports a syntax error in a file that has none — it lexed `a#`, then
`;(b) c)` as a line comment. `#|…|#` and `#(` give the round-trip guard's
"internal error" instead. One space fixes every case, which is the control.
Three implementations disagree about what `b#|c|#` even means (kaappi reads
`b` + comment; chibi and guile each read one symbol; `fmt` reads three lexemes,
matching none), so this is not a straightforward conformance bug — the issue
has the table. The bug is that `fmt` picked a different answer from its own
reader while documenting that it does not.

**#2149 — fit-to-width is measured in bytes, not the columns `fmt.md`
promises.** Found by hand rather than by the fuzzer, and cosmetic: `measure` and
the inline emitter are both byte-based, so the predicate stays consistent and
the output is idempotent. But twelve five-character Unicode identifiers — 75
columns, 135 bytes — break into 12 lines, while the identical ASCII shape at the
same 75 columns stays on one. Doc-truth: `fmt_print.zig` says "in bytes" and
`fmt.md` says "columns".

## What is committed

* **`tests/scheme/fmt/fmt-adversarial.sh`** — 62 assertions, ~2 s. 53 comment
  placements where the layout engine must decide (between `define` and its
  name, after a dotted `.`, inside a `case` datum list, `#|` inside a `;` and
  `;` inside a `#| |#`, a comment as a file's only content, one with no
  trailing newline, `#;` chains, comments containing unbalanced parens and
  quotes, …), each asserting all three of: `fmt` accepts it, every comment
  survives in order, and a second pass changes nothing. Plus the four
  blank-line controls, the three space-separated lexeme controls, the
  parser-depth property, and the fit-to-width property. The seven repros for
  #2141, #2142, #2143 and #2149 are committed **disabled** with
  `# FAIL: #NNNN` markers directly above, per the campaign protocol — the fix
  PRs re-enable them.
* **`tools/fmt_fuzz.py`** — the fuzzer, on demand, four modes
  (`byte`/`ws`/`cmt`/`blank`). Deliberately not in `run-all.sh`: a useful run
  takes minutes, past the 60 s per-file budget. `blank` reproduces #2142's 58
  shapes in 10 s; `cmt --glue` reproduces #2143 in bulk (and is off by default
  because it swamps everything else). Nothing it writes can reach a corpus
  file.
* **`docs/dev/fmt.md`** — both new files added to § *Tests*, with why a fuzzer
  earns its keep on this particular tool.

## Verification

* `bash tests/scheme/run-all.sh` — **2062 pass, 0 fail; R7RS 1395/1395.**
* `tests/scheme/fmt/fmt.sh` unchanged and still 37/37, including the 903-file
  corpus's zero-drift and idempotence properties.
* Fresh ReleaseSafe build, isolated `KAAPPI_HOME` throughout (three other audit
  units were running concurrently).

One note on getting to green, since it cost time and the standing diagnosis is
wrong. `compile-import-error-703.sh` and `compile-preamble-gc-700.sh` failed
twice for me and #2093 attributed the same pair to machine load. They are not
load-sensitive: `bundle_fixture_binary` compiles the `.sbc` with the *installed*
`zig-out/bin/kaappi` and embeds it in a *freshly built* binary, so any build-id
skew — a dirty tree, or a commit made since the last `zig build` — makes the
standalone binary reject its own bytecode with `fatal: invalid embedded
bytecode`. It reproduces deterministically on an idle machine and disappears
after one `zig build`. Already filed twice (#1930, #2097); citing rather than
re-filing, but the "load" attribution should not be inherited by the next unit.

Also confirmed rather than re-filed: `fmt` reporting a reader error as
`internal error: formatting would change the program` is #2080, and it is the
message behind the BOM, NUL-byte, over-deep-prefix and #2143 refusals — four
more classes for that issue's list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
