### PR TITLE
Phase 7D: cross-endian .sbc — the format is clean, but a paired byte-swap was invisible; golden bytes close it, and the cache key has no target

### DIFF
--- a/docs/dev/cache.md
+++ b/docs/dev/cache.md
@@ -61,6 +61,25 @@ rebuilds. It reads exactly like nondeterminism in the code under test.
 changes, or measure with `--no-ir-opt`, which bypasses the cache in both
 directions.** See [performance.md](performance.md) for the full A/B protocol.
 
+### The other case it does not cover: a different *target*
+
+`compilerHashFor` takes the version string and the build id, and nothing else —
+in particular, **not** the target triple. Two binaries built from the same clean
+commit for different targets (`aarch64-macos` and `x86_64-windows`, say) have
+identical keys, and all 17 platform binaries in a release are built from one
+checkout. That would be harmless if bytecode were target-independent, but
+`cond-expand` is resolved at compile time against `types.platform_features` and
+only the taken branch survives into the `.sbc`. Tracked as
+[#2155](https://github.com/kaappi/kaappi/issues/2155); the exposure today is
+Windows-vs-POSIX and native-vs-WASM (the other feature identifiers are not
+arch-gated), and the reachable path is `zig build -Dbundle=out.sbc` with a
+cross `-Dtarget`, rather than the auto-run cache.
+
+Byte order is *not* part of this: `.sbc` scalars are canonically little-endian
+through explicit conversions, pinned against committed golden bytes in
+`src/tests_endian.zig` (audit v2 Phase 7D) so a swap on either side — or on
+both — fails on every host.
+
 A *filename* collision is self-correcting, never a wrong result: even if two
 different source paths hashed to the same cache filename, the stored source
 hash would not match, so the load misses and recompiles. The dirty-build-id

--- a/docs/dev/porting.md
+++ b/docs/dev/porting.md
@@ -318,14 +318,31 @@ all, only build/CI work — *provided* the preconditions hold.
       suite is a separate, deliberately small entry point rather than
       the whole tree. Two blind spots remain, both structural:
 
-      * **A paired byte-swap cancels out.** Every `.sbc` test writes and
-        reads on the same host, so a bug that swapped *both* directions
-        stays green everywhere. `src/tests_endian.zig` breaks the pairing
-        one direction at a time — the writer against literal expected
-        bytes, the reader against a hand-assembled literal-little-endian
-        header — but no test yet writes a file on one endianness and
-        reads it on the other. The nightly `cross-diff` fuzz job does not
-        close this either: both sides run against their own arch's cache.
+      * **A paired byte-swap used to cancel out — closed by golden
+        bytes (audit v2 Phase 7D).** Every `.sbc` *round-trip* test still
+        writes and reads on the same host, so a bug swapping both
+        directions leaves those green everywhere; no test writes a file on
+        one endianness and reads it on the other, and the nightly
+        `cross-diff` fuzz job does not close that either (both sides run
+        against their own arch's cache). What removes the need for a
+        second machine is a committed **golden byte sequence**:
+        `GOLDEN_BODY` in `src/tests_endian.zig` is a literal, hand-derived
+        from the format, used twice with no contact between the uses — the
+        serializer must reproduce it, and the deserializer must decode it.
+        Neither expected value is a function of the host, so a swap on
+        either side, or on both, fails on every target. Measured: flipping
+        `nativeToLittle`→`nativeToBig` in `writeU32` **and**
+        `littleToNative`→`bigToNative` in `readU32` leaves all 10
+        `bytecode_file.zig` round-trip tests passing and fails both golden
+        tests. The same shape covers SRFI 271's determinized random ports
+        in `tests/scheme/audit/endianness-audit.scm`, whose own suite is
+        likewise blind: a `.little`→`.big` flip in the seed-word read
+        leaves `tests/scheme/srfi/srfi271.scm` at 35/35.
+        **Still not covered:** what a `.sbc` carries that is
+        target-*dependent* rather than byte-order-dependent. The cache key
+        has no target component, so a binary built for one target loads
+        another's bytecode with its `cond-expand` branches already
+        chosen (#2155).
       * **A local `zig build test -Dtarget=s390x-linux` proves nothing
         about behaviour.** `build.zig` sets `skip_foreign_checks = true`,
         so on a host with no emulator registered the run step is

--- a/src/tests_endian.zig
+++ b/src/tests_endian.zig
@@ -50,6 +50,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const build_options = @import("build_options");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const file_utils = @import("file_utils.zig");
@@ -281,4 +282,354 @@ test "endian: a written .sbc file carries VERSION and source_hash little-endian"
         &.{ 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01 },
         bytes[6..14],
     );
+}
+
+// ---------------------------------------------------------------------------
+// 5. The whole-file golden fixture (audit v2, Phase 7D)
+//
+// Section 2 checks the writer's scalar helpers and section 3 checks the
+// reader's header parse. Neither reaches the *body*: the per-function record
+// (arity/locals/upvalues/name/code/constants/line table) and every constant
+// encoding. Those are exercised only by the round-trip tests in
+// `bytecode_file.zig`, which write and read on the same host — so a byte-swap
+// present on BOTH sides cancels out and leaves them green on every machine,
+// big-endian included. That is the exact bug class s390x exists to catch and
+// the one thing no existing test can see.
+//
+// The fixture below breaks the pairing. `GOLDEN_BODY` is a literal byte
+// sequence, hand-derived field by field from the format in
+// `bytecode_file_write.writeFunctionsToBuffer`, and it is used twice with no
+// contact between the two uses:
+//
+//   * `writer` builds the corresponding Function graph, serializes it, and
+//     asserts the file equals the literal. Consults no reader code.
+//   * `reader` feeds the literal to `deserializeFromBuffer` and asserts every
+//     decoded field. Consults no writer code.
+//
+// Neither expected value is a function of the host, so both mean the same
+// thing on s390x as on x86_64. A swap on one side fails one test; a *paired*
+// swap fails both — while the round-trip tests stay green, which is the point.
+//
+// Every multi-byte value below was chosen so its byte-reverse is a different
+// value (no zero padding that hides a swap, no palindromes). Read any comment
+// as "value V, LSB first" and the ordering is checkable by eye.
+// ---------------------------------------------------------------------------
+
+/// Emit `n` bytes of `v`, least-significant first, using shifts only — so the
+/// helper itself cannot inherit the host's byte order the way a `@bitCast`
+/// would. This is what makes the hand-assembled header independent of the
+/// codec under test.
+fn appendLe(list: *std.ArrayList(u8), allocator: std.mem.Allocator, n: usize, v: u64) !void {
+    var i: usize = 0;
+    while (i < n) : (i += 1) {
+        try list.append(allocator, @truncate(v >> @intCast(i * 8)));
+    }
+}
+
+const GOLDEN_SOURCE_HASH: u64 = 0x0102030405060708;
+const GOLDEN_SOURCE_PATH = "g.scm";
+/// Only the reader test uses this: the writer stamps `build_options.git_build_id`,
+/// which differs per build, so the writer test spells the real one instead.
+const GOLDEN_BUILD_ID = "bid";
+
+const LOAD_VOID: u8 = @intFromEnum(types.OpCode.load_void);
+const RETURN: u8 = @intFromEnum(types.OpCode.@"return");
+
+/// Everything after the variable-length header (magic, version, source hash,
+/// compiler hash, build id, source path). Offsets 0..14 of the header are
+/// already pinned by section 4; the compiler hash and the two string length
+/// prefixes are spelled by hand in both tests below.
+///
+/// Written as one `++` chain of per-field literals rather than a flat array so
+/// `zig fmt` cannot reflow a value across a line boundary: each line below is
+/// exactly one field, and its comment names the value it spells LSB-first.
+const GOLDEN_BODY =
+    [_]u8{ 0x02, 0x00, 0x00, 0x00 } ++ // func_count u32 = 2
+    [_]u8{ 0x01, 0x00, 0x00, 0x00 } ++ // top_level_count u32 = 1
+
+    // ---- function 0 (top level) ----
+    [_]u8{0x02} ++ // arity u8 = 2
+    [_]u8{ 0x01, 0x02 } ++ // locals_count u16 = 0x0201
+    [_]u8{ 0x03, 0x04 } ++ // upvalue_count u16 = 0x0403
+    [_]u8{0x01} ++ // is_variadic u8 = 1
+    [_]u8{ 0x02, 0x00 } ++ "fn".* ++ // name: u16 length 2, then bytes
+    [_]u8{ 0x06, 0x00, 0x00, 0x00 } ++ // code_len u32 = 6
+    [_]u8{ LOAD_VOID, 0x00, 0x00, RETURN, 0x00, 0x00 } ++
+    [_]u8{ 0x12, 0x00, 0x00, 0x00 } ++ // const_count u32 = 18
+
+    // 0: fixnum -2, i64 0xFFFFFFFFFFFFFFFE
+    [_]u8{bf.TAG_FIXNUM} ++ [_]u8{ 0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } ++
+    // 1: flonum 1.5, IEEE-754 bits 0x3FF8000000000000
+    [_]u8{bf.TAG_FLONUM} ++ [_]u8{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0x3F } ++
+    // 2: symbol "ab", u16 length prefix
+    [_]u8{bf.TAG_SYMBOL} ++ [_]u8{ 0x02, 0x00 } ++ "ab".* ++
+    // 3: string "cd", u32 length prefix
+    [_]u8{bf.TAG_STRING} ++ [_]u8{ 0x02, 0x00, 0x00, 0x00 } ++ "cd".* ++
+    [_]u8{ bf.TAG_BOOLEAN, 0x01 } ++ // 4: #t
+    [_]u8{ bf.TAG_BOOLEAN, 0x00 } ++ // 5: #f
+    [_]u8{bf.TAG_NIL} ++ // 6: '()
+    [_]u8{bf.TAG_VOID} ++ // 7: void
+    [_]u8{bf.TAG_EOF} ++ // 8: eof object
+    [_]u8{bf.TAG_UNDEFINED} ++ // 9: undefined
+    // 10: char U+1F600, u32 0x0001F600
+    [_]u8{bf.TAG_CHAR} ++ [_]u8{ 0x00, 0xF6, 0x01, 0x00 } ++
+    // 11: function reference, index u32 = 1
+    [_]u8{bf.TAG_FUNCTION} ++ [_]u8{ 0x01, 0x00, 0x00, 0x00 } ++
+    // 12: pair (3 . 4), two nested fixnum constants
+    [_]u8{bf.TAG_PAIR} ++
+    [_]u8{bf.TAG_FIXNUM} ++ [_]u8{ 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } ++
+    [_]u8{bf.TAG_FIXNUM} ++ [_]u8{ 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } ++
+    // 13: vector #(5), u32 length then one nested fixnum
+    [_]u8{bf.TAG_VECTOR} ++ [_]u8{ 0x01, 0x00, 0x00, 0x00 } ++
+    [_]u8{bf.TAG_FIXNUM} ++ [_]u8{ 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } ++
+    // 14: bytevector #u8(7 8), u32 length then raw bytes
+    [_]u8{bf.TAG_BYTEVECTOR} ++ [_]u8{ 0x02, 0x00, 0x00, 0x00 } ++ [_]u8{ 0x07, 0x08 } ++
+    // 15: bignum +0x0102030405060708: sign u8, limb count u32, one limb u64
+    [_]u8{bf.TAG_BIGNUM} ++ [_]u8{0x01} ++ [_]u8{ 0x01, 0x00, 0x00, 0x00 } ++
+    [_]u8{ 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01 } ++
+    // 16: rational 22/7, two nested fixnum constants
+    [_]u8{bf.TAG_RATIONAL} ++
+    [_]u8{bf.TAG_FIXNUM} ++ [_]u8{ 0x16, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } ++
+    [_]u8{bf.TAG_FIXNUM} ++ [_]u8{ 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } ++
+    // 17: complex 3.0+4.0i: f64 0x4008000000000000, f64 0x4010000000000000,
+    //     then exact_real u8, exact_imag u8
+    [_]u8{bf.TAG_COMPLEX} ++
+    [_]u8{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x40 } ++
+    [_]u8{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x40 } ++
+    [_]u8{ 0x00, 0x00 } ++
+    [_]u8{ 0x01, 0x02, 0x03, 0x00 } ++ // source_line u32 = 0x00030201
+    [_]u8{ 0x01, 0x00, 0x00, 0x00 } ++ // line_table count u32 = 1
+    [_]u8{ 0x02, 0x01 } ++ // entry offset u16 = 0x0102
+    [_]u8{ 0x02, 0x03, 0x04, 0x00 } ++ // entry line u32 = 0x00040302
+    [_]u8{ 0x05, 0x06, 0x07, 0x00 } ++ // entry col  u32 = 0x00070605
+
+    // ---- function 1 (nested, referenced by constant 11) ----
+    [_]u8{0x00} ++ // arity u8 = 0
+    [_]u8{ 0x01, 0x00 } ++ // locals_count u16 = 1
+    [_]u8{ 0x00, 0x00 } ++ // upvalue_count u16 = 0
+    [_]u8{0x00} ++ // is_variadic u8 = 0
+    [_]u8{ 0x00, 0x00 } ++ // name_len u16 = 0
+    [_]u8{ 0x06, 0x00, 0x00, 0x00 } ++ // code_len u32 = 6
+    [_]u8{ LOAD_VOID, 0x00, 0x00, RETURN, 0x00, 0x00 } ++
+    [_]u8{ 0x00, 0x00, 0x00, 0x00 } ++ // const_count u32 = 0
+    [_]u8{ 0x00, 0x00, 0x00, 0x00 } ++ // source_line u32 = 0
+    [_]u8{ 0x00, 0x00, 0x00, 0x00 } ++ // line_table count u32 = 0
+
+    [_]u8{ 0x00, 0x00, 0x00, 0x00 } ++ // bundled-files count u32 = 0
+    [_]u8{ 0x00, 0x00, 0x00, 0x00 }; // preamble count u32 = 0
+
+comptime {
+    // The fixture is worthless if a value in it is its own byte-reverse: the
+    // assertion would hold under a swapped codec. Guard the four scalars that
+    // carry the argument (the rest are checked by eye against the comments).
+    const pal = struct {
+        fn isPalindrome(comptime n: usize, comptime v: u64) bool {
+            comptime var i: usize = 0;
+            inline while (i < n / 2) : (i += 1) {
+                const lo: u8 = @truncate(v >> @intCast(i * 8));
+                const hi: u8 = @truncate(v >> @intCast((n - 1 - i) * 8));
+                if (lo != hi) return false;
+            }
+            return true;
+        }
+    };
+    if (pal.isPalindrome(8, GOLDEN_SOURCE_HASH)) @compileError("GOLDEN_SOURCE_HASH is a byte-palindrome");
+    if (pal.isPalindrome(2, 0x0201)) @compileError("locals_count is a byte-palindrome");
+    if (pal.isPalindrome(4, 0x0001F600)) @compileError("the char codepoint is a byte-palindrome");
+    if (pal.isPalindrome(8, 0x0102030405060708)) @compileError("the bignum limb is a byte-palindrome");
+}
+
+/// The header the writer stamps, spelled by hand with shifts. `build_id` is a
+/// parameter because the writer always emits `build_options.git_build_id`
+/// while the reader accepts any string there.
+fn goldenHeader(
+    list: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    build_id: []const u8,
+) !void {
+    try list.appendSlice(allocator, &bf.MAGIC);
+    try appendLe(list, allocator, 2, bf.VERSION);
+    try appendLe(list, allocator, 8, GOLDEN_SOURCE_HASH);
+    // Must equal this binary's own key or the reader treats the buffer as a
+    // stale-build miss. Its *bytes* are still hand-spelled little-endian.
+    try appendLe(list, allocator, 8, bf.compilerHash());
+    try appendLe(list, allocator, 2, build_id.len);
+    try list.appendSlice(allocator, build_id);
+    try appendLe(list, allocator, 2, GOLDEN_SOURCE_PATH.len);
+    try list.appendSlice(allocator, GOLDEN_SOURCE_PATH);
+}
+
+/// The Function graph `GOLDEN_BODY` encodes. Both functions stay rooted for the
+/// caller's lifetime via `gc.pushRoot`, so the caller must pop twice.
+fn buildGoldenGraph(gc: *GC, allocator: std.mem.Allocator, roots: *[2]types.Value) !*Function {
+    const child = try gc.allocFunction();
+    roots[0] = types.makePointer(&child.header);
+    gc.pushRoot(&roots[0]);
+    child.code.appendSlice(allocator, &.{ LOAD_VOID, 0, 0, RETURN, 0, 0 }) catch unreachable;
+    child.arity = 0;
+    child.locals_count = 1;
+
+    const parent = try gc.allocFunction();
+    roots[1] = types.makePointer(&parent.header);
+    gc.pushRoot(&roots[1]);
+    parent.code.appendSlice(allocator, &.{ LOAD_VOID, 0, 0, RETURN, 0, 0 }) catch unreachable;
+    parent.arity = 2;
+    parent.locals_count = 0x0201;
+    parent.upvalue_count = 0x0403;
+    parent.is_variadic = true;
+    parent.name = "fn"; // static literal; owns_name stays false
+
+    const c = &parent.constants;
+    c.append(allocator, types.makeFixnum(-2)) catch unreachable;
+    c.append(allocator, types.makeFlonum(1.5)) catch unreachable;
+    c.append(allocator, try gc.allocSymbol("ab")) catch unreachable;
+    c.append(allocator, try gc.allocString("cd")) catch unreachable;
+    c.append(allocator, types.TRUE) catch unreachable;
+    c.append(allocator, types.FALSE) catch unreachable;
+    c.append(allocator, types.NIL) catch unreachable;
+    c.append(allocator, types.VOID) catch unreachable;
+    c.append(allocator, types.EOF) catch unreachable;
+    c.append(allocator, types.UNDEFINED) catch unreachable;
+    c.append(allocator, types.makeChar(0x1F600)) catch unreachable;
+    c.append(allocator, types.makePointer(&child.header)) catch unreachable;
+    c.append(allocator, try gc.allocPair(types.makeFixnum(3), types.makeFixnum(4))) catch unreachable;
+    const vec_data = [_]types.Value{types.makeFixnum(5)};
+    c.append(allocator, try gc.allocVector(&vec_data)) catch unreachable;
+    c.append(allocator, try gc.allocBytevector(&[_]u8{ 7, 8 })) catch unreachable;
+    const limbs = [_]u64{0x0102030405060708};
+    c.append(allocator, try gc.allocBignumFromLimbs(&limbs, 1, true)) catch unreachable;
+    c.append(allocator, try gc.allocRational(types.makeFixnum(22), types.makeFixnum(7))) catch unreachable;
+    c.append(allocator, try gc.allocComplexEx(3.0, 4.0, false, false)) catch unreachable;
+
+    parent.source_line = 0x00030201;
+    parent.line_table.append(allocator, .{ .offset = 0x0102, .line = 0x00040302, .col = 0x00070605 }) catch unreachable;
+    return parent;
+}
+
+test "endian: the serializer reproduces the golden .sbc byte sequence" {
+    const allocator = std.testing.allocator;
+    var gc = GC.init(allocator);
+    defer gc.deinit();
+
+    var roots: [2]types.Value = .{ types.NIL, types.NIL };
+    const parent = try buildGoldenGraph(&gc, allocator, &roots);
+    defer gc.popRoot();
+    defer gc.popRoot();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try th.tmpDirRealPathAlloc(&tmp, allocator);
+    defer allocator.free(dir);
+    const path = try std.fs.path.joinZ(allocator, &.{ dir, "golden.sbc" });
+    defer allocator.free(path);
+
+    var funcs_arr = [_]*Function{parent};
+    try bf.writeFileWithTopLevel(allocator, &funcs_arr, GOLDEN_SOURCE_HASH, GOLDEN_SOURCE_PATH, path);
+
+    var expected: std.ArrayList(u8) = .empty;
+    defer expected.deinit(allocator);
+    try goldenHeader(&expected, allocator, build_options.git_build_id);
+    try expected.appendSlice(allocator, &GOLDEN_BODY);
+
+    const actual = try file_utils.readWholeFile(allocator, path, 1 << 20);
+    defer allocator.free(actual);
+
+    try std.testing.expectEqualSlices(u8, expected.items, actual);
+}
+
+test "endian: the deserializer decodes the golden .sbc byte sequence" {
+    const allocator = std.testing.allocator;
+    var gc = GC.init(allocator);
+    defer gc.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    try goldenHeader(&buf, allocator, GOLDEN_BUILD_ID);
+    try buf.appendSlice(allocator, &GOLDEN_BODY);
+
+    const result = (try bf.deserializeFromBuffer(&gc, buf.items, GOLDEN_SOURCE_HASH)) orelse
+        return error.GoldenBufferRejected;
+    defer allocator.free(result.funcs);
+
+    try std.testing.expectEqual(@as(u32, 1), result.top_level_count);
+    try std.testing.expectEqual(@as(usize, 2), result.funcs.len);
+
+    const f = result.funcs[0];
+    try std.testing.expectEqual(@as(u8, 2), f.arity);
+    try std.testing.expectEqual(@as(u16, 0x0201), f.locals_count);
+    try std.testing.expectEqual(@as(u16, 0x0403), f.upvalue_count);
+    try std.testing.expect(f.is_variadic);
+    try std.testing.expectEqualStrings("fn", f.name.?);
+    try std.testing.expectEqualSlices(u8, &.{ LOAD_VOID, 0, 0, RETURN, 0, 0 }, f.code.items);
+
+    const k = f.constants.items;
+    try std.testing.expectEqual(@as(usize, 18), k.len);
+    try std.testing.expectEqual(@as(i64, -2), types.toFixnum(k[0]));
+    try std.testing.expectEqual(@as(f64, 1.5), types.toFlonum(k[1]));
+    try std.testing.expectEqualStrings("ab", types.symbolName(k[2]));
+    try std.testing.expectEqualStrings("cd", types.toObject(k[3]).as(types.SchemeString).data);
+    try std.testing.expectEqual(types.TRUE, k[4]);
+    try std.testing.expectEqual(types.FALSE, k[5]);
+    try std.testing.expectEqual(types.NIL, k[6]);
+    try std.testing.expectEqual(types.VOID, k[7]);
+    try std.testing.expectEqual(types.EOF, k[8]);
+    try std.testing.expectEqual(types.UNDEFINED, k[9]);
+    try std.testing.expectEqual(@as(u21, 0x1F600), types.toChar(k[10]));
+    try std.testing.expect(types.isFunction(k[11]));
+    try std.testing.expect(types.toObject(k[11]).as(Function) == result.funcs[1]);
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(types.car(k[12])));
+    try std.testing.expectEqual(@as(i64, 4), types.toFixnum(types.cdr(k[12])));
+    try std.testing.expectEqual(@as(i64, 5), types.toFixnum(types.toVector(k[13]).data[0]));
+    try std.testing.expectEqualSlices(u8, &.{ 7, 8 }, types.toBytevector(k[14]).data);
+
+    const bn = types.toBignum(k[15]);
+    try std.testing.expectEqual(@as(usize, 1), bn.len);
+    try std.testing.expectEqual(@as(u64, 0x0102030405060708), bn.limbs[0]);
+    try std.testing.expect(bn.positive);
+
+    const rat = types.toObject(k[16]).as(types.Rational);
+    try std.testing.expectEqual(@as(i64, 22), types.toFixnum(rat.numerator));
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(rat.denominator));
+
+    const cx = types.toObject(k[17]).as(types.Complex);
+    try std.testing.expectEqual(@as(f64, 3.0), cx.real);
+    try std.testing.expectEqual(@as(f64, 4.0), cx.imag);
+
+    try std.testing.expectEqual(@as(u32, 0x00030201), f.source_line);
+    try std.testing.expectEqual(@as(usize, 1), f.line_table.items.len);
+    try std.testing.expectEqual(@as(u16, 0x0102), f.line_table.items[0].offset);
+    try std.testing.expectEqual(@as(u32, 0x00040302), f.line_table.items[0].line);
+    try std.testing.expectEqual(@as(u32, 0x00070605), f.line_table.items[0].col);
+
+    const child = result.funcs[1];
+    try std.testing.expectEqual(@as(u8, 0), child.arity);
+    try std.testing.expectEqual(@as(u16, 1), child.locals_count);
+    try std.testing.expectEqual(@as(usize, 0), child.constants.items.len);
+    try std.testing.expect(child.name == null);
+}
+
+// ---------------------------------------------------------------------------
+// 6. The cache key itself is a function of bytes, not of host byte order
+//
+// `sourceHash` and `compilerHashFor` are Wyhash, whose Zig implementation reads
+// its input through `std.mem.readInt(..., .little)` — so the same source text
+// keys to the same u64 on s390x as on x86_64, and a `.sbc` is not silently
+// re-compiled (or silently *accepted*) because of the host's byte order.
+// Nothing states that today, and it is not obvious: a hash that used native
+// loads would make the key host-dependent while every other test stayed green.
+//
+// The expected values are captured constants, not derived ones — for a hash
+// there is no independent derivation, and the property being pinned is
+// host-invariance, not the specific number. A failure therefore means one of
+// two things, both worth knowing: the host disagrees (the bug this file exists
+// for), or Wyhash changed under a Zig upgrade, which silently invalidates every
+// cache entry in the wild.
+// ---------------------------------------------------------------------------
+
+test "endian: sourceHash is host-independent" {
+    try std.testing.expectEqual(@as(u64, 15036897837213381375), bf.sourceHash("(display \"hello\")\n"));
+}
+
+test "endian: compilerHashFor is host-independent" {
+    try std.testing.expectEqual(@as(u64, 15108339539155468146), bf.compilerHashFor("0.0.0-test", "abc1234"));
 }

--- a/tests/scheme/audit/endianness-audit.scm
+++ b/tests/scheme/audit/endianness-audit.scm
@@ -54,6 +54,7 @@
         (srfi 160 u8) (srfi 160 u16) (srfi 160 s16) (srfi 160 u32) (srfi 160 s32)
         (srfi 160 u64) (srfi 160 s64) (srfi 160 f32) (srfi 160 f64)
         (srfi 160 c64) (srfi 160 c128)
+        (prefix (srfi 271 determinized) d:)
         (kaappi primitives))
 
 (test-begin "endianness audit")
@@ -445,6 +446,100 @@
             "18446744073709551617" (number->string (+ (expt 2 64) 1)))
 (test-equal "a negative two-limb bignum round-trips through string->number"
             (- (+ (expt 2 64) 1)) (string->number "-18446744073709551617"))
+
+;;; ------------------------------------------------------------------
+;;; 8. SRFI 271 determinized random ports: golden byte sequences.
+;;;
+;;;    `primitives_random_port.zig` and `types_port.zig` move u64s across the
+;;;    bytevector boundary with an explicit `.little` in four places: the seed
+;;;    words in, the state words in, the state words out, and each 8-byte
+;;;    output block. `tests/scheme/srfi/srfi271.scm` compares one port against
+;;;    another *on the same host*, so a swap present on both sides of any of
+;;;    those pairings cancels out and stays green everywhere -- the same
+;;;    cancelling pairing the `.sbc` round-trip tests have (audit v2, 7D).
+;;;
+;;;    Every expected value below is a literal, derived from the published
+;;;    xoshiro256** algorithm rather than captured from this implementation,
+;;;    so it means the same thing on a big-endian host as on a little-endian
+;;;    one. The two directions never touch: the "from a seed" assertions
+;;;    consult no literal state, and the "from a literal state" assertions
+;;;    consult no seed.
+;;; ------------------------------------------------------------------
+
+(define endian-seed
+  #u8(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16
+      17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32))
+
+(define (endian-seeded-port) (d:make-random-port (open-input-bytevector endian-seed)))
+
+;; Direction 1: seed bytes -> state words -> output blocks.
+;; xoshiro256** mixes the words, so a byte-swapped seed read produces a
+;; different stream rather than a mirrored one -- there is nothing here for a
+;; swap on the output side to cancel against.
+(test-equal "SRFI 271: a fixed 32-byte seed yields a fixed first 16 output bytes"
+            #u8(#xE8 #xCB #x61 #xF8 #x8E #x25 #xBC #x52
+                #x80 #x32 #xCB #x61 #xF8 #x8E #x25 #xBC)
+            (read-bytevector 16 (endian-seeded-port)))
+
+;; The state of an *unread* port is the cancelling case, stated explicitly so
+;; the assertion after it is not mistaken for a duplicate: the words go in
+;; through readInt(.little) and straight back out through writeInt(.little),
+;; so the state bytes equal the seed bytes under any consistent byte order.
+(test-equal "SRFI 271: an unread port's state echoes the seed bytes (the cancelling case)"
+            endian-seed
+            (bytevector-copy (d:random-port-state (endian-seeded-port)) 14 46))
+
+;; After one byte the words have advanced, so the state bytes are a real
+;; function of the seed rather than a copy of it.
+(test-equal "SRFI 271: the state after one byte is a fixed 46-byte sequence"
+            #u8(#x53 #x32 #x37 #x31 #x01 #x01 #xE8 #xCB
+                #x61 #xF8 #x8E #x25 #xBC #x52 #x11 #x12
+                #x13 #x14 #x15 #x16 #x17 #x38 #x19 #x1A
+                #x1B #x1C #x1D #x1E #x1F #x00 #x10 #x10
+                #x02 #x04 #x06 #x08 #x0A #x0C #x02 #x02
+                #x02 #x02 #x02 #x06 #x02 #x02)
+            (let ((p (endian-seeded-port)))
+              (read-u8 p)
+              (d:random-port-state p)))
+
+;; Direction 2: a literal state in. Consults nothing above.
+(define endian-literal-state
+  #u8(#x53 #x32 #x37 #x31 #x01 #x08 #x00 #x00
+      #x00 #x00 #x00 #x00 #x00 #x00 #x08 #x07
+      #x06 #x05 #x04 #x03 #x02 #x01 #x18 #x17
+      #x16 #x15 #x14 #x13 #x12 #x11 #x28 #x27
+      #x26 #x25 #x24 #x23 #x22 #x21 #x38 #x37
+      #x36 #x35 #x34 #x33 #x32 #x31))
+
+(test-assert "SRFI 271: the hand-written literal state is accepted as a state"
+             (d:random-port-state? endian-literal-state))
+
+(test-equal "SRFI 271: a literal state yields a fixed first 8 output bytes"
+            #u8(#x7A #x9D #x07 #x71 #xDA #x43 #xAD #x16)
+            (read-bytevector 8 (d:make-random-port endian-literal-state)))
+
+(test-equal "SRFI 271: a literal state's own state after three bytes is fixed"
+            #u8(#x53 #x32 #x37 #x31 #x01 #x03 #x7A #x9D
+                #x07 #x71 #xDA #x43 #xAD #x16 #x28 #x27
+                #x26 #x25 #x24 #x23 #x22 #x21 #x38 #x37
+                #x36 #x35 #x34 #x33 #x32 #x31 #x20 #x20
+                #x10 #x0E #x0C #x0A #x08 #x06 #x04 #x04
+                #x04 #x04 #x04 #x04 #x04 #x04)
+            (let ((p (d:make-random-port endian-literal-state)))
+              (read-bytevector 3 p)
+              (d:random-port-state p)))
+
+;; The fixed part of the layout, spelled out so a header change is a named
+;; failure rather than a diff inside a 46-byte blob.
+(test-equal "SRFI 271: a state begins with the ASCII magic S271 and version 1"
+            '(83 50 55 49 1)
+            (let ((st (d:random-port-state (endian-seeded-port))))
+              (list (bytevector-u8-ref st 0) (bytevector-u8-ref st 1)
+                    (bytevector-u8-ref st 2) (bytevector-u8-ref st 3)
+                    (bytevector-u8-ref st 4))))
+
+(test-equal "SRFI 271: a state is 46 bytes"
+            46 (bytevector-length (d:random-port-state (endian-seeded-port))))
 
 (let ((runner (test-runner-current)))
   (test-end "endianness audit")

--- a/tools/run-endian-suite.sh
+++ b/tools/run-endian-suite.sh
@@ -66,9 +66,12 @@ fi
 #                     and `types_port.zig` move u64s in and out of a bytevector
 #                     with an explicit `.little`, so a seeded stream is meant
 #                     to be identical on every host. Its own assertions compare
-#                     two ports *on the same host*, which is the same
-#                     cancelling pairing the `.sbc` tests have -- running it
-#                     big-endian at least catches a write/read side disagreeing
+#                     two ports *on the same host*, so they cannot see a
+#                     byte-order change at all: flipping the seed-word read to
+#                     `.big` leaves this file at 35/35. The golden byte
+#                     sequences that DO see it live in endianness-audit.scm
+#                     above (audit v2 Phase 7D); this file stays in the list
+#                     because it is the behavioural suite around them
 #   internal-primitives-audit
 #                     %host-big-endian? reachability and arity
 FILES=(


### PR DESCRIPTION
Phase 7D: golden .sbc bytes, because a paired byte-swap cancels

Audit v2, Phase 7D. Refs #1890.

7C broke the writer/reader pairing for the `.sbc` *header* — writer against
literal bytes, reader against a hand-assembled little-endian header — and
handed 7D the rest: the per-function record and every constant encoding are
reached only by the round-trip tests in `bytecode_file.zig`, which write and
read on the same host. A swap present on *both* sides cancels and leaves them
green on every machine, s390x included.

## Field-by-field: nothing is unconverted

Every scalar in the format goes through a helper, and every `@bitCast` in
either half is paired with a `nativeToLittle`/`littleToNative`. The two
apparent exceptions are not fields: `readI16FromCode` bitcasts a u16 already
assembled byte-at-a-time from the code stream (bytecode operands are emitted
`v >> 8`, `v & 0xFF` and read back the same way, so they are endian-neutral by
construction), and bignum limbs are `[]u64` in little-endian *limb* order with
each limb serialized whole through `writeU64`. No field is written with a raw
`asBytes` or an unconverted `@bitCast`. **There is no byte-order bug here** —
what was missing is the instrument that would show one.

## The instrument

`GOLDEN_BODY` in `src/tests_endian.zig`: a committed literal covering
`func_count`/`top_level_count`, both function records
(arity/locals/upvalues/variadic/name/code/line table) and all 18 constant
encodings — fixnum, flonum, symbol, string, boolean, nil, void, eof,
undefined, char, function reference, pair, vector, bytevector, bignum,
rational, complex — plus the bundled-files and preamble trailers. Written as a
`++` chain of one-field-per-line literals so `zig fmt` cannot reflow a value
across a line boundary; each line's comment names the value it spells LSB-first,
and a `comptime` guard rejects a byte-palindrome for the four scalars carrying
the argument.

It is used twice with no contact between the uses: the serializer must
reproduce it, and the deserializer must decode it. The hand-assembled header
uses shifts only, never a `@bitCast`, so it cannot inherit the host's byte
order from the code under test. Neither expected value is a function of the
host.

## Mutation evidence

| mutation | `bytecode_file.zig` round-trips | writer golden | reader golden |
|---|---|---|---|
| paired: `writeU32` **and** `readU32` flipped | 10/10 **pass** | **fail** | **fail** |
| writer only (`writeU64`) | fail | **fail** | pass |
| reader only (`readU32`) | pass | pass | **fail** |
| byte-reverse one fixture field (the bignum limb) | pass | **fail** | **fail** |

Row 1 is the point: the bug class that is invisible to every existing test now
fails on every host. Rows 2–3 confirm the two directions are independent —
neither test can mask the other's mutation. Row 4 confirms the literal is what
is being asserted.

## SRFI 271 has the identical shape

`tests/scheme/srfi/srfi271.scm` compares two ports on the same host, so it is
blind to byte order outright: flipping the seed-word read to `.big` leaves it
at **35/35**. Eight golden assertions in
`tests/scheme/audit/endianness-audit.scm` (which the s390x leg runs, via 7C's
`tools/run-endian-suite.sh` step) pin both directions — a literal 32-byte seed
to a literal 16-byte output prefix and a literal 46-byte state, and separately a
hand-written literal state to its own literal output. Expected values were
derived from the published xoshiro256** algorithm, not captured from the
implementation, and matched it exactly on the first run. Three mutations
(`.little`→`.big` in the seed read, in the paired state read+write, and in the
output block write) each leave `srfi271.scm` at 35/35 and fail 3–4 of the new
assertions. The unread-port state is called out explicitly as *the* cancelling
case — the words go in and straight back out, so those bytes equal the seed
under any consistent order — which is why the assertion after it reads the
state one byte in.

Also pins `sourceHash`/`compilerHashFor` as host-independent: Wyhash reads
through `readInt(..., .little)`, so the cache key is a function of bytes, not of
host byte order. Nothing stated that, and a native-load hash would make the key
host-dependent with every other test still green.

## The cache-key question: it should include the target

Filed as #2155 rather than fixed. `compilerHashFor` takes the version string
and the git build id and nothing else — not the target triple — and
`gitBuildId` has no `-Dtarget` input, so all 17 platform binaries in a release
share one key. The load gate checks only magic, VERSION, source hash and
compiler hash; the header carries no target field. Meanwhile `cond-expand` is
resolved at compile time and only the taken branch survives into the `.sbc`
(measured: the cache entry for a `cond-expand` inside a procedure contains
`POSIX-BRANCH` and not `WINDOWS-BRANCH`). Honest exposure, since it changes the
priority: the realistic shared-`$KAAPPI_HOME` pairs all have identical feature
sets today, so the reachable path is `zig build -Dbundle=out.sbc` with a cross
`-Dtarget` — a documented workflow where the compiler-hash check silently
passes.

Also filed #2156: `kaappi --compile` executes top-level `cond-expand`, `begin`
and `define-values` bodies for real — a compile-only command that deletes a
file — while a bare top-level form, `define-record-type` and code inside a
lambda are not executed.

## Verification

Verified, little-endian macOS aarch64 ReleaseSafe at `910f7c75`: `zig build
test` green; the endian tests green under `-Dgc-stress=true`; `kaappi test
tests/scheme/audit` 5306/0 and `tests/scheme/srfi` 33937/0; the endian suite
11/11; `zig fmt --check` and markdownlint clean; every mutation result above
run and reverted.

Not verified, by construction: how any of this *behaves* big-endian. No s390x
execution was performed here, and a local `zig build test -Dtarget=s390x-linux`
proves compilation only (`skip_foreign_checks`). The `s390x-test` leg on this PR
is the first big-endian run of the new assertions — read that check before
merging, and treat a failure there as a finding.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
