### PR TITLE
Phase 7E: gate PRs on gc-stress — 6 min for the unit suite, 21 for the Scheme corpus, +58 s on the critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,13 @@ jobs:
           fi
           exit "$code"
 
+      # --summary all deliberately: `zig build test` prints NOTHING on success,
+      # so a passing run and a run that compiled everything and executed no
+      # test produce byte-identical logs. The summary's `run test unit-tests
+      # N pass` line is the only thing that tells them apart, and it is what
+      # the gc-stress job below is read against (its skip count differs).
       - name: Unit tests (leak detection via std.testing.allocator)
-        run: zig build test -Doptimize=${{ matrix.optimize }}
+        run: zig build test -Doptimize=${{ matrix.optimize }} --summary all
 
       - name: Scheme suites
         run: bash tests/scheme/run-all.sh
@@ -171,6 +176,145 @@ jobs:
           zig-out/bin/thottam remove kaappi-json
           ! zig-out/bin/thottam list | grep kaappi-json
           rm -rf "$KAAPPI_HOME"
+
+  # -------------------------------------------------------------------------
+  # gc-stress: a collection is ATTEMPTED AT EVERY ALLOCATION.
+  #
+  # This is the only configuration that turns a GC rooting bug -- a heap value
+  # held in a Zig local across an allocation without `gc.pushRoot` -- from
+  # rare, unattributable corruption into a deterministic failure at the site
+  # that caused it (.claude/rules/gc-safety.md; #1401 crashed ~440 of 690 tests
+  # this way, #1687 added the freed-owner sentinel and quarantine that make it
+  # panic instead of aliasing by luck).
+  #
+  # Until audit v2 Phase 7E no pull request was ever gated on it (#1898):
+  # `-Dgc-stress` appeared 0 times in this file. It was not absent from CI
+  # altogether -- fuzz.yml's two gc-stress legs run this same unit suite as
+  # their pre-fuzz phase -- but daily at 02:47 UTC against whatever landed that
+  # day, not against the diff that introduced it. On a green nightly the
+  # difference is nothing; on a red one it is the difference between a named
+  # PR and a bisect.
+  #
+  # WHY IT IS AFFORDABLE NOW, WHEN IT WAS NOT WHEN THAT SPLIT WAS DECIDED.
+  # The cost fell by roughly 30x with #1802/#1804 and #1809, which stopped
+  # ReleaseSafe 0xAA-filling `= undefined` buffers. Both surviving estimates
+  # predate that and are stale by about that factor: .claude/skills/
+  # do-stress-test said "1.5-3 hours" until Phase 5F measured 5 min and
+  # corrected it, and fuzz.yml still says "~35 min locally on M-series" beside
+  # a 300-minute timeout. Measured on hosted runners by fuzz.yml itself, its
+  # WHOLE gc-stress leg -- checkout, Zig, build, this unit suite, and 100 fuzz
+  # runs across 7 targets -- completes in 10-13 min (10m20s / 12m22s on
+  # 2026-08-01; 12m54s / 12m58s on 2026-07-31).
+  #
+  # WALL CLOCK. Both jobs below hang off `format` and run concurrently with
+  # everything else. The critical path through this workflow is
+  # `test (ubuntu-latest, Debug)` at 19 min, with riscv64-test and netbsd-test
+  # at 17 and the macOS/OpenBSD legs at 16 (last main run). Staying inside that
+  # shadow is the design constraint, and it is why the unit suite and the
+  # Scheme corpus are two jobs rather than two steps of one: serialised they
+  # would exceed 19 min and become the new critical path; in parallel each is
+  # comfortably under it and the cost is CPU minutes, which this workflow
+  # already spends 18 legs' worth of.
+  gc-stress:
+    needs: format
+    runs-on: ubuntu-latest
+    # Not a budget -- a hang bound. A rooting bug can present as a livelock in
+    # the collector rather than a crash, and that must not sit until the job
+    # limit. Healthy runs are ~10 min (see above).
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Zig
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # v1.0.2
+        with:
+          version: 0.16.0
+          cache-key: gc-stress
+
+      # `--summary all` is load-bearing here, not decoration. `zig build test`
+      # prints nothing on success, so this step's log would be identical
+      # whether it ran 1582 tests or zero -- and a build flag that silently
+      # fails to apply is exactly the failure mode a stress gate has (Phase 5F
+      # nearly reported a false clean on it). The summary line is the evidence:
+      # a stressed run reports `1582 pass` where the plain legs above report
+      # `1579 pass, 3 skip`, because three tests opt out of stress builds
+      # (#1447, #1452, src/tests_fuzz.zig). Different counts, same suite.
+      - name: Unit tests (collection on every allocation)
+        run: zig build test -Dgc-stress=true --summary all
+
+  # The Scheme half. Not redundant with the unit suite above: these 600+ files
+  # drive the library loader, the macro expander and all 178 SRFIs at a scale
+  # no Zig unit test reaches, and src/tests_gc_root_boundary.zig's own OOM
+  # sweeps find leaks *only* in the expander. Before Phase 5F ran it by hand on
+  # a droplet, the Scheme corpus had never executed against a stress build at
+  # all; this makes it a gate rather than a one-off.
+  gc-stress-scheme:
+    needs: format
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Zig
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # v1.0.2
+        with:
+          version: 0.16.0
+          cache-key: gc-stress-scheme
+
+      - name: Build (gc-stress)
+        run: zig build -Dgc-stress=true
+
+      # Nothing about running a .scm file reveals which build options produced
+      # the binary, so a plain build would pass every assertion in the suite
+      # and the job would go green having stressed nothing. The script refuses
+      # to run unless `kaappi features --json` reports gc_stress:true; this
+      # step is the same check, hoisted so a mis-build fails in one second
+      # instead of ten minutes.
+      - name: Confirm the flag applied
+        run: zig-out/bin/kaappi features --json | grep -q '"gc_stress":true'
+
+      - name: Scheme corpus + R7RS suite (gc-stress binary)
+        run: bash tools/run-gc-stress-suite.sh zig-out/bin/kaappi
+        env:
+          # Two kinds of exclusion, both temporary, both named.
+          #
+          # (a) TOO SLOW UNDER STRESS -- same knob, same spelling and the same
+          #     reason as the Debug leg's KAAPPI_TEST_SKIP above. Stress
+          #     collection costs O(live heap) per allocation, so a file that
+          #     allocates against a large live heap is quadratic:
+          #     trampoline-polish-1375.scm builds a 300,000-character string
+          #     and maps over it -- ~0.2 s plain, and it had not finished
+          #     after 25 minutes stressed, while the other 602 files completed
+          #     in 11 minutes in aggregate on the same run. srfi14.scm
+          #     (Unicode inversion lists) and srfi264.scm are the same shape at
+          #     ~10 and ~9 minutes.
+          #
+          # (b) REAL BUGS THIS GATE FOUND ON ITS FIRST RUN -- excluded so the
+          #     gate is green for everything else, exactly as the campaign
+          #     comments out a failing assertion behind a `;; FAIL: #N` marker
+          #     rather than leaving the suite red. Each fix PR deletes its
+          #     names from this list:
+          #       #2160  primitives_srfi1 buildList reads freed values from its
+          #              unrooted `items` slice -- all three abort with
+          #              "GC: marking freed object (use-after-free)"
+          #       #2161  record_uid_registry keys are borrowed slices into
+          #              GC-owned strings, so a nongenerative uid stops
+          #              resolving once its string is collected (19 assertions)
+          #
+          # All nine still run stressed in the nightly fuzz.yml legs' unit
+          # phase where applicable, and unstressed under run-all.sh on every
+          # other leg here, so nothing is untested -- only unstressed.
+          #
+          # The script FAILS if a name here matches no file, so this list
+          # cannot rot into a silent no-op.
+          KAAPPI_GC_STRESS_SKIP: >-
+            trampoline-polish-1375.scm srfi14.scm srfi264.scm
+            primitives_srfi1-audit.scm srfi1-ext.scm srfi1-gc-stress.scm
+            primitives_srfi237-audit.scm srfi237.scm srfi240-audit.scm
 
   riscv64-test:
     needs: format

--- a/tools/run-gc-stress-suite.sh
+++ b/tools/run-gc-stress-suite.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# Run the Scheme corpus against a `-Dgc-stress=true` build, in one command.
+#
+#     bash tools/run-gc-stress-suite.sh [path/to/kaappi]
+#
+# WHY THIS EXISTS. `-Dgc-stress=true` attempts a collection at every
+# allocation. It is the only configuration that turns a GC rooting bug -- a
+# heap value held in a Zig local across an allocation without `gc.pushRoot`
+# -- from rare, unattributable corruption into a deterministic failure at the
+# site that caused it (`.claude/rules/gc-safety.md`, kaappi#1401, #1687).
+#
+# Until audit v2 Phase 7E it gated nothing on a pull request (kaappi#1898),
+# and the *Scheme* corpus had run against a stress build exactly once ever --
+# by hand, on a droplet, in Phase 5F. The unit suite is the other half and is
+# run directly by `ci.yml`'s `gc-stress` job (`zig build test
+# -Dgc-stress=true`); this script is the Scheme half, and it is not
+# redundant with it: these files drive the library loader, the expander and
+# all 178 SRFIs at a scale no Zig unit test reaches, and
+# `src/tests_gc_root_boundary.zig`'s own OOM sweeps find leaks only in the
+# expander.
+#
+# Deliberately NOT wired into run-all.sh: run-all.sh already runs every file
+# below against whatever `zig-out/bin/kaappi` happens to be, and several of
+# its shell suites fork `zig build` *without* the flag. This is the entry
+# point for a run whose entire point is the binary's build configuration --
+# which is why the first thing it does is make the binary prove it.
+#
+# Exit status is 0 only if every file exits 0 and the R7RS suite reports no
+# failed assertions. Each corpus file is an `(srfi 64)` suite with the
+# exit-on-fail epilogue, so a failed assertion is a nonzero exit; the R7RS
+# suite is the documented exception and is handled separately below.
+
+set -u
+
+# Resolve the binary against the CALLER's cwd first -- a relative argument
+# means what the caller meant, not what it happens to mean after the cd below.
+KAAPPI="${1:-zig-out/bin/kaappi}"
+case "$KAAPPI" in
+    /*) ;;
+    *) KAAPPI="$PWD/$KAAPPI" ;;
+esac
+
+# Then run from the repo root regardless of where we were invoked: every path
+# below is repo-relative, and so is the --lib-path passed to each run.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 2
+
+if [[ ! -x "$KAAPPI" ]]; then
+    echo "run-gc-stress-suite: no executable kaappi at '$KAAPPI'" >&2
+    echo "Usage: bash tools/run-gc-stress-suite.sh [path/to/kaappi]" >&2
+    exit 2
+fi
+
+# THE POINT OF THIS CHECK. Nothing about running a .scm file reveals which
+# build options produced the binary, so a plain build would sail through
+# every assertion below and the run would report success -- a green log for a
+# stress suite that was never stressed. `kaappi features --json` reports the
+# comptime `build_options.gc_stress` directly (src/features.zig), so refusing
+# here is the difference between a gate and a decoration.
+if ! "$KAAPPI" features --json 2>/dev/null | grep -q '"gc_stress":true'; then
+    echo "run-gc-stress-suite: '$KAAPPI' is NOT a -Dgc-stress=true build." >&2
+    echo "  kaappi features --json reports:" >&2
+    "$KAAPPI" features --json 2>/dev/null \
+        | tr ',' '\n' | grep -i 'gc_stress\|version' >&2 || true
+    echo "  Rebuild with: zig build -Dgc-stress=true" >&2
+    exit 2
+fi
+
+# One EXIT trap, set once. bash replaces a trap rather than adding to it, so
+# a second `trap ... EXIT` later in the file would silently drop this one and
+# leak the temp home on every run.
+SCRATCH_DIRS=()
+# shellcheck disable=SC2329  # invoked indirectly, by the EXIT trap below
+cleanup() {
+    # The length guard is not cosmetic: `"${arr[@]}"` on an empty array is an
+    # unbound-variable error under `set -u` in bash 3.2, which is what macOS
+    # ships and what a developer running this by hand will use.
+    if [[ ${#SCRATCH_DIRS[@]} -gt 0 ]]; then
+        rm -rf "${SCRATCH_DIRS[@]}"
+    fi
+}
+trap cleanup EXIT
+
+# Keep the cache out of the invoking user's real KAAPPI_HOME: plain
+# `kaappi <file>` runs write a bytecode cache under $KAAPPI_HOME/cache
+# (kaappi#1516), and run-all.sh isolates for the same reason.
+if [[ -z "${KAAPPI_HOME:-}" ]]; then
+    KAAPPI_HOME="$(mktemp -d)"
+    export KAAPPI_HOME
+    SCRATCH_DIRS+=("$KAAPPI_HOME")
+fi
+
+# The same list run-all.sh globs (its SCM_SUITE_DIRS). Kept as directories
+# rather than a curated file list so a new test file joins this run by
+# existing, with no second place to update -- but see the floor check below,
+# because a glob that silently matches nothing is the failure mode a curated
+# list does not have.
+SCM_SUITE_DIRS="smoke compliance continuations hygiene srfi ffi audit"
+
+# A file that legitimately takes minutes under stress collection is fine; a
+# file that HANGS must not silently consume the whole CI job's budget with no
+# indication of which one it was (the kaappi#1748 shape). macOS ships no
+# `timeout`, so fall back to running unbounded there rather than failing.
+#
+# 900 s is set from measurement, not taste. Stress collection costs roughly
+# O(live heap) per allocation, so a file that builds a large heap is
+# superlinear, and the corpus has a long tail of exactly those. Measured on
+# macOS aarch64 (12 cores, 12-way, load average 8-13 from concurrent work):
+#
+#   tests/scheme/smoke/trampoline-polish-1375.scm   ~13 min
+#   tests/scheme/srfi/srfi14.scm                    ~10 min
+#   tests/scheme/srfi/srfi264.scm                   ~9 min
+#
+# while the other 602 files finished inside 11 min *in aggregate*. A tighter
+# bound would not catch a hang any sooner -- it would just turn the three
+# slowest legitimate files red, which is the worse failure by far: a red gate
+# that is right about nothing trains people to ignore it.
+TIMEOUT_SECS="${KAAPPI_GC_STRESS_TIMEOUT:-900}"
+if command -v timeout > /dev/null 2>&1; then
+    RUN_TIMEOUT=(timeout "$TIMEOUT_SECS")
+elif command -v gtimeout > /dev/null 2>&1; then
+    RUN_TIMEOUT=(gtimeout "$TIMEOUT_SECS")
+else
+    RUN_TIMEOUT=()
+fi
+
+# Build the FFI fixture when a compiler is around so uint64-range.scm
+# exercises real code instead of skipping -- the same non-fatal step, and the
+# same reason, as run-all.sh's.
+FIXTURE_SRC=tests/scheme/ffi/fixtures/u64test.c
+if command -v zig > /dev/null 2>&1; then
+    case "$(uname)" in
+        Darwin) FIXTURE_LIB=tests/scheme/ffi/fixtures/libu64test.dylib
+                FIXTURE_FLAGS="-dynamiclib" ;;
+        *)      FIXTURE_LIB=tests/scheme/ffi/fixtures/libu64test.so
+                FIXTURE_FLAGS="-shared -fPIC" ;;
+    esac
+    if [[ ! -e "$FIXTURE_LIB" || "$FIXTURE_SRC" -nt "$FIXTURE_LIB" ]]; then
+        # shellcheck disable=SC2086  # FIXTURE_FLAGS is a flag list
+        zig cc $FIXTURE_FLAGS "$FIXTURE_SRC" -o "$FIXTURE_LIB" \
+            || echo "  WARN  could not build $FIXTURE_LIB (uint64-range.scm will skip)"
+    fi
+fi
+
+# Stress collection makes each file 10-20x slower, which is what makes the
+# parallelism load-bearing here rather than a nicety: sequentially this run
+# is ~19 min where run-all.sh's own .scm half is ~1. Each file is a fresh
+# interpreter with no shared state (tests/scheme/CLAUDE.md), which is the
+# same property run-all.sh relies on for its own JOBS knob.
+detect_jobs() {
+    local n=""
+    n=$(getconf _NPROCESSORS_ONLN 2>/dev/null) \
+        || n=$(sysctl -n hw.ncpu 2>/dev/null) \
+        || n=$(nproc 2>/dev/null) \
+        || n=""
+    case "$n" in
+        ''|*[!0-9]*|0) echo 4 ;;
+        *) echo "$n" ;;
+    esac
+}
+JOBS="${KAAPPI_GC_STRESS_JOBS:-$(detect_jobs)}"
+case "$JOBS" in
+    ''|*[!0-9]*|0)
+        echo "run-gc-stress-suite: KAAPPI_GC_STRESS_JOBS must be a positive integer (got '${KAAPPI_GC_STRESS_JOBS:-}')" >&2
+        exit 2
+        ;;
+esac
+
+echo "=== Scheme corpus under -Dgc-stress=true ==="
+echo "kaappi: $KAAPPI"
+"$KAAPPI" --version
+echo "jobs:   $JOBS (override: KAAPPI_GC_STRESS_JOBS)"
+echo ""
+
+# Space-separated BASENAMES to skip, same spelling and semantics as
+# run-all.sh's KAAPPI_TEST_SKIP -- and set for the same kind of reason
+# ci.yml already sets that one on the Debug leg: a build configuration
+# 10-20x slower than the default makes a handful of files pathological
+# without making them interesting. Deliberately empty by default, so the
+# exclusion lives next to the job that needs it and is visible in the diff
+# that adds it rather than buried here.
+SKIP="${KAAPPI_GC_STRESS_SKIP:-}"
+skipped_file() {
+    local base
+    base="$(basename "$1")"
+    for s in $SKIP; do
+        [[ "$base" == "$s" ]] && return 0
+    done
+    return 1
+}
+
+FILES=()
+SKIPPED=0
+SKIPPED_NAMES=()
+for dir in $SCM_SUITE_DIRS; do
+    for f in tests/scheme/"$dir"/*.scm; do
+        [[ -e "$f" ]] || continue
+        if skipped_file "$f"; then
+            SKIPPED=$((SKIPPED + 1))
+            SKIPPED_NAMES+=("$f")
+            continue
+        fi
+        FILES+=("$f")
+    done
+done
+
+# A skip that is not printed is coverage silently lost. Name them.
+if [[ $SKIPPED -gt 0 ]]; then
+    echo "  Skipping $SKIPPED file(s) via KAAPPI_GC_STRESS_SKIP:"
+    printf '    %s\n' "${SKIPPED_NAMES[@]}"
+    echo ""
+fi
+
+# A name in SKIP that matches nothing is a typo or a renamed file, and it
+# would silently mean "no exclusion" -- the same shape as a glob matching
+# nothing. Fail rather than run a differently-scoped suite than was asked for.
+SKIP_COUNT=0
+for s in $SKIP; do SKIP_COUNT=$((SKIP_COUNT + 1)); done
+if [[ $SKIP_COUNT -ne $SKIPPED ]]; then
+    echo "run-gc-stress-suite: KAAPPI_GC_STRESS_SKIP names $SKIP_COUNT file(s) but $SKIPPED matched." >&2
+    echo "  A skip entry that matches nothing has silently stopped excluding anything." >&2
+    exit 2
+fi
+
+# One marker file per failure, written by the worker, counted after the pool
+# drains: a subshell in a pipeline cannot increment the parent's counter, and
+# a failure that only ever incremented a lost variable is the same
+# cannot-fail shape the checks above exist to avoid.
+FAILDIR="$(mktemp -d)"
+SCRATCH_DIRS+=("$FAILDIR")
+# NOT `export KAAPPI`, however natural that name looks for the binary under
+# test: tests/scheme/audit/primitives_filesystem-audit.scm asserts that an
+# environment variable literally named KAAPPI is *unset*, so exporting it
+# turns three of its assertions red for reasons that have nothing to do with
+# the GC. Found the hard way -- the first run of this script reported those
+# three as gc-stress failures (kaappi#2162).
+export GC_STRESS_KAAPPI_BIN="$KAAPPI"
+export FAILDIR
+export RUN_TIMEOUT_CMD="${RUN_TIMEOUT[*]:-}"
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    echo "run-gc-stress-suite: no .scm files matched under tests/scheme/{$SCM_SUITE_DIRS}." >&2
+    exit 2
+fi
+
+# shellcheck disable=SC2016  # the worker body must expand in the CHILD, not here
+printf '%s\0' "${FILES[@]}" | xargs -0 -P "$JOBS" -I{} bash -c '
+    f="$1"
+    # shellcheck disable=SC2086  # RUN_TIMEOUT_CMD is a command prefix or empty
+    out="$($RUN_TIMEOUT_CMD "$GC_STRESS_KAAPPI_BIN" --lib-path lib "$f" 2>&1)"
+    status=$?
+    if [[ $status -ne 0 ]]; then
+        { echo "  FAIL  $f (exit $status)"
+          printf "%s\n" "$out" | tail -30 | sed "s/^/        /"
+        } > "$FAILDIR/$(echo "$f" | tr / _)"
+    fi
+' _ {}
+
+FAIL=$(find "$FAILDIR" -type f | wc -l | tr -d ' ')
+PASS=$(( ${#FILES[@]} - FAIL ))
+if [[ $FAIL -gt 0 ]]; then
+    cat "$FAILDIR"/*
+fi
+
+# A glob that matches nothing exits 0 for every file it did not run. Eleven
+# days of tests/scheme/srfi/slow/ going unnoticed (kaappi#1900) is what that
+# costs, and here it would additionally read as "gc-stress found nothing".
+# The floor is deliberately well below the current count (605 as of writing)
+# so it needs no maintenance as files are added, but well above zero.
+FLOOR="${KAAPPI_GC_STRESS_FLOOR:-500}"
+if [[ $((PASS + FAIL)) -lt $FLOOR ]]; then
+    echo ""
+    echo "run-gc-stress-suite: only $((PASS + FAIL)) files ran, expected at least $FLOOR." >&2
+    echo "  A suite directory was renamed or the globs stopped matching." >&2
+    exit 2
+fi
+
+# The R7RS suite is the one file that reports failures WITHOUT exiting
+# nonzero: it uses the (chibi test) shim, which has no exit-on-fail epilogue,
+# so `kaappi tests/scheme/r7rs/r7rs-tests.scm; echo $?` prints 0 with a failed
+# assertion in the log. run-all.sh has always parsed its counts for exactly
+# this reason (tests/scheme/run-all.sh); five other ci.yml steps invoke it
+# bare and therefore cannot fail on a wrong answer -- kaappi#2157. The
+# awk below is run-all.sh's, verbatim, so the two agree by construction.
+echo ""
+echo "=== R7RS suite under -Dgc-stress=true ==="
+R7RS_OUTPUT="$("${RUN_TIMEOUT[@]}" "$KAAPPI" --lib-path lib tests/scheme/r7rs/r7rs-tests.scm 2>&1)"
+R7RS_STATUS=$?
+R7RS_PASS=$(printf "%s\n" "$R7RS_OUTPUT" | awk '{for (i = 1; i < NF; i++) { w=$(i+1); gsub(",", "", w); if ($i ~ /^[0-9]+$/ && w == "pass") s += $i }} END {print s + 0}')
+R7RS_FAIL=$(printf "%s\n" "$R7RS_OUTPUT" | awk '{for (i = 1; i < NF; i++) { w=$(i+1); gsub(",", "", w); if ($i ~ /^[0-9]+$/ && w == "fail") s += $i }} END {print s + 0}')
+echo "  $R7RS_PASS pass, $R7RS_FAIL fail (exit $R7RS_STATUS)"
+if [[ $R7RS_STATUS -ne 0 || $R7RS_FAIL -gt 0 ]]; then
+    printf '%s\n' "$R7RS_OUTPUT" | grep -E '^FAIL|ERROR' | head -30 | sed 's/^/        /'
+fi
+# Zero passing assertions means the suite did not run, which must not read as
+# "no failures" -- the same cannot-fail shape this block exists to close.
+if [[ $R7RS_PASS -eq 0 ]]; then
+    echo "run-gc-stress-suite: the R7RS suite reported 0 passing assertions." >&2
+    exit 2
+fi
+
+echo ""
+echo "=== Summary: $PASS files passed, $FAIL failed, $SKIPPED skipped; R7RS $R7RS_PASS pass, $R7RS_FAIL fail ==="
+
+if [[ $FAIL -gt 0 || $R7RS_FAIL -gt 0 || $R7RS_STATUS -ne 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #1898 (audit v2 reconnaissance finding F9). Phase 7E.

`-Dgc-stress=true` — a collection attempted at every allocation, the only
configuration that turns a rooting bug into a deterministic failure at the site
that caused it — appeared **0 times** in `ci.yml`. It was not absent from CI:
`fuzz.yml`'s two gc-stress legs run the same unit suite as their pre-fuzz
phase. But that is daily at 02:47 UTC against whatever landed that day, not
against the diff that introduced it.

## Measured — by this PR's own run

**All 19 checks green.** Both new jobs, on `ubuntu-latest`, from the run this
PR triggered:

| job | wall | what it reported |
|---|---|---|
| `gc-stress` | **6 m 11 s** | `run test unit-tests` **1601 pass** (0 skip), 3 m, MaxRSS 96 M |
| `gc-stress-scheme` | **20 m 49 s** | **596 files passed, 0 failed, 9 skipped; R7RS 1395 pass, 0 fail** (suite step 17 m 25 s) |

The plain `test (ubuntu-latest, ReleaseSafe)` leg on the same run — now that
`--summary all` makes it say so — reports `1598 pass, 3 skip, **39 s**,
MaxRSS 95 M`. So on the runner the stress cost is **4.6×** (39 s → 3 m), which
matches 5F's droplet ratio (6.1×) and *not* my laptop's (below): the
counts and the skip delta are the same, the absolute times are not.

**Critical-path cost: +58 seconds, not zero.** `gc-stress-scheme` at 20 m 49 s
is now marginally the longest job in the workflow, displacing
`test (ubuntu-latest, Debug)` at 19 m 51 s on the same run. `gc-stress` at 6 m 11 s is free — it
finishes before nine other legs. If +2 min is judged too much, the lever is
this job alone: dropping the R7RS suite or narrowing the corpus, both one-line
changes, with the unit-suite gate unaffected.

## The premise is stale, and so is its correction

Unit 5F measured the stress unit suite at 5 minutes against a documented 1.5–3
hours. Measured again here, on this machine, both configurations,
`--summary all`:

| | `run test unit-tests` | compile |
|---|---|---|
| plain | **1579 pass, 3 skip** (1582 total) — **4 m** | 46 s |
| `-Dgc-stress=true` | **1582 pass, 0 skip** (1582 total) — **7 m** | 46 s |

**1.75×, not 30×** — and, as the CI table above shows, **that ratio is wrong
too**: macOS aarch64, 12 cores, **load average 4–6 throughout** from two other
audit units building concurrently, which inflated the *plain* run (4 m here vs
39 s on a 4-core runner) far more than the stressed one and squashed the ratio.
Reported as taken, with the load, because the conclusion — the stress suite is
minutes, not hours — survives either number, and because the differing skip
count (3 vs 0) is the control that the flag applied. Those counts are the only
thing in a `zig build test` log that distinguishes a passing run from one that
executed nothing, which is why `--summary all` is now on every unit-test
step — and why the 39 s plain figure above was readable at all.

The number that decides the CI question is not mine, though — it is
`fuzz.yml`'s own hosted-runner timings, which nobody had read:

| run | date | x86_64 | arm64 |
|---|---|---|---|
| 30696041228 | 2026-08-01 | 10 m 20 s | 12 m 22 s |
| 30607976466 | 2026-07-31 | 12 m 54 s | 12 m 58 s |

That is checkout + Zig + build + **the whole stress unit suite** + 100 fuzz runs
across 7 targets, against a `timeout: 300`. → #2164.

## What this adds

Two jobs, both `needs: format`, both concurrent with everything else:

- **`gc-stress`** — `zig build test -Dgc-stress=true --summary all`.
- **`gc-stress-scheme`** — builds the stress binary and runs the 605-file `.scm`
  corpus plus the R7RS suite through a new `tools/run-gc-stress-suite.sh`
  (modelled on #2145's `tools/run-endian-suite.sh`, for the same reason: a leg
  that needs a targeted runner because `run-all.sh` is the wrong shape — several
  of its shell suites fork `zig build` *without* the flag).

Two jobs rather than two steps of one, because the critical path through this
workflow is `test (ubuntu-latest, Debug)` at 19 min (riscv64/netbsd 17,
macOS/OpenBSD 16, on the last main run). Serialised they would exceed that and
become the new critical path; in parallel each sits inside its shadow.
Measured cost on the critical path: **+58 s** (see the table at the top —
`gc-stress` is free, `gc-stress-scheme` is 58 s longer than the 19 m 51 s Debug
leg it displaces). Locally, at 4 jobs, the corpus suite was 11 m 38 s at load
average 17.

### Three things that make it a gate rather than a decoration

Nothing about running a `.scm` file reveals which build options produced the
binary, so a plain build would pass every assertion and the job would go green
having stressed nothing.

1. `kaappi features --json` must report `"gc_stress":true` — as its own CI step
   *and* inside the script, which refuses to run otherwise.
2. The corpus is globbed, so a new test file joins by existing — with a **floor
   check** (≥500 files) so a glob matching nothing cannot read as "found nothing
   wrong" (the `tests/scheme/srfi/slow/` shape, #1900).
3. The R7RS suite's **counts** are parsed, not its exit status — see #2157.

## Mutation evidence: the gate catches a rooting bug the plain job misses

Deliberate bug: delete the `pushRoot`/`popRoot` pair around the datum-label
placeholder in `src/reader_datum.zig`, so the pre-allocated pair for `#0=…` is
unrooted across the nested `readDatum` that fills it.

```console
# gc-stress build, mutated source:
$ zig-out/bin/kaappi /tmp/cyc.scm
kaappi internal error — this is a bug in kaappi, not in your program.
thread 42241121 panic: GC: marking freed object (use-after-free)
src/gc_collect.zig:725:17: in markValueInner

# plain build, same mutated source, 5 consecutive runs:
1  <- run 1 … 1  <- run 5
```

Full suites, same mutated tree — the contrast the job exists for:

| `zig build test …` | verdict |
|---|---|
| `-Dgc-stress=true` | `1579 pass, **3 crash**` · `test transitive failure` · `error: the following build command failed with exit code 1` |
| (plain) | `1579 pass, 3 skip` · `test success` · 11/11 steps succeeded |

Same tree, same commit, same compiler — one flag apart. Reverted before commit;
`git diff` in this PR touches no `src/`.

The first mutation attempted — removing the `pushRoot` in `compareExactReals`
(`primitives_arithmetic.zig`), the textbook #1414 shape — was **not** caught by
either configuration. Worth recording: gc-stress detects a lost root when the
freed object is later *marked*, not merely read, and that value is only ever
read. Reverted; the reader mutation was chosen because its freed object is
stored back into a structure the next collection walks.

## What the gate found on its first run

The Scheme corpus does **not** pass under gc-stress today. Two root causes,
both filed, both excluded by name until fixed — the `;; FAIL: #N` convention
applied to files instead of assertions:

- **#2160** — `primitives_srfi1.buildList` reads freed values out of its
  unrooted `items` slice. Three files abort with `GC: marking freed object
  (use-after-free)`; ~20 call sites share the cause.
  `tests/scheme/srfi/srfi1-gc-stress.scm` — a file written to exercise SRFI-1
  under GC pressure — has been green on every plain leg and aborting under the
  build its name refers to, which nothing in CI ran.
- **#2161** — `VM.record_uid_registry` keys are borrowed slices into GC-owned
  string bytes, so a `nongenerative` uid stops resolving once its string is
  collected. 19 assertions across three files. The map three lines below it in
  `VM.deinit` owns and frees its keys, so the convention was known.

Also filed:

- **#2157** — five `ci.yml` steps run `r7rs-tests.scm` bare. The `(chibi test)`
  shim exits **0** on a failed assertion (verified by breaking one), so 1,395
  assertions gate nothing on riscv64, s390x, ppc64le and both Windows legs —
  including the big-endian canary, whose failure mode is *wrong answers*.
- **#2163** — `run-all.sh` silently `zig build`s a **plain** binary when
  `zig-out/bin/kaappi` is missing, and `zig build test -Dgc-stress=true`
  installs no executable, so the natural two-command "run everything stressed"
  runs the Scheme half unstressed. This is why the new script demands proof —
  and why 5F's `2061 pass, 0 fail, 0 timeout` Scheme result is arithmetically
  inconsistent with a stressed binary (three corpus files exceed `run-all.sh`'s
  60 s per-file budget by two orders of magnitude under stress).
- **#2162** — `primitives_filesystem-audit.scm` asserts the environment variable
  `KAAPPI` is unset. That is the name CI's own Windows legs export.
  Self-inflicted here: this script's first draft exported it and three
  assertions went red for reasons unrelated to the GC.
- **#2164** — `fuzz.yml` budgets 300 minutes for a 10–13 minute job, the same
  ~30×-stale estimate #2147 corrected one file over, and sizes its fuzz limit
  (100 vs 2K) on that belief.

## Skip list

Nine files, each named, in two groups the job's comment separates: three too
slow under stress to be useful (`trampoline-polish-1375.scm` builds a
300,000-character string and maps over it — ~0.2 s plain, unfinished after 25
minutes stressed, while the other 602 files completed in 11 minutes in
aggregate), and six carrying #2160/#2161. The script **fails** if a skip name
matches no file, so the list cannot rot into a silent no-op, and each fix PR
deletes its own names.

## TSan and valgrind — the neighbours F9 names

Recorded rather than left implicit; neither is added here.

**TSan: feasible, and cheaper than I first concluded.** Zig 0.16 has
`-fsanitize-thread`, but `build.zig` exposes no option for it, so this needs a
`-Dtsan` flag first — a small build change, not a CI one.

I initially called it infeasible on memory: the unit suite's `MaxRSS` is
**8–9 GB** on this Mac, and TSan's shadow is 4–8× the application's, which
would be 32–72 GB against a 16 GB runner. **That reasoning does not survive
its own evidence.** The `--summary all` lines this PR adds report **MaxRSS 95–96 M**
for the same suite on `ubuntu-latest` — the macOS figure is an artefact of how
`std.testing.allocator`'s never-reused address space is accounted there, not
the working set. At ~100 MB, TSan's shadow is ~1 GB: comfortably affordable.

So the real cost is time (typically 5–15×, i.e. 3–10 min on top of the 39 s
plain baseline) and false positives — expect them from `memory.symbol_mutex`,
a hand-rolled spinlock whose happens-before edges TSan cannot see without
annotation. A **targeted** job over the concurrency tests
(`-Dtest-filter=srfi18 -Dtest-filter=channel -Dtest-filter=fiber`) is still
the right first cut, because that is where the value is, not because the full
suite cannot fit. Recommended as a follow-up; deliberately not bundled here,
since it needs a `build.zig` change this unit has no mandate for.

**Valgrind: low marginal value here.** 20–50× slowdown puts the unit suite at
13–33 min (on the 39 s runner baseline), and most of what memcheck would find
is already covered:
`std.testing.allocator` leak-checks every test, Debug and gc-stress builds
poison freed objects, and #1687's freed-owner sentinel plus quarantine turn a
dangling GC reference into a named panic rather than silent aliasing. The one
uncovered surface is C interop (linenoise, the FFI dispatcher), which a targeted
run over `tests/scheme/ffi/` would reach cheaply. Not proposed as a PR gate
either way.

## Also here

`--summary all` on the existing `test` job's unit step (all five legs). Output
only, no behaviour change: it makes the log say `run test unit-tests N pass`
instead of nothing at all, which is the distinction this whole measurement
turned on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
