### PR TITLE
Make (read port) safe across the 4096-byte chunk boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,13 @@ jobs:
           #     after 25 minutes stressed, while the other 602 files completed
           #     in 11 minutes in aggregate on the same run. srfi14.scm
           #     (Unicode inversion lists) and srfi264.scm are the same shape at
-          #     ~10 and ~9 minutes.
+          #     ~10 and ~9 minutes. reader-port-refill-gaps.scm sweeps ~800
+          #     chunk-boundary fixtures, each an incremental `read` that
+          #     re-parses a 4 KiB buffer per refill (~1 s plain, exit 124 at
+          #     the 900 s stress timeout on this job's first run against it,
+          #     PR #2174); the incomplete-input reader mode it guards gets its
+          #     stress coverage from src/tests_reader_incremental.zig in the
+          #     gc-stress unit job instead.
           #
           # (b) REAL BUGS THIS GATE FOUND ON ITS FIRST RUN -- excluded so the
           #     gate is green for everything else, exactly as the campaign
@@ -305,7 +311,7 @@ jobs:
           #              GC-owned strings, so a nongenerative uid stops
           #              resolving once its string is collected (19 assertions)
           #
-          # All nine still run stressed in the nightly fuzz.yml legs' unit
+          # All ten still run stressed in the nightly fuzz.yml legs' unit
           # phase where applicable, and unstressed under run-all.sh on every
           # other leg here, so nothing is untested -- only unstressed.
           #
@@ -313,6 +319,7 @@ jobs:
           # cannot rot into a silent no-op.
           KAAPPI_GC_STRESS_SKIP: >-
             trampoline-polish-1375.scm srfi14.scm srfi264.scm
+            reader-port-refill-gaps.scm
             primitives_srfi1-audit.scm srfi1-ext.scm srfi1-gc-stress.scm
             primitives_srfi237-audit.scm srfi237.scm srfi240-audit.scm
 

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -1583,16 +1583,25 @@ fn writeStringFn(args: []const Value) PrimitiveError!Value {
 }
 
 /// Parses one datum with R7RS 6.13.2 `read` semantics: EOF before any datum
-/// text begins yields null (the caller returns the EOF object); EOF that
+/// text begins — including after trailing comments or a trailing `#!`
+/// directive — yields null (the caller returns the EOF object); EOF that
 /// interrupts an incomplete datum — including an unterminated comment —
 /// propagates as an error so the caller can signal one satisfying read-error?.
 fn parseDatumForRead(reader: *reader_mod.Reader) reader_mod.ReadError!?Value {
-    if (!try reader.hasMore()) return null;
-    return try reader.readDatum();
+    return reader.readDatumOrEof();
 }
 
-fn raiseReadError(gc: *@import("memory.zig").GC) PrimitiveError!Value {
-    var msg = gc.allocString("read error") catch return PrimitiveError.OutOfMemory;
+fn raiseReadError(gc: *@import("memory.zig").GC, err: anyerror) PrimitiveError!Value {
+    // Name what actually failed instead of a bare "read error" (#1920): the
+    // registry template for the reader's error, or — when the reader left
+    // one — its own richer detail (e.g. the malformed token echoed back).
+    const diagnostics = @import("diagnostics.zig");
+    const detail = reader_mod.getReadErrorDetail();
+    const specific: []const u8 = if (detail.len > 0) detail else diagnostics.readErrorCode(err).message();
+    var buf: [320]u8 = undefined;
+    const text = std.fmt.bufPrint(&buf, "read error: {s}", .{specific}) catch "read error";
+    reader_mod.resetReadErrorDetail();
+    var msg = gc.allocString(text) catch return PrimitiveError.OutOfMemory;
     gc.pushRoot(&msg);
     defer gc.popRoot();
     const err_obj = gc.allocErrorObject(msg, types.NIL) catch return PrimitiveError.OutOfMemory;
@@ -1611,7 +1620,7 @@ fn readFromPeekByteOnly(gc: *@import("memory.zig").GC, port: *types.Port) Primit
     defer reader.deinit();
     const maybe_datum = parseDatumForRead(&reader) catch |err| {
         if (err == reader_mod.ReadError.OutOfMemory) return PrimitiveError.OutOfMemory;
-        return raiseReadError(gc);
+        return raiseReadError(gc, err);
     };
     return maybe_datum orelse types.EOF;
 }
@@ -1646,7 +1655,7 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
         defer reader.deinit();
         const maybe_datum = parseDatumForRead(&reader) catch |err| {
             if (err == reader_mod.ReadError.OutOfMemory) return PrimitiveError.OutOfMemory;
-            return raiseReadError(gc);
+            return raiseReadError(gc, err);
         };
         const datum = maybe_datum orelse return types.EOF;
         // Advance string_pos by amount consumed
@@ -1691,10 +1700,17 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
     maybeSetNonblocking(port);
     var tmp: [read_chunk_size]u8 = undefined;
     while (true) {
-        // Try to parse a datum from what we already have.
+        // Try to parse a datum from what we already have. The buffer is a
+        // possibly-truncated prefix of the input, so parse in incomplete-
+        // input mode: any token or datum cut off at the end of the buffer
+        // reports exactly UnexpectedEof — the signal to read another chunk —
+        // rather than a spurious final error (#1893/#1920/#1945) or a
+        // silently split token (#1940). Only the post-EOF parse below, which
+        // sees the whole input, delivers final verdicts.
         if (buf.items.len > 0) {
             var reader = reader_mod.Reader.init(gc, buf.items);
             reader.mark_immutable = false;
+            reader.incomplete_input = true;
             defer reader.deinit();
             const result = parseDatumForRead(&reader);
             if (result) |maybe_datum| {
@@ -1709,11 +1725,14 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
                     }
                     return datum;
                 }
-                // Buffer was only whitespace/comments — discard and read more.
-                buf.clearRetainingCapacity();
+                // Buffer was only whitespace/comments — discard and read
+                // more. Not when a `#!` directive was among them: it carries
+                // state (fold-case) that each refill's fresh Reader recovers
+                // by re-parsing the buffer from its start.
+                if (!reader.saw_directive) buf.clearRetainingCapacity();
             } else |err| {
                 if (err != reader_mod.ReadError.UnexpectedEof)
-                    return if (err == reader_mod.ReadError.OutOfMemory) PrimitiveError.OutOfMemory else raiseReadError(gc);
+                    return if (err == reader_mod.ReadError.OutOfMemory) PrimitiveError.OutOfMemory else raiseReadError(gc, err);
                 // Incomplete datum — fall through to read more.
             }
         }
@@ -1739,7 +1758,9 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
         buf.appendSlice(gc.allocator, tmp[0..n]) catch return PrimitiveError.OutOfMemory;
     }
 
-    // Reached EOF — parse whatever remains.
+    // Reached EOF — parse whatever remains, now with the whole input known
+    // (incomplete_input stays false): a token ending here genuinely ends,
+    // and a datum still cut short is a real error satisfying read-error?.
     if (buf.items.len == 0) return types.EOF;
 
     var reader = reader_mod.Reader.init(gc, buf.items);
@@ -1747,7 +1768,7 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
     defer reader.deinit();
     const maybe_datum = parseDatumForRead(&reader) catch |err| {
         if (err == reader_mod.ReadError.OutOfMemory) return PrimitiveError.OutOfMemory;
-        return raiseReadError(gc);
+        return raiseReadError(gc, err);
     };
     const datum = maybe_datum orelse return types.EOF;
 

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -93,6 +93,22 @@ pub const Reader = struct {
     labels: [32]?Value = .{null} ** 32,
     source_name: []const u8 = "<input>",
     depth: u32 = 0,
+    /// True when `source` is a possibly-truncated prefix of a longer input:
+    /// the incremental `read` path (primitives_io.readDatumFn) parses a
+    /// growing buffer chunk by chunk, refilling on `UnexpectedEof`. In this
+    /// mode a scan that stops at end-of-slice — rather than at a delimiter
+    /// or a closing character — must report `UnexpectedEof`: never finalize
+    /// a token more bytes could extend, and never reject one more bytes
+    /// could complete (kaappi#1893/#1920/#1940/#1945). Whole-input parses
+    /// (file loading, string ports, the final parse at fd EOF) leave it
+    /// false and keep the precise error kinds.
+    incomplete_input: bool = false,
+    /// Set when a `#!` directive was consumed. The incremental `read` loop
+    /// must not discard a buffer that held one the way it discards pure
+    /// whitespace/comments: a directive carries state (fold-case) forward,
+    /// and every refill re-parses the buffer from scratch with a fresh
+    /// Reader, so the directive's bytes have to stay in the buffer.
+    saw_directive: bool = false,
 
     pub const MAX_NESTING_DEPTH = 1024;
     pub const MAX_BLOCK_COMMENT_DEPTH = 256;
@@ -184,6 +200,13 @@ pub const Reader = struct {
         return c;
     }
 
+    /// True when the current position is at end-of-slice while more input
+    /// may still follow — the point where a token scan cannot be finalized
+    /// or rejected yet (see `incomplete_input`).
+    pub fn truncatedHere(self: *const Reader) bool {
+        return self.incomplete_input and self.pos >= self.source.len;
+    }
+
     fn ensureTokenSpace(self: *Reader, extra: usize) ReadError!void {
         if (self.token_buf.items.len + extra > MAX_TOKEN_BYTES) {
             return ReadError.TokenTooLong;
@@ -209,6 +232,10 @@ pub const Reader = struct {
                 while (self.pos < self.source.len and self.source[self.pos] != '\n') {
                     self.pos += 1;
                 }
+                // A line comment cut off by end-of-slice may continue in the
+                // next chunk; resuming there after a refill would feed the
+                // comment's tail to the datum stream as code (#1940).
+                if (self.truncatedHere()) return ReadError.UnexpectedEof;
             } else if (c == '#' and self.pos + 1 < self.source.len and self.source[self.pos + 1] == ';') {
                 self.pos += 2;
                 _ = try self.readDatum();
@@ -332,7 +359,15 @@ pub const Reader = struct {
                 if (self.pos + 1 < self.source.len and std.ascii.isDigit(self.source[self.pos + 1])) {
                     return self.readNumber();
                 }
-                if (self.pos + 1 >= self.source.len or isDelimiter(self.source[self.pos + 1])) {
+                if (self.pos + 1 >= self.source.len) {
+                    // "." as the slice's last byte is undecidable while more
+                    // input may follow: it could be a pair dot, ".5", or
+                    // "..." (#1920's DotNotInList case).
+                    if (self.incomplete_input) return ReadError.UnexpectedEof;
+                    self.pos += 1;
+                    return .dot;
+                }
+                if (isDelimiter(self.source[self.pos + 1])) {
                     self.pos += 1;
                     return .dot;
                 }
@@ -348,7 +383,12 @@ pub const Reader = struct {
                 // Check for Unicode identifier start (multi-byte UTF-8)
                 if (c >= 0x80) {
                     const seq_len = std.unicode.utf8ByteSequenceLength(c) catch return ReadError.UnexpectedChar;
-                    if (self.pos + seq_len > self.source.len) return ReadError.UnexpectedChar;
+                    if (self.pos + seq_len > self.source.len) {
+                        // A codepoint whose bytes straddle the end of the
+                        // slice is a truncation, not bad UTF-8 (#1945).
+                        if (self.incomplete_input) return ReadError.UnexpectedEof;
+                        return ReadError.UnexpectedChar;
+                    }
                     const cp = std.unicode.utf8Decode(self.source[self.pos .. self.pos + seq_len]) catch return ReadError.UnexpectedChar;
                     if (isUnicodeLetter(cp)) {
                         return self.readUnicodeSymbol();
@@ -366,6 +406,9 @@ pub const Reader = struct {
     fn readNumber(self: *Reader) ReadError!Token {
         const start = self.pos;
         const tok = try reader_tokens.readNumber(self);
+        // A numeric token whose scan stopped only because the slice ended
+        // may be a prefix of a longer literal ("1" of "12", "3." of "3.5").
+        if (self.truncatedHere()) return ReadError.UnexpectedEof;
         if (self.pos < self.source.len and !isDelimiter(self.source[self.pos])) {
             // Only reclassify when the character actually glued onto the number
             // could continue an identifier (`<subsequent>`, ASCII or Unicode) --
@@ -380,6 +423,9 @@ pub const Reader = struct {
             // that were the problem.
             const glued_start = self.pos;
             consumeGluedIdentifierChars(self);
+            // Glue running to end-of-slice can't be judged yet: "1e" may be
+            // the prefix of the valid "1e5", not a malformed identifier.
+            if (self.truncatedHere()) return ReadError.UnexpectedEof;
             if (self.pos == glued_start) return ReadError.UnexpectedChar;
             // Consume the rest of the token so the message can echo it in full,
             // then rewind to the token's start so the reported position is the
@@ -466,7 +512,12 @@ pub const Reader = struct {
                 }
             } else {
                 const seq_len = std.unicode.utf8ByteSequenceLength(sc) catch break;
-                if (self.pos + seq_len > self.source.len) break;
+                if (self.pos + seq_len > self.source.len) {
+                    // Mid-codepoint truncation: ending the symbol here would
+                    // split it and leave stray lead bytes behind (#1945).
+                    if (self.incomplete_input) return ReadError.UnexpectedEof;
+                    break;
+                }
                 const scp = std.unicode.utf8Decode(self.source[self.pos .. self.pos + seq_len]) catch break;
                 if (isUnicodeSubsequent(scp)) {
                     self.pos += seq_len;
@@ -499,7 +550,11 @@ pub const Reader = struct {
             } else {
                 // Multi-byte UTF-8: decode and check
                 const seq_len = std.unicode.utf8ByteSequenceLength(c) catch break;
-                if (self.pos + seq_len > self.source.len) break;
+                if (self.pos + seq_len > self.source.len) {
+                    // Mid-codepoint truncation, as in readSymbol (#1945).
+                    if (self.incomplete_input) return ReadError.UnexpectedEof;
+                    break;
+                }
                 const cp = std.unicode.utf8Decode(self.source[self.pos .. self.pos + seq_len]) catch break;
                 if (isUnicodeSubsequent(cp)) {
                     self.pos += seq_len;
@@ -535,7 +590,11 @@ pub const Reader = struct {
                         while (self.pos < self.source.len and self.source[self.pos] != ';') {
                             self.pos += 1;
                         }
-                        if (self.pos >= self.source.len) return ReadError.InvalidEscape;
+                        if (self.pos >= self.source.len) {
+                            // The terminating ';' may be in the next chunk.
+                            if (self.incomplete_input) return ReadError.UnexpectedEof;
+                            return ReadError.InvalidEscape;
+                        }
                         const hex_str = self.source[hex_start..self.pos];
                         const cp = std.fmt.parseInt(u21, hex_str, 16) catch return ReadError.InvalidEscape;
                         var buf: [4]u8 = undefined;
@@ -572,7 +631,10 @@ pub const Reader = struct {
             }
             if (c == '\\') {
                 self.pos += 1;
-                if (self.pos >= self.source.len) return ReadError.UnterminatedString;
+                if (self.pos >= self.source.len) {
+                    if (self.incomplete_input) return ReadError.UnexpectedEof;
+                    return ReadError.UnterminatedString;
+                }
                 const esc = self.source[self.pos];
                 switch (esc) {
                     'n' => try self.appendTokenByte('\n'),
@@ -589,7 +651,11 @@ pub const Reader = struct {
                         while (self.pos < self.source.len and self.source[self.pos] != ';') {
                             self.pos += 1;
                         }
-                        if (self.pos >= self.source.len) return ReadError.InvalidEscape;
+                        if (self.pos >= self.source.len) {
+                            // The terminating ';' may be in the next chunk.
+                            if (self.incomplete_input) return ReadError.UnexpectedEof;
+                            return ReadError.InvalidEscape;
+                        }
                         const hex_str = self.source[hex_start..self.pos];
                         const cp = std.fmt.parseInt(u21, hex_str, 16) catch return ReadError.InvalidEscape;
                         var buf: [4]u8 = undefined;
@@ -627,6 +693,9 @@ pub const Reader = struct {
                             }
                             continue;
                         }
+                        // The line continuation's newline may be in the next
+                        // chunk; only a real non-newline byte is an error.
+                        if (self.truncatedHere()) return ReadError.UnexpectedEof;
                         return ReadError.InvalidEscape;
                     },
                     else => return ReadError.InvalidEscape,
@@ -636,6 +705,7 @@ pub const Reader = struct {
             }
             self.pos += 1;
         }
+        if (self.incomplete_input) return ReadError.UnexpectedEof;
         return ReadError.UnterminatedString;
     }
 
@@ -656,6 +726,13 @@ pub const Reader = struct {
 
     pub fn readDatum(self: *Reader) ReadError!Value {
         return reader_datum.readDatum(self);
+    }
+
+    /// readDatum, but a clean end of input (only whitespace, comments, or
+    /// `#!` directives left) yields null instead of UnexpectedEof — the
+    /// distinction `read` needs to return the EOF object rather than raise.
+    pub fn readDatumOrEof(self: *Reader) ReadError!?Value {
+        return reader_datum.readDatumOrEof(self);
     }
 
     pub fn hasMore(self: *Reader) ReadError!bool {

--- a/src/reader_datum.zig
+++ b/src/reader_datum.zig
@@ -7,6 +7,17 @@ const ReadError = reader_mod.ReadError;
 const Token = reader_mod.Token;
 
 pub fn readDatum(self: *Reader) ReadError!Value {
+    return (try readDatumOrEof(self)) orelse ReadError.UnexpectedEof;
+}
+
+/// readDatum, except a clean end of input — nothing left but whitespace,
+/// comments, and `#!` directives — yields null instead of UnexpectedEof.
+/// `hasMore()` + readDatum cannot make that distinction: a `#!` directive is
+/// consumed inside nextToken, so when one is the last thing in the input,
+/// hasMore() answers true and readDatum then reports UnexpectedEof, which
+/// `read` callers would mistake for a truncated datum and turn into a read
+/// error instead of the EOF object.
+pub fn readDatumOrEof(self: *Reader) ReadError!?Value {
     if (self.depth >= Reader.MAX_NESTING_DEPTH) return ReadError.NestingTooDeep;
     self.depth += 1;
     defer self.depth -= 1;
@@ -17,6 +28,7 @@ pub fn readDatum(self: *Reader) ReadError!Value {
     try self.skipWhitespaceAndCommentsChecked();
     const start_pos = self.pos;
     const tok = try self.nextToken();
+    if (tok == .eof) return null;
     const val = try tokenToValue(self, tok);
     self.recordSpan(val, start_pos);
     return val;
@@ -130,9 +142,11 @@ fn readList(self: *Reader) ReadError!Value {
             self.gc.pushRoot(&rest_root);
             defer self.gc.popRoot();
             try self.skipWhitespaceAndCommentsChecked();
-            if (self.pos >= self.source.len or self.source[self.pos] != ')') {
-                return ReadError.UnexpectedChar;
-            }
+            // Exhausted input where `)` belongs is the incomplete-datum
+            // case, not a wrong character (#1920): the incremental `read`
+            // loop keys "read more input" on exactly UnexpectedEof.
+            if (self.pos >= self.source.len) return ReadError.UnexpectedEof;
+            if (self.source[self.pos] != ')') return ReadError.UnexpectedChar;
             self.pos += 1;
             const pair = self.gc.allocPair(first_root, rest_root) catch return ReadError.OutOfMemory;
             if (self.mark_immutable) types.toObject(pair).flags.immutable = true;
@@ -180,9 +194,10 @@ fn readListTail(self: *Reader) ReadError!Value {
                 self.gc.writeBarrier(types.toObject(tail), rest);
             }
             try self.skipWhitespaceAndCommentsChecked();
-            if (self.pos >= self.source.len or self.source[self.pos] != ')') {
-                return ReadError.UnexpectedChar;
-            }
+            // As in readList: no more input where `)` belongs means the
+            // datum is incomplete, not malformed (#1920).
+            if (self.pos >= self.source.len) return ReadError.UnexpectedEof;
+            if (self.source[self.pos] != ')') return ReadError.UnexpectedChar;
             self.pos += 1;
             return result;
         }

--- a/src/reader_tokens.zig
+++ b/src/reader_tokens.zig
@@ -85,8 +85,35 @@ fn bigRationalToken(self: *Reader, num_str: []const u8, den_str: []const u8, rad
     return .{ .big_rational = .{ .num_str = num_str, .den_str = den_str, .radix = radix } };
 }
 
+/// A malformed numeric token with no delimiter between the failure point and
+/// end-of-slice may be a truncated prefix of a valid literal (`3.` of `3.5`,
+/// `1_` of `1_2`, `#e+in` of `#e+inf.0` — the scan can stop with unconsumed
+/// bytes left, so this is a tail scan, not just pos >= len): in
+/// incomplete-input mode report UnexpectedEof so the incremental reader
+/// fetches more bytes instead of delivering a final verdict (#1940).
+/// Identity — plain InvalidNumber — whenever a delimiter ends the token
+/// within the slice or the whole input is known; deferral never loses the
+/// error, because the whole-input parse at fd EOF re-judges the full token.
+fn invalidNumberOrEof(self: *Reader) ReadError {
+    return if (numberTailTruncated(self)) ReadError.UnexpectedEof else ReadError.InvalidNumber;
+}
+
+/// True when, in incomplete-input mode, everything from the current position
+/// to end-of-slice is delimiter-free. A just-scanned numeric token followed
+/// by such a tail cannot be finalized: the tail (e.g. the "+2" a backtracked
+/// complex-literal attempt left behind out of a straddled "1+2i") may
+/// continue in the next chunk (#1940).
+fn numberTailTruncated(self: *Reader) bool {
+    if (!self.incomplete_input) return false;
+    var i = self.pos;
+    while (i < self.source.len) : (i += 1) {
+        if (Reader.isDelimiter(self.source[i])) return false;
+    }
+    return true;
+}
+
 pub fn readNumber(self: *Reader) ReadError!Token {
-    if (self.pos >= self.source.len) return ReadError.InvalidNumber;
+    if (self.pos >= self.source.len) return invalidNumberOrEof(self);
     const start = self.pos;
     if (self.source[self.pos] == '+' or self.source[self.pos] == '-') {
         self.pos += 1;
@@ -126,7 +153,7 @@ pub fn readNumber(self: *Reader) ReadError!Token {
             (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])))
         {
             self.pos += 1;
-            const real = parseDecimalReal(num_str) orelse return ReadError.InvalidNumber;
+            const real = parseDecimalReal(num_str) orelse return invalidNumberOrEof(self);
             const imag: f64 = if (self.source[imag_start] == '+') 1.0 else -1.0;
             return .{ .complex = .{ .real = real, .imag = imag, .exact_real = real_exact, .exact_imag = true } };
         }
@@ -146,7 +173,7 @@ pub fn readNumber(self: *Reader) ReadError!Token {
                     (self.pos + 6 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 6])))
                 {
                     self.pos += 6; // skip inf.0i / nan.0i
-                    const real = parseDecimalReal(num_str) orelse return ReadError.InvalidNumber;
+                    const real = parseDecimalReal(num_str) orelse return invalidNumberOrEof(self);
                     const imag = if (self.source[imag_start] == '-') -special_val else special_val;
                     return .{ .complex = .{ .real = real, .imag = imag, .exact_real = real_exact, .exact_imag = false } };
                 }
@@ -176,9 +203,9 @@ pub fn readNumber(self: *Reader) ReadError!Token {
         // Must end with 'i'
         if (self.pos < self.source.len and (self.source[self.pos] == 'i' or self.source[self.pos] == 'I')) {
             self.pos += 1;
-            const real = parseDecimalReal(num_str) orelse return ReadError.InvalidNumber;
+            const real = parseDecimalReal(num_str) orelse return invalidNumberOrEof(self);
             const imag_str = self.source[imag_start .. self.pos - 1];
-            const imag = parseDecimalReal(imag_str) orelse return ReadError.InvalidNumber;
+            const imag = parseDecimalReal(imag_str) orelse return invalidNumberOrEof(self);
             const imag_exact = !imag_has_dot and !imag_has_exp;
             return .{ .complex = .{ .real = real, .imag = imag, .exact_real = real_exact, .exact_imag = imag_exact } };
         }
@@ -194,13 +221,13 @@ pub fn readNumber(self: *Reader) ReadError!Token {
         const imag = if (num_str.len == 0 or (num_str.len == 1 and (num_str[0] == '+' or num_str[0] == '-')))
             (if (num_str.len == 1 and num_str[0] == '-') @as(f64, -1.0) else @as(f64, 1.0))
         else
-            parseDecimalReal(num_str) orelse return ReadError.InvalidNumber;
+            parseDecimalReal(num_str) orelse return invalidNumberOrEof(self);
         const imag_exact2 = !has_dot and !has_exp;
         return .{ .complex = .{ .real = 0.0, .imag = imag, .exact_real = true, .exact_imag = imag_exact2 } };
     }
 
     if (has_dot or has_exp) {
-        const f = parseDecimalReal(num_str) orelse return ReadError.InvalidNumber;
+        const f = parseDecimalReal(num_str) orelse return invalidNumberOrEof(self);
         return .{ .flonum = f };
     } else {
         // SRFI 169: strip+validate embedded digit-separator underscores
@@ -210,9 +237,9 @@ pub fn readNumber(self: *Reader) ReadError!Token {
         // .bignum_str are parsed later by parseBignumString, which strips
         // internally.
         var num_strip_buf: [256]u8 = undefined;
-        const clean_num_str = bignum.stripUnderscores(num_str, 10, &num_strip_buf) orelse return ReadError.InvalidNumber;
+        const clean_num_str = bignum.stripUnderscores(num_str, 10, &num_strip_buf) orelse return invalidNumberOrEof(self);
         const n = std.fmt.parseInt(i64, clean_num_str, 10) catch |err| {
-            if (err != error.Overflow) return ReadError.InvalidNumber;
+            if (err != error.Overflow) return invalidNumberOrEof(self);
             // Numerator overflows i64: still check for a rational literal N/D
             // so bignum numerators fall back to bignum parsing in the datum
             // constructor instead of leaving '/' behind as a stray token.
@@ -230,10 +257,10 @@ pub fn readNumber(self: *Reader) ReadError!Token {
         {
             const den_str = scanDenominatorDigits(self, 10);
             var den_strip_buf: [256]u8 = undefined;
-            const clean_den_str = bignum.stripUnderscores(den_str, 10, &den_strip_buf) orelse return ReadError.InvalidNumber;
+            const clean_den_str = bignum.stripUnderscores(den_str, 10, &den_strip_buf) orelse return invalidNumberOrEof(self);
             const den = std.fmt.parseInt(i64, clean_den_str, 10) catch |err| {
                 if (err == error.Overflow) return bigRationalToken(self, num_str, den_str, 10);
-                return ReadError.InvalidNumber;
+                return invalidNumberOrEof(self);
             };
             // Check for complex after rational: 1/2+3/4i
             if (self.pos < self.source.len and (self.source[self.pos] == '+' or self.source[self.pos] == '-')) {
@@ -278,6 +305,11 @@ pub fn readNumber(self: *Reader) ReadError!Token {
 /// and check for special float literals on the folded text.
 /// Returns the (possibly folded) symbol token.
 pub fn foldAndReturnSymbol(self: *Reader, sym_text: []const u8) ReadError!Token {
+    // A symbol scan that stopped only because the slice ended (every caller
+    // otherwise stops at a delimiter or non-subsequent byte, leaving pos on
+    // it) may be a prefix of a longer identifier — "zz" of "zzz", "+inf" of
+    // "+inf.0". Silently finalizing here is #1940's split-symbol bug.
+    if (self.truncatedHere()) return ReadError.UnexpectedEof;
     if (sym_text.len > Reader.MAX_TOKEN_BYTES) return ReadError.TokenTooLong;
     const text = if (self.fold_case) blk: {
         self.token_buf.clearRetainingCapacity();
@@ -462,23 +494,37 @@ fn applyExactness(tok: Token, exact: ?bool) ReadError!Token {
 fn readNumberPrefixed(self: *Reader, radix0: u8, exact0: ?bool) ReadError!Token {
     var radix = radix0;
     var exact = exact0;
-    if (self.pos + 1 < self.source.len and self.source[self.pos] == '#') {
-        var consumed = true;
-        switch (std.ascii.toLower(self.source[self.pos + 1])) {
-            'b' => radix = 2,
-            'o' => radix = 8,
-            'd' => radix = 10,
-            'x' => radix = 16,
-            'e' => exact = true,
-            'i' => exact = false,
-            else => consumed = false,
+    if (self.pos < self.source.len and self.source[self.pos] == '#') {
+        if (self.pos + 1 >= self.source.len) {
+            // "#e#" cut right at the second prefix's letter: the letter may
+            // be in the next chunk (falls through to readNumber's own
+            // InvalidNumber when the whole input is known).
+            if (self.incomplete_input) return ReadError.UnexpectedEof;
+        } else {
+            var consumed = true;
+            switch (std.ascii.toLower(self.source[self.pos + 1])) {
+                'b' => radix = 2,
+                'o' => radix = 8,
+                'd' => radix = 10,
+                'x' => radix = 16,
+                'e' => exact = true,
+                'i' => exact = false,
+                else => consumed = false,
+            }
+            if (consumed) self.pos += 2;
         }
-        if (consumed) self.pos += 2;
     }
 
-    if (tryReadInfNan(self)) |f| return applyExactness(.{ .flonum = f }, exact);
+    if (tryReadInfNan(self)) |f| {
+        // "#e+inf.0" ending exactly at the slice can't be finalized: a
+        // non-delimiter in the next chunk would make it a different (and
+        // invalid) token, not this flonum.
+        if (self.truncatedHere()) return ReadError.UnexpectedEof;
+        return applyExactness(.{ .flonum = f }, exact);
+    }
 
     const tok = if (radix == 10) try readNumber(self) else try readIntegerWithRadix(self, radix);
+    if (numberTailTruncated(self)) return ReadError.UnexpectedEof;
     return applyExactness(tok, exact);
 }
 
@@ -495,9 +541,13 @@ pub fn readHash(self: *Reader) ReadError!Token {
                 while (self.pos < self.source.len and std.ascii.isAlphabetic(self.source[self.pos])) {
                     self.pos += 1;
                 }
+                // "#tru" cut mid-word may be a prefix of "#true" (#1940).
+                if (self.truncatedHere()) return ReadError.UnexpectedEof;
                 const word = self.source[start..self.pos];
                 if (!std.mem.eql(u8, word, "true")) return ReadError.UnexpectedChar;
             }
+            // Bare "#t" at end-of-slice may be "#true" cut after the t.
+            if (self.truncatedHere()) return ReadError.UnexpectedEof;
             if (self.pos < self.source.len and !Reader.isDelimiter(self.source[self.pos]))
                 return ReadError.UnexpectedChar;
             return .{ .boolean = true };
@@ -509,9 +559,11 @@ pub fn readHash(self: *Reader) ReadError!Token {
                 while (self.pos < self.source.len and std.ascii.isAlphabetic(self.source[self.pos])) {
                     self.pos += 1;
                 }
+                if (self.truncatedHere()) return ReadError.UnexpectedEof;
                 const word = self.source[start..self.pos];
                 if (!std.mem.eql(u8, word, "false")) return ReadError.UnexpectedChar;
             }
+            if (self.truncatedHere()) return ReadError.UnexpectedEof;
             if (self.pos < self.source.len and !Reader.isDelimiter(self.source[self.pos]))
                 return ReadError.UnexpectedChar;
             return .{ .boolean = false };
@@ -535,6 +587,13 @@ pub fn readHash(self: *Reader) ReadError!Token {
                     return readByteStringLiteral(self);
                 }
             }
+            // "#u" or "#u8" cut at end-of-slice may still become #u8( or
+            // #u8" once the next chunk arrives (#1940). "#u<other>" is a
+            // real error regardless of what follows.
+            if (self.incomplete_input and
+                (self.pos + 1 >= self.source.len or
+                    (self.source[self.pos + 1] == '8' and self.pos + 2 >= self.source.len)))
+                return ReadError.UnexpectedEof;
             return ReadError.UnexpectedChar;
         },
         'b', 'B' => {
@@ -563,6 +622,7 @@ pub fn readHash(self: *Reader) ReadError!Token {
         },
         '!' => {
             self.pos += 1;
+            self.saw_directive = true;
             const dir_start = self.pos;
             while (self.pos < self.source.len) {
                 const dc = self.source[self.pos];
@@ -572,6 +632,9 @@ pub fn readHash(self: *Reader) ReadError!Token {
                     break;
                 }
             }
+            // "#!fold-c" cut mid-name: judging (and ignoring) the directive
+            // now would drop its effect once the rest arrives.
+            if (self.truncatedHere()) return ReadError.UnexpectedEof;
             const directive = self.source[dir_start..self.pos];
             if (std.mem.eql(u8, directive, "fold-case")) {
                 self.fold_case = true;
@@ -588,8 +651,11 @@ pub fn readHash(self: *Reader) ReadError!Token {
                 self.pos += 1;
             }
             const label_str = self.source[label_start..self.pos];
-            const label_num = std.fmt.parseInt(u32, label_str, 10) catch return ReadError.InvalidNumber;
+            // Exhausting the slice mid-label is a truncation whatever the
+            // digits parse to, so check before parseInt: an overflowing
+            // label cut at the boundary must refill, not report a verdict.
             if (self.pos >= self.source.len) return ReadError.UnexpectedEof;
+            const label_num = std.fmt.parseInt(u32, label_str, 10) catch return ReadError.InvalidNumber;
             if (self.source[self.pos] == '=') {
                 self.pos += 1;
                 return .{ .datum_label_def = label_num };
@@ -623,7 +689,11 @@ pub fn readRawString(self: *Reader) ReadError!Token {
     while (self.pos < self.source.len and self.source[self.pos] != '"') {
         self.pos += 1;
     }
-    if (self.pos >= self.source.len) return ReadError.UnterminatedString;
+    if (self.pos >= self.source.len) {
+        // The delimiter's closing `"` may be in the next chunk (#1940).
+        if (self.incomplete_input) return ReadError.UnexpectedEof;
+        return ReadError.UnterminatedString;
+    }
     const delim = self.source[delim_start..self.pos];
     self.pos += 1; // consume the `"` closing the delimiter / opening the content
 
@@ -638,6 +708,7 @@ pub fn readRawString(self: *Reader) ReadError!Token {
         self.token_buf.append(self.gc.allocator, self.source[self.pos]) catch return ReadError.OutOfMemory;
         self.pos += 1;
     }
+    if (self.incomplete_input) return ReadError.UnexpectedEof;
     return ReadError.UnterminatedString;
 }
 
@@ -685,7 +756,10 @@ pub fn readByteStringLiteral(self: *Reader) ReadError!Token {
         }
         if (c == '\\') {
             self.pos += 1;
-            if (self.pos >= self.source.len) return ReadError.UnterminatedString;
+            if (self.pos >= self.source.len) {
+                if (self.incomplete_input) return ReadError.UnexpectedEof;
+                return ReadError.UnterminatedString;
+            }
             const esc = self.source[self.pos];
             switch (esc) {
                 'n' => try appendByteStringByte(self, '\n'),
@@ -702,7 +776,11 @@ pub fn readByteStringLiteral(self: *Reader) ReadError!Token {
                     while (self.pos < self.source.len and self.source[self.pos] != ';') {
                         self.pos += 1;
                     }
-                    if (self.pos >= self.source.len) return ReadError.InvalidEscape;
+                    if (self.pos >= self.source.len) {
+                        // The terminating ';' may be in the next chunk.
+                        if (self.incomplete_input) return ReadError.UnexpectedEof;
+                        return ReadError.InvalidEscape;
+                    }
                     const hex_str = self.source[hex_start..self.pos];
                     const byte_val = std.fmt.parseInt(u8, hex_str, 16) catch return ReadError.InvalidEscape;
                     try appendByteStringByte(self, byte_val);
@@ -728,6 +806,9 @@ pub fn readByteStringLiteral(self: *Reader) ReadError!Token {
                         skipIntralineWhitespace(self);
                         continue;
                     }
+                    // The line continuation's newline may be in the next
+                    // chunk; only a real non-newline byte is an error.
+                    if (self.truncatedHere()) return ReadError.UnexpectedEof;
                     return ReadError.InvalidEscape;
                 },
                 else => return ReadError.InvalidEscape,
@@ -743,6 +824,7 @@ pub fn readByteStringLiteral(self: *Reader) ReadError!Token {
         try appendByteStringByte(self, c);
         self.pos += 1;
     }
+    if (self.incomplete_input) return ReadError.UnexpectedEof;
     return ReadError.UnterminatedString;
 }
 
@@ -782,7 +864,7 @@ pub fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
 
     const num_str = self.source[start..self.pos];
     if (num_str.len > Reader.MAX_TOKEN_BYTES) return ReadError.TokenTooLong;
-    if (num_str.len == 0 or (num_str.len == 1 and (num_str[0] == '+' or num_str[0] == '-'))) return ReadError.InvalidNumber;
+    if (num_str.len == 0 or (num_str.len == 1 and (num_str[0] == '+' or num_str[0] == '-'))) return invalidNumberOrEof(self);
     // SRFI 169: num_str/den_str may carry embedded digit-separator
     // underscores at this point (the scan loops above tolerate but don't
     // validate them); strip+validate right before parseInt, which doesn't
@@ -790,9 +872,9 @@ pub fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
     // slices, since bigRationalToken/.bignum_str are parsed later by
     // parseBignumString, which strips internally.
     var num_strip_buf: [256]u8 = undefined;
-    const clean_num_str = bignum.stripUnderscores(num_str, radix, &num_strip_buf) orelse return ReadError.InvalidNumber;
+    const clean_num_str = bignum.stripUnderscores(num_str, radix, &num_strip_buf) orelse return invalidNumberOrEof(self);
     const n = std.fmt.parseInt(i64, clean_num_str, radix) catch |err| {
-        if (err != error.Overflow) return ReadError.InvalidNumber;
+        if (err != error.Overflow) return invalidNumberOrEof(self);
         // Numerator overflows i64: still consume a rational N/D so the '/'
         // does not get re-tokenized as the start of a symbol.
         if (self.pos < self.source.len and self.source[self.pos] == '/') {
@@ -809,10 +891,10 @@ pub fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
         const den_str = scanDenominatorDigits(self, radix);
         if (den_str.len > 0) {
             var den_strip_buf: [256]u8 = undefined;
-            const clean_den_str = bignum.stripUnderscores(den_str, radix, &den_strip_buf) orelse return ReadError.InvalidNumber;
+            const clean_den_str = bignum.stripUnderscores(den_str, radix, &den_strip_buf) orelse return invalidNumberOrEof(self);
             const den = std.fmt.parseInt(i64, clean_den_str, radix) catch |err| {
                 if (err == error.Overflow) return bigRationalToken(self, num_str, den_str, radix);
-                return ReadError.InvalidNumber;
+                return invalidNumberOrEof(self);
             };
             return .{ .rational = .{ .num = n, .den = den } };
         }
@@ -844,7 +926,7 @@ fn readHexFloatSuffix(self: *Reader, start: usize) ReadError!Token {
     }
     const full_str = self.source[start..self.pos];
     if (full_str.len > Reader.MAX_TOKEN_BYTES) return ReadError.TokenTooLong;
-    const f = bignum.parseHexFloat(full_str) orelse return ReadError.InvalidNumber;
+    const f = bignum.parseHexFloat(full_str) orelse return invalidNumberOrEof(self);
     return .{ .flonum = f };
 }
 
@@ -864,6 +946,8 @@ pub fn readCharacter(self: *Reader) ReadError!Token {
                 while (self.pos < self.source.len and std.ascii.isHex(self.source[self.pos])) {
                     self.pos += 1;
                 }
+                // "#\x4" cut mid-digits may continue as "#\x41" (#1940).
+                if (self.truncatedHere()) return ReadError.UnexpectedEof;
                 const hex_str = self.source[start + 1 .. self.pos];
                 const cp = std.fmt.parseInt(u21, hex_str, 16) catch return ReadError.InvalidNumber;
                 if (cp > 0x10FFFF or (cp >= 0xD800 and cp <= 0xDFFF)) return ReadError.InvalidCharacterName;
@@ -873,6 +957,8 @@ pub fn readCharacter(self: *Reader) ReadError!Token {
             }
             // Just #\x alone — return 'x'
             if (self.pos >= self.source.len or !std.ascii.isAlphabetic(self.source[self.pos])) {
+                // "#\x" at end-of-slice may be "#\x41" cut before its digits.
+                if (self.truncatedHere()) return ReadError.UnexpectedEof;
                 if (self.pos < self.source.len and !Reader.isDelimiter(self.source[self.pos]))
                     return ReadError.UnexpectedChar;
                 return .{ .character = first_byte };
@@ -881,6 +967,9 @@ pub fn readCharacter(self: *Reader) ReadError!Token {
         while (self.pos < self.source.len and std.ascii.isAlphabetic(self.source[self.pos])) {
             self.pos += 1;
         }
+        // A name scan stopped by end-of-slice may be a prefix: "#\s" of
+        // "#\space", "#\spa" of "#\space" (#1940's #\s + `pace' split).
+        if (self.truncatedHere()) return ReadError.UnexpectedEof;
         const name = self.source[start..self.pos];
         if (name.len == 1) {
             if (self.pos < self.source.len and !Reader.isDelimiter(self.source[self.pos]))
@@ -903,6 +992,9 @@ pub fn readCharacter(self: *Reader) ReadError!Token {
             return ReadError.InvalidCharacterName;
         };
         self.pos += seq_len;
+        // "#\λ" at end-of-slice: a non-delimiter in the next chunk would
+        // make this a (malformed) longer literal, not the character λ.
+        if (self.truncatedHere()) return ReadError.UnexpectedEof;
         if (self.pos < self.source.len and !Reader.isDelimiter(self.source[self.pos]))
             return ReadError.UnexpectedChar;
         return .{ .character = cp };

--- a/src/tests_reader_incremental.zig
+++ b/src/tests_reader_incremental.zig
@@ -1,0 +1,213 @@
+//! Incomplete-input mode of the reader (kaappi#1893/#1920/#1940/#1945).
+//!
+//! The incremental `read` path (primitives_io.readDatumFn) parses a growing
+//! buffer chunk by chunk and refills on exactly `UnexpectedEof`. The
+//! invariant that makes it sound, and that these tests pin at the reader
+//! level, is:
+//!
+//!   with `incomplete_input = true`, EVERY proper byte-prefix of a datum's
+//!   text parses to `UnexpectedEof` — never to a different error (which the
+//!   loop treats as final: #1893/#1920/#1945) and never to a successful
+//!   prefix datum (which the loop commits, silently splitting the token:
+//!   #1940).
+//!
+//! The prefix sweep below runs that property over one representative source
+//! per token class. The end-to-end fd-port behavior (real 4096-byte chunk
+//! boundaries, stash, the string-port oracle) is covered by
+//! tests/scheme/compliance/reader-port-refill-gaps.scm.
+
+const std = @import("std");
+const testing = std.testing;
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const reader_mod = @import("reader.zig");
+const printer = @import("printer.zig");
+const th = @import("testing_helpers.zig");
+const Reader = reader_mod.Reader;
+const ReadError = reader_mod.ReadError;
+
+fn parseOne(gc: *memory.GC, source: []const u8, incomplete: bool) ReadError!?types.Value {
+    var r = Reader.init(gc, source);
+    r.incomplete_input = incomplete;
+    defer r.deinit();
+    return r.readDatumOrEof();
+}
+
+/// Every proper byte-prefix of `src`, parsed in incomplete-input mode, must
+/// yield UnexpectedEof (truncated: refill and re-parse) or null (only
+/// complete trivia so far — a finished comment or directive; discarding is
+/// safe because no datum text has begun). What the incremental loop can
+/// never recover from is the other two outcomes: a successful datum commits
+/// a silently split token (#1940), and any other error is treated as final
+/// (#1893/#1920/#1945). Then `src` followed by a newline must parse.
+fn expectPrefixesIncomplete(src: []const u8) !void {
+    var gc = memory.GC.init(testing.allocator);
+    defer gc.deinit();
+
+    var k: usize = 1;
+    while (k < src.len) : (k += 1) {
+        const result = parseOne(&gc, src[0..k], true);
+        if (result) |maybe_datum| {
+            if (maybe_datum != null) {
+                std.debug.print("prefix {d} of \"{s}\" finalized a datum\n", .{ k, src });
+                return error.TestUnexpectedResult;
+            }
+        } else |err| {
+            if (err != ReadError.UnexpectedEof) {
+                std.debug.print("prefix {d} of \"{s}\" reported {s}\n", .{ k, src, @errorName(err) });
+                return error.TestUnexpectedResult;
+            }
+        }
+    }
+
+    // With its terminating delimiter present the datum must parse even in
+    // incomplete mode — otherwise the incremental loop could never return it.
+    const with_delim = try std.mem.concat(testing.allocator, u8, &.{ src, "\n" });
+    defer testing.allocator.free(with_delim);
+    const parsed = parseOne(&gc, with_delim, true) catch |e| {
+        std.debug.print("\"{s}\" + newline failed to parse in incomplete mode\n", .{src});
+        return e;
+    };
+    try testing.expect(parsed != null);
+}
+
+test "incomplete mode: every proper prefix of every token class is UnexpectedEof" {
+    // One representative per scanner path. Each entry is a single datum.
+    const catalog = [_][]const u8{
+        // strings (#1893) — plain, \n escape, \x escape, UTF-8 content
+        "\"zzzz zzzz\"",
+        "\"aa\\nbb\"",
+        "\"aa\\x41;bb\"",
+        "\"aaλbb\"",
+        // raw string, byte string, quoted symbol with escape (#1940 raisers)
+        "#\"Q\"raw \" body\"Q\"",
+        "#u8\"ab\\x41;cd\"",
+        "|q s\\x41;m|",
+        // silent splitters (#1940)
+        "zzzzzz",
+        "123456",
+        "12.5e3",
+        "1/24",
+        "1+2i",
+        "#true",
+        "#false",
+        "#\\space",
+        "#\\x41",
+        "#\\a",
+        "#d1234",
+        "#xFF/3",
+        "#e#x10",
+        "#x1.8p3",
+        "#e+inf.0",
+        "+inf.0",
+        "...",
+        ".5",
+        "#u8(1 2)",
+        // multi-byte UTF-8 codepoints (#1945): 2-, 3-, 4-byte, bare and
+        // inside a container
+        "λλ",
+        "ああ",
+        "𝜆𝜆",
+        "(qqλqq)",
+        "(qqあqq)",
+        "(qq𝜆qq)",
+        "#\\λ",
+        // dotted pairs (#1920): truncation after the tail datum and with
+        // the dot as the last byte are interior prefixes here
+        "(a . b)",
+        "(#t . 0)",
+        // structure, comments, labels, directives
+        "(aa bb cc)",
+        "#(1 2 3)",
+        "'(a b)",
+        "; c\n(a)",
+        "#|blk|# (x)",
+        "#;(skip) (x)",
+        "#0=(a #0#)",
+        "#!fold-case ABC",
+    };
+    for (catalog) |src| {
+        try expectPrefixesIncomplete(src);
+    }
+}
+
+test "incomplete mode: bare tokens at end-of-slice do not finalize" {
+    // The full text of an extendable token is itself "a prefix of something
+    // longer" while more input may follow; only a delimiter finalizes it.
+    var gc = memory.GC.init(testing.allocator);
+    defer gc.deinit();
+    const extendable = [_][]const u8{ "zzz", "123", "#true", "#\\space", "1+2i", "+inf.0" };
+    for (extendable) |src| {
+        try testing.expectError(ReadError.UnexpectedEof, parseOne(&gc, src, true));
+    }
+}
+
+test "incomplete mode: self-delimiting closers finalize at end-of-slice" {
+    var gc = memory.GC.init(testing.allocator);
+    defer gc.deinit();
+    const closed = [_][]const u8{ "(a b)", "\"zz\"", "#u8(1)", "#(x)", "|qq|", "(a . b)", "#\"D\"r\"D\"", "#u8\"a\"" };
+    for (closed) |src| {
+        const parsed = try parseOne(&gc, src, true);
+        try testing.expect(parsed != null);
+    }
+}
+
+test "incomplete mode: truncated line comment is UnexpectedEof, complete one is clean EOF" {
+    var gc = memory.GC.init(testing.allocator);
+    defer gc.deinit();
+    // No newline yet: the comment may continue in the next chunk — resuming
+    // mid-comment turns its tail into program data (#1940's worst case).
+    try testing.expectError(ReadError.UnexpectedEof, parseOne(&gc, "; secret", true));
+    // Newline present: the comment is complete trivia.
+    try testing.expectEqual(@as(?types.Value, null), try parseOne(&gc, "; done\n", true));
+}
+
+test "whole-input mode keeps the precise final verdicts" {
+    var gc = memory.GC.init(testing.allocator);
+    defer gc.deinit();
+    // Truncations at real EOF are genuine errors again, with their kinds.
+    try testing.expectError(ReadError.UnterminatedString, parseOne(&gc, "\"abc", false));
+    try testing.expectError(ReadError.UnterminatedString, parseOne(&gc, "#\"Q\"abc", false));
+    try testing.expectError(ReadError.DotNotInList, parseOne(&gc, "(a .", false));
+    // #1920: input exhausted where `)` belongs is UnexpectedEof in every
+    // mode — the incomplete-datum case, not a wrong character.
+    try testing.expectError(ReadError.UnexpectedEof, parseOne(&gc, "(a . b", false));
+    try testing.expectError(ReadError.UnexpectedEof, parseOne(&gc, "(a b", false));
+    // Bare tokens genuinely end at EOF.
+    const sym = (try parseOne(&gc, "zzz", false)).?;
+    const sym_str = try printer.valueToString(testing.allocator, sym, .write);
+    defer testing.allocator.free(sym_str);
+    try testing.expectEqualStrings("zzz", sym_str);
+}
+
+test "readDatumOrEof: trailing trivia is clean EOF, not a read error" {
+    var gc = memory.GC.init(testing.allocator);
+    defer gc.deinit();
+    // hasMore()+readDatum reported UnexpectedEof for a trailing #! directive
+    // (hasMore cannot see directives), which `read` turned into a spurious
+    // read error instead of the EOF object.
+    try testing.expectEqual(@as(?types.Value, null), try parseOne(&gc, "#!fold-case", false));
+    try testing.expectEqual(@as(?types.Value, null), try parseOne(&gc, "; only a comment", false));
+    try testing.expectEqual(@as(?types.Value, null), try parseOne(&gc, "#|block|#", false));
+    try testing.expectEqual(@as(?types.Value, null), try parseOne(&gc, "   ", false));
+    try testing.expectEqual(@as(?types.Value, null), try parseOne(&gc, "", false));
+}
+
+test "read procedure: trailing directive yields the EOF object" {
+    try th.expectEvalTrue("(eof-object? (read (open-input-string \"#!fold-case\")))");
+    // A directive before a datum still applies to it.
+    try th.expectEvalTrue("(eq? 'abc (read (open-input-string \"#!fold-case ABC\")))");
+}
+
+test "read procedure: error message names what failed (#1920)" {
+    try th.expectEvalTrue(
+        \\(equal? "read error: unterminated string literal"
+        \\        (guard (e (#t (error-object-message e)))
+        \\          (read (open-input-string "\"abc"))))
+    );
+    try th.expectEvalTrue(
+        \\(equal? "read error: unexpected end of input"
+        \\        (guard (e (#t (error-object-message e)))
+        \\          (read (open-input-string "(a . b"))))
+    );
+}

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -12,6 +12,7 @@ test {
     _ = @import("tests_exceptions.zig");
     _ = @import("tests_records.zig");
     _ = @import("tests_io.zig");
+    _ = @import("tests_reader_incremental.zig");
     _ = @import("tests_continuations.zig");
     _ = @import("tests_advanced.zig");
     _ = @import("tests_filesystem.zig");

--- a/tests/scheme/compliance/reader-port-refill-gaps.scm
+++ b/tests/scheme/compliance/reader-port-refill-gaps.scm
@@ -1,18 +1,20 @@
-;; Reader / port read-buffer refill boundary — audit v2 Phase 1C.
+;; Reader / port read-buffer refill boundary — audit v2 Phase 1C, fixed by
+;; the incomplete-input reader mode (#1893/#1920/#1940/#1945).
 ;;
 ;; `(read port)` on an fd-backed port reads the fd in 4096-byte chunks
 ;; (`read_chunk_size`, src/primitives_io.zig) and re-parses the accumulated
 ;; buffer after each chunk.  It treats `ReadError.UnexpectedEof` as
 ;; "incomplete datum, read more" and every other outcome as final.  A token
 ;; whose bytes straddle a chunk boundary therefore only survives if its
-;; scanner reports truncation as exactly `UnexpectedEof`.
+;; scanner reports truncation as exactly `UnexpectedEof` — which is what
+;; `Reader.incomplete_input` (src/reader.zig) now guarantees.
 ;;
-;; Two failure modes exist:
-;;   (a) the scanner reports truncation as some other error
+;; Two failure modes existed:
+;;   (a) the scanner reported truncation as some other error
 ;;       (UnterminatedString / InvalidEscape / UnexpectedChar) — the read
-;;       raises instead of refilling;
-;;   (b) the scanner treats end-of-buffer as a legitimate token terminator —
-;;       the read silently returns a *truncated* datum and resumes in the
+;;       raised instead of refilling;
+;;   (b) the scanner treated end-of-buffer as a legitimate token terminator —
+;;       the read silently returned a *truncated* datum and resumed in the
 ;;       middle of the token, with no error at all.
 ;;
 ;; The invariant every case below asserts is the same: the identical bytes
@@ -155,6 +157,9 @@
 (define p-qsymbol-hex "|aaaaaaaaaaaaaaa\\x41;bbbbbbbbbbbbbbbbb|")
 (define p-number      "12345678901234567890123456789012345678")
 (define p-number-hex  "#x1234567890abcdef1234567890abcdef")
+(define p-complex     "12.5+3.25i")
+(define p-complex-pfx "#d12.5+3.25i")
+(define p-exact-inf   "#e+inf.0")
 (define p-char-space  "#\\space")
 (define p-char-hex    "#\\x41")
 (define p-true        "#true")
@@ -226,84 +231,126 @@
   (and (refill-ok-at? 8192 p-string 0)
        (refill-ok-at? 8192 p-string (utf8-length p-string))))
 
-;; --- failure mode (a): truncation reported as a non-refillable error ------
+;; --- failure mode (a): truncation once reported as a non-refillable error -
 
-;; FAIL: #1893 (string literal straddling the boundary raises KP3000 read error)
-;; (test-equal "string literal, every split" #t (all-splits-ok? p-string))
-;; FAIL: #1893 (a \n escape does not change it — readString's UnterminatedString)
-;; (test-equal "string with \\n escape, every split" #t (all-splits-ok? p-string-esc))
-;; FAIL: #1893 (\x41; escape truncated mid-escape reports InvalidEscape)
-;; (test-equal "string with \\x escape, every split" #t (all-splits-ok? p-string-hex))
-;; FAIL: #1893 (multi-byte string content is the same scanner)
-;; (test-equal "string with UTF-8 content, every split" #t (all-splits-ok? p-string-utf8))
-;; FAIL: #1893 (a string longer than the whole buffer can never be read)
-;; (test-assert "string longer than the buffer" (refill-ok-from? 2000 p-long-string))
+;; #1893: string literal straddling the boundary raised KP3000 read error
+(test-equal "string literal, every split" #t (all-splits-ok? p-string))
+;; #1893: a \n escape did not change it — readString's UnterminatedString
+(test-equal "string with \\n escape, every split" #t (all-splits-ok? p-string-esc))
+;; #1893: \x41; escape truncated mid-escape reported InvalidEscape
+(test-equal "string with \\x escape, every split" #t (all-splits-ok? p-string-hex))
+;; #1893: multi-byte string content is the same scanner
+(test-equal "string with UTF-8 content, every split" #t (all-splits-ok? p-string-utf8))
+;; #1893: a string longer than the whole buffer could never be read
+(test-assert "string longer than the buffer" (refill-ok-from? 2000 p-long-string))
 
-;; FAIL: #1940 (SRFI 267 raw string: readRawString returns UnterminatedString)
-;; (test-equal "raw string, every split" #t (all-splits-ok? p-rawstring))
-;; FAIL: #1940 (SRFI 207 #u8"...": readByteStringLiteral returns UnterminatedString)
-;; (test-equal "byte string, every split" #t (all-splits-ok? p-bytestring))
-;; FAIL: #1940 (|sym\x41;| truncated mid-escape reports InvalidEscape, splits 18-20)
-;; (test-equal "|quoted symbol| with \\x escape, every split" #t (all-splits-ok? p-qsymbol-hex))
-;; FAIL: #1940 (#u8( prefix truncated after #u or #u8 reports UnexpectedChar)
-;; (test-equal "bytevector, every split" #t (all-splits-ok? p-bytevector))
-;; FAIL: #1920 (dotted pair truncated after the . reports UnexpectedChar/DotNotInList)
-;; (test-equal "dotted pair, every split" #t (all-splits-ok? p-dotted))
+;; #1940: SRFI 267 raw string — readRawString returned UnterminatedString
+(test-equal "raw string, every split" #t (all-splits-ok? p-rawstring))
+;; #1940: SRFI 207 #u8"..." — readByteStringLiteral returned UnterminatedString
+(test-equal "byte string, every split" #t (all-splits-ok? p-bytestring))
+;; #1940: |sym\x41;| truncated mid-escape reported InvalidEscape
+(test-equal "|quoted symbol| with \\x escape, every split" #t (all-splits-ok? p-qsymbol-hex))
+;; #1940: #u8( prefix truncated after #u or #u8 reported UnexpectedChar
+(test-equal "bytevector, every split" #t (all-splits-ok? p-bytevector))
+;; #1920: dotted pair truncated after the . reported UnexpectedChar/DotNotInList
+(test-equal "dotted pair, every split" #t (all-splits-ok? p-dotted))
 
 ;; A multi-byte codepoint whose own bytes straddle the boundary — distinct
-;; from a token straddling it.  nextToken (src/reader.zig) reports a
+;; from a token straddling it.  nextToken (src/reader.zig) reported a
 ;; truncated UTF-8 sequence as UnexpectedChar, so even a list, which refills
-;; correctly for every ASCII payload, fails.
-;; FAIL: #1945 (multi-byte UTF-8 codepoint split across the boundary)
-;; (test-assert "UTF-8 codepoint split inside a list"
-;;   (and (refill-ok? p-utf8-list 4) (refill-ok? p-utf8-list 5)))
+;; correctly for every ASCII payload, failed.
+;; #1945: multi-byte UTF-8 codepoint split across the boundary
+(test-assert "UTF-8 codepoint split inside a list"
+  (and (refill-ok? p-utf8-list 4) (refill-ok? p-utf8-list 5)))
 
 ;; --- failure mode (b): silent truncation, no error at all -----------------
-;; These are strictly worse: `read` returns a datum that is a prefix of the
-;; real one and then resumes mid-token, so the caller sees extra datums it
-;; never wrote.  #1893's own stated discriminating control — "the same file
-;; with a bare symbol payload reads all 1024 datums" — is compromised by the
-;; first case here: the symbol only survived because #1893 wrapped it in a
-;; list (which does refill) and counted datums rather than comparing them.
+;; These were strictly worse: `read` returned a datum that is a prefix of the
+;; real one and then resumed mid-token, so the caller saw extra datums it
+;; never wrote.
 
-;; FAIL: #1940 (bare symbol split at the boundary reads as TWO symbols, silently)
-;; (test-equal "symbol, every split" #t (all-splits-ok? p-symbol))
-;; FAIL: #1945 (UTF-8 symbol: splits between codepoints truncate, splits inside raise)
-;; (test-equal "UTF-8 symbol, every split" #t (all-splits-ok? p-symbol-utf8))
-;; FAIL: #1940 (number split at the boundary reads as TWO numbers, silently)
-;; (test-equal "number, every split" #t (all-splits-ok? p-number))
-;; FAIL: #1940 (#x number: silent split plus InvalidNumber on a truncated prefix)
-;; (test-equal "hex number, every split" #t (all-splits-ok? p-number-hex))
-;; FAIL: #1940 (#\space truncated to #\s plus the symbol `pace')
-;; (test-equal "#\\space, every split" #t (all-splits-ok? p-char-space))
-;; FAIL: #1940 (#\x41 truncated to #\x plus the number 41)
-;; (test-equal "#\\x41, every split" #t (all-splits-ok? p-char-hex))
-;; FAIL: #1940 (#true truncated to #t plus the symbol `rue')
-;; (test-equal "#true, every split" #t (all-splits-ok? p-true))
-;; FAIL: #1940 (line comment truncated at the boundary: the REST OF THE COMMENT
-;;            is read as program data, because a buffer holding only a comment
-;;            is discarded and reading resumes inside it)
-;; (test-equal "line comment, every split" #t (all-splits-ok? p-linecmt))
-;; FAIL: #1940 (symbol longer than the whole buffer splits into two symbols)
-;; (test-assert "symbol longer than the buffer" (refill-ok-from? 2000 p-long-symbol))
-;; FAIL: #1940 (line comment longer than the whole buffer leaks its body as data)
-;; (test-assert "line comment longer than the buffer" (refill-ok-from? 2000 p-long-linecmt))
+;; #1940: bare symbol split at the boundary read as TWO symbols, silently
+(test-equal "symbol, every split" #t (all-splits-ok? p-symbol))
+;; #1945: UTF-8 symbol — splits between codepoints truncated, splits inside raised
+(test-equal "UTF-8 symbol, every split" #t (all-splits-ok? p-symbol-utf8))
+;; #1940: number split at the boundary read as TWO numbers, silently
+(test-equal "number, every split" #t (all-splits-ok? p-number))
+;; #1940: #x number — silent split plus InvalidNumber on a truncated prefix
+(test-equal "hex number, every split" #t (all-splits-ok? p-number-hex))
+;; #1940: #\space truncated to #\s plus the symbol `pace'
+(test-equal "#\\space, every split" #t (all-splits-ok? p-char-space))
+;; #1940: #\x41 truncated to #\x plus the number 41
+(test-equal "#\\x41, every split" #t (all-splits-ok? p-char-hex))
+;; #1940: #true truncated to #t plus the symbol `rue'
+(test-equal "#true, every split" #t (all-splits-ok? p-true))
+;; #1940: line comment truncated at the boundary — the rest of the comment
+;; was read as program data, because a buffer holding only a comment was
+;; discarded and reading resumed inside it
+(test-equal "line comment, every split" #t (all-splits-ok? p-linecmt))
+;; A complex literal exercises the backtracking scan: a straddled "1+2" is a
+;; committed fixnum 1 unless the delimiter-free tail defers the verdict.
+(test-equal "complex number, every split" #t (all-splits-ok? p-complex))
+(test-equal "#d-prefixed complex, every split" #t (all-splits-ok? p-complex-pfx))
+;; An exactness-prefixed inf: "#e+in" is InvalidNumber only once the whole
+;; token is known.
+(test-equal "#e+inf.0, every split" #t (all-splits-ok? p-exact-inf))
+;; #1940: symbol longer than the whole buffer split into two symbols
+(test-assert "symbol longer than the buffer" (refill-ok-from? 2000 p-long-symbol))
+;; #1940: line comment longer than the whole buffer leaked its body as data
+(test-assert "line comment longer than the buffer" (refill-ok-from? 2000 p-long-linecmt))
 
-;; --- the same failures repeat at every later boundary ---------------------
-;; FAIL: #1893 (nothing about the boundary is specific to the first chunk)
-;; (test-equal "string literal at the 8192 boundary, every split" #t
-;;   (let ((n (utf8-length p-string)))
-;;     (let loop ((i 1))
-;;       (cond ((>= i n) #t)
-;;             ((refill-ok-at? 8192 p-string i) (loop (+ i 1)))
-;;             (else i)))))
-;; FAIL: #1940 (symbol splits identically at 8192)
-;; (test-equal "symbol at the 8192 boundary, every split" #t
-;;   (let ((n (utf8-length p-symbol)))
-;;     (let loop ((i 1))
-;;       (cond ((>= i n) #t)
-;;             ((refill-ok-at? 8192 p-symbol i) (loop (+ i 1)))
-;;             (else i)))))
+;; --- the same failures repeated at every later boundary --------------------
+;; #1893: nothing about the boundary is specific to the first chunk
+(test-equal "string literal at the 8192 boundary, every split" #t
+  (let ((n (utf8-length p-string)))
+    (let loop ((i 1))
+      (cond ((>= i n) #t)
+            ((refill-ok-at? 8192 p-string i) (loop (+ i 1)))
+            (else i)))))
+;; #1940: symbol split identically at 8192
+(test-equal "symbol at the 8192 boundary, every split" #t
+  (let ((n (utf8-length p-symbol)))
+    (let loop ((i 1))
+      (cond ((>= i n) #t)
+            ((refill-ok-at? 8192 p-symbol i) (loop (+ i 1)))
+            (else i)))))
+
+;; --- read-loop state the fix must preserve --------------------------------
+
+;; A #! directive whose buffer holds nothing else is NOT discarded the way
+;; pure whitespace/comments are: fold-case state must survive into the next
+;; chunk, where each refill's fresh Reader recovers it by re-parsing the
+;; buffer from its start.
+(test-equal "fold-case directive separated from its datum by the boundary"
+  '((foo))
+  (let ()
+    (write-fixture (string-append "#!fold-case"
+                                  (make-string (- 4096 11) #\space)
+                                  "(FOO)\n"))
+    (let ((r (drain-file)))
+      (delete-file fixture-file)
+      r)))
+
+;; A trailing #! directive is trivia, so read must answer with the EOF
+;; object — not a read error (hasMore()+readDatum used to conflate this
+;; with a truncated datum).
+(test-assert "trailing directive on a file port yields eof"
+  (let ()
+    (write-fixture "42 #!fold-case")
+    (let* ((p (open-input-file fixture-file))
+           (d1 (read p))
+           (d2 (guard (e (#t 'read-error)) (read p))))
+      (close-port p)
+      (delete-file fixture-file)
+      (and (equal? d1 42) (eof-object? d2)))))
+(test-assert "trailing directive on a string port yields eof"
+  (eof-object? (read (open-input-string "#!fold-case"))))
+
+;; #1920's diagnostic half: the raised error names what failed instead of a
+;; bare "read error".
+(test-equal "read error message names the failure"
+  "read error: unterminated string literal"
+  (guard (e (#t (error-object-message e)))
+    (read (open-input-string "\"abc"))))
 
 (if (file-exists? fixture-file) (delete-file fixture-file))
 

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -371,6 +371,13 @@ assert_output_contains "uncaught raise of non-error object shows the value" \
 assert_output_contains "uncaught exception inside procedure shows message" \
     '(define (f) (error "boom" 1)) (f)' 'error[KP3000]: boom 1'
 
+# The `read` procedure's error object names what failed instead of a bare
+# "read error" (#1920): the reader's KP1xxx registry template (or its richer
+# detail string, when one was recorded) rides along in the message.
+assert_output_contains "read procedure error names the failure" \
+    '(import (scheme read)) (read (open-input-string "\"abc"))' \
+    'error[KP3000]: read error: unterminated string literal'
+
 cat > "$TMPDIR/uncaught.scm" << 'SCHEME'
 (error "script boom" 7)
 SCHEME


### PR DESCRIPTION
`(read port)` on an fd-backed port reads 4096-byte chunks and re-parses the accumulated buffer, treating `UnexpectedEof` as "incomplete — read more" and **every other outcome as final**. Tokens straddling a chunk boundary broke that contract in two directions:

- **Spurious errors on valid files** — a scanner reported truncation as something other than `UnexpectedEof`, so the loop gave up: string literals (#1893, `UnterminatedString`), dotted pairs (#1920, `UnexpectedChar`/`DotNotInList`), mid-codepoint UTF-8 splits (#1945, `UnexpectedChar`), raw strings, `#u8"…"`, `|sym\x41;|` escapes, and `#u8`/`#tru`/`#fals` prefixes (#1940).
- **Silent splits** — a scanner treated end-of-buffer as a legitimate token terminator, so `read` returned a *prefix* of the datum and resumed mid-token: bare symbols, numbers, `#\space` → `#\s` + `pace`, `#true` → `#t` + `rue`, and — worst — a line comment's tail re-entering the stream as program data (#1940).

## The fix: an incomplete-input reader mode

Rather than patching each scanner ad hoc, `Reader` gains one mode, `incomplete_input`, set **only** by `readDatumFn`'s incremental loop: the source is a possibly-truncated prefix of a longer input, so any scan that stops at end-of-slice — rather than at a delimiter or a closing character — reports exactly `UnexpectedEof`. Never finalize a token more bytes could extend; never reject one more bytes could complete. Deferral loses nothing: the whole-input parse at fd EOF (flag off, like every other Reader user — file loading, string ports, `check`, the LSP) still delivers today's precise verdicts.

Guarded scan-stop points: line comments, symbols (including the peculiar-identifier and Unicode paths, and mid-codepoint truncation), all numeric paths (including backtracked complex-literal tails like a straddled `1+2i`, via a delimiter-free-tail check), strings and both `\x…;` escape scanners, raw strings, `#u8"…"`, `#t`/`#f` word scans, `#u8(` prefixes, `#\` character names and hex, `#!` directives, datum labels, `.`-as-last-byte, and truncated UTF-8 lead sequences.

Two `readList` fixes are unconditional per #1920's analysis: input exhausted where `)` belongs is the *incomplete-datum* case in every mode (`UnexpectedEof`), not a wrong character.

## Loop-level fixes

- The "buffer was only whitespace/comments — discard" optimization no longer fires when the buffer held a `#!` directive: fold-case state must survive into the next chunk (each refill re-parses from the buffer's start with a fresh Reader). The comment-tail case is handled upstream — a comment with no newline yet is `UnexpectedEof`, so the buffer is kept.
- New `Reader.readDatumOrEof` distinguishes "clean end of input" from "truncated datum" — fixing an adjacent bug where a trailing `#!fold-case` made `read` raise instead of returning the EOF object (`hasMore()` can't see directives; they're consumed inside `nextToken`).
- `raiseReadError` now names what failed (#1920's diagnostic half): the error object's message is e.g. `read error: unterminated string literal` — the reader's KP1xxx registry template, or its richer detail string when one was recorded (kaappi#1723 channel). `read-error?` classification unchanged.

## One deliberate semantic change

A bare atom sent down a still-open pipe **without its delimiter** now waits for the delimiter (or EOF) instead of returning immediately — that early return *was* the silent-split bug: `read` cannot know `foo` isn't the prefix of `foobar`. Newline-terminated interactive input is unaffected (#847's return-per-line behavior preserved; regression-tested with a timed two-datum pipe).

## Tests

- `src/tests_reader_incremental.zig` — a prefix-sweep property test: for ~40 sources covering every token class, **every proper byte-prefix** parsed in incomplete mode must yield `UnexpectedEof` or null (complete trivia) — never a committed datum, never a fatal error; plus flag-off regressions pinning the precise whole-input verdicts, and the message/EOF-object fixes.
- `tests/scheme/compliance/reader-port-refill-gaps.scm` — all 18 previously-failing audit cases enabled (every-interior-split sweeps against the string-port oracle, longer-than-buffer payloads, the 8192 boundary, byte-identical controls), plus new complex-number/`#e+inf.0` sweeps and the directive-state tests. 53 checks, 0 failures.
- `tests/scheme/errors/error-format.sh` — pins the new `read error: …` message.

Verified: full `zig build test`, the new file under `-Dgc-stress=true`, `bash tests/scheme/run-all.sh`, and all four issues' original reproductions.

Closes #1893. Closes #1920. Closes #1940. Closes #1945.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
