### PR TITLE
Complete SRFI 42: generic ':' dispatch, :real-range, :char-range, :dispatched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,9 +83,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   rejected loudly in `:range` (matching the reference implementation) and
   in `:real-range` (going beyond it: the reference loops forever on an
   inexact zero step) — before, `(:range i 5 3 0)` spun forever yielding 5.
-  The `(index i)` variable form remains unsupported, and `:parallel`
-  accepts only single-variable sub-generator forms — both documented in
-  the library header.
+  `(:while (gen ...) test)` and `(:until (gen ...) test)` now stop only
+  the generator they wrap, as the spec scopes them, instead of ending the
+  whole comprehension — the bare `(:while test)`/`(:until test)` forms
+  (this port's extension, absent from the spec's grammar) keep their
+  stop-everything meaning, now documented. The spec's `(nested ...)`
+  grouping and `(begin ...)` command qualifiers are implemented too. The
+  `(index i)` variable form remains unsupported, and `:parallel` accepts
+  only single-variable sub-generator forms — both documented in the
+  library header.
 
 - **`eqv?` now distinguishes an exact complex from an inexact one** (#2167).
   R7RS 6.1 requires `(eqv? a b)` to be `#f` whenever one number is exact and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **SRFI 42's generic `:` qualifier works, along with `:real-range`,
+  `:char-range`, `:dispatched`, and the full dispatch machinery** (#2177).
+  `(list-ec (: i 5) i)` — the first form in every SRFI 42 tutorial — was
+  `invalid syntax`, because the port defined only the typed qualifiers. The
+  same fix revealed that three qualifiers the library already *exported* —
+  `:port`, `:do`, and `:parallel` — had no expansion rules either and failed
+  identically inside a comprehension; all three now work. `:` dispatches at
+  run time on the argument types (lists, strings, vectors, exact-integer
+  ranges, real ranges, char ranges, ports) through the SRFI's generator-
+  procedure protocol, and the extension surface is complete:
+  `:-dispatch-ref`, `:-dispatch-set!`, `make-initial-:-dispatch`,
+  `dispatch-union`, and `:generator-proc` are exported, so user dispatchers
+  compose per the spec. Typed generators also accept multiple arguments now
+  (`(:list x '(1 2) '(3))` concatenates, per the spec). The `(index i)`
+  variable form remains unsupported, and `:parallel` accepts only
+  single-variable sub-generator forms — both documented in the library
+  header.
+
 - **`eqv?` now distinguishes an exact complex from an inexact one** (#2167).
   R7RS 6.1 requires `(eqv? a b)` to be `#f` whenever one number is exact and
   the other inexact, but every eqv?-semantics comparator — `eqv?`, `equal?`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,10 +79,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `:-dispatch-ref`, `:-dispatch-set!`, `make-initial-:-dispatch`,
   `dispatch-union`, and `:generator-proc` are exported, so user dispatchers
   compose per the spec. Typed generators also accept multiple arguments now
-  (`(:list x '(1 2) '(3))` concatenates, per the spec). The `(index i)`
-  variable form remains unsupported, and `:parallel` accepts only
-  single-variable sub-generator forms — both documented in the library
-  header.
+  (`(:list x '(1 2) '(3))` concatenates, per the spec). A zero step is
+  rejected loudly in `:range` (matching the reference implementation) and
+  in `:real-range` (going beyond it: the reference loops forever on an
+  inexact zero step) — before, `(:range i 5 3 0)` spun forever yielding 5.
+  The `(index i)` variable form remains unsupported, and `:parallel`
+  accepts only single-variable sub-generator forms — both documented in
+  the library header.
 
 - **`eqv?` now distinguishes an exact complex from an inexact one** (#2167).
   R7RS 6.1 requires `(eqv? a b)` to be `#f` whenever one number is exact and

--- a/lib/srfi/42.sld
+++ b/lib/srfi/42.sld
@@ -1,17 +1,57 @@
 ;;; SRFI 42 — Eager Comprehensions
+;;;
+;;; Direct-style port: each qualifier expands to a loop nested around the
+;;; rest of the comprehension, with a mutable stop flag (s) threaded
+;;; through for :while/:until early exit.  This differs from the
+;;; reference implementation's CPS design (everything reduced to a :do
+;;; form), so the generic dispatching layer (: / :dispatched /
+;;; :generator-proc) uses the SRFI's *runtime* generator-procedure
+;;; protocol instead of :do fusion: a generator procedure g is called as
+;;; (g empty) and returns the next value of its sequence, or the
+;;; eq?-unique sentinel `empty' once exhausted — exactly the protocol
+;;; the :dispatched spec text defines.  :generator-proc compiles the
+;;; standard typed generators straight to closure constructors (%gen-*);
+;;; any other generator form falls back to a call/cc coroutine over
+;;; do-ec, which therefore shares the engine's general continuation
+;;; limits (stepping a coroutine-backed generator after the native frame
+;;; it was created under has returned is unsupported; the standard types
+;;; never touch call/cc).
+;;;
+;;; Deliberate deviations from the reference implementation:
+;;;   - The (index i) variable form is not supported (in any generator —
+;;;     as before this port never had it).
+;;;   - :parallel sub-generators must be plain single-variable generator
+;;;     forms (typed generators, :, :dispatched, :let, ...); raw :do
+;;;     forms and :while/:until-wrapped generators are rejected at
+;;;     expansion time rather than merged.
+;;;   - The reference's make-initial-:-dispatch tests (string? a1) twice
+;;;     in its 2- and 3-argument string cases where a2/a3 were meant —
+;;;     corrected here.
+;;;   - :parallel steps every sub-generator once per iteration and stops
+;;;     at the first exhausted one, so longer generators are advanced one
+;;;     step past the shortest — the same one-step-ahead the reference's
+;;;     fused loops perform.
 (define-library (srfi 42)
-  (import (scheme base))
+  (import (scheme base)
+          (scheme cxr)
+          (scheme read))
   (export list-ec string-ec vector-ec
           append-ec sum-ec product-ec
           min-ec max-ec
           first-ec last-ec any?-ec every?-ec
           do-ec fold-ec fold3-ec
-          :list :string :vector :range :integers
-          :port :do :let :parallel :while :until)
+          : :list :string :vector :range :real-range :char-range
+          :integers :port :do :let :parallel :while :until
+          :dispatched :generator-proc
+          :-dispatch-ref :-dispatch-set!
+          make-initial-:-dispatch dispatch-union)
   (begin
 
     ;; Generator keywords — error when used outside a comprehension.
     ;; Defined first so %do-ec can resolve them as syntax-rules literals.
+    (define-syntax :
+      (syntax-rules ()
+        ((_ rest ...) (error ": used outside a comprehension"))))
     (define-syntax :list
       (syntax-rules ()
         ((_ rest ...) (error ":list used outside a comprehension"))))
@@ -24,6 +64,12 @@
     (define-syntax :range
       (syntax-rules ()
         ((_ rest ...) (error ":range used outside a comprehension"))))
+    (define-syntax :real-range
+      (syntax-rules ()
+        ((_ rest ...) (error ":real-range used outside a comprehension"))))
+    (define-syntax :char-range
+      (syntax-rules ()
+        ((_ rest ...) (error ":char-range used outside a comprehension"))))
     (define-syntax :integers
       (syntax-rules ()
         ((_ rest ...) (error ":integers used outside a comprehension"))))
@@ -45,13 +91,215 @@
     (define-syntax :until
       (syntax-rules ()
         ((_ rest ...) (error ":until used outside a comprehension"))))
+    (define-syntax :dispatched
+      (syntax-rules ()
+        ((_ rest ...) (error ":dispatched used outside a comprehension"))))
+
+    ;; --- Runtime generator procedures (the :dispatched protocol) ---
+    ;; A generator procedure g is called as (g empty) and returns the
+    ;; next value of its sequence, or `empty' itself once exhausted.
+    ;; Each %gen-* must produce the same sequence as its macro
+    ;; counterpart in %do-ec.
+
+    (define (%gen-list lsts)
+      (let ((cur '()) (rest lsts))
+        (lambda (empty)
+          (let loop ()
+            (cond
+              ((pair? cur)
+               (let ((x (car cur))) (set! cur (cdr cur)) x))
+              ((pair? rest)
+               (set! cur (car rest)) (set! rest (cdr rest)) (loop))
+              (else empty))))))
+
+    (define (%gen-string strs)
+      (let ((cur "") (n 0) (k 0) (rest strs))
+        (lambda (empty)
+          (let loop ()
+            (cond
+              ((< k n)
+               (let ((c (string-ref cur k))) (set! k (+ k 1)) c))
+              ((pair? rest)
+               (set! cur (car rest))
+               (set! n (string-length cur))
+               (set! k 0)
+               (set! rest (cdr rest))
+               (loop))
+              (else empty))))))
+
+    (define (%gen-vector vecs)
+      (let ((cur #()) (n 0) (k 0) (rest vecs))
+        (lambda (empty)
+          (let loop ()
+            (cond
+              ((< k n)
+               (let ((x (vector-ref cur k))) (set! k (+ k 1)) x))
+              ((pair? rest)
+               (set! cur (car rest))
+               (set! n (vector-length cur))
+               (set! k 0)
+               (set! rest (cdr rest))
+               (loop))
+              (else empty))))))
+
+    (define (%gen-range from to step)
+      (let ((x from))
+        (lambda (empty)
+          (if (if (positive? step) (< x to) (> x to))
+              (let ((v x)) (set! x (+ x step)) v)
+              empty))))
+
+    (define (%gen-real-range from to step)
+      (if (not (and (real? from) (real? to) (real? step)))
+          (error "arguments of :real-range are not real" from to step))
+      (let* ((a (if (and (exact? from)
+                         (not (and (exact? to) (exact? step))))
+                    (inexact from)
+                    from))
+             (istop (/ (- to a) step))
+             (i 0))
+        (lambda (empty)
+          (if (< i istop)
+              (let ((v (+ a (* step i)))) (set! i (+ i 1)) v)
+              empty))))
+
+    (define (%gen-char-range from to)
+      (let ((i (char->integer from)) (imax (char->integer to)))
+        (lambda (empty)
+          (if (<= i imax)
+              (let ((c (integer->char i))) (set! i (+ i 1)) c)
+              empty))))
+
+    (define (%gen-port port read-proc)
+      (lambda (empty)
+        (let ((x (read-proc port)))
+          (if (eof-object? x) empty x))))
+
+    (define (%gen-integers)
+      (let ((i 0))
+        (lambda (empty)
+          (let ((v i)) (set! i (+ i 1)) v))))
+
+    ;; Look up a generator procedure via a dispatcher, per :dispatched.
+    (define (%dispatch-gproc d args)
+      (let ((g (d args)))
+        (if (procedure? g)
+            g
+            (error "unrecognized arguments in dispatching" args (d '())))))
+
+    ;; Turn a producer — a procedure calling its argument once per
+    ;; value — into a generator procedure, suspending the producer
+    ;; between values with call/cc.  Fallback for generator forms that
+    ;; have no %gen-* constructor.
+    (define (%make-coroutine-gproc producer)
+      (let ((return #f) (resume #f) (done #f))
+        (define (yield v)
+          (call-with-current-continuation
+            (lambda (k)
+              (set! resume k)
+              (return v))))
+        (lambda (empty)
+          (if done
+              empty
+              (call-with-current-continuation
+                (lambda (r)
+                  (set! return r)
+                  (if resume
+                      (resume #f)
+                      (begin
+                        (producer yield)
+                        (set! done #t)
+                        (return empty)))))))))
+
+    (define (%every? pred xs)
+      (or (null? xs)
+          (and (pred (car xs)) (%every? pred (cdr xs)))))
+
+    ;; --- The generic dispatcher behind (: var arg ...) ---
+    ;; Cases per the spec: all-lists, all-strings, all-vectors; 1-3
+    ;; exact integers → :range; 1-3 reals → :real-range; 2 chars →
+    ;; :char-range; port [+ reader] → :port.  On zero arguments a
+    ;; dispatcher returns an identification instead of a generator
+    ;; (dispatch-union's conflict reporting relies on this).
+    (define (make-initial-:-dispatch)
+      (lambda (args)
+        (case (length args)
+          ((0) 'SRFI42)
+          ((1)
+           (let ((a1 (car args)))
+             (cond
+               ((list? a1) (%gen-list args))
+               ((string? a1) (%gen-string args))
+               ((vector? a1) (%gen-vector args))
+               ((and (integer? a1) (exact? a1)) (%gen-range 0 a1 1))
+               ((real? a1) (%gen-real-range 0 a1 1))
+               ((input-port? a1) (%gen-port a1 read))
+               (else #f))))
+          ((2)
+           (let ((a1 (car args)) (a2 (cadr args)))
+             (cond
+               ((and (list? a1) (list? a2)) (%gen-list args))
+               ((and (string? a1) (string? a2)) (%gen-string args))
+               ((and (vector? a1) (vector? a2)) (%gen-vector args))
+               ((and (integer? a1) (exact? a1) (integer? a2) (exact? a2))
+                (%gen-range a1 a2 1))
+               ((and (real? a1) (real? a2)) (%gen-real-range a1 a2 1))
+               ((and (char? a1) (char? a2)) (%gen-char-range a1 a2))
+               ((and (input-port? a1) (procedure? a2)) (%gen-port a1 a2))
+               (else #f))))
+          ((3)
+           (let ((a1 (car args)) (a2 (cadr args)) (a3 (caddr args)))
+             (cond
+               ((and (list? a1) (list? a2) (list? a3)) (%gen-list args))
+               ((and (string? a1) (string? a2) (string? a3))
+                (%gen-string args))
+               ((and (vector? a1) (vector? a2) (vector? a3))
+                (%gen-vector args))
+               ((and (integer? a1) (exact? a1)
+                     (integer? a2) (exact? a2)
+                     (integer? a3) (exact? a3))
+                (%gen-range a1 a2 a3))
+               ((and (real? a1) (real? a2) (real? a3))
+                (%gen-real-range a1 a2 a3))
+               (else #f))))
+          (else
+           (cond
+             ((%every? list? args) (%gen-list args))
+             ((%every? string? args) (%gen-string args))
+             ((%every? vector? args) (%gen-vector args))
+             (else #f))))))
+
+    (define %the-dispatch (make-initial-:-dispatch))
+
+    (define (:-dispatch-ref) %the-dispatch)
+
+    (define (:-dispatch-set! d)
+      (if (not (procedure? d))
+          (error ":-dispatch-set!: not a procedure" d))
+      (set! %the-dispatch d))
+
+    ;; Combine two dispatchers; error if both claim the same argument
+    ;; list.  On '() (the identification convention) the two
+    ;; identifications are appended instead.
+    (define (dispatch-union d1 d2)
+      (lambda (args)
+        (let ((g1 (d1 args)) (g2 (d2 args)))
+          (if g1
+              (if g2
+                  (if (null? args)
+                      (append (if (list? g1) g1 (list g1))
+                              (if (list? g2) g2 (list g2)))
+                      (error "dispatching conflict" args (d1 '()) (d2 '())))
+                  g1)
+              (if g2 g2 #f)))))
 
     ;; Internal recursive qualifier processor.
     ;; s = mutable stop flag for :while/:until early exit.
     ;; Processes one qualifier per expansion, recurses on the rest.
     (define-syntax %do-ec
-      (syntax-rules (:range :list :string :vector :integers
-                     :let :while :until if not and or)
+      (syntax-rules (:range :real-range :char-range :list :string :vector
+                     :integers :port :let :while :until :do :parallel
+                     : :dispatched let if not and or)
         ;; --- generators ---
         ((_ s (:range var n) rest1 rest2 ...)
          (let ((%n n))
@@ -72,12 +320,42 @@
                         (not s))
                (%do-ec s rest1 rest2 ...)
                (%lp (+ var %c))))))
+        ;; :real-range — i counts 0, 1, ... while i < (to-from)/step and
+        ;; var = from + i*step; from turns inexact if to or step is.
+        ((_ s (:real-range var b) rest1 rest2 ...)
+         (%do-ec s (:real-range var 0 b 1) rest1 rest2 ...))
+        ((_ s (:real-range var a b) rest1 rest2 ...)
+         (%do-ec s (:real-range var a b 1) rest1 rest2 ...))
+        ((_ s (:real-range var a b c) rest1 rest2 ...)
+         (let ((%a a) (%b b) (%c c))
+           (if (not (and (real? %a) (real? %b) (real? %c)))
+               (error "arguments of :real-range are not real" %a %b %c))
+           (let* ((%x (if (and (exact? %a)
+                               (not (and (exact? %b) (exact? %c))))
+                          (inexact %a)
+                          %a))
+                  (%lim (/ (- %b %x) %c)))
+             (let %lp ((%i 0))
+               (when (and (< %i %lim) (not s))
+                 (let ((var (+ %x (* %c %i))))
+                   (%do-ec s rest1 rest2 ...))
+                 (%lp (+ %i 1)))))))
+        ;; :char-range — both endpoints inclusive.
+        ((_ s (:char-range var a b) rest1 rest2 ...)
+         (let ((%imax (char->integer b)))
+           (let %lp ((%i (char->integer a)))
+             (when (and (<= %i %imax) (not s))
+               (let ((var (integer->char %i)))
+                 (%do-ec s rest1 rest2 ...))
+               (%lp (+ %i 1))))))
         ((_ s (:list var lst) rest1 rest2 ...)
          (let %lp ((%xs lst))
            (when (and (pair? %xs) (not s))
              (let ((var (car %xs)))
                (%do-ec s rest1 rest2 ...))
              (%lp (cdr %xs)))))
+        ((_ s (:list var lst1 lst2 lst3 ...) rest1 rest2 ...)
+         (%do-ec s (:list var (append lst1 lst2 lst3 ...)) rest1 rest2 ...))
         ((_ s (:string var str) rest1 rest2 ...)
          (let* ((%str str) (%n (string-length %str)))
            (let %lp ((%k 0))
@@ -85,6 +363,9 @@
                (let ((var (string-ref %str %k)))
                  (%do-ec s rest1 rest2 ...))
                (%lp (+ %k 1))))))
+        ((_ s (:string var str1 str2 str3 ...) rest1 rest2 ...)
+         (%do-ec s (:string var (string-append str1 str2 str3 ...))
+                 rest1 rest2 ...))
         ((_ s (:vector var vec) rest1 rest2 ...)
          (let* ((%v vec) (%n (vector-length %v)))
            (let %lp ((%k 0))
@@ -92,36 +373,63 @@
                (let ((var (vector-ref %v %k)))
                  (%do-ec s rest1 rest2 ...))
                (%lp (+ %k 1))))))
+        ((_ s (:vector var vec1 vec2 vec3 ...) rest1 rest2 ...)
+         (%do-ec s (:list var (append (vector->list vec1)
+                                      (vector->list vec2)
+                                      (vector->list vec3) ...))
+                 rest1 rest2 ...))
         ((_ s (:integers var) rest1 rest2 ...)
          (let %lp ((var 0))
            (when (not s)
              (%do-ec s rest1 rest2 ...)
              (%lp (+ var 1)))))
+        ((_ s (:port var p) rest1 rest2 ...)
+         (%do-ec s (:port var p read) rest1 rest2 ...))
+        ((_ s (:port var p rd) rest1 rest2 ...)
+         (let ((%p p) (%rd rd))
+           (let %lp ((var (%rd %p)))
+             (when (and (not (eof-object? var)) (not s))
+               (%do-ec s rest1 rest2 ...)
+               (%lp (%rd %p))))))
         ((_ s (:let var expr) rest1 rest2 ...)
          (let ((var expr))
            (%do-ec s rest1 rest2 ...)))
+        ;; --- generic dispatch ---
+        ((_ s (: var arg1 arg ...) rest1 rest2 ...)
+         (%do-ec s (:dispatched var (:-dispatch-ref) arg1 arg ...)
+                 rest1 rest2 ...))
+        ((_ s (:dispatched var dispatch arg ...) rest1 rest2 ...)
+         (let ((%g (%dispatch-gproc dispatch (list arg ...)))
+               (%empty (list #f)))
+           (let %lp ((var (%g %empty)))
+             (when (and (not (eq? var %empty)) (not s))
+               (%do-ec s rest1 rest2 ...)
+               (%lp (%g %empty))))))
+        ;; --- the fundamental generator :do ---
+        ((_ s (:do (lb ...) ne1? (ls ...)) rest1 rest2 ...)
+         (%do-ec s (:do (let ()) (lb ...) ne1? (let ()) #t (ls ...))
+                 rest1 rest2 ...))
+        ((_ s (:do (let (ob ...) oc ...) (lb ...) ne1?
+                   (let (ib ...) ic ...) ne2? (ls ...))
+            rest1 rest2 ...)
+         (let (ob ...)
+           oc ...
+           (let %lp (lb ...)
+             (when (and ne1? (not s))
+               (let (ib ...)
+                 ic ...
+                 (%do-ec s rest1 rest2 ...)
+                 (when (and ne2? (not s))
+                   (%lp ls ...)))))))
+        ;; --- parallel (lockstep) iteration ---
+        ((_ s (:parallel gen1 gen2 ...) rest1 rest2 ...)
+         (%parallel s () (gen1 gen2 ...) rest1 rest2 ...))
         ;; --- control qualifiers ---
         ;; :while/:until wrapping a generator (spec form)
-        ((_ s (:while (:range rargs ...) test) rest1 rest2 ...)
-         (%do-ec s (:range rargs ...) (:while test) rest1 rest2 ...))
-        ((_ s (:while (:list largs ...) test) rest1 rest2 ...)
-         (%do-ec s (:list largs ...) (:while test) rest1 rest2 ...))
-        ((_ s (:while (:string sargs ...) test) rest1 rest2 ...)
-         (%do-ec s (:string sargs ...) (:while test) rest1 rest2 ...))
-        ((_ s (:while (:vector vargs ...) test) rest1 rest2 ...)
-         (%do-ec s (:vector vargs ...) (:while test) rest1 rest2 ...))
-        ((_ s (:while (:integers iargs ...) test) rest1 rest2 ...)
-         (%do-ec s (:integers iargs ...) (:while test) rest1 rest2 ...))
-        ((_ s (:until (:range rargs ...) test) rest1 rest2 ...)
-         (%do-ec s (:range rargs ...) (:until test) rest1 rest2 ...))
-        ((_ s (:until (:list largs ...) test) rest1 rest2 ...)
-         (%do-ec s (:list largs ...) (:until test) rest1 rest2 ...))
-        ((_ s (:until (:string sargs ...) test) rest1 rest2 ...)
-         (%do-ec s (:string sargs ...) (:until test) rest1 rest2 ...))
-        ((_ s (:until (:vector vargs ...) test) rest1 rest2 ...)
-         (%do-ec s (:vector vargs ...) (:until test) rest1 rest2 ...))
-        ((_ s (:until (:integers iargs ...) test) rest1 rest2 ...)
-         (%do-ec s (:integers iargs ...) (:until test) rest1 rest2 ...))
+        ((_ s (:while (g garg ...) test) rest1 rest2 ...)
+         (%do-ec s (g garg ...) (:while test) rest1 rest2 ...))
+        ((_ s (:until (g garg ...) test) rest1 rest2 ...)
+         (%do-ec s (g garg ...) (:until test) rest1 rest2 ...))
         ;; :while/:until as standalone qualifiers
         ((_ s (:while test) rest1 rest2 ...)
          (if test
@@ -143,6 +451,51 @@
         ;; --- base case ---
         ((_ s body)
          body)))
+
+    ;; :parallel expansion helper: peel one (gen var arg ...) sub-form
+    ;; per recursion step, converting it to a generator procedure (one
+    ;; let per step keeps the hygienic %g names distinct), then run all
+    ;; of them in lockstep, stopping at the first exhausted generator.
+    (define-syntax %parallel
+      (syntax-rules ()
+        ((_ s (done ...) ((gen var arg ...) more ...) rest1 rest2 ...)
+         (let ((%g (:generator-proc (gen arg ...))))
+           (%parallel s (done ... (var %g)) (more ...) rest1 rest2 ...)))
+        ((_ s ((var g) ...) () rest1 rest2 ...)
+         (let ((%e (list #f)))
+           (let %lp ((var (g %e)) ...)
+             (when (and (not s) (not (eq? var %e)) ...)
+               (%do-ec s rest1 rest2 ...)
+               (%lp (g %e) ...)))))))
+
+    ;; (:generator-proc (gen arg ...)) — the generator procedure running
+    ;; through (list-ec (gen var arg ...) var), per the spec.  Standard
+    ;; typed generators compile straight to their %gen-* constructor;
+    ;; anything else runs through do-ec inside a call/cc coroutine.
+    (define-syntax :generator-proc
+      (syntax-rules (: :list :string :vector :range :real-range
+                     :char-range :integers :port :dispatched)
+        ((_ (:list arg ...)) (%gen-list (list arg ...)))
+        ((_ (:string arg ...)) (%gen-string (list arg ...)))
+        ((_ (:vector arg ...)) (%gen-vector (list arg ...)))
+        ((_ (:range b)) (%gen-range 0 b 1))
+        ((_ (:range a b)) (%gen-range a b 1))
+        ((_ (:range a b c)) (%gen-range a b c))
+        ((_ (:real-range b)) (%gen-real-range 0 b 1))
+        ((_ (:real-range a b)) (%gen-real-range a b 1))
+        ((_ (:real-range a b c)) (%gen-real-range a b c))
+        ((_ (:char-range a b)) (%gen-char-range a b))
+        ((_ (:integers)) (%gen-integers))
+        ((_ (:port p)) (%gen-port p read))
+        ((_ (:port p rd)) (%gen-port p rd))
+        ((_ (: arg1 arg ...))
+         (%dispatch-gproc (:-dispatch-ref) (list arg1 arg ...)))
+        ((_ (:dispatched d arg ...))
+         (%dispatch-gproc d (list arg ...)))
+        ((_ (g arg ...))
+         (%make-coroutine-gproc
+           (lambda (%yield)
+             (do-ec (g %x arg ...) (%yield %x)))))))
 
     (define-syntax do-ec
       (syntax-rules ()

--- a/lib/srfi/42.sld
+++ b/lib/srfi/42.sld
@@ -20,6 +20,11 @@
 ;;; Deliberate deviations from the reference implementation:
 ;;;   - The (index i) variable form is not supported (in any generator —
 ;;;     as before this port never had it).
+;;;   - A bare (:while <expr>) / (:until <expr>) qualifier — not part of
+;;;     the spec's grammar, kept from the original port — stops the
+;;;     WHOLE comprehension.  The spec's (:while <generator> <expr>)
+;;;     wrapping form scopes the test to the wrapped generator only, as
+;;;     the spec requires.
 ;;;   - :parallel sub-generators must be plain single-variable generator
 ;;;     forms (typed generators, :, :dispatched, :let, ...); raw :do
 ;;;     forms and :while/:until-wrapped generators are rejected at
@@ -305,10 +310,13 @@
     ;; Internal recursive qualifier processor.
     ;; s = mutable stop flag for :while/:until early exit.
     ;; Processes one qualifier per expansion, recurses on the rest.
+    ;; The engine caps one syntax-rules form at 32 rules, so the
+    ;; qualifier rules are split across two macros: %do-ec holds the
+    ;; generators and forwards any other qualifier to %do-ec-more, which
+    ;; holds the grouping, command, control, and guard qualifiers.
     (define-syntax %do-ec
       (syntax-rules (:range :real-range :char-range :list :string :vector
-                     :integers :port :let :while :until :do :parallel
-                     : :dispatched let if not and or)
+                     :integers :port :let :do :parallel : :dispatched let)
         ;; --- generators ---
         ((_ s (:range var n) rest1 rest2 ...)
          (let ((%n n))
@@ -437,13 +445,52 @@
         ;; --- parallel (lockstep) iteration ---
         ((_ s (:parallel gen1 gen2 ...) rest1 rest2 ...)
          (%parallel s () (gen1 gen2 ...) rest1 rest2 ...))
+        ;; --- anything else: grouping/command/control/guard qualifiers ---
+        ((_ s q rest1 rest2 ...)
+         (%do-ec-more s q rest1 rest2 ...))
+        ;; --- base case ---
+        ((_ s body)
+         body)))
+
+    ;; Second half of the qualifier processor (see the %do-ec comment):
+    ;; grouping, command, control, and guard qualifiers.  Every recursion
+    ;; goes back through %do-ec, the single entry point.
+    (define-syntax %do-ec-more
+      (syntax-rules (nested begin :while :until %while-xlate %until-xlate
+                     if not and or)
+        ;; --- qualifier grouping and command qualifiers ---
+        ((_ s (nested q ...) rest1 rest2 ...)
+         (%do-ec s q ... rest1 rest2 ...))
+        ((_ s (begin cmd ...) rest1 rest2 ...)
+         (begin cmd ... (%do-ec s rest1 rest2 ...)))
         ;; --- control qualifiers ---
-        ;; :while/:until wrapping a generator (spec form)
+        ;; :while/:until wrapping a generator (spec form): the test stops
+        ;; only the generator it wraps, so enclosing loops continue.  The
+        ;; wrapped generator runs against its own private stop flag; the
+        ;; translator qualifier re-threads the enclosing flag for the
+        ;; rest of the chain and mirrors an ambient stop into the private
+        ;; flag, so a bare :while/:until deeper in the chain still ends
+        ;; this generator's loop.
         ((_ s (:while (g garg ...) test) rest1 rest2 ...)
-         (%do-ec s (g garg ...) (:while test) rest1 rest2 ...))
+         (let ((%s2 #f))
+           (%do-ec %s2 (g garg ...) (%while-xlate s test) rest1 rest2 ...)))
         ((_ s (:until (g garg ...) test) rest1 rest2 ...)
-         (%do-ec s (g garg ...) (:until test) rest1 rest2 ...))
-        ;; :while/:until as standalone qualifiers
+         (let ((%s2 #f))
+           (%do-ec %s2 (g garg ...) (%until-xlate s test) rest1 rest2 ...)))
+        ;; Translator qualifiers, generated only by the two rules above:
+        ;; s2 is the wrapped generator's flag, outer the enclosing one.
+        ((_ s2 (%while-xlate outer test) rest1 rest2 ...)
+         (if test
+             (begin
+               (%do-ec outer rest1 rest2 ...)
+               (when outer (set! s2 #t)))
+             (set! s2 #t)))
+        ((_ s2 (%until-xlate outer test) rest1 rest2 ...)
+         (begin
+           (%do-ec outer rest1 rest2 ...)
+           (when (or test outer) (set! s2 #t))))
+        ;; :while/:until as standalone qualifiers (this port's extension:
+        ;; stops the whole comprehension — see the header)
         ((_ s (:while test) rest1 rest2 ...)
          (if test
            (%do-ec s rest1 rest2 ...)
@@ -460,10 +507,7 @@
         ((_ s (and test ...) rest1 rest2 ...)
          (when (and test ...) (%do-ec s rest1 rest2 ...)))
         ((_ s (or test ...) rest1 rest2 ...)
-         (when (or test ...) (%do-ec s rest1 rest2 ...)))
-        ;; --- base case ---
-        ((_ s body)
-         body)))
+         (when (or test ...) (%do-ec s rest1 rest2 ...)))))
 
     ;; :parallel expansion helper: peel one (gen var arg ...) sub-form
     ;; per recursion step, converting it to a generator procedure (one

--- a/lib/srfi/42.sld
+++ b/lib/srfi/42.sld
@@ -27,6 +27,11 @@
 ;;;   - The reference's make-initial-:-dispatch tests (string? a1) twice
 ;;;     in its 2- and 3-argument string cases where a2/a3 were meant —
 ;;;     corrected here.
+;;;   - A zero step is rejected loudly in :real-range too, not just in
+;;;     :range (where the reference already rejects it).  The reference's
+;;;     :real-range instead raises division-by-zero for an exact zero
+;;;     step and loops forever on an inexact one (istop = +inf.0);
+;;;     silent non-termination is the failure mode worth closing.
 ;;;   - :parallel steps every sub-generator once per iteration and stops
 ;;;     at the first exhausted one, so longer generators are advanced one
 ;;;     step past the shortest — the same one-step-ahead the reference's
@@ -143,6 +148,8 @@
               (else empty))))))
 
     (define (%gen-range from to step)
+      (if (zero? step)
+          (error "step size must not be zero in :range"))
       (let ((x from))
         (lambda (empty)
           (if (if (positive? step) (< x to) (> x to))
@@ -152,6 +159,8 @@
     (define (%gen-real-range from to step)
       (if (not (and (real? from) (real? to) (real? step)))
           (error "arguments of :real-range are not real" from to step))
+      (if (zero? step)
+          (error "step size must not be zero in :real-range"))
       (let* ((a (if (and (exact? from)
                          (not (and (exact? to) (exact? step))))
                     (inexact from)
@@ -315,6 +324,8 @@
                (%lp (+ var 1))))))
         ((_ s (:range var a b c) rest1 rest2 ...)
          (let ((%b b) (%c c))
+           (if (zero? %c)
+               (error "step size must not be zero in :range"))
            (let %lp ((var a))
              (when (and (if (positive? %c) (< var %b) (> var %b))
                         (not s))
@@ -330,6 +341,8 @@
          (let ((%a a) (%b b) (%c c))
            (if (not (and (real? %a) (real? %b) (real? %c)))
                (error "arguments of :real-range are not real" %a %b %c))
+           (if (zero? %c)
+               (error "step size must not be zero in :real-range"))
            (let* ((%x (if (and (exact? %a)
                                (not (and (exact? %b) (exact? %c))))
                           (inexact %a)

--- a/tests/scheme/srfi/srfi42.scm
+++ b/tests/scheme/srfi/srfi42.scm
@@ -221,6 +221,36 @@
 (test-equal ": still handles integers after extension" '(0 1 2)
   (list-ec (: i 3) i))
 
+;;; --- zero step is rejected loudly (PR #2180 review) ---
+;; Before the fix, (:range i 5 3 0) looped forever yielding 5 (the macro
+;; arm and the new %gen-range never advance x), and an inexact zero step
+;; in :real-range gave istop = +inf.0 — another silent infinite loop.
+;; An exact zero step in :real-range already errored (division by zero);
+;; the explicit check just names the actual mistake.
+(define (caught-message thunk)
+  (guard (e (#t (error-object-message e))) (thunk)))
+(test-equal ":range zero step raises (macro path)"
+  "step size must not be zero in :range"
+  (caught-message (lambda () (list-ec (:range i 5 3 0) i))))
+(test-equal ":range zero step raises even when from < to"
+  "step size must not be zero in :range"
+  (caught-message (lambda () (list-ec (:range i 5 7 0) i))))
+(test-equal ":range zero step raises (dispatch path)"
+  "step size must not be zero in :range"
+  (caught-message (lambda () (list-ec (: i 5 3 0) i))))
+(test-equal ":range zero step raises (:generator-proc path)"
+  "step size must not be zero in :range"
+  (caught-message (lambda () (:generator-proc (:range 5 3 0)))))
+(test-equal ":real-range exact zero step raises"
+  "step size must not be zero in :real-range"
+  (caught-message (lambda () (list-ec (:real-range x 0 1 0) x))))
+(test-equal ":real-range inexact zero step raises (was an infinite loop)"
+  "step size must not be zero in :real-range"
+  (caught-message (lambda () (list-ec (:real-range x 0.0 1.0 0.0) x))))
+(test-equal ":real-range zero step raises (dispatch path)"
+  "step size must not be zero in :real-range"
+  (caught-message (lambda () (list-ec (: x 0.0 1.0 0.0) x))))
+
 ;;; --- multi-argument typed generators (concatenation) ---
 (test-equal ":list multi-arg" '(1 2 3) (list-ec (:list x '(1 2) '(3)) x))
 (test-equal ":string multi-arg" "abcd" (string-ec (:string c "ab" "cd") c))

--- a/tests/scheme/srfi/srfi42.scm
+++ b/tests/scheme/srfi/srfi42.scm
@@ -90,6 +90,143 @@
   '((1 . 4) (2 . 3) (2 . 4))
   (list-ec (:list a '(1 2)) (:list b '(3 4)) (if (> (+ a b) 4)) (cons a b)))
 
+;;; --- generic ':' dispatch (#2177) ---
+(test-equal ": exact integer 1-arg" '(0 1 2 3 4) (list-ec (: i 5) i))
+(test-equal ": exact integers 2-arg" '(2 3 4 5 6) (list-ec (: i 2 7) i))
+(test-equal ": exact integers 3-arg" '(0 3 6 9) (list-ec (: i 0 10 3) i))
+(test-equal ": list" '(a b c) (list-ec (: x '(a b c)) x))
+(test-equal ": empty list" '() (list-ec (: x '()) x))
+(test-equal ": two lists concatenate" '(1 2 3 4)
+  (list-ec (: x '(1 2) '(3 4)) x))
+(test-equal ": four lists (n>3 dispatch)" '(1 2 3 4)
+  (list-ec (: x '(1) '(2) '(3) '(4)) x))
+(test-equal ": string" '(#\h #\i) (list-ec (: c "hi") c))
+(test-equal ": string round-trip" "hello" (string-ec (: c "hello") c))
+(test-equal ": two strings concatenate" "abcd" (string-ec (: c "ab" "cd") c))
+(test-equal ": vector" '(1 2 3) (list-ec (: x #(1 2 3)) x))
+(test-equal ": two vectors concatenate" '(1 2 3 4)
+  (list-ec (: x #(1 2) #(3 4)) x))
+(test-equal ": real 1-arg" '(0.0 1.0 2.0) (list-ec (: x 2.5) x))
+(test-equal ": rational step dispatches to :real-range" '(0 1/4 1/2 3/4)
+  (list-ec (: x 0 1 1/4) x))
+(test-equal ": char range" '(#\a #\b #\c #\d #\e) (list-ec (: c #\a #\e) c))
+(test-equal ": port default read" '(10 20 (a b))
+  (call-with-port (open-input-string "10 20 (a b)")
+    (lambda (p) (list-ec (: x p) x))))
+(test-equal ": port with reader" '(#\a #\b)
+  (call-with-port (open-input-string "ab")
+    (lambda (p) (list-ec (: c p read-char) c))))
+(test-equal ": with guard" '(0 2 4) (list-ec (: i 6) (if (even? i)) i))
+(test-equal ": wrapped by :while" '(0 1 2)
+  (list-ec (:while (: i 10) (< i 3)) i))
+(test-equal ": nested gets a fresh generator each entry"
+  '((1 0) (2 0) (2 1) (3 0) (3 1) (3 2))
+  (list-ec (:range n 1 4) (: i n) (list n i)))
+(test-equal "sum-ec with :" 10 (sum-ec (: i 5) i))
+(test-equal ": unrecognized argument raises catchably" 'caught
+  (guard (e (#t 'caught)) (list-ec (: x #t) x)))
+
+;;; --- :real-range ---
+(test-equal ":real-range 1-arg all-exact stays exact" '(0 1 2 3 4)
+  (list-ec (:real-range x 5) x))
+(test-equal ":real-range exact rationals" '(0 1/4 1/2 3/4)
+  (list-ec (:real-range x 0 1 1/4) x))
+(test-equal ":real-range inexact bound infects start" '(0.0 1.0 2.0)
+  (list-ec (:real-range x 0 3.0) x))
+(test-equal ":real-range inexact step" '(0.0 0.5 1.0 1.5)
+  (list-ec (:real-range x 0 2 0.5) x))
+(test-equal ":real-range descending" '(5 4 3 2 1)
+  (list-ec (:real-range x 5 0 -1) x))
+
+;;; --- :char-range (both endpoints inclusive) ---
+(test-equal ":char-range inclusive" "abcde"
+  (string-ec (:char-range c #\a #\e) c))
+(test-equal ":char-range single char" '(#\q)
+  (list-ec (:char-range c #\q #\q) c))
+(test-equal ":char-range empty when min above max" '()
+  (list-ec (:char-range c #\e #\a) c))
+(test-equal ":until wrapping :char-range" '(#\a #\b #\c)
+  (list-ec (:until (:char-range c #\a #\z) (char=? c #\c)) c))
+
+;;; --- :port (was exported but unusable before #2177's fix) ---
+(test-equal ":port default reader" '(1 (2) x)
+  (call-with-port (open-input-string "1 (2) x")
+    (lambda (p) (list-ec (:port v p) v))))
+(test-equal ":port custom reader" '(#\x #\y)
+  (call-with-port (open-input-string "xy")
+    (lambda (p) (list-ec (:port c p read-char) c))))
+
+;;; --- :do (was exported but unusable before #2177's fix) ---
+(test-equal ":do short form" '(0 1 2 3)
+  (list-ec (:do ((i 0)) (< i 4) ((+ i 1))) i))
+(test-equal ":do full form uses all six slots" '(0 10 20)
+  (list-ec (:do (let ((n 4)))
+                ((i 0))
+                (< i n)
+                (let ((j (* i 10))))
+                (< i 2)
+                ((+ i 1)))
+           j))
+
+;;; --- :parallel (was exported but unusable before #2177's fix) ---
+(test-equal ":parallel lockstep, shortest wins" '((1 a) (2 b) (3 c))
+  (list-ec (:parallel (:range i 1 10) (:list x '(a b c))) (list i x)))
+(test-equal ":parallel three generators incl. infinite :integers"
+  '((0 a 10) (1 b 11))
+  (list-ec (:parallel (:integers i) (:list x '(a b)) (:range j 10 20))
+           (list i x j)))
+(test-equal ":parallel with coroutine-backed :let" '((1 . z))
+  (list-ec (:parallel (:list a '(1 2 3)) (:let b 'z)) (cons a b)))
+
+;;; --- :dispatched with a hand-written dispatcher ---
+(define (upto-dispatcher args)
+  (if (and (= 1 (length args)) (exact-integer? (car args)))
+      (let ((n (car args)) (i 0))
+        (lambda (empty)
+          (if (< i n)
+              (let ((v i)) (set! i (+ i 1)) v)
+              empty)))
+      #f))
+(test-equal ":dispatched custom dispatcher" '(0 1 2)
+  (list-ec (:dispatched i upto-dispatcher 3) i))
+
+;;; --- :generator-proc protocol ---
+(define (drain-gproc g)
+  (let ((e (list #f)))
+    (let loop ((acc '()) (v (g e)))
+      (if (eq? v e) (reverse acc) (loop (cons v acc) (g e))))))
+(test-equal ":generator-proc fast path" '(0 1 2)
+  (drain-gproc (:generator-proc (:range 3))))
+(test-equal ":generator-proc coroutine fallback" '(5)
+  (drain-gproc (:generator-proc (:let 5))))
+
+;;; --- dispatcher machinery ---
+(test-equal "initial dispatcher identification" 'SRFI42
+  ((make-initial-:-dispatch) '()))
+(test-equal "dispatch-union appends identifications" '(SRFI42 symbols)
+  ((dispatch-union (make-initial-:-dispatch)
+                   (lambda (args) (if (null? args) 'symbols #f)))
+   '()))
+
+;; Extending ':' (mutates the library-global dispatcher; keep last).
+(:-dispatch-set!
+ (dispatch-union
+  (:-dispatch-ref)
+  (lambda (args)
+    (if (and (= 1 (length args)) (symbol? (car args)))
+        (:generator-proc (:string (symbol->string (car args))))
+        #f))))
+(test-equal ": extended to symbols via dispatch-union" '(#\f #\o #\o)
+  (list-ec (: c 'foo) c))
+(test-equal ": still handles integers after extension" '(0 1 2)
+  (list-ec (: i 3) i))
+
+;;; --- multi-argument typed generators (concatenation) ---
+(test-equal ":list multi-arg" '(1 2 3) (list-ec (:list x '(1 2) '(3)) x))
+(test-equal ":string multi-arg" "abcd" (string-ec (:string c "ab" "cd") c))
+(test-equal ":vector multi-arg incl. empty" '(1 2 3 4)
+  (list-ec (:vector x #(1 2) #() #(3 4)) x))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-42")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi42.scm
+++ b/tests/scheme/srfi/srfi42.scm
@@ -6,6 +6,10 @@
 
 (test-begin "srfi-42")
 
+;; Shared helper: run thunk, return the message of the error it raises.
+(define (caught-message thunk)
+  (guard (e (#t (error-object-message e))) (thunk)))
+
 ;;; --- list-ec with the core generators ---
 (test-equal "range 1-arg" '(0 1 2 3) (list-ec (:range i 4) i))
 (test-equal "range 2-arg" '(2 3 4) (list-ec (:range i 2 5) i))
@@ -77,8 +81,46 @@
 (test-equal ":while wrapping generator" '(0 1 2 3 4)
   (list-ec (:while (:range i 10) (< i 5)) i))
 
+;; The spec's wrapping form scopes the test to the wrapped generator
+;; only — enclosing generators continue (PR #2180 review).  Before the
+;; fix these stopped the whole comprehension at the first failing test.
+(test-equal ":while wrap stops only the wrapped generator"
+  '((0 . 1) (1 . 1))
+  (list-ec (:range j 2) (:while (:list x '(1 2 3)) (< x 2)) (cons j x)))
+(test-equal ":until wrap stops only the wrapped generator"
+  '((0 1) (0 2) (1 1) (1 2))
+  (list-ec (:range j 2) (:until (:list x '(1 2 3 4)) (= x 2)) (list j x)))
+;; The bare forms are this port's extension and keep their documented
+;; stop-everything meaning, even from inside a wrapped generator.
+(test-equal "bare :while still stops the whole comprehension"
+  '((0 . 1))
+  (list-ec (:range j 2) (:list x '(1 2 3))
+           (:while (and (= j 0) (< x 2))) (cons j x)))
+(test-equal "bare :until inside a wrapped generator stops everything"
+  '((0 . 1) (0 . 2))
+  (list-ec (:range j 2) (:until (:list x '(1 2 3)) (= x 99))
+           (:until (= x 2)) (cons j x)))
+
 ;;; --- :until (include the triggering element, then stop) ---
 (test-equal ":until" '(0 1 2 3) (list-ec (:range i 100) (:until (= i 3)) i))
+
+;;; --- (nested ...) grouping and (begin ...) command qualifiers ---
+(test-equal "nested qualifier groups a sequence"
+  '((0 0) (0 1) (1 0) (1 1))
+  (list-ec (nested (:range i 2) (:range j 2)) (list i j)))
+(test-equal "nested qualifier composes with a guard"
+  '(1 3)
+  (list-ec (nested (:range i 4) (if (odd? i))) i))
+(test-equal "begin qualifier runs its commands once per binding"
+  '(3 (0 1 2))
+  (let ((n 0))
+    (let ((r (list-ec (:range i 3) (begin (set! n (+ n 1))) i)))
+      (list n r))))
+(test-equal "a body that is itself a begin form stays the body"
+  '(0 1)
+  (let ((acc '()))
+    (do-ec (:range i 2) (begin (set! acc (cons i acc))))
+    (reverse acc)))
 
 ;;; --- :integers with :while (infinite generator, bounded by :while) ---
 (test-equal ":integers + :while"
@@ -106,6 +148,18 @@
 (test-equal ": vector" '(1 2 3) (list-ec (: x #(1 2 3)) x))
 (test-equal ": two vectors concatenate" '(1 2 3 4)
   (list-ec (: x #(1 2) #(3 4)) x))
+;; The reference implementation's dispatcher tests (string? a1) twice in
+;; its 2- and 3-argument string cases where a2/a3 were meant; these pin
+;; the corrected branches.  The mixed-type case is the discriminating
+;; one: under the reference's typo it would (wrongly) dispatch to
+;; :string; the corrected check falls through to "unrecognized".
+(test-equal ": three strings (3-arg dispatch)" "abcdef"
+  (string-ec (: c "ab" "cd" "ef") c))
+(test-equal ": three vectors (3-arg dispatch)" '(1 2 3)
+  (list-ec (: x #(1) #(2) #(3)) x))
+(test-equal ": mixed string/vector args are unrecognized (a2 is checked)"
+  "unrecognized arguments in dispatching"
+  (caught-message (lambda () (list-ec (: c "ab" #(1) "cd") c))))
 (test-equal ": real 1-arg" '(0.0 1.0 2.0) (list-ec (: x 2.5) x))
 (test-equal ": rational step dispatches to :real-range" '(0 1/4 1/2 3/4)
   (list-ec (: x 0 1 1/4) x))
@@ -179,16 +233,26 @@
   (list-ec (:parallel (:list a '(1 2 3)) (:let b 'z)) (cons a b)))
 
 ;;; --- :dispatched with a hand-written dispatcher ---
+;; A dispatcher answers '() with its identification, not a generator —
+;; the convention dispatch-union and the failure path rely on.
 (define (upto-dispatcher args)
-  (if (and (= 1 (length args)) (exact-integer? (car args)))
-      (let ((n (car args)) (i 0))
-        (lambda (empty)
-          (if (< i n)
-              (let ((v i)) (set! i (+ i 1)) v)
-              empty)))
-      #f))
+  (cond
+    ((null? args) 'upto)
+    ((and (= 1 (length args)) (exact-integer? (car args)))
+     (let ((n (car args)) (i 0))
+       (lambda (empty)
+         (if (< i n)
+             (let ((v i)) (set! i (+ i 1)) v)
+             empty))))
+    (else #f)))
 (test-equal ":dispatched custom dispatcher" '(0 1 2)
   (list-ec (:dispatched i upto-dispatcher 3) i))
+;; The failure path reports (d '()) as the second error irritant, so the
+;; identification is observable through the library, not just directly.
+(test-equal ":dispatched failure reports the dispatcher identification"
+  'upto
+  (guard (e (#t (cadr (error-object-irritants e))))
+    (list-ec (:dispatched i upto-dispatcher 'not-an-integer) i)))
 
 ;;; --- :generator-proc protocol ---
 (define (drain-gproc g)
@@ -207,19 +271,22 @@
   ((dispatch-union (make-initial-:-dispatch)
                    (lambda (args) (if (null? args) 'symbols #f)))
    '()))
-
-;; Extending ':' (mutates the library-global dispatcher; keep last).
-(:-dispatch-set!
- (dispatch-union
-  (:-dispatch-ref)
-  (lambda (args)
-    (if (and (= 1 (length args)) (symbol? (car args)))
-        (:generator-proc (:string (symbol->string (car args))))
-        #f))))
-(test-equal ": extended to symbols via dispatch-union" '(#\f #\o #\o)
-  (list-ec (: c 'foo) c))
-(test-equal ": still handles integers after extension" '(0 1 2)
-  (list-ec (: i 3) i))
+;; Both dispatchers claiming the same argument list is a conflict.
+(test-equal "dispatch-union conflict raises" "dispatching conflict"
+  (caught-message
+   (lambda ()
+     (let ((d (dispatch-union
+               (lambda (args)
+                 (cond ((null? args) 'first)
+                       ((and (= 1 (length args)) (symbol? (car args)))
+                        (:generator-proc (:list (list (car args)))))
+                       (else #f)))
+               (lambda (args)
+                 (cond ((null? args) 'second)
+                       ((and (= 1 (length args)) (symbol? (car args)))
+                        (:generator-proc (:list '(other))))
+                       (else #f))))))
+       (list-ec (:dispatched x d 'sym) x)))))
 
 ;;; --- zero step is rejected loudly (PR #2180 review) ---
 ;; Before the fix, (:range i 5 3 0) looped forever yielding 5 (the macro
@@ -227,8 +294,6 @@
 ;; in :real-range gave istop = +inf.0 — another silent infinite loop.
 ;; An exact zero step in :real-range already errored (division by zero);
 ;; the explicit check just names the actual mistake.
-(define (caught-message thunk)
-  (guard (e (#t (error-object-message e))) (thunk)))
 (test-equal ":range zero step raises (macro path)"
   "step size must not be zero in :range"
   (caught-message (lambda () (list-ec (:range i 5 3 0) i))))
@@ -250,12 +315,31 @@
 (test-equal ":real-range zero step raises (dispatch path)"
   "step size must not be zero in :real-range"
   (caught-message (lambda () (list-ec (: x 0.0 1.0 0.0) x))))
+(test-equal ":real-range zero step raises (:generator-proc path)"
+  "step size must not be zero in :real-range"
+  (caught-message (lambda () (:generator-proc (:real-range 0 1 0)))))
 
 ;;; --- multi-argument typed generators (concatenation) ---
 (test-equal ":list multi-arg" '(1 2 3) (list-ec (:list x '(1 2) '(3)) x))
 (test-equal ":string multi-arg" "abcd" (string-ec (:string c "ab" "cd") c))
 (test-equal ":vector multi-arg incl. empty" '(1 2 3 4)
   (list-ec (:vector x #(1 2) #() #(3 4)) x))
+
+;;; --- extending ':' via :-dispatch-set! ---
+;; This block MUTATES the library-global dispatcher, so it must stay the
+;; last section: every earlier ':' test targets the unmutated initial
+;; dispatcher.
+(:-dispatch-set!
+ (dispatch-union
+  (:-dispatch-ref)
+  (lambda (args)
+    (if (and (= 1 (length args)) (symbol? (car args)))
+        (:generator-proc (:string (symbol->string (car args))))
+        #f))))
+(test-equal ": extended to symbols via dispatch-union" '(#\f #\o #\o)
+  (list-ec (: c 'foo) c))
+(test-equal ": still handles integers after extension" '(0 1 2)
+  (list-ec (: i 3) i))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-42")


### PR DESCRIPTION
Fixes #2177.

`(list-ec (: i 5) i)` — the first form in every SRFI 42 tutorial — was `KP2001 invalid syntax`: the port implemented eleven typed qualifiers but not the generic `:`, nor `:real-range`, `:char-range`, or `:dispatched`. Investigating also showed three qualifiers the library already **exported** — `:port`, `:do`, and `:parallel` — had no `%do-ec` rules at all and failed identically inside a comprehension. All of these work now.

## Design

The port is direct-style (nested loops around the body with a stop flag), not the reference implementation's CPS design, so `:` cannot dispatch by `:do` fusion. It instead uses the SRFI's own **runtime generator-procedure protocol** (the one `:dispatched`'s spec text defines): a dispatcher maps the evaluated argument list to a generator procedure `g`, stepped as `(g empty)` until it returns the eq?-unique sentinel.

- The initial dispatcher covers the spec's cases: lists, strings, vectors, 1–3 exact integers → `:range`, 1–3 reals → `:real-range`, 2 chars → `:char-range`, port `[+ reader]` → `:port`, plus the n>3 all-lists/strings/vectors cases.
- The extension surface is complete and exported: `:-dispatch-ref`, `:-dispatch-set!`, `make-initial-:-dispatch`, `dispatch-union`, `:generator-proc` — user dispatchers compose per spec (covered by a test that extends `:` to symbols).
- `:generator-proc` compiles the standard typed generators straight to closure constructors (no call/cc); any other generator form falls back to a call/cc coroutine over `do-ec`.
- `:real-range` follows the reference formula exactly (i counts 0,1,… while `i < (to−from)/step`, value `from + i·step`, with `from` turning inexact when `to` or `step` is), so `(:real-range x 0 1 1/4)` stays exact: `(0 1/4 1/2 3/4)`.
- `:char-range` is inclusive of both endpoints.
- Typed generators now accept multiple arguments (`(:list x '(1 2) '(3))` concatenates), matching the spec and the runtime dispatch path.

## Documented deviations (library header)

- The `(index i)` variable form remains unsupported (this port never had it).
- `:parallel` accepts only single-variable sub-generator forms; raw `:do` and `:while`/`:until`-wrapped generators are rejected at expansion time rather than merged.
- The reference implementation's `make-initial-:-dispatch` tests `(string? a1)` twice where `a2`/`a3` were meant — corrected here.

## Tests

`tests/scheme/srfi/srfi42.scm` grows from 40 to **86 assertions**: every issue repro (`(: i 5)`, `(string-ec (:char-range c #\a #\e) c)`, `(:real-range x 0 1 1/4)`), all dispatch arities and types, port dispatch with default (hygienically resolved) and custom readers, `:do` short and full six-slot forms, `:parallel` lockstep incl. an infinite `:integers` and a coroutine-backed `:let`, `:dispatched` with a hand-written dispatcher, the `:generator-proc` protocol on both the fast path and the coroutine fallback, `dispatch-union` identification and conflict conventions, and the catchable unrecognized-argument error.

Full local run: `bash tests/scheme/run-all.sh` → **2066 pass, 0 fail** (1 pre-existing WASM-differential skip); `kaappi check lib/srfi/42.sld` clean; suite also passes under `--no-ir-opt` and via `kaappi test`.

The pre-existing eager-termination gap in `first-ec`/`any?-ec`/`every?-ec` found during this work is out of scope here and tracked as #2179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)