### PR TITLE
Route reader #e/#i through string->number's digit-exact parser (#1911 family)

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -974,9 +974,9 @@ pub fn makeComplexOrRealEx(real: f64, imag: f64, exact_real: bool, exact_imag: b
     return gc.allocComplexEx(real, imag, exact_real, exact_imag) catch return PrimitiveError.OutOfMemory;
 }
 
-const Exactness = enum { unspecified, exact, inexact };
+pub const Exactness = enum { unspecified, exact, inexact };
 
-fn applyExactness(_: *@import("memory.zig").GC, val: Value, exactness: Exactness) PrimitiveError!Value {
+fn applyExactness(gc: *@import("memory.zig").GC, val: Value, exactness: Exactness) PrimitiveError!Value {
     switch (exactness) {
         .unspecified => return val,
         .inexact => {
@@ -997,6 +997,11 @@ fn applyExactness(_: *@import("memory.zig").GC, val: Value, exactness: Exactness
                 const den_f = types.toF64(rat.denominator);
                 return types.makeFlonum(num_f / den_f);
             }
+            if (types.isComplex(val)) {
+                const c = types.toComplex(val);
+                if (!c.exact_real and !c.exact_imag) return val;
+                return gc.allocComplexEx(c.real, c.imag, false, false) catch return PrimitiveError.OutOfMemory;
+            }
             return val;
         },
         .exact => {
@@ -1004,6 +1009,15 @@ fn applyExactness(_: *@import("memory.zig").GC, val: Value, exactness: Exactness
                 const f = types.toFlonum(val);
                 if (std.math.isNan(f) or std.math.isInf(f)) return types.FALSE;
                 return exactFn(&.{val});
+            }
+            if (types.isComplex(val)) {
+                // A complex stays f64+flag pairs; #e sets both flags. A
+                // non-finite part has no exact representation (same rule as
+                // the flonum arm above -- #f, per #419).
+                const c = types.toComplex(val);
+                if (!std.math.isFinite(c.real) or !std.math.isFinite(c.imag)) return types.FALSE;
+                if (c.exact_real and c.exact_imag) return val;
+                return gc.allocComplexEx(c.real, c.imag, true, true) catch return PrimitiveError.OutOfMemory;
             }
             return val;
         },
@@ -1102,7 +1116,6 @@ fn stringToNumber(args: []const Value) PrimitiveError!Value {
     if (!types.isString(args[0])) return primitives.typeError("string->number", "string", args[0]);
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const str = types.toObject(args[0]).as(types.SchemeString);
-    var s: []const u8 = str.data[0..str.len];
 
     var radix: u8 = 10;
     if (args.len > 1) {
@@ -1112,9 +1125,23 @@ fn stringToNumber(args: []const Value) PrimitiveError!Value {
         radix = @intCast(@as(u64, @bitCast(r)));
     }
 
+    return parseNumberText(gc, str.data[0..str.len], radix, .unspecified);
+}
+
+/// Parse a complete number text into a Value, or `types.FALSE` when the text
+/// is not a number. This is the single number grammar behind BOTH
+/// `string->number` and the reader's `#e`/`#i` literals: R7RS 6.2.7 requires
+/// the two to agree, and until kaappi#1911 they were separate parsers whose
+/// divergence produced #1891/#1907/#1908/#1909. The reader hands the token
+/// body over with `exactness_in` set (its own prefixes already consumed)
+/// instead of re-implementing exactness at the token level.
+pub fn parseNumberText(gc: *@import("memory.zig").GC, text: []const u8, radix_in: u8, exactness_in: Exactness) PrimitiveError!Value {
+    var s: []const u8 = text;
+    var radix = radix_in;
+
     // R7RS prefix handling: #b #o #d #x (radix) and #e #i (exactness)
     // Both can appear in either order: #e#xff or #x#eff
-    var exactness: Exactness = .unspecified;
+    var exactness: Exactness = exactness_in;
     for (0..2) |_| {
         if (s.len >= 2 and s[0] == '#') {
             switch (s[1] | 0x20) { // case-insensitive
@@ -1227,11 +1254,17 @@ fn stringToNumber(args: []const Value) PrimitiveError!Value {
         return applyExactness(gc, result, exactness);
     } else |err| {
         if (err == error.Overflow) {
-            const result = bignum_mod.parseBignumString(gc, s, radix) catch |e| switch (e) {
-                error.InvalidCharacter => return types.FALSE,
+            // A digit run that overflows i64 may still be a valid decimal
+            // float rather than a bignum -- "9223372036854775808.0" hits
+            // Overflow on its last digit before parseInt ever sees the '.'
+            // (#1921). InvalidCharacter therefore falls through to the
+            // decimal shapes below instead of rejecting outright.
+            if (bignum_mod.parseBignumString(gc, s, radix)) |result| {
+                return applyExactness(gc, result, exactness);
+            } else |e| switch (e) {
+                error.InvalidCharacter => {},
                 else => return PrimitiveError.OutOfMemory,
-            };
-            return applyExactness(gc, result, exactness);
+            }
         }
     }
 

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -368,10 +368,15 @@ fn writeBigPowerOfTwoDecimal(writer: anytype, mantissa: u64, shift: u16) !void {
 }
 
 /// Write one part of a complex number. Inexact parts print as flonums. An
-/// exact-flagged part prints a spelling that reads back to the same f64 with
-/// its exact flag: plain integer digits when integral (bignum-wide past i64),
-/// the small-rational form when it reproduces the f64 exactly, and the f64's
-/// own mantissa/2^k value otherwise -- never a value-destroying collapse.
+/// exact-flagged part prints its exact value, never a value-destroying
+/// collapse: plain integer digits when integral (bignum-wide past i64), the
+/// small-rational form when it reproduces the f64 exactly, and the f64's own
+/// mantissa/2^k value otherwise. The first two spellings read back with the
+/// exact flag intact; the mantissa/2^k fallback is exact but does NOT read
+/// back yet -- the reader's complex grammar stops at i64 rational parts
+/// (kaappi#2182), and closing that needs the scaled rational->f64
+/// conversion first or tiny components would read back as a silent 0.0
+/// (kaappi#2183).
 fn writeComplexPart(writer: anytype, f: f64, exact: bool) !void {
     var buf: [64]u8 = undefined;
     if (!exact or std.math.isNan(f) or std.math.isInf(f)) {

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -328,28 +328,101 @@ fn symbolNeedsBars(name: []const u8) bool {
     return false;
 }
 
-/// Format a flonum in Scheme syntax into `buf`, returning the slice. Uses
-/// scientific notation for very large/small magnitudes so the output stays
-/// bounded (plain `{d}` expands denormals/huge values to hundreds of decimal
-/// digits, overflowing fixed buffers). Always includes a `.`/`e` so the result
-/// reads back as inexact.
-fn formatComplexPart(buf: []u8, f: f64, exact: bool) []const u8 {
-    if (std.math.isNan(f) or std.math.isInf(f)) return formatFlonum(buf, f);
-    if (exact) {
-        const trunc = @trunc(f);
-        if (f == trunc and @abs(f) < 4.5e18) {
-            const i: i64 = @intFromFloat(trunc);
-            return std.fmt.bufPrint(buf, "{d}", .{i}) catch return formatFlonum(buf, f);
-        }
-        // Exact non-integer: try rational notation
-        const numeric = @import("primitives_numeric.zig");
-        const rat = numeric.floatToRational(f);
-        if (rat.den != 1) {
-            return std.fmt.bufPrint(buf, "{d}/{d}", .{ rat.num, rat.den }) catch return formatFlonum(buf, f);
-        }
-        return std.fmt.bufPrint(buf, "{d}", .{rat.num}) catch return formatFlonum(buf, f);
+/// Write the exact decimal digits of `mantissa << shift` (unsigned). Any
+/// finite f64 decomposes into such a pair (mantissa < 2^53, shift <= 971 for
+/// integers; 2^k denominators use mantissa 1, k <= 1074), so this covers up
+/// to ~325 digits -- far past any fixed format buffer, which is why exact
+/// complex parts beyond i64 used to print as the unreadable `0/0` (#1910).
+fn writeBigPowerOfTwoDecimal(writer: anytype, mantissa: u64, shift: u16) !void {
+    // Callers pass f64 decompositions: mantissa < 2^53 with shift <= 971
+    // (integers), or mantissa 1 with shift <= 1074 (2^k denominators).
+    // 20 digits of u64 + 1100 doublings adding at most one digit each
+    // stays under 360.
+    var digits: [360]u8 = undefined; // little-endian, values 0..9
+    var len: usize = 0;
+    var m = mantissa;
+    while (m > 0) : (m /= 10) {
+        digits[len] = @intCast(m % 10);
+        len += 1;
     }
-    return formatFlonum(buf, f);
+    if (len == 0) {
+        digits[0] = 0;
+        len = 1;
+    }
+    var i: u16 = 0;
+    while (i < shift) : (i += 1) {
+        var carry: u8 = 0;
+        for (digits[0..len]) |*d| {
+            const v = d.* * 2 + carry;
+            d.* = v % 10;
+            carry = v / 10;
+        }
+        if (carry > 0 and len < digits.len) {
+            digits[len] = carry;
+            len += 1;
+        }
+    }
+    var out: [360]u8 = undefined;
+    for (0..len) |j| out[j] = '0' + digits[len - 1 - j];
+    try writer.writeAll(out[0..len]);
+}
+
+/// Write one part of a complex number. Inexact parts print as flonums. An
+/// exact-flagged part prints a spelling that reads back to the same f64 with
+/// its exact flag: plain integer digits when integral (bignum-wide past i64),
+/// the small-rational form when it reproduces the f64 exactly, and the f64's
+/// own mantissa/2^k value otherwise -- never a value-destroying collapse.
+fn writeComplexPart(writer: anytype, f: f64, exact: bool) !void {
+    var buf: [64]u8 = undefined;
+    if (!exact or std.math.isNan(f) or std.math.isInf(f)) {
+        try writer.writeAll(formatFlonum(&buf, f));
+        return;
+    }
+    if (f == @trunc(f)) {
+        // 2^63 spelled as a literal: maxInt(i64) is not representable as
+        // f64 and @floatFromInt would round the bound up to admit 2^63
+        // itself -- the exact off-by-one behind #1907's reader panic.
+        if (f >= -9223372036854775808.0 and f < 9223372036854775808.0) {
+            const i: i64 = @intFromFloat(f);
+            try writer.writeAll(std.fmt.bufPrint(&buf, "{d}", .{i}) catch unreachable);
+            return;
+        }
+        // Integral beyond i64: |f| >= 2^63 with a 53-bit mantissa forces a
+        // strictly positive binary exponent.
+        if (f < 0) try writer.writeByte('-');
+        const bits: u64 = @bitCast(@abs(f));
+        const mantissa = (bits & 0x000FFFFFFFFFFFFF) | 0x0010000000000000;
+        const exp: u16 = @intCast(@as(i16, @intCast((bits >> 52) & 0x7FF)) - 1023 - 52);
+        try writeBigPowerOfTwoDecimal(writer, mantissa, exp);
+        return;
+    }
+    // Exact non-integer: prefer the small-rational spelling, but only when
+    // it reads back to this exact f64 -- the search collapses magnitudes
+    // below its granularity to 0/1, which silently destroys the value.
+    const numeric = @import("primitives_numeric.zig");
+    const rat = numeric.floatToRational(f);
+    if (rat.den > 0 and
+        @as(f64, @floatFromInt(rat.num)) / @as(f64, @floatFromInt(rat.den)) == f)
+    {
+        try writer.print("{d}/{d}", .{ rat.num, rat.den });
+        return;
+    }
+    // Fall back to the f64's own exact value: odd-mantissa / 2^k.
+    if (f < 0) try writer.writeByte('-');
+    const bits: u64 = @bitCast(@abs(f));
+    const raw_exp: u11 = @intCast((bits >> 52) & 0x7FF);
+    var m: u64 = if (raw_exp == 0)
+        bits & 0x000FFFFFFFFFFFFF
+    else
+        (bits & 0x000FFFFFFFFFFFFF) | 0x0010000000000000;
+    var k: u16 = if (raw_exp == 0) 1074 else 1075 - @as(u16, raw_exp);
+    while (m & 1 == 0 and k > 0) {
+        m >>= 1;
+        k -= 1;
+    }
+    try writeBigPowerOfTwoDecimal(writer, m, 0);
+    try writer.writeByte('/');
+    try writeBigPowerOfTwoDecimal(writer, 1, k);
 }
 
 pub fn formatFlonum(buf: []u8, f: f64) []const u8 {
@@ -655,7 +728,7 @@ fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u3
                     try writer.writeAll(formatFlonum(&buf, c.real));
                 } else {
                     const has_real = c.real != 0.0 or std.math.signbit(c.real);
-                    if (has_real) try writer.writeAll(formatComplexPart(&buf, c.real, c.exact_real));
+                    if (has_real) try writeComplexPart(writer, c.real, c.exact_real);
                     const im = c.imag;
                     if (std.math.isNan(im)) {
                         try writer.writeAll("+nan.0i");
@@ -664,7 +737,7 @@ fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u3
                     } else {
                         try writer.writeByte(if (im < 0 or std.math.signbit(im)) '-' else '+');
                         const mag = @abs(im);
-                        if (mag != 1.0 or has_real) try writer.writeAll(formatComplexPart(&buf, mag, c.exact_imag));
+                        if (mag != 1.0 or has_real) try writeComplexPart(writer, mag, c.exact_imag);
                         try writer.writeByte('i');
                     }
                 }

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -79,6 +79,11 @@ pub const Token = union(enum) {
     /// Rational literal whose numerator or denominator overflows i64.
     /// Digit runs are parsed as bignums at datum construction.
     big_rational: struct { num_str: []const u8, den_str: []const u8, radix: u8 },
+    /// Number body carrying an explicit #e/#i prefix (str = the body span,
+    /// prefixes already consumed). Converted at datum construction through
+    /// the same digit-exact parseNumberText that backs string->number, so
+    /// the two parsers cannot diverge on exactness (R7RS 6.2.7, #1911).
+    prefixed_real: struct { str: []const u8, exact: bool, radix: u8 },
     complex: struct { real: f64, imag: f64, exact_real: bool = false, exact_imag: bool = false },
     eof,
 };

--- a/src/reader_datum.zig
+++ b/src/reader_datum.zig
@@ -65,6 +65,12 @@ fn tokenToValue(self: *Reader, tok: Token) ReadError!Value {
         .prefixed_real => |p| {
             // #e/#i literal body: same parser as string->number, so the two
             // can never disagree on an exactness-prefixed number (#1911).
+            // Non-OOM errors all become InvalidNumber deliberately: in a
+            // literal context every parse-side failure IS a bad number
+            // literal, and the tokenizer has already validated the shape.
+            // If parseNumberText ever grows a failure that is not the
+            // text's fault, give it its own arm here rather than letting
+            // it masquerade as a user typo.
             const numeric = @import("primitives_numeric.zig");
             const v = numeric.parseNumberText(self.gc, p.str, p.radix, if (p.exact) .exact else .inexact) catch |err| switch (err) {
                 error.OutOfMemory => return ReadError.OutOfMemory,

--- a/src/reader_datum.zig
+++ b/src/reader_datum.zig
@@ -62,6 +62,17 @@ fn tokenToValue(self: *Reader, tok: Token) ReadError!Value {
             if (bignum_mod.isZero(den)) return ReadError.InvalidNumber;
             return arith.makeRationalReduced(self.gc, slot_num.get(), den) catch return ReadError.OutOfMemory;
         },
+        .prefixed_real => |p| {
+            // #e/#i literal body: same parser as string->number, so the two
+            // can never disagree on an exactness-prefixed number (#1911).
+            const numeric = @import("primitives_numeric.zig");
+            const v = numeric.parseNumberText(self.gc, p.str, p.radix, if (p.exact) .exact else .inexact) catch |err| switch (err) {
+                error.OutOfMemory => return ReadError.OutOfMemory,
+                else => return ReadError.InvalidNumber,
+            };
+            if (v == types.FALSE) return ReadError.InvalidNumber;
+            return v;
+        },
         .complex => |c| return self.gc.allocComplexEx(c.real, c.imag, c.exact_real, c.exact_imag) catch return ReadError.OutOfMemory,
         .boolean => |b| return if (b) types.TRUE else types.FALSE,
         .character => |c| return types.makeChar(c),

--- a/src/reader_tokens.zig
+++ b/src/reader_tokens.zig
@@ -421,76 +421,19 @@ fn tryReadInfNan(self: *Reader) ?f64 {
     return null;
 }
 
-/// Apply an exactness prefix (#e / #i) to a freshly read numeric token.
-fn applyExactness(tok: Token, exact: ?bool) ReadError!Token {
-    const want_exact = exact orelse return tok;
-    if (want_exact) {
-        return switch (tok) {
-            .fixnum, .rational, .bignum_str, .big_rational => tok,
-            .flonum => |f| blk: {
-                if (!std.math.isFinite(f)) break :blk Token{ .flonum = f };
-                const max_i64_f: f64 = @floatFromInt(@as(i64, std.math.maxInt(i64)));
-                const min_i64_f: f64 = @floatFromInt(@as(i64, std.math.minInt(i64)));
-                if (f > max_i64_f or f < min_i64_f) break :blk Token{ .flonum = f };
-                const trunc: i64 = @intFromFloat(f);
-                if (@as(f64, @floatFromInt(trunc)) == f) break :blk Token{ .fixnum = trunc };
-                // Non-integer float: convert to rational via continued fraction
-                var num: i64 = 1;
-                var den: i64 = 0;
-                var prev_num: i64 = 0;
-                var prev_den: i64 = 1;
-                var x = @abs(f);
-                var iters: u32 = 0;
-                while (iters < 64) : (iters += 1) {
-                    if (x > max_i64_f) break;
-                    const a: i64 = @intFromFloat(x);
-                    const new_num = @mulWithOverflow(a, num);
-                    if (new_num[1] != 0) break;
-                    const final_num = @addWithOverflow(new_num[0], prev_num);
-                    if (final_num[1] != 0) break;
-                    const new_den = @mulWithOverflow(a, den);
-                    if (new_den[1] != 0) break;
-                    const final_den = @addWithOverflow(new_den[0], prev_den);
-                    if (final_den[1] != 0) break;
-                    prev_num = num;
-                    prev_den = den;
-                    num = final_num[0];
-                    den = final_den[0];
-                    const approx = @as(f64, @floatFromInt(num)) / @as(f64, @floatFromInt(den));
-                    if (@abs(approx - @abs(f)) < 1e-15) break;
-                    const frac = x - @as(f64, @floatFromInt(a));
-                    if (frac < 1e-15) break;
-                    x = 1.0 / frac;
-                }
-                if (f < 0) num = -num;
-                if (den == 1) break :blk Token{ .fixnum = num };
-                break :blk Token{ .rational = .{ .num = num, .den = den } };
-            },
-            .complex => |c| blk: {
-                break :blk Token{ .complex = .{ .real = c.real, .imag = c.imag, .exact_real = true, .exact_imag = true } };
-            },
-            else => ReadError.InvalidNumber,
-        };
-    }
-    return switch (tok) {
-        .flonum, .complex => tok,
-        .fixnum => |n| .{ .flonum = @floatFromInt(n) },
-        .rational => |r| .{ .flonum = @as(f64, @floatFromInt(r.num)) / @as(f64, @floatFromInt(r.den)) },
-        .bignum_str => |bs| .{ .flonum = std.fmt.parseFloat(f64, bs.str) catch return ReadError.InvalidNumber },
-        // Like .bignum_str, only decimal digit runs can go through parseFloat.
-        .big_rational => |r| blk: {
-            if (r.radix != 10) return ReadError.InvalidNumber;
-            const nf = std.fmt.parseFloat(f64, r.num_str) catch return ReadError.InvalidNumber;
-            const df = std.fmt.parseFloat(f64, r.den_str) catch return ReadError.InvalidNumber;
-            break :blk .{ .flonum = nf / df };
-        },
-        else => ReadError.InvalidNumber,
-    };
-}
-
 /// Read a number after an initial radix/exactness prefix has been consumed,
 /// allowing one further prefix of the other kind (R7RS permits `#e#x10`,
-/// `#x#i10`, etc.). Then read the body in the chosen radix and apply exactness.
+/// `#x#i10`, etc.). Then read the body in the chosen radix.
+///
+/// An exactness prefix is NOT applied at token level: the body span becomes
+/// a `.prefixed_real` token that datum construction routes through the same
+/// digit-exact `parseNumberText` behind `string->number`, so `read` cannot
+/// diverge from it (R7RS 6.2.7). The old token-level conversion parsed to
+/// f64 first and un-rounded with an i64 continued fraction, which panicked
+/// at 2^63 (#1907), dropped `#e` past i64 (#1891), collapsed sub-1e-15
+/// values to 0 (#1909), and read `#i` radix bignums as decimal (#1908).
+/// The tokenizer still runs first so token-boundary and incremental-input
+/// (`incomplete_input`) behavior is exactly what unprefixed numbers get.
 fn readNumberPrefixed(self: *Reader, radix0: u8, exact0: ?bool) ReadError!Token {
     var radix = radix0;
     var exact = exact0;
@@ -520,12 +463,36 @@ fn readNumberPrefixed(self: *Reader, radix0: u8, exact0: ?bool) ReadError!Token 
         // non-delimiter in the next chunk would make it a different (and
         // invalid) token, not this flonum.
         if (self.truncatedHere()) return ReadError.UnexpectedEof;
-        return applyExactness(.{ .flonum = f }, exact);
+        // #e on an infinity/NaN has no exact representation: a read error,
+        // matching string->number's #f on the same text (#419, #1911).
+        if (exact orelse false) return ReadError.InvalidNumber;
+        return .{ .flonum = f };
     }
 
+    const body_start = self.pos;
     const tok = if (radix == 10) try readNumber(self) else try readIntegerWithRadix(self, radix);
     if (numberTailTruncated(self)) return ReadError.UnexpectedEof;
-    return applyExactness(tok, exact);
+    const want_exact = exact orelse return tok;
+    switch (tok) {
+        // Complex tokens keep their token-level parse: readNumber's complex
+        // grammar is wider than parseNumberText's (rational and inf/nan
+        // parts), so re-parsing the span would reject valid literals.
+        // Exactness on a complex is exactly its two flags, with #e refusing
+        // non-finite parts the same way the parseNumberText path does.
+        .complex => |c| {
+            if (want_exact) {
+                if (!std.math.isFinite(c.real) or !std.math.isFinite(c.imag))
+                    return ReadError.InvalidNumber;
+                return .{ .complex = .{ .real = c.real, .imag = c.imag, .exact_real = true, .exact_imag = true } };
+            }
+            return .{ .complex = .{ .real = c.real, .imag = c.imag, .exact_real = false, .exact_imag = false } };
+        },
+        else => return .{ .prefixed_real = .{
+            .str = self.source[body_start..self.pos],
+            .exact = want_exact,
+            .radix = radix,
+        } },
+    }
 }
 
 pub fn readHash(self: *Reader) ReadError!Token {

--- a/src/tests_numeric.zig
+++ b/src/tests_numeric.zig
@@ -524,10 +524,23 @@ test "#e/#i reach complex literals on both parsers (#1910, #751)" {
     );
     // An exact-flagged component below the rational search's granularity
     // used to print as 0 (value destroyed); it now prints its exact
-    // mantissa/2^k value.
-    try th.expectEvalBool(
-        "(let ((p (open-output-string))) (write #e1e-300+1i p) (string-prefix? \"0+\" (get-output-string p)))",
-        false,
+    // mantissa/2^k value, verified against the independent bignum printer
+    // behind (exact f).
+    try th.expectEvalTrue(
+        "(let ((p (open-output-string)) (ex (exact 1e-300))) (write #e1e-300+1i p)" ++
+            " (equal? (get-output-string p) (string-append (number->string (numerator ex))" ++
+            " \"/\" (number->string (denominator ex)) \"+1i\")))",
+    );
+    // KNOWN GAP, pinned: that spelling does not read back yet. The reader's
+    // complex grammar stops at i64 rational parts (kaappi#2182), and closing
+    // it needs the scaled rational->f64 conversion first or this would read
+    // back as a silent 0.0+1i (kaappi#2183). A loud error still beats the
+    // old silently-wrong 0. When those land, the read succeeds, this
+    // deliberately returns #f, and the failure tells you to replace it with
+    // a round-trip equal? assertion.
+    try th.expectEvalTrue(
+        "(let ((p (open-output-string))) (write #e1e-300+1i p)" ++
+            " (guard (e (#t #t)) (read (open-input-string (get-output-string p))) #f))",
     );
     // #e refuses non-finite components, like the flonum rule (#419).
     try th.expectEvalTrue("(guard (e (#t #t)) (read (open-input-string \"#e1e999+2i\")) #f)");

--- a/src/tests_numeric.zig
+++ b/src/tests_numeric.zig
@@ -452,3 +452,108 @@ test "eqv? discriminates exact and inexact complex (#2167)" {
         "(eq? 'hit (case (- (make-rectangular 3/2 1)) ((-3/2-1i) 'hit) (else 'miss)))",
     );
 }
+
+// ---------------------------------------------------------------------------
+// #1911 family: the reader's #e/#i path now routes through the same
+// digit-exact parseNumberText as string->number, replacing a token-level
+// f64-unrounding conversion that failed at both ends of the range.
+// ---------------------------------------------------------------------------
+
+test "#e keeps exactness past i64 (#1891)" {
+    try th.expectEvalBool("(exact? #e1e19)", true);
+    try th.expectEvalTrue("(= #e1e19 (expt 10 19))");
+    try th.expectEvalBool("(exact? #e1e400)", true);
+    try th.expectEvalTrue("(= #e1e400 (expt 10 400))");
+    try th.expectEvalTrue("(= #e-1e19 (- (expt 10 19)))");
+    try th.expectEvalTrue("(= #e1.5e20 (* 15 (expt 10 19)))");
+    try th.expectEvalBool("(exact? #e#d1e20)", true);
+}
+
+test "#e decimal at the 2^63 boundary parses exactly, no panic (#1907)" {
+    // Every double rounding to exactly 2^63 used to overflow @intFromFloat
+    // and abort the process (exit 134): maxInt(i64) is not representable as
+    // f64, so the old `f > @floatFromInt(maxInt(i64))` guard admitted 2^63
+    // itself. Source literals are deliberate — a regression aborts this
+    // test run loudly.
+    try th.expectEvalTrue("(= #e9223372036854775808.0 (expt 2 63))");
+    try th.expectEvalTrue("(= #e9223372036854775296.0 9223372036854775296)");
+    try th.expectEvalTrue("(= #e-9223372036854775808.0 (- (expt 2 63)))");
+    try th.expectEvalTrue("(= #e9223372036854774784.0 9223372036854774784)");
+    // Digit-exact semantics: the exponent spelling denotes its decimal
+    // value, not the f64 it happens to round to. string->number agrees.
+    try th.expectEvalTrue("(= #e9.223372036854776e18 9223372036854776000)");
+    try th.expectEvalTrue(
+        "(equal? #e9.223372036854776e18 (string->number \"#e9.223372036854776e18\"))",
+    );
+}
+
+test "#i honors the radix on bignum digit runs (#1908)" {
+    // The digits used to be fed to parseFloat as decimal, silently wrong by
+    // orders of magnitude (and a spurious error for hex letters). The
+    // conversion is now the identical limb walk string->number uses.
+    try th.expectEvalTrue("(= #i#x1000000000000000000 (inexact #x1000000000000000000))");
+    try th.expectEvalTrue("(= #i#o100000000000000000000000 (inexact #o100000000000000000000000))");
+    try th.expectEvalTrue("(= #i#xFFFFFFFFFFFFFFFFFF (inexact #xFFFFFFFFFFFFFFFFFF))");
+    try th.expectEvalTrue("(equal? #i#x1000000000000000000 (string->number \"#i#x1000000000000000000\"))");
+    try th.expectEvalBool("(exact? #i#x1000000000000000000/3)", false);
+}
+
+test "#e below 1e-15 keeps the value and its sign (#1909)" {
+    // The old continued-fraction conversion converged to 0/1 inside its
+    // absolute 1e-15 tolerance, losing the entire value.
+    try th.expectEvalTrue("(= #e1e-16 (/ 1 (expt 10 16)))");
+    try th.expectEvalTrue("(= #e1e-15 (/ 1 (expt 10 15)))");
+    try th.expectEvalTrue("(negative? #e-1e-20)");
+    try th.expectEvalTrue("(= #e1e-30 (/ 1 (expt 10 30)))");
+    try th.expectEvalTrue("(= #e1.5e-18 (/ 3 (* 2 (expt 10 18))))");
+}
+
+test "#e/#i reach complex literals on both parsers (#1910, #751)" {
+    try th.expectEvalBool("(exact? #i1+2i)", false);
+    try th.expectEvalBool("(exact? (string->number \"#e1+2i\"))", true);
+    try th.expectEvalBool("(exact? (string->number \"#i1+2i\"))", false);
+    try th.expectEvalTrue("(equal? #i1+2i (string->number \"#i1+2i\"))");
+    try th.expectEvalTrue("(equal? #e1+2i (string->number \"#e1+2i\"))");
+    // A component past i64 used to write as the unreadable 0/0; it now
+    // writes its exact digits and round-trips.
+    try th.expectEvalTrue(
+        "(let ((p (open-output-string))) (write #e1e19+1i p) (string=? (get-output-string p) \"10000000000000000000+1i\"))",
+    );
+    try th.expectEvalTrue(
+        "(let ((x #e1e19+1i) (p (open-output-string))) (write x p) (equal? x (read (open-input-string (get-output-string p)))))",
+    );
+    // An exact-flagged component below the rational search's granularity
+    // used to print as 0 (value destroyed); it now prints its exact
+    // mantissa/2^k value.
+    try th.expectEvalBool(
+        "(let ((p (open-output-string))) (write #e1e-300+1i p) (string-prefix? \"0+\" (get-output-string p)))",
+        false,
+    );
+    // #e refuses non-finite components, like the flonum rule (#419).
+    try th.expectEvalTrue("(guard (e (#t #t)) (read (open-input-string \"#e1e999+2i\")) #f)");
+    try th.expectEvalBool("(string->number \"#e1e999+2i\")", false);
+}
+
+test "#e on inf/nan is a read error matching string->number's #f (#1911)" {
+    try th.expectEvalTrue("(guard (e (#t #t)) (read (open-input-string \"#e+inf.0\")) #f)");
+    try th.expectEvalTrue("(guard (e (#t #t)) (read (open-input-string \"#e-inf.0\")) #f)");
+    try th.expectEvalTrue("(guard (e (#t #t)) (read (open-input-string \"#e+nan.0\")) #f)");
+    try th.expectEvalBool("(string->number \"#e+inf.0\")", false);
+    try th.expectEvalTrue("(and (inexact? #i+inf.0) (infinite? #i+inf.0))");
+}
+
+test "string->number accepts the unprefixed decimal spelling of 2^63 (#1921)" {
+    // parseInt overflows on the final digit before ever seeing the '.', and
+    // the bignum fallback's InvalidCharacter used to reject outright
+    // instead of falling through to the decimal parse.
+    try th.expectEvalTrue("(= (string->number \"9223372036854775808.0\") 9223372036854775808.0)");
+    try th.expectEvalTrue(
+        "(equal? (string->number \"9223372036854775808.0\") (read (open-input-string \"9223372036854775808.0\")))",
+    );
+    try th.expectEvalTrue("(= (string->number \"#e9223372036854775808.0\") (expt 2 63))");
+    try th.expectEvalTrue("(= (string->number \"9223372036854775807.0\") 9223372036854775807.0)");
+    try th.expectEvalTrue("(= (string->number \"-9223372036854775808.0\") -9223372036854775808.0)");
+    // Overflowing digits followed by genuinely invalid text still reject.
+    try th.expectEvalBool("(string->number \"92233720368547758081abc\")", false);
+    try th.expectEvalBool("(string->number \"9223372036854775808.0.0\")", false);
+}

--- a/src/tests_reader_incremental.zig
+++ b/src/tests_reader_incremental.zig
@@ -98,7 +98,10 @@ test "incomplete mode: every proper prefix of every token class is UnexpectedEof
         "#xFF/3",
         "#e#x10",
         "#x1.8p3",
-        "#e+inf.0",
+        // #i, not #e: #e+inf.0 is InvalidNumber since #1911 (no exact
+        // representation — string->number parity), so #i is the valid
+        // representative of the prefixed inf/nan scanner path.
+        "#i+inf.0",
         "+inf.0",
         "...",
         ".5",

--- a/tests/scheme/compliance/reader-delimiter-gaps.scm
+++ b/tests/scheme/compliance/reader-delimiter-gaps.scm
@@ -214,7 +214,10 @@
   (test-eqv "#e-1/2" -1/2 #e-1/2)
   (test-eqv "hex bignum" 725355491768777504823705 #x99999999999999999999)
   (test-assert "hex bignum reads clean" (clean? "#x99999999999999999999"))
-  (test-assert "#e+inf.0 reads clean"   (clean? "#e+inf.0"))
+  ;; #e+inf.0 is a read error since #1911: no exact representation exists,
+  ;; and string->number already rejected it (#419).  #i+inf.0 stays valid.
+  (test-assert "#e+inf.0 rejected"      (rejects? "#e+inf.0"))
+  (test-assert "#i+inf.0 reads clean"   (clean? "#i+inf.0"))
   ;; A digit that is out of range for the radix is a read error, not a split
   ;; -- the token has no valid digits at all, so there is nothing to split.
   (test-assert "#b2 rejected" (rejects? "#b2"))
@@ -505,14 +508,14 @@
 ;;; ---------------------------------------------------------------------
 
 (test-group "reader vs string->number, non-delimiter divergences"
-  ;; `#e+inf.0` reads as the inexact +inf.0 while `string->number` rejects
-  ;; the same string.  Chibi 0.12 also reads it as +inf.0, so the reader
-  ;; side matches the project's own differential oracle and the divergence
-  ;; is on the `string->number` side.
-  (test-assert "reader accepts #e+inf.0" (clean? "#e+inf.0"))
-  ;; FAIL: TBD (string->number "#e+inf.0" returns #f where READ yields +inf.0)
-  ;; (test-assert "s->n agrees with read on #e+inf.0"
-  ;;   (string->number "#e+inf.0"))
+  ;; `#e+inf.0`: the reader used to yield the inexact +inf.0 while
+  ;; string->number rejected the same string.  R7RS 6.2.3 permits either
+  ;; treatment of an unrepresentable exact constant (Chibi reads it as
+  ;; +inf.0, Racket errors), but 6.2.7 requires the two parsers to agree;
+  ;; #1911 settled the divergence on the #419 side, so both now reject.
+  (test-assert "reader rejects #e+inf.0" (rejects? "#e+inf.0"))
+  (test-assert "s->n agrees with read on #e+inf.0"
+    (not (string->number "#e+inf.0")))
 
   ;; The same shape again: the READER accepts `1/2+3i`, which R7RS 7.1.1's
   ;; <complex R> --> <real R> + <ureal R> i production allows (and Chibi

--- a/tests/scheme/compliance/reader-exactness-gaps.scm
+++ b/tests/scheme/compliance/reader-exactness-gaps.scm
@@ -23,14 +23,16 @@
 ;;   has bignums and exact rationals, so the constants below ARE representable
 ;;   and this escape hatch does not apply.
 ;;
-;; Every disabled assertion below was reproduced against a fresh ReleaseSafe
-;; build with an isolated KAAPPI_HOME.  Each disabled group carries a
-;; discriminating control that stays ENABLED, so the file keeps proving that
-;; the neighbouring path still works.
+;; This file was written while the #1911 family (#1891/#1907/#1908/#1909/
+;; #1910/#1921) was open, with the failing cells disabled.  Those are all
+;; fixed -- the reader's `#e`/`#i` path now routes through the same
+;; digit-exact parseNumberText as string->number -- and every cell is
+;; enabled as a regression guard, except section 9's trailing-junk cases
+;; (#1892, closed NOT_PLANNED), which stay disabled as documentation.
 ;;
-;; NOTE: numbers whose reading crashes the process are exercised only through
-;; `(read (open-input-string ...))`, never as source literals, so that
-;; re-enabling a test cannot abort the whole suite at read time.
+;; NOTE: numbers whose reading once crashed the process are exercised only
+;; through `(read (open-input-string ...))`, never as source literals, so a
+;; regression cannot abort the whole suite at read time.
 
 ;; `(scheme inexact)` is declared for finite?/infinite?/nan?.  They resolve at
 ;; top level even without it -- a script reaches vm.globals directly -- so
@@ -83,9 +85,11 @@
 ;; ---------------------------------------------------------------------------
 ;; 2. `#e` at and beyond the i64 boundary.
 ;;
-;;    Known bug #1891: the flonum->exact conversion in reader_tokens.zig
-;;    `applyExactness` bails out to the unconverted flonum once the value
-;;    exceeds i64 range, so the `#e` prefix is silently dropped.
+;;    Regression guard for #1891: the reader's token-level flonum->exact
+;;    conversion bailed out to the unconverted flonum past i64 range,
+;;    silently dropping the `#e` prefix.  Fixed by #1911's unification: the
+;;    reader now routes `#e`/`#i` bodies through the same digit-exact
+;;    parseNumberText as string->number.
 ;; ---------------------------------------------------------------------------
 
 ;; Controls: below the cliff `#e` works, in both signs.
@@ -99,18 +103,12 @@
 (test-assert "#e on a bignum literal stays exact"
              (exact? (rd "#e10000000000000000000")))
 
-;; FAIL: #1891 (#e1e19 reads inexact -- exactness prefix dropped past i64)
-;; (test-assert "#e1e19 is exact" (exact? (rd "#e1e19")))
-;; FAIL: #1891 (#e1e20 reads inexact)
-;; (test-assert "#e1e20 is exact" (exact? (rd "#e1e20")))
-;; FAIL: #1891 (#e-1e19 reads inexact -- same cliff, negative side)
-;; (test-assert "#e-1e19 is exact" (exact? (rd "#e-1e19")))
-;; FAIL: #1891 (#e1e19 value)
-;; (test-equal "#e1e19 value" 10000000000000000000 (rd "#e1e19"))
-;; FAIL: #1891 (#e1e400 yields +inf.0 -- an exactness prefix producing infinity)
-;; (test-assert "#e1e400 is exact" (exact? (rd "#e1e400")))
-;; FAIL: #1891 (#e1e400 must not be infinite)
-;; (test-assert "#e1e400 is finite" (finite? (rd "#e1e400")))
+(test-assert "#e1e19 is exact" (exact? (rd "#e1e19")))
+(test-assert "#e1e20 is exact" (exact? (rd "#e1e20")))
+(test-assert "#e-1e19 is exact" (exact? (rd "#e-1e19")))
+(test-equal "#e1e19 value" 10000000000000000000 (rd "#e1e19"))
+(test-assert "#e1e400 is exact" (exact? (rd "#e1e400")))
+(test-assert "#e1e400 is finite" (finite? (rd "#e1e400")))
 
 ;; R7RS 6.2.7 parity: string->number gets all of these RIGHT, which is what
 ;; makes the divergence a 6.2.7 violation rather than a shared limitation.
@@ -118,22 +116,21 @@
 (test-assert "string->number #e1e400 is exact" (exact? (string->number "#e1e400")))
 (test-equal  "string->number #e1e19 value"
              10000000000000000000 (string->number "#e1e19"))
-;; FAIL: #1891 (6.2.7 consistency: read and string->number must agree)
-;; (test-equal "read/string->number agree on #e1e19"
-;;             (rd "#e1e19") (string->number "#e1e19"))
+(test-equal "read/string->number agree on #e1e19"
+            (rd "#e1e19") (string->number "#e1e19"))
 
 ;; ---------------------------------------------------------------------------
-;; 3. NEW: reader panic on `#e<decimal that rounds to exactly 2^63>`.
+;; 3. Regression guard for #1907: reader panic on `#e<decimal that rounds to
+;;    exactly 2^63>`.
 ;;
-;;    reader_tokens.zig guards the conversion with `f > max_i64_f`, where
+;;    The old token-level conversion guarded with `f > max_i64_f`, where
 ;;    max_i64_f is @floatFromInt(maxInt(i64)) -- which rounds UP to 2^63.  A
-;;    value of exactly 2^63 therefore passes the guard and then overflows
+;;    value of exactly 2^63 therefore passed the guard and then overflowed
 ;;    @intFromFloat, panicking with "integer part of floating point value out
-;;    of bounds" (exit 134).  minInt(i64) = -2^63 is exactly representable, so
-;;    the negative side is unaffected -- hence the asymmetry below.
-;;
-;;    This also aborts `kaappi check` and `kaappi fmt --check`, i.e. tools that
-;;    never execute the program.
+;;    of bounds" (exit 134), aborting `kaappi check`/`fmt`/`ast` too.  The
+;;    digit-exact path has no f64 conversion to guard, so the whole window is
+;;    gone; minInt(i64) = -2^63 is exactly representable, which is why the
+;;    negative side never crashed.
 ;; ---------------------------------------------------------------------------
 
 ;; Controls: the neighbouring doubles on both sides are fine.
@@ -160,26 +157,28 @@
              (let ((v (string->number "#e9223372036854775808.0")))
                (or (not v) (number? v))))
 
-;; FAIL: #1907 (reader panics: #e<double == 2^63> overflows @intFromFloat)
-;; (test-equal "#e2^63 as a decimal float" 9223372036854775808
-;;             (rd "#e9223372036854775808.0"))
-;; FAIL: #1907 (same panic -- lowest decimal that rounds up to 2^63)
-;; (test-equal "#e lowest double rounding to 2^63" 9223372036854775808
-;;             (rd "#e9223372036854775296.0"))
-;; FAIL: #1907 (same panic via exponent notation)
-;; (test-equal "#e2^63 via exponent" 9223372036854775808
-;;             (rd "#e9.223372036854776e18"))
+(test-equal "#e2^63 as a decimal float" 9223372036854775808
+            (rd "#e9223372036854775808.0"))
+;; Digit-exact: the literal denotes its own decimal value.  The old disabled
+;; expectation (9223372036854775808) encoded the un-round-the-f64 strategy;
+;; #e9223372036854775296.0 IS 9223372036854775296, and string->number agrees.
+(test-equal "#e decimal just below 2^63 (used to panic)" 9223372036854775296
+            (rd "#e9223372036854775296.0"))
+(test-equal "#e2^63 via exponent" 9223372036854776000
+            (rd "#e9.223372036854776e18"))
+(test-equal "#e2^63 via exponent = string->number"
+            (rd "#e9.223372036854776e18")
+            (string->number "#e9.223372036854776e18"))
 
 ;; ---------------------------------------------------------------------------
-;; 4. NEW: `#i` on a radix-prefixed BIGNUM reinterprets its digits as decimal.
+;; 4. Regression guard for #1908: `#i` on a radix-prefixed BIGNUM
+;;    reinterpreted its digits as decimal.
 ;;
-;;    reader_tokens.zig's `.bignum_str` arm of the inexact path calls
-;;    parseFloat on the raw digit slice without consulting `bs.radix`.  The
-;;    adjacent `.big_rational` arm DOES check the radix, and the comment above
-;;    `.bignum_str` even asserts the invariant the code fails to enforce.
-;;
-;;    Silent wrong answers when the digits happen to be decimal-valid, and a
-;;    spurious read error when they are not (hex a-f).
+;;    The old token-level `.bignum_str` arm called parseFloat on the raw
+;;    digit slice without consulting the radix: silent wrong answers when
+;;    the digits happened to be decimal-valid, a spurious read error when
+;;    not (hex a-f).  The unified path parses the bignum in its radix and
+;;    converts with the identical limb walk string->number uses.
 ;; ---------------------------------------------------------------------------
 
 ;; Controls: without `#i`, every radix reads the bignum correctly.
@@ -203,36 +202,33 @@
 (test-equal "string->number #i#x bignum with letters"
             4.722366482869645e21 (string->number "#i#xFFFFFFFFFFFFFFFFFF"))
 
-;; FAIL: #1908 (#i#x<bignum> parses hex digits as decimal: gives 1e18, want ~4.72e21)
-;; (test-equal "#i#x bignum" 4.722366482869645e21 (rd "#i#x1000000000000000000"))
-;; FAIL: #1908 (#i#b<bignum> parses binary digits as decimal: gives 1.111...e64)
-;; (test-equal "#i#b bignum" 3.6893488147419103e19
-;;             (rd "#i#b11111111111111111111111111111111111111111111111111111111111111111"))
-;; FAIL: #1908 (#i#o<bignum> parses octal digits as decimal: gives 1.0e23)
-;; (test-equal "#i#o bignum" 5.902958103587057e20
-;;             (rd "#i#o100000000000000000000000"))
-;; FAIL: #1908 (#i#x<bignum with a-f> raises a spurious read error)
-;; (test-equal "#i#x bignum with letters" 4.722366482869645e21
-;;             (rd "#i#xFFFFFFFFFFFFFFFFFF"))
-;; FAIL: #1908 (#i on a radix-prefixed bignum RATIONAL raises a spurious read error)
-;; (test-assert "#i#x bignum rational"
-;;              (inexact? (rd "#i#x1000000000000000000/3")))
+(test-equal "#i#x bignum" 4.722366482869645e21 (rd "#i#x1000000000000000000"))
+(test-equal "#i#b bignum" 3.6893488147419103e19
+            (rd "#i#b11111111111111111111111111111111111111111111111111111111111111111"))
+(test-equal "#i#o bignum" 5.902958103587057e20
+            (rd "#i#o100000000000000000000000"))
+(test-equal "#i#x bignum with letters" 4.722366482869645e21
+            (rd "#i#xFFFFFFFFFFFFFFFFFF"))
+(test-assert "#i#x bignum rational"
+             (inexact? (rd "#i#x1000000000000000000/3")))
+(test-equal "#i#x bignum rational = string->number"
+            (rd "#i#x1000000000000000000/3")
+            (string->number "#i#x1000000000000000000/3"))
 
 ;; Control for the rational case: `#e` on the same text is correct.
 (test-equal "#e#x bignum rational" 4722366482869645213696/3
             (rd "#e#x1000000000000000000/3"))
 
 ;; ---------------------------------------------------------------------------
-;; 5. NEW: `#e` on a decimal below 1e-15 collapses to exact ZERO.
+;; 5. Regression guard for #1909: `#e` on a decimal below 1e-15 collapsed to
+;;    exact ZERO.
 ;;
-;;    The continued-fraction conversion in reader_tokens.zig terminates on
-;;    ABSOLUTE tolerances (`< 1e-15`).  For a magnitude below that tolerance
-;;    the very first iteration already "converges", yielding 0/1.  The whole
-;;    value is lost.  At exactly 1e-15 the same tolerance produces an
-;;    off-by-one denominator.
-;;
-;;    This is the opposite end of the number line from #1891, and a different
-;;    mechanism: nothing here overflows anything.
+;;    The old continued-fraction conversion terminated on ABSOLUTE
+;;    tolerances (`< 1e-15`): below that magnitude the very first iteration
+;;    already "converged" at 0/1, losing the whole value, sign included.  At
+;;    exactly 1e-15 the same tolerance produced an off-by-one denominator.
+;;    The digit-exact path never approximates, so there is no tolerance to
+;;    fall inside.
 ;; ---------------------------------------------------------------------------
 
 ;; Controls: down to 1e-14 the conversion is exact and correct.
@@ -252,36 +248,28 @@
 (test-assert "(exact 1e-19) is not zero" (not (zero? (exact 1e-19))))
 (test-assert "(exact 1e-30) is not zero" (not (zero? (exact 1e-30))))
 
-;; FAIL: #1909 (#e1e-16 collapses to exact 0 -- entire value lost)
-;; (test-assert "#e1e-16 is not zero" (not (zero? (rd "#e1e-16"))))
-;; FAIL: #1909 (#e1e-19 collapses to exact 0)
-;; (test-assert "#e1e-19 is not zero" (not (zero? (rd "#e1e-19"))))
-;; FAIL: #1909 (#e1e-30 collapses to exact 0)
-;; (test-assert "#e1e-30 is not zero" (not (zero? (rd "#e1e-30"))))
-;; FAIL: #1909 (#e-1e-20 collapses to exact 0, sign lost too)
-;; (test-assert "#e-1e-20 is negative" (negative? (rd "#e-1e-20")))
-;; FAIL: #1909 (#e1.5e-18 collapses to exact 0)
-;; (test-assert "#e1.5e-18 is not zero" (not (zero? (rd "#e1.5e-18"))))
-;; FAIL: #1909 (#e1e-15 off-by-one denominator: gives 1/999999999999999)
-;; (test-equal "#e1e-15" 1/1000000000000000 (rd "#e1e-15"))
-;; FAIL: #1909 (#e0.000000000000001 off-by-one denominator)
-;; (test-equal "#e0.000000000000001" 1/1000000000000000 (rd "#e0.000000000000001"))
-;; FAIL: #1909 (6.2.7 consistency for the tiny end)
-;; (test-equal "read/string->number agree on #e1e-16"
-;;             (rd "#e1e-16") (string->number "#e1e-16"))
+(test-assert "#e1e-16 is not zero" (not (zero? (rd "#e1e-16"))))
+(test-assert "#e1e-19 is not zero" (not (zero? (rd "#e1e-19"))))
+(test-assert "#e1e-30 is not zero" (not (zero? (rd "#e1e-30"))))
+(test-assert "#e-1e-20 is negative" (negative? (rd "#e-1e-20")))
+(test-assert "#e1.5e-18 is not zero" (not (zero? (rd "#e1.5e-18"))))
+(test-equal "#e1e-16 value" 1/10000000000000000 (rd "#e1e-16"))
+(test-equal "#e1e-15" 1/1000000000000000 (rd "#e1e-15"))
+(test-equal "#e0.000000000000001" 1/1000000000000000 (rd "#e0.000000000000001"))
+(test-equal "read/string->number agree on #e1e-16"
+            (rd "#e1e-16") (string->number "#e1e-16"))
 
 ;; ---------------------------------------------------------------------------
-;; 6. NEW: `#i` on a COMPLEX literal is a no-op in the reader.
+;; 6. Regression guard for #1910: `#i` on a COMPLEX literal was a no-op in
+;;    the reader.
 ;;
-;;    reader_tokens.zig's inexact path passes `.complex` tokens through
-;;    untouched, so the prefix is silently ignored.
-;;
-;;    Both copies of `applyExactness` have a Complex hole, in complementary
-;;    places -- see the table in section 8.  Closed issue #751 covers the
-;;    string->number half; its fix wired the four complex call sites through
-;;    applyExactness, but that function has no Complex arm in EITHER direction
-;;    (primitives_numeric.zig -- the `.inexact` and `.exact` branches both fall
-;;    through to a bare `return val`), so the prefix is still dropped.
+;;    Both copies of `applyExactness` had a Complex hole in complementary
+;;    places: the reader's inexact path passed `.complex` tokens through
+;;    untouched, and string->number's applyExactness (the destination #751's
+;;    fix wired the four complex call sites into) fell through to a bare
+;;    `return val` in both directions.  Both now handle complexes: `#i`
+;;    clears the two exactness flags, `#e` sets them (refusing non-finite
+;;    parts, the flonum rule of #419).
 ;; ---------------------------------------------------------------------------
 
 ;; Controls: `#i` works on every non-complex shape, and the runtime `inexact`
@@ -292,22 +280,22 @@
 (test-assert "(inexact 1+2i) is inexact" (inexact? (inexact (rd "1+2i"))))
 (test-assert "1.5+2.5i is inexact"     (inexact? (rd "1.5+2.5i")))
 
-;; FAIL: #1910 (#i on a complex literal is ignored: (exact? #i1+2i) => #t)
-;; (test-assert "#i1+2i is inexact" (inexact? (rd "#i1+2i")))
-;; FAIL: #1910 (#i on a complex literal is ignored)
-;; (test-assert "#i3+4i is inexact" (inexact? (rd "#i3+4i")))
+(test-assert "#i1+2i is inexact" (inexact? (rd "#i1+2i")))
+(test-assert "#i3+4i is inexact" (inexact? (rd "#i3+4i")))
+;; #e refuses a non-finite component the same way both parsers refuse
+;; #e+inf.0 (an infinity from decimal overflow has no exact value).
+(test-assert "#e1e999+2i is a read error" (eq? 'read-error (rd/safe "#e1e999+2i")))
+(test-assert "string->number #e1e999+2i is #f" (not (string->number "#e1e999+2i")))
 
 ;; ---------------------------------------------------------------------------
-;; 7. NEW: `#e` on a complex whose component exceeds i64 yields an unreadable
-;;    `0/0`.
+;; 7. Regression guard for #1910's write half: `#e` on a complex whose
+;;    component exceeds i64 printed as the unreadable `0/0`.
 ;;
-;;    reader_tokens.zig's `.complex` arm of the exact path sets both exactness
-;;    flags with NO range check at all, so the printer later renders the
-;;    out-of-range component as the rational `0/0`.  That external
-;;    representation does not read back: bare `0/0` is a read error, and inside
-;;    a complex it comes back as `+nan.0`.
-;;
-;;    This is the only round-trip failure across the whole matrix (section 9).
+;;    The printer's exact-component formatter converted through i64 and
+;;    rendered any out-of-range component as `0/0` -- which does not read
+;;    back (bare `0/0` is a read error; inside a complex it came back as
+;;    `+nan.0`).  Exact components now print their exact digits at any
+;;    magnitude, so the spelling reads back to the identical value.
 ;; ---------------------------------------------------------------------------
 
 ;; Controls: within i64 the same shapes are correct and DO round-trip.
@@ -316,39 +304,25 @@
 (test-assert "#e1e18+1i round-trips"  (round-trips? (rd "#e1e18+1i")))
 (test-assert "bare 0/0 is a read error" (eq? 'read-error (rd/safe "0/0")))
 
-;; FAIL: #1910 (#e1e19+1i prints as 0/0+1i and reads back as +nan.0+1i)
-;; (test-assert "#e1e19+1i round-trips" (round-trips? (rd "#e1e19+1i")))
+(test-assert "#e1e19+1i round-trips" (round-trips? (rd "#e1e19+1i")))
+(test-equal "#e1e19+1i writes its exact digits" "10000000000000000000+1i"
+            (wr (rd "#e1e19+1i")))
 
 ;; ---------------------------------------------------------------------------
-;; 8. R7RS 6.2.7 parity: `read` and `string->number` are two independent
-;;    parsers, and they disagree.
+;; 8. R7RS 6.2.7 parity: `read` and `string->number` used to be two
+;;    independent parsers with different strategies, and they disagreed.
 ;;
-;;    There are two separate `applyExactness` implementations --
-;;    `reader_tokens.zig:393` (read / the program reader) and
-;;    `primitives_numeric.zig:979` (string->number) -- with different
-;;    strategies.  string->number reconstructs the value from the decimal
-;;    digits exactly (mantissa x 10^scale, via bignum); the reader parses to
-;;    f64 FIRST and then tries to un-round it with a tolerance-based continued
-;;    fraction.  That structural difference is why the reader loses at both
-;;    ends of the range (sections 2, 3 and 5) while string->number does not.
+;;    Until #1911 there were two separate `applyExactness` implementations:
+;;    string->number reconstructed the value from the decimal digits exactly
+;;    (mantissa x 10^scale, via bignum), while the reader parsed to f64
+;;    FIRST and un-rounded with a tolerance-based continued fraction --
+;;    which is why the reader lost at both ends of the range (sections 2, 3
+;;    and 5) while string->number did not, and why historical fixes (#79,
+;;    #419, #604, #751, #1891) kept landing in one copy at a time.
 ;;
-;;    Historical fixes have landed in one copy at a time:
-;;
-;;      issue | fixed in           | still live in
-;;      ------+--------------------+---------------------------------------
-;;      #79   | reader_tokens      | (guard added, but off by one -- sec. 3)
-;;      #604  | primitives_numeric | --
-;;      #419  | primitives_numeric | reader_tokens (`#e+inf.0` => +inf.0)
-;;      #751  | primitives_numeric | fix incomplete -- no Complex arm at all
-;;      #1891 | --                 | reader_tokens
-;;
-;;    Beyond the divergences already covered above, these cells disagree on
-;;    their own:
-;;      - `#e+inf.0` / `#e-inf.0` / `#e+nan.0`: read yields the inexact
-;;        infinity/NaN, string->number yields #f.  #419 settled that #f is the
-;;        intended answer, so the reader is the side that is wrong.
-;;      - `#e`/`#i` on a complex: string->number ignores the prefix entirely
-;;        (closed #751, fix incomplete); the reader honours `#e` but not `#i`.
+;;    The reader's copy is gone: `#e`/`#i` bodies now go through the same
+;;    parseNumberText behind string->number, so these cells cannot diverge
+;;    again by construction.
 ;; ---------------------------------------------------------------------------
 
 ;; Controls: the parsers agree on the ordinary cases.
@@ -378,21 +352,28 @@
             (rd "-9223372036854775808.0") (string->number "-9223372036854775808.0"))
 (test-equal "parity 1e19" (rd "1e19") (string->number "1e19"))
 (test-equal "parity 1e300" (rd "1e300") (string->number "1e300"))
-;; FAIL: #1919 (unprefixed 2^63 decimal: reader ok, string->number gives #f)
-;; (test-equal "parity 2^63 as a decimal"
-;;             (rd "9223372036854775808.0") (string->number "9223372036854775808.0"))
+;; #1921 (filed as the #1919 review follow-up): parseInt overflows on the
+;; final digit before seeing the '.', and the bignum fallback rejected
+;; instead of falling through to the decimal parse.
+(test-equal "parity 2^63 as a decimal"
+            (rd "9223372036854775808.0") (string->number "9223372036854775808.0"))
+(test-assert "string->number 2^63 decimal is a number"
+             (number? (string->number "9223372036854775808.0")))
 
-;; FAIL: #1911 (6.2.7: read gives +inf.0, string->number gives #f)
-;; (test-equal "parity #e+inf.0" (rd "#e+inf.0") (string->number "#e+inf.0"))
-;; FAIL: #1911 (6.2.7: read gives -inf.0, string->number gives #f)
-;; (test-equal "parity #e-inf.0" (rd "#e-inf.0") (string->number "#e-inf.0"))
-;; FAIL: #1911 (6.2.7: read gives +nan.0, string->number gives #f)
-;; (test-assert "parity #e+nan.0"
-;;              (eq? (not (rd "#e+nan.0")) (not (string->number "#e+nan.0"))))
-;; FAIL: #1910 (string->number ignores #e on a complex: yields 1.0+2.0i inexact)
-;; (test-assert "string->number #e1+2i is exact" (exact? (string->number "#e1+2i")))
-;; FAIL: #1910 (string->number ignores #i on a complex: yields 1.0+2.0i either way)
-;; (test-equal "parity #i1+2i" (rd "#i1+2i") (string->number "#i1+2i"))
+;; #e on an infinity/NaN: both sides now reject -- read raises, and
+;; string->number keeps #419's settled #f.
+(test-assert "parity #e+inf.0 (both reject)"
+             (and (eq? 'read-error (rd/safe "#e+inf.0"))
+                  (not (string->number "#e+inf.0"))))
+(test-assert "parity #e-inf.0 (both reject)"
+             (and (eq? 'read-error (rd/safe "#e-inf.0"))
+                  (not (string->number "#e-inf.0"))))
+(test-assert "parity #e+nan.0 (both reject)"
+             (and (eq? 'read-error (rd/safe "#e+nan.0"))
+                  (not (string->number "#e+nan.0"))))
+(test-assert "string->number #e1+2i is exact" (exact? (string->number "#e1+2i")))
+(test-equal "parity #i1+2i" (rd "#i1+2i") (string->number "#i1+2i"))
+(test-equal "parity #e1+2i" (rd "#e1+2i") (string->number "#e1+2i"))
 
 ;; ---------------------------------------------------------------------------
 ;; 9. NEW: an exactness/radix prefix disables the trailing-delimiter check on
@@ -434,8 +415,7 @@
 ;;
 ;;     The campaign's systematic reader check:
 ;;       (equal? x (read (open-input-string (write-to-string x))))
-;;     Holds on every cell reachable without a panic except `#e1e19+1i`
-;;     (section 7).
+;;     Holds on every cell (`#e1e19+1i`, once the sole failure, included).
 ;; ---------------------------------------------------------------------------
 
 (for-each
@@ -447,10 +427,12 @@
    "#e1e-16" "#e1e-19" "#i1" "#i1/2" "#i#xFF" "#i#x1000000000000000000"
    "#e#x10" "#x#e10" "#e+inf.0" "#i+inf.0" "#e1+2i" "#i1+2i" "#e1.5+2.5i"
    "#e+i" "#e10000000000000000000" "#i10000000000000000000"
-   "#e9223372036854775807" "#x1e5" "#e1/3" "#i22/7"))
+   "#e9223372036854775807" "#x1e5" "#e1/3" "#i22/7"
+   "#e9223372036854775808.0" "#e9223372036854775296.0" "#e1e-15"
+   "#e1e-30" "#i3+4i" "#i#xFFFFFFFFFFFFFFFFFF" "#i#x1000000000000000000/3"
+   "9223372036854775808.0"))
 
-;; FAIL: #1910 (see section 7 -- writes 0/0+1i, reads back +nan.0+1i)
-;; (test-assert "round-trip #e1e19+1i" (round-trips? (rd "#e1e19+1i")))
+(test-assert "round-trip #e1e19+1i" (round-trips? (rd "#e1e19+1i")))
 
 ;; ---------------------------------------------------------------------------
 ;; 11. Confirmed-correct areas, pinned so a future change cannot regress them

--- a/tests/scheme/compliance/reader-exactness-gaps.scm
+++ b/tests/scheme/compliance/reader-exactness-gaps.scm
@@ -294,8 +294,15 @@
 ;;    The printer's exact-component formatter converted through i64 and
 ;;    rendered any out-of-range component as `0/0` -- which does not read
 ;;    back (bare `0/0` is a read error; inside a complex it came back as
-;;    `+nan.0`).  Exact components now print their exact digits at any
-;;    magnitude, so the spelling reads back to the identical value.
+;;    `+nan.0`) -- and its small-rational search silently printed tiny
+;;    exact components as `0`.  Exact components now print their exact
+;;    digits at any magnitude.  Integral and i64-rational spellings read
+;;    back with the exact flag intact; the mantissa/2^k fallback for tiny
+;;    components is exact but does NOT read back yet -- the reader's
+;;    complex grammar stops at i64 rational parts (#2182), and closing
+;;    that needs the scaled rational->f64 conversion first (#2183) or the
+;;    form would read back as a silent 0.0.  A loud error beats the old
+;;    silent value corruption; the gap is pinned below.
 ;; ---------------------------------------------------------------------------
 
 ;; Controls: within i64 the same shapes are correct and DO round-trip.
@@ -307,6 +314,19 @@
 (test-assert "#e1e19+1i round-trips" (round-trips? (rd "#e1e19+1i")))
 (test-equal "#e1e19+1i writes its exact digits" "10000000000000000000+1i"
             (wr (rd "#e1e19+1i")))
+
+;; The tiny-component gap, pinned in both directions: the written form is
+;; the true exact value (cross-checked against the independent bignum
+;; printer behind `exact`), and reading it back is currently a read error.
+;; When #2182+#2183 land, the second assertion fails loudly -- replace it
+;; with (round-trips? (rd "#e1e-300+1i")).
+(test-equal "#e1e-300+1i writes its exact value"
+            (let ((ex (exact 1e-300)))
+              (string-append (number->string (numerator ex))
+                             "/" (number->string (denominator ex)) "+1i"))
+            (wr (rd "#e1e-300+1i")))
+(test-assert "#e1e-300+1i read-back is a (loud) read error until #2182/#2183"
+             (eq? 'read-error (rd/safe (wr (rd "#e1e-300+1i")))))
 
 ;; ---------------------------------------------------------------------------
 ;; 8. R7RS 6.2.7 parity: `read` and `string->number` used to be two
@@ -415,7 +435,11 @@
 ;;
 ;;     The campaign's systematic reader check:
 ;;       (equal? x (read (open-input-string (write-to-string x))))
-;;     Holds on every cell (`#e1e19+1i`, once the sole failure, included).
+;;     Holds on every cell below (`#e1e19+1i`, once the sole failure,
+;;     included).  The one known shape it does NOT hold for -- an exact
+;;     complex with a sub-i64-rational component like `#e1e-300+1i`, whose
+;;     honest spelling the reader cannot parse yet -- is deliberately not a
+;;     cell here; section 7 pins it in both directions (#2182, #2183).
 ;; ---------------------------------------------------------------------------
 
 (for-each


### PR DESCRIPTION
Unify the two number parsers behind `#e`/`#i`: the reader now routes exactness through `string->number`'s digit-exact `parseNumberText`, deleting its own f64-unrounding `applyExactness`. One structural change closes the whole audit family.

Closes #1911, closes #1891, closes #1907, closes #1908, closes #1909, closes #1910, closes #1921.

## The root cause (#1911)

`applyExactness` existed twice with structurally different strategies: `string->number` rebuilt exact values from the decimal digits (mantissa × 10^scale via bignum), while the reader parsed to **f64 first** and tried to un-round it with an i64 continued fraction under an absolute 1e-15 tolerance. Every past fix (#79, #419, #604, #751, #1891) landed in one copy. The weaker algorithm is why the reader lost at both ends of the range — and R7RS §6.2.7 explicitly requires `read` and `string->number` to follow the same rules.

## What changed

**`primitives_numeric.zig`** — `stringToNumber`'s body is extracted into pub `parseNumberText(gc, text, radix, exactness)`; `string->number` is now a thin argument-unwrapping wrapper over it.

**Reader** — `readNumberPrefixed` still tokenizes exactly as before (token boundaries and incremental-input `UnexpectedEof` semantics are untouched), but when an exactness prefix is present the body span becomes a new `Token.prefixed_real{str, exact, radix}`, and `tokenToValue` re-parses that span through `parseNumberText`. The reader's 65-line token-level `applyExactness` is **deleted**. The two parsers cannot diverge on `#e`/`#i` again by construction.

`.complex` tokens are the one deliberate exception: `readNumber`'s complex grammar is wider than `string->number`'s (rational real/imag parts like `1/2+3/4i`, inf/nan parts like `3.0+inf.0i`), so re-parsing the span would reject valid literals. Exactness on a complex is exactly its two flags, set/cleared at token level, with `#e` refusing non-finite parts — the same rule the `parseNumberText` path applies.

## Per-issue effect

| issue | before | after |
|---|---|---|
| #1891 | `#e1e19` inexact, `#e1e400` ⟹ `+inf.0` | exact `10^19`, exact `10^400` |
| #1907 | **panic, exit 134** on `#e9223372036854775808.0` (also aborted `check`/`fmt`/`ast`) | exact `2^63`; all four tools exit 0 |
| #1908 | `#i#x1000000000000000000` ⟹ `1e18` (digits read as decimal) | `4.722366482869645e21`, identical to `string->number` (same limb walk) |
| #1909 | `#e1e-16` ⟹ exact `0`, sign lost; `#e1e-15` off-by-one denominator | full exact value at any magnitude; `1/10^15` exactly |
| #1910 | `#i1+2i` a no-op; `(exact? (string->number "#e1+2i"))` ⟹ `#f`; `#e1e19+1i` wrote unreadable `0/0+1i` | both `applyExactness` sides have Complex arms; `#e1e19+1i` writes `10000000000000000000+1i` and round-trips |
| #1921 | `string->number "9223372036854775808.0"` ⟹ `#f` | the flonum the reader gives — parseInt's `Overflow` no longer masks a valid decimal (`InvalidCharacter` from the bignum fallback now falls through to the decimal shapes) |
| inf/nan parity gap (#1911 body) | reader: `#e+inf.0` ⟹ `+inf.0`; `string->number` ⟹ `#f` | reader raises a read error (#419 settled `#f` as the intended answer) |

## The printer half of #1910

`formatComplexPart` converted exact-flagged components through i64 and rendered anything beyond as `0/0` — and its small-rational search silently printed exact-flagged tiny values as `0`. It is now writer-based `writeComplexPart`: integral values print exact digits at any magnitude (a fixed-buffer double-and-carry decimal printer; the i64 window bound is spelled as the literal `9223372036854775808.0` — `@floatFromInt(maxInt(i64))` rounds up, which was exactly #1907's off-by-one), the small-rational form is used only when it validates against the f64, and everything else prints the f64's own exact `m/2^k` value. Verified `string=?` against an independent oracle: `(number->string (exact f))`.

Integral and i64-rational spellings read back with the exact flag intact. The `m/2^k` fallback for tiny components (e.g. `#e1e-300+1i`) prints the correct exact value but does **not** read back yet — the reader's complex grammar stops at i64 rational parts (#2182), and extending it must wait for the scaled rational→f64 conversion (#2183) or the form would read back as a silently wrong `0.0+1i`. A loud read error beats the old silent collapse to `0`; the gap is pinned in both directions (written form matches the `exact` oracle; read-back is asserted to error, failing loudly when #2182/#2183 land so the pin gets flipped to a round-trip assertion). Surfaced by review.

## Semantics note: one corrected test expectation

The disabled cell for `#e9.223372036854776e18` expected `9223372036854775808` — the un-round-the-f64 answer. Digit-exact semantics (and `string->number`, unchanged here) give `9223372036854776000`: the literal denotes its own decimal value; that is what `#e` makes exact. The re-enabled cell asserts the digit-exact value plus explicit parity with `string->number`.

Similarly `#e9223372036854775296.0` is now `9223372036854775296` (its own digits), where the old expectation encoded the rounding to `2^63`.

## Deliberately unchanged

- **#1892 behavior** (trailing junk after a prefixed number reads as two datums) — closed NOT_PLANNED; the tokenize-first design preserves it, and section 9 of the parity test stays disabled as documentation.
- **Bare (unprefixed) complex exactness and the complex part grammar**: `1+2i` is exact via the reader but inexact via `string->number`; `string->number` cannot parse rational complex parts (`"1/2+3/4i"` ⟹ `#f`) or inf/nan parts; the reader's own rational parts stop at i64. Filed as #2182, sequenced after #2183 (the rational→f64 conversion bug that would otherwise turn the tiny-component read error into a silent `0.0`).
- #751 stays closed: its repro line is now a passing regression test here (#1910 covers the reopen recommendation).

## Tests

- `src/tests_numeric.zig`: 7 new tests pinning every issue, including the #1907 crash window as source literals (a regression aborts the run loudly), the corrected digit-exact expectations, write/round-trip of `#e1e19+1i`, and the two-direction pin of the tiny-exact-component gap (written form matches the `exact` oracle; read-back errors until #2182/#2183, then fails loudly to force the flip to a round-trip assertion).
- `src/tests_reader_incremental.zig`: the prefixed inf/nan scanner-path representative is now `#i+inf.0` (`#e+inf.0` is deliberately an error).
- `tests/scheme/compliance/reader-exactness-gaps.scm`: all 39 disabled cells of the #1911 family re-enabled (181 assertions pass), banners rewritten as regression-guard documentation, round-trip matrix extended with the previously-crashing and previously-wrong cells.
- Full unit suite, gc-stress on the touched paths, and `tests/scheme/run-all.sh` green; `kaappi check`/`ast`/`fmt`/`fmt --check` verified on the #1907 literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
