### PR TITLE
Fix the uncatchable-abort family: record sizing, devfs stat, SRFI-18 timeouts, 255-arg calls

### DIFF
--- a/src/compiler_ir.zig
+++ b/src/compiler_ir.zig
@@ -271,6 +271,13 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
             if (!types.isPair(param_list)) return CompileError.InvalidSyntax;
             const param = types.car(param_list);
             if (!types.isSymbol(param)) return CompileError.InvalidSyntax;
+            // Same 255-fixed-params cap as compiler_lambda.compileLambda: the
+            // call ISA's u8 nargs means a 256th argument could never be
+            // supplied, so reject cleanly instead of overflowing (#2185).
+            // InvalidSyntax for the same reason as there: TooManyLocals
+            // surfaces as a KP9001 "internal error", and this one is user
+            // syntax.
+            if (arity == 255) return CompileError.InvalidSyntax;
             const slot = child.allocReg() catch return CompileError.TooManyLocals;
             child.locals.append(child.gc.allocator, .{
                 .name = types.symbolName(param),

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -68,6 +68,15 @@ pub fn compileLambda(self: *Compiler, args: Value, dst: u16, name: ?[]const u8) 
             const param = types.car(param_list);
             if (!types.isSymbol(param)) return CompileError.InvalidSyntax;
 
+            // arity is a u8, and the call ISA encodes nargs as one byte, so
+            // no call site could ever supply a 256th argument (the apply
+            // path already rejects >255 loudly). Reject the formals list
+            // cleanly instead of overflowing the counter below (#2185).
+            // InvalidSyntax, not TooManyLocals: the latter reads as a KP9001
+            // "internal error -- report this bug", and an oversized formals
+            // list is the user's, matching parseRecordSpec's 255-field cap.
+            if (arity == 255) return CompileError.InvalidSyntax;
+
             const slot = child.allocReg() catch return CompileError.TooManyLocals;
             child.locals.append(child.gc.allocator, .{
                 .name = types.symbolName(param),

--- a/src/gc_alloc.zig
+++ b/src/gc_alloc.zig
@@ -470,7 +470,12 @@ pub fn allocRecordInstance(self: *GC, record_type: *RecordType, field_values: []
         .record_type = record_type,
         .fields = fields,
     };
-    self.finishAlloc(&ri.header, @sizeOf(RecordInstance) + record_type.num_fields * @sizeOf(Value));
+    // num_fields is a u8 -- widen before multiplying, or the whole size
+    // expression is evaluated in u8 arithmetic and overflows at 27 fields
+    // (40 + 8*27 = 256): a panic under ReleaseSafe, wrapped GC accounting
+    // under ReleaseFast (#1973). gc_sweep.objectSize sizes the same object
+    // from fields.len (usize), so the two agree only with this widening.
+    self.finishAlloc(&ri.header, @sizeOf(RecordInstance) + @as(usize, record_type.num_fields) * @sizeOf(Value));
     return types.makePointer(&ri.header);
 }
 

--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -68,6 +68,21 @@ fn makedev(major: u64, minor: u64) u64 {
         ((minor & ~@as(u64, 0xff)) << 12) | ((major & ~@as(u64, 0xfff)) << 32);
 }
 
+/// dev_t is signed on macOS and OpenBSD (i32), and devfs reports device ids
+/// with the sign bit set -- macOS's /dev/null stats as st_dev = -1296473318.
+/// A range-checked @intCast into u64 therefore aborted the process on any
+/// devfs path (#1976). Reinterpret the bits as the unsigned same-width type,
+/// then zero-extend: the id is an opaque identity, not a quantity, so the
+/// bit pattern is what matters.
+fn devToU64(dev: anytype) u64 {
+    const info = @typeInfo(@TypeOf(dev)).int;
+    if (info.signedness == .signed) {
+        const U = std.meta.Int(.unsigned, info.bits);
+        return @as(U, @bitCast(dev));
+    }
+    return dev;
+}
+
 fn doStat(path: [*:0]const u8, follow: bool) ?StatResult {
     if (comptime platform.is_windows) {
         // _wstat64 always follows reparse points (`follow` has no effect)
@@ -83,10 +98,10 @@ fn doStat(path: [*:0]const u8, follow: bool) ?StatResult {
             .mtime_sec = st.st_mtime,
             .atime_sec = st.st_atime,
             .ctime_sec = st.st_ctime,
-            .dev = @intCast(st.st_dev),
+            .dev = devToU64(st.st_dev),
             .ino = @intCast(st.st_ino),
             .nlinks = @intCast(@max(st.st_nlink, 0)),
-            .rdev = @intCast(st.st_rdev),
+            .rdev = devToU64(st.st_rdev),
             .blksize = 0,
             .blocks = 0,
             .uid = 0,
@@ -131,10 +146,10 @@ fn doStat(path: [*:0]const u8, follow: bool) ?StatResult {
             .mtime_sec = stat_buf.mtime().sec,
             .atime_sec = stat_buf.atime().sec,
             .ctime_sec = stat_buf.ctime().sec,
-            .dev = @intCast(stat_buf.dev),
+            .dev = devToU64(stat_buf.dev),
             .ino = @intCast(stat_buf.ino),
             .nlinks = @intCast(stat_buf.nlink),
-            .rdev = @intCast(stat_buf.rdev),
+            .rdev = devToU64(stat_buf.rdev),
             .blksize = @intCast(stat_buf.blksize),
             .blocks = @intCast(stat_buf.blocks),
             .uid = stat_buf.uid,

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -222,6 +222,20 @@ pub fn hasLiveChildThreads() bool {
     return @atomicLoad(usize, &live_child_threads, .acquire) > 0;
 }
 
+/// Relative seconds -> saturated nanoseconds, shared by
+/// timeoutToDeadlineNs's number branch and threadSleepFn (#1983). One
+/// implementation on purpose: the bug existed as three diverged copies of
+/// this exact conversion, so any future policy change (say, to NaN
+/// handling) must have a single edit point. lossyCast saturates where the
+/// old @intFromFloat panicked: +inf.0 and any product >= 2^64 become
+/// maxInt(u64) ("never times out"), NaN becomes 0 (the old @max treatment
+/// of it -- @max(0.0, secs) before the multiply and @max on the product
+/// are equivalent here, since scaling by a positive constant is monotone
+/// and NaN propagates either way), negatives clamp to 0.
+fn saturatedNsFromSeconds(secs: f64) u64 {
+    return std.math.lossyCast(u64, @max(0.0, secs) * 1_000_000_000.0);
+}
+
 /// `pub` since KEP-0002 Phase 4 (#1469): primitives_fiber.zig's
 /// channel-send/channel-receive timeouts reuse this exact SRFI-18-shaped
 /// number-or-time-object-or-#f parsing rather than duplicating it.
@@ -248,13 +262,9 @@ pub fn timeoutToDeadlineNs(timeout: Value) PrimitiveError!?u64 {
     const secs = primitives.toF64(timeout) catch
         return primitives.typeError("thread", "time object or number", timeout);
     const mono_now = fiber_mod.clockNs();
-    // lossyCast saturates where the old @intFromFloat panicked (#1983):
-    // +inf.0 and any product >= 2^64 become maxInt(u64) ("never times out"),
-    // NaN becomes 0 (matching the old @max treatment of it), and the
-    // saturating add keeps the deadline pinned at "never" instead of
-    // wrapping around into the past.
-    const delta_ns: u64 = std.math.lossyCast(u64, @max(0.0, secs) * 1_000_000_000.0);
-    return mono_now +| delta_ns;
+    // The saturating add keeps a saturated delta pinned at "never" instead
+    // of wrapping around into the past (#1983).
+    return mono_now +| saturatedNsFromSeconds(secs);
 }
 
 pub fn makeErrorWithType(error_type: types.ErrorObject.ErrorType, msg: []const u8, reason: Value) PrimitiveError!Value {
@@ -613,13 +623,12 @@ fn threadSleepFn(args: []const Value) PrimitiveError!Value {
     if (me.deadline_ns == null) {
         const seconds = try getSleepSeconds(args[0]);
         if (seconds <= 0) return types.VOID;
-        // lossyCast + saturating add (#1983): a duration too large for the
+        // Saturation + saturating add (#1983): a duration too large for the
         // u64 nanosecond clock (+inf.0, 1e300, an overflowed computation)
         // saturates to a deadline that never fires -- an unbounded sleep,
         // per the SRFI-18 "+inf.0 never times out" convention -- where the
         // old @intFromFloat aborted the process uncatchably.
-        const total_ns: u64 = std.math.lossyCast(u64, @max(0.0, seconds * 1e9));
-        const deadline = fiber_mod.clockNs() +| total_ns;
+        const deadline = fiber_mod.clockNs() +| saturatedNsFromSeconds(seconds);
 
         me.waiting_on = types.VOID;
         me.status = .waiting;

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -231,18 +231,30 @@ pub fn timeoutToDeadlineNs(timeout: Value) PrimitiveError!?u64 {
         const t = types.toSrfi18Time(timeout);
         if (t.seconds < 0) return 0;
         const ns_clamped: u64 = if (t.nanoseconds > 0) @intCast(t.nanoseconds) else 0;
-        const sec_ns: u64 = @as(u64, @intCast(t.seconds)) * 1_000_000_000 + ns_clamped;
+        // Saturating arithmetic throughout (#1983): a deadline past what the
+        // u64 nanosecond clock can express (wall time beyond ~year 2554) is a
+        // perfectly legal time object, and "so far out it never fires" is the
+        // correct reading of it -- the SRFI-18 timeout convention treats
+        // +inf.0 as "never time out" (Gambit). The old unchecked multiply
+        // aborted the whole process instead, uncatchably, and through this
+        // pub function took (kaappi fibers) channel timeouts down too.
+        const sec_ns: u64 = @as(u64, @intCast(t.seconds)) *| 1_000_000_000 +| ns_clamped;
         const now_rt = platform.realTime();
         const now_ns = @as(u64, @intCast(now_rt.sec)) * 1_000_000_000 + @as(u64, @intCast(now_rt.nsec));
         if (sec_ns <= now_ns) return 0;
         const mono_now = fiber_mod.clockNs();
-        return mono_now + (sec_ns - now_ns);
+        return mono_now +| (sec_ns - now_ns);
     }
     const secs = primitives.toF64(timeout) catch
         return primitives.typeError("thread", "time object or number", timeout);
     const mono_now = fiber_mod.clockNs();
-    const delta_ns: u64 = @intFromFloat(@max(0.0, secs) * 1_000_000_000.0);
-    return mono_now + delta_ns;
+    // lossyCast saturates where the old @intFromFloat panicked (#1983):
+    // +inf.0 and any product >= 2^64 become maxInt(u64) ("never times out"),
+    // NaN becomes 0 (matching the old @max treatment of it), and the
+    // saturating add keeps the deadline pinned at "never" instead of
+    // wrapping around into the past.
+    const delta_ns: u64 = std.math.lossyCast(u64, @max(0.0, secs) * 1_000_000_000.0);
+    return mono_now +| delta_ns;
 }
 
 pub fn makeErrorWithType(error_type: types.ErrorObject.ErrorType, msg: []const u8, reason: Value) PrimitiveError!Value {
@@ -601,8 +613,13 @@ fn threadSleepFn(args: []const Value) PrimitiveError!Value {
     if (me.deadline_ns == null) {
         const seconds = try getSleepSeconds(args[0]);
         if (seconds <= 0) return types.VOID;
-        const total_ns: u64 = @intFromFloat(@max(0.0, seconds * 1e9));
-        const deadline = fiber_mod.clockNs() + total_ns;
+        // lossyCast + saturating add (#1983): a duration too large for the
+        // u64 nanosecond clock (+inf.0, 1e300, an overflowed computation)
+        // saturates to a deadline that never fires -- an unbounded sleep,
+        // per the SRFI-18 "+inf.0 never times out" convention -- where the
+        // old @intFromFloat aborted the process uncatchably.
+        const total_ns: u64 = std.math.lossyCast(u64, @max(0.0, seconds * 1e9));
+        const deadline = fiber_mod.clockNs() +| total_ns;
 
         me.waiting_on = types.VOID;
         me.status = .waiting;
@@ -1394,6 +1411,17 @@ fn secondsToTimeFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const secs = primitives.toF64(args[0]) catch
         return primitives.typeError("seconds->time", "number", args[0]);
+    // A time object stores whole seconds in an i64, so anything outside
+    // [-2^63, 2^63) has no representation -- including +inf.0/-inf.0 and
+    // +nan.0, which fail both comparisons here. The old unchecked
+    // @intFromFloat aborted the process on all of them (#1983). Unlike a
+    // timeout, this constructs an observable value, so saturating would
+    // silently build a wrong time; raise catchably instead. The upper bound
+    // must be 2^63 written exactly, not @floatFromInt(maxInt(i64)): that
+    // constant rounds UP to 2^63 and would re-admit the first aborting
+    // value -- the same off-by-one-ULP guard bug #1907 was made of.
+    if (!(secs >= -0x1p63 and secs < 0x1p63))
+        return primitives.argError("seconds->time", "{d} is outside the representable time range", .{secs});
     const int_secs = @as(i64, @intFromFloat(@floor(secs)));
     const frac = secs - @floor(secs);
     const ns = @as(i64, @intFromFloat(@round(frac * 1_000_000_000.0)));

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -690,3 +690,93 @@ test "call_global heal does not serve a stale callee after rebinding" {
     const result = try ctx.vm.eval("(h)");
     try std.testing.expectEqual(@as(i64, 2), types.toFixnum(result));
 }
+
+// #2185: 255 is the largest argument count the call ISA can encode (nargs is
+// a u8), and it is exactly the count that aborted the process -- callClosure
+// computed `nargs + 1` in u8 arithmetic for the register window, and the
+// three tail-dispatch paths computed the variadic `arity + 1` rest-slot the
+// same way. A 256-parameter lambda additionally overflowed the compiler's own
+// u8 arity counter at DEFINITION time. All paths must now either work (255)
+// or fail as a clean compile error (256).
+test "255-argument calls work on every dispatch path; 256 params reject cleanly (#2185)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const a = std.testing.allocator;
+    const Gen = struct {
+        fn append(buf: *std.ArrayList(u8), al: std.mem.Allocator, comptime fmt: []const u8, args: anytype) !void {
+            const s = try std.fmt.allocPrint(al, fmt, args);
+            defer al.free(s);
+            try buf.appendSlice(al, s);
+        }
+        /// "(p0 p1 ... pN-1)" without parens; ".. . rest" appended when rest.
+        fn params(al: std.mem.Allocator, n: usize, rest: bool) ![]u8 {
+            var buf: std.ArrayList(u8) = .empty;
+            errdefer buf.deinit(al);
+            for (0..n) |i| try append(&buf, al, " p{d}", .{i});
+            if (rest) try buf.appendSlice(al, " . rest");
+            return buf.toOwnedSlice(al);
+        }
+        fn nums(al: std.mem.Allocator, n: usize) ![]u8 {
+            var buf: std.ArrayList(u8) = .empty;
+            errdefer buf.deinit(al);
+            for (0..n) |i| try append(&buf, al, " {d}", .{i});
+            return buf.toOwnedSlice(al);
+        }
+    };
+
+    const p255 = try Gen.params(a, 255, false);
+    defer a.free(p255);
+    const p255r = try Gen.params(a, 255, true);
+    defer a.free(p255r);
+    const p256 = try Gen.params(a, 256, false);
+    defer a.free(p256);
+    const n255 = try Gen.nums(a, 255);
+    defer a.free(n255);
+
+    // Exact 255-ary callee: direct call (callClosure's u8 `nargs + 1`),
+    // tail call, and apply (255 args is the apply limit itself).
+    {
+        const def = try std.fmt.allocPrint(a, "(define (f {s}) p254)", .{p255});
+        defer a.free(def);
+        _ = try vm.eval(def);
+        const direct = try std.fmt.allocPrint(a, "(f {s})", .{n255});
+        defer a.free(direct);
+        try std.testing.expectEqual(@as(i64, 254), types.toFixnum(try vm.eval(direct)));
+        const tail = try std.fmt.allocPrint(a, "(define (g) (f {s})) (g)", .{n255});
+        defer a.free(tail);
+        try std.testing.expectEqual(@as(i64, 254), types.toFixnum(try vm.eval(tail)));
+        const applied = try std.fmt.allocPrint(a, "(apply f (list {s}))", .{n255});
+        defer a.free(applied);
+        try std.testing.expectEqual(@as(i64, 254), types.toFixnum(try vm.eval(applied)));
+    }
+
+    // Variadic callee with 255 FIXED params: its frame needs arity + 1 = 256
+    // arg slots (the rest list), the exact quantity the tail paths computed
+    // in u8. The rest list is necessarily empty (nargs tops out at 255).
+    {
+        const def = try std.fmt.allocPrint(a, "(define (v {s}) (cons p254 rest))", .{p255r});
+        defer a.free(def);
+        _ = try vm.eval(def);
+        const direct = try std.fmt.allocPrint(a, "(equal? '(254) (v {s}))", .{n255});
+        defer a.free(direct);
+        try std.testing.expectEqual(types.TRUE, try vm.eval(direct));
+        const tail = try std.fmt.allocPrint(a, "(define (h) (v {s})) (equal? '(254) (h))", .{n255});
+        defer a.free(tail);
+        try std.testing.expectEqual(types.TRUE, try vm.eval(tail));
+        const applied = try std.fmt.allocPrint(a, "(equal? '(254) (apply v (list {s})))", .{n255});
+        defer a.free(applied);
+        try std.testing.expectEqual(types.TRUE, try vm.eval(applied));
+    }
+
+    // 256 fixed params: uncallable by construction, so definition must be a
+    // clean compile error (the compiler's own u8 arity counter overflowed
+    // here before the fix).
+    {
+        const def = try std.fmt.allocPrint(a, "(define (w {s}) p0)", .{p256});
+        defer a.free(def);
+        try std.testing.expectError(vm_mod.VMError.CompileError, vm.eval(def));
+    }
+}

--- a/src/tests_fibers.zig
+++ b/src/tests_fibers.zig
@@ -534,3 +534,44 @@ test "an expired timer popped by the dispatch tick ends the wait instead of park
     try std.testing.expect(me.timed_out);
     try std.testing.expect(elapsed < 1_000_000_000);
 }
+
+// #1983: timeoutToDeadlineNs is pub and backs (kaappi fibers) channel
+// timeouts too, so the unguarded @intFromFloat took channel-receive down
+// with the whole process on a huge timeout. A fiber sender makes the
+// receive complete promptly; the timeout is converted eagerly (the old
+// abort site) and then never fires.
+test "channel-receive with a huge timeout converts without aborting (#1983)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define ch (make-channel 0))");
+    _ = try vm.eval("(spawn (lambda () (channel-send ch 41)))");
+    const result = try vm.eval("(+ 1 (channel-receive ch 1e300))");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+}
+
+// #1983: thread-sleep!'s own conversion site (a third copy of the same
+// unguarded @intFromFloat). The sleeping fiber saturates to a deadline that
+// never fires and parks; the main fiber must keep running -- before the fix
+// the conversion aborted the process the moment the fiber was dispatched.
+test "thread-sleep! with an unbounded duration parks without aborting (#1983)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define progress 0)
+        \\(spawn (lambda () (set! progress (+ progress 1)) (thread-sleep! 1e300) 'unreachable))
+        \\(spawn (lambda () (set! progress (+ progress 1)) (thread-sleep! +inf.0) 'unreachable))
+        \\(let loop ((i 0))
+        \\  (when (and (< progress 2) (< i 10)) (yield) (loop (+ i 1))))
+    );
+    // progress = 2 proves both fibers ran up to their thread-sleep! call --
+    // i.e. both conversions actually executed -- and parked, rather than the
+    // test passing because the fibers were never dispatched.
+    const got = try vm.eval("progress");
+    try std.testing.expectEqual(@as(i64, 2), types.toFixnum(got));
+}

--- a/src/tests_filesystem.zig
+++ b/src/tests_filesystem.zig
@@ -379,3 +379,30 @@ test "set-file-mode changes permissions" {
         \\    (= (modulo mode #o10000) #o644)))
     ));
 }
+
+// #1976: dev_t is signed on macOS and OpenBSD, and devfs reports st_dev
+// values with the sign bit set (macOS /dev/null: st_dev = -1296473318), so
+// the old range-checked @intCast into StatResult.dev (u64) aborted the whole
+// process on any devfs path -- uncatchable, exit 134. /dev/fd is the
+// discriminating control: a *directory* with st_rdev = 0 that still aborted,
+// pinning the fault on st_dev rather than rdev or the file type.
+test "file-info on devfs paths does not abort (#1976)" {
+    if (comptime platform.is_windows) return error.SkipZigTest;
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    try std.testing.expectEqual(types.TRUE, try vm.eval(
+        \\(let ((fi (file-info "/dev/null" #t)))
+        \\  (and (file-info? fi)
+        \\       (exact-integer? (file-info:device fi))
+        \\       (exact-integer? (file-info:rdev fi))
+        \\       (>= (file-info:device fi) 0)))
+    ));
+    // /dev/fd may be a broken /proc symlink on minimal containers, so only
+    // assert the stat cannot take the process down.
+    _ = try vm.eval(
+        \\(guard (e (#t 'stat-failed)) (file-info? (file-info "/dev/fd" #t)))
+    );
+}

--- a/src/tests_records.zig
+++ b/src/tests_records.zig
@@ -300,3 +300,90 @@ test "record-set! field survives full GC" {
     try std.testing.expect(types.isPair(result));
     try std.testing.expect(types.isSymbol(types.car(result)));
 }
+
+// #1973: allocRecordInstance sized its allocation as
+// `@sizeOf(RecordInstance) + num_fields * @sizeOf(Value)` in u8 arithmetic
+// (num_fields is a u8), so instantiating any record with >= 27 fields
+// (40 + 8*27 = 256) aborted the process with an uncatchable integer-overflow
+// panic. The type itself was created without complaint; only the first
+// instance died. A 256-field spec was worse: parseRecordSpec admitted it and
+// handleDefineRecordType's @intCast into the u8 panicked at DEFINITION time.
+test "wide records: 27 and 255 fields instantiate; 256 fields error cleanly" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const a = std.testing.allocator;
+
+    // Builds "(define-record-type big<n> (mk<n> f0 ... f<n-1>) big<n>?
+    //          (f0 g<n>-0) ... )" plus "(g<n>-<n-1> (mk<n> 0 1 ... <n-1>))".
+    const Gen = struct {
+        fn append(buf: *std.ArrayList(u8), al: std.mem.Allocator, comptime fmt: []const u8, args: anytype) !void {
+            const s = try std.fmt.allocPrint(al, fmt, args);
+            defer al.free(s);
+            try buf.appendSlice(al, s);
+        }
+        fn defSource(al: std.mem.Allocator, n: usize) ![]u8 {
+            var buf: std.ArrayList(u8) = .empty;
+            errdefer buf.deinit(al);
+            try append(&buf, al, "(define-record-type big{d} (mk{d}", .{ n, n });
+            for (0..n) |i| try append(&buf, al, " f{d}", .{i});
+            try append(&buf, al, ") big{d}?", .{n});
+            for (0..n) |i| try append(&buf, al, " (f{d} g{d}-{d})", .{ i, n, i });
+            try buf.appendSlice(al, ")");
+            return buf.toOwnedSlice(al);
+        }
+        fn probeSource(al: std.mem.Allocator, n: usize) ![]u8 {
+            var buf: std.ArrayList(u8) = .empty;
+            errdefer buf.deinit(al);
+            try append(&buf, al, "(g{d}-{d} (mk{d}", .{ n, n - 1, n });
+            for (0..n) |i| try append(&buf, al, " {d}", .{i});
+            try buf.appendSlice(al, "))");
+            return buf.toOwnedSlice(al);
+        }
+    };
+
+    // 27 fields: the first count past the old u8 cliff.
+    {
+        const def = try Gen.defSource(a, 27);
+        defer a.free(def);
+        _ = try vm.eval(def);
+        const probe = try Gen.probeSource(a, 27);
+        defer a.free(probe);
+        const got = try vm.eval(probe);
+        try std.testing.expectEqual(@as(i64, 26), types.toFixnum(got));
+    }
+
+    // 254 fields: the syntactic ceiling. The desugared constructor body is
+    // (%make-record __rt f0 ... fN-1), a call with N+1 arguments, and the
+    // call ISA encodes nargs as a u8 -- so 254 fields is the widest record
+    // a syntactic define-record-type can build (255 needs a 256-argument
+    // call). The record TYPE itself supports 255 (procedural layer).
+    {
+        const def = try Gen.defSource(a, 254);
+        defer a.free(def);
+        _ = try vm.eval(def);
+        const probe = try Gen.probeSource(a, 254);
+        defer a.free(probe);
+        const got = try vm.eval(probe);
+        try std.testing.expectEqual(@as(i64, 253), types.toFixnum(got));
+    }
+
+    // 255 fields: the desugared %make-record call exceeds the ISA's 255-arg
+    // width -- a clean, pre-existing compile error (not part of #1973).
+    {
+        const def = try Gen.defSource(a, 255);
+        defer a.free(def);
+        try std.testing.expectError(vm_mod.VMError.CompileError, vm.eval(def));
+    }
+
+    // 256 fields: over RecordType.num_fields' u8 ceiling -- must be a clean
+    // compile error from parseRecordSpec, not a definition-time @intCast
+    // panic in handleDefineRecordType.
+    {
+        const def = try Gen.defSource(a, 256);
+        defer a.free(def);
+        try std.testing.expectError(vm_mod.VMError.CompileError, vm.eval(def));
+    }
+}

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -652,3 +652,69 @@ test "concurrent thread-sleep! retries across fibers resolve without unbounded s
     try std.testing.expect(waiter_result < 100_000);
     try std.testing.expectEqual(types.TRUE, signal);
 }
+
+// #1983: unguarded float->int conversions in the SRFI-18 time/timeout paths
+// aborted the process -- uncatchably, exit 134 -- on +/-inf.0, NaN, and any
+// magnitude past the destination type. seconds->time now raises a catchable
+// error for values no time object can represent (it constructs an observable
+// value, so saturating would silently build a wrong one); timeouts saturate
+// instead, because "so far out it never fires" is the legal SRFI-18 reading
+// of a huge deadline (+inf.0 conventionally means "never time out").
+test "seconds->time rejects unrepresentable seconds catchably (#1983)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Each of these aborted the whole process before the fix.
+    const rejected = [_][]const u8{
+        "(guard (e (#t 'caught)) (seconds->time +inf.0))",
+        "(guard (e (#t 'caught)) (seconds->time -inf.0))",
+        "(guard (e (#t 'caught)) (seconds->time +nan.0))",
+        "(guard (e (#t 'caught)) (seconds->time 9.3e18))",
+        // 2^63 exactly: the first aborting value. A bound written as
+        // @floatFromInt(maxInt(i64)) rounds UP to this very value and would
+        // re-admit it -- the off-by-one-ULP guard shape #1907 was made of.
+        "(guard (e (#t 'caught)) (seconds->time 9223372036854775808.0))",
+    };
+    for (rejected) |src| {
+        const got = try vm.eval(src);
+        try std.testing.expect(types.isSymbol(got));
+        try std.testing.expectEqualStrings("caught", types.symbolName(got));
+    }
+
+    // Controls: the issue's last-accepted magnitude below 2^63, and the
+    // exactly-representable minimum (-2^63 is a valid i64, unlike +2^63).
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(= 9.2e18 (time->seconds (seconds->time 9.2e18)))"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(= -9223372036854775808.0 (time->seconds (seconds->time -9223372036854775808.0)))"));
+    // Round-trip sanity away from the boundary.
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(< (abs (- 1.5 (time->seconds (seconds->time 1.5)))) 1e-9)"));
+}
+
+test "huge and infinite timeouts saturate instead of aborting (#1983)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Uncontended mutex: the timeout is converted eagerly (the old abort
+    // site) and then never consulted, because the lock is free. 1e300
+    // exercises the float branch's multiply overflow; +inf.0 the infinity
+    // path. Control from the issue: 1.8e10 was already fine.
+    _ = try vm.eval("(define m (make-mutex))");
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(mutex-lock! m 1.8e10)"));
+    _ = try vm.eval("(mutex-unlock! m)");
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(mutex-lock! m 1e300)"));
+    _ = try vm.eval("(mutex-unlock! m)");
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(mutex-lock! m +inf.0)"));
+    _ = try vm.eval("(mutex-unlock! m)");
+
+    // Far-future TIME OBJECT: timeoutToDeadlineNs' other branch, whose u64
+    // seconds*1e9 multiply was a separate "integer overflow" panic.
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(mutex-lock! m (seconds->time 9.2e18))"));
+    _ = try vm.eval("(mutex-unlock! m)");
+
+    // thread-join! with an infinite timeout on a thread that finishes.
+    _ = try vm.eval("(define t (thread-start! (make-thread (lambda () 42))))");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(try vm.eval("(thread-join! t +inf.0)")));
+}

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -505,7 +505,9 @@ pub fn callValue(vm: *VM, callee: Value, base: u32, nargs: u8) VMError!void {
 pub fn callClosure(vm: *VM, closure: *types.Closure, base: u32, nargs: u8) VMError!void {
     const func = closure.func;
 
-    try vm.ensureRegisterCapacity(@as(usize, base) + @as(usize, @max(nargs + 1, func.locals_count)) + 1);
+    // nargs is a u8 and 255 is a legal argument count (the ISA's maximum),
+    // so the +1 must not happen in u8 arithmetic (#2185).
+    try vm.ensureRegisterCapacity(@as(usize, base) + @max(@as(usize, nargs) + 1, func.locals_count) + 1);
 
     if (!func.is_variadic) {
         if (nargs != func.arity) {

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -459,7 +459,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         self.registers[abs_base + 1 + rest_start] = try buildRestList(self.gc, self.registers[abs_base + 1 + rest_start .. abs_base + 1 + nargs]);
                     }
 
-                    const arg_count = if (func.is_variadic) func.arity + 1 else nargs;
+                    // arity is a u8 and 255 is legal, so the variadic +1 for
+                    // the rest-list slot must widen first (#2185).
+                    const arg_count: usize = if (func.is_variadic) @as(usize, func.arity) + 1 else nargs;
                     for (0..arg_count) |i| {
                         const dst_idx = @as(usize, frame.base) + i;
                         const src_idx = @as(usize, abs_base) + 1 + i;
@@ -671,7 +673,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         flat_args[rest_start] = try buildRestList(self.gc, flat_args[rest_start..total_nargs]);
                     }
 
-                    const arg_count: u8 = if (func.is_variadic) func.arity + 1 else total_nargs;
+                    // Same u8 widening as tail_call above (#2185): a variadic
+                    // callee with 255 fixed params needs 256 arg slots.
+                    const arg_count: usize = if (func.is_variadic) @as(usize, func.arity) + 1 else total_nargs;
                     for (0..arg_count) |i| {
                         const dst_idx = @as(usize, frame.base) + i;
                         if (dst_idx >= self.registers.len) return VMError.InvalidBytecode;
@@ -1076,7 +1080,8 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         }
                         self.registers[abs_base + 1 + rest_start] = try buildRestList(self.gc, self.registers[abs_base + 1 + rest_start .. abs_base + 1 + nargs]);
                     }
-                    const arg_count = if (tfunc.is_variadic) tfunc.arity + 1 else nargs;
+                    // Same u8 widening as tail_call above (#2185).
+                    const arg_count: usize = if (tfunc.is_variadic) @as(usize, tfunc.arity) + 1 else nargs;
                     for (0..arg_count) |ai| {
                         const dst_idx = @as(usize, frame.base) + ai;
                         const src_idx = @as(usize, abs_base) + 1 + ai;

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -878,7 +878,12 @@ pub fn parseRecordSpec(args: Value) ?RecordSpec {
         if (!types.isPair(fspec)) return null;
         const fname_sym = types.car(fspec);
         if (!types.isSymbol(fname_sym)) return null;
-        if (spec.field_count >= 256) return null;
+        // Cap at 255, not the arrays' 256: RecordType.num_fields is a u8, and
+        // handleDefineRecordType @intCasts field_count into it -- admitting a
+        // 256-field spec here turned that cast into an uncatchable panic at
+        // definition time (#1973). The R6RS parser caps at 255 for the same
+        // reason.
+        if (spec.field_count >= 255) return null;
         const fname = types.symbolName(fname_sym);
         for (spec.field_names[0..spec.field_count]) |existing| {
             if (std.mem.eql(u8, existing, fname)) return null;

--- a/tests/scheme/audit/primitives_filesystem-audit.scm
+++ b/tests/scheme/audit/primitives_filesystem-audit.scm
@@ -589,19 +589,19 @@
    (test-assert "(exact-integer? (file-info:rdev (file-info (string-append dir '/fifo..."
      (exact-integer? (file-info:rdev (file-info (string-append dir "/fifo") #f))))))
 
-;; FAIL: #1976 (file-info panics — SIGABRT, not catchable — on any path whose
-;; st_dev is negative when read as i32; on macOS that is every entry under
-;; /dev, whose devfs st_dev is 2998493978 = -1296473318 as i32.  The cast is
-;; `.dev = @intCast(stat_buf.dev)` at src/primitives_filesystem.zig:134.
-;; /dev/fd has st_rdev = 0 and still aborts, which discriminates dev from
-;; rdev.  Enabling either line below aborts the whole suite.)
-;; (test-equal "(file-info-type (file-info '/dev/null' #t))" 'char-special (file-info-type (file-info "/dev/null" #t)))
-;; (test-equal "(file-info-device? (file-info '/dev/null' #t))" #t (file-info-device? (file-info "/dev/null" #t)))
-;; (test-equal "(file-info-type (file-info '/dev/fd' #t))" 'directory (file-info-type (file-info "/dev/fd" #t)))
+;; #1976 regression: file-info used to abort (SIGABRT, uncatchable) on any
+;; path whose st_dev is negative when read as i32 — on macOS that is every
+;; entry under /dev, whose devfs st_dev is 2998493978 = -1296473318 as i32,
+;; via the old `.dev = @intCast(stat_buf.dev)`. Fixed by reinterpreting the
+;; bits as unsigned before widening (devToU64). /dev/fd has st_rdev = 0 and
+;; still aborted, which is what discriminated dev from rdev.
+(test-equal "(file-info-type (file-info '/dev/null' #t))" 'char-special (file-info-type (file-info "/dev/null" #t)))
+(test-equal "(file-info-device? (file-info '/dev/null' #t))" #t (file-info-device? (file-info "/dev/null" #t)))
+(test-equal "(file-info-type (file-info '/dev/fd' #t))" 'directory (file-info-type (file-info "/dev/fd" #t)))
 ;;
-;; Enabled control: an ordinary path on a filesystem whose st_dev is
-;; positive stats without incident, so the failure is the device number and
-;; not the char-device type or the /dev path text.
+;; Control: an ordinary path on a filesystem whose st_dev is positive stats
+;; without incident, so the old failure was the device number and not the
+;; char-device type or the /dev path text.
 (test-equal "(file-info-type (file-info '/tmp' #t))" 'directory (file-info-type (file-info "/tmp" #t)))
 (test-equal "(> (file-info:device (file-info '/tmp' #t)) 0)" #t (> (file-info:device (file-info "/tmp" #t)) 0))
 

--- a/tests/scheme/audit/primitives_filesystem-audit.scm
+++ b/tests/scheme/audit/primitives_filesystem-audit.scm
@@ -597,7 +597,14 @@
 ;; still aborted, which is what discriminated dev from rdev.
 (test-equal "(file-info-type (file-info '/dev/null' #t))" 'char-special (file-info-type (file-info "/dev/null" #t)))
 (test-equal "(file-info-device? (file-info '/dev/null' #t))" #t (file-info-device? (file-info "/dev/null" #t)))
-(test-equal "(file-info-type (file-info '/dev/fd' #t))" 'directory (file-info-type (file-info "/dev/fd" #t)))
+;; /dev/fd resolves to a directory on every current CI leg, but on Linux it
+;; is a symlink into /proc, which a minimal environment may not have
+;; mounted -- so accept a catchable stat failure too. The regression being
+;; pinned is the uncatchable abort; the 'directory answer, where /dev/fd
+;; does resolve, additionally pins the dev-vs-rdev discriminator.
+(test-assert "(file-info-type (file-info '/dev/fd' #t)) is directory where resolvable"
+  (let ((t (guard (e (#t 'unresolvable)) (file-info-type (file-info "/dev/fd" #t)))))
+    (or (eq? t 'directory) (eq? t 'unresolvable))))
 ;;
 ;; Control: an ordinary path on a filesystem whose st_dev is positive stats
 ;; without incident, so the old failure was the device number and not the

--- a/tests/scheme/audit/primitives_srfi18-audit.scm
+++ b/tests/scheme/audit/primitives_srfi18-audit.scm
@@ -831,37 +831,28 @@
 (test-assert "time->seconds rejects a thread" (raises? (lambda () (time->seconds (current-thread)))))
 (test-assert "time->seconds rejects a mutex" (raises? (lambda () (time->seconds (make-mutex)))))
 
-;; -- BUG: seconds->time ABORTS the process (uncatchable, exit 134) once
-;;    floor(x) leaves i64 range.
-;; secondsToTimeFn (primitives_srfi18.zig:1397) does
-;;   @as(i64, @intFromFloat(@floor(secs)))
-;; with no range guard, so ReleaseSafe panics "integer part of floating
-;; point value out of bounds". `guard` cannot catch a panic.
-;; Cliff measured: 9.2e18 is fine, 9.3e18 aborts — exactly the i64 edge.
-;; These stay COMMENTED OUT: running one takes the whole test runner down.
-;; FAIL: #1983 (seconds->time panics, exit 134, on +inf.0/-inf.0 and any
-;;       |x| >= 2^63 — uncatchable, aborts the process)
-;; (test-assert "seconds->time +inf.0 raises catchably" (raises? (lambda () (seconds->time +inf.0))))
-;; (test-assert "seconds->time -inf.0 raises catchably" (raises? (lambda () (seconds->time -inf.0))))
-;; (test-assert "seconds->time 1e300 raises catchably"  (raises? (lambda () (seconds->time 1e300))))
-;; (test-assert "seconds->time 2^63 raises catchably"   (raises? (lambda () (seconds->time (expt 2 63)))))
-;; (test-assert "seconds->time 9.3e18 raises catchably" (raises? (lambda () (seconds->time 9.3e18))))
-;; CONTROL (enabled): just below the cliff, the same code path is fine.
+;; seconds->time used to ABORT the process (uncatchable, exit 134) once
+;; floor(x) left i64 range: secondsToTimeFn did an unguarded
+;; @intFromFloat, cliff measured at 9.2e18 fine / 9.3e18 abort. Fixed by
+;; #1983: values outside [-2^63, 2^63) — including the infinities and
+;; NaN — now raise a catchable KP3007, because a time object is an
+;; observable value and clamping would silently build a wrong one.
+(test-assert "seconds->time +inf.0 raises catchably" (raises? (lambda () (seconds->time +inf.0))))
+(test-assert "seconds->time -inf.0 raises catchably" (raises? (lambda () (seconds->time -inf.0))))
+(test-assert "seconds->time 1e300 raises catchably" (raises? (lambda () (seconds->time 1e300))))
+(test-assert "seconds->time 2^63 raises catchably" (raises? (lambda () (seconds->time (expt 2 63)))))
+(test-assert "seconds->time 9.3e18 raises catchably" (raises? (lambda () (seconds->time 9.3e18))))
+;; CONTROL: just below the cliff, the same code path is fine.
 (test-assert "CONTROL: 9.2e18 is below the i64 cliff and works"
   (time? (seconds->time 9.2e18)))
 (test-assert "CONTROL: 2^62 works" (time? (seconds->time (expt 2 62))))
 
-;; NaN is silently wrong rather than a panic -- which is the point worth
-;; pinning, because +inf.0 and |x| >= 2^63 DO abort the process (#1983).
-;;
-;; Do NOT assert the resulting value.  It comes from @intFromFloat on a
-;; NaN, which is undefined -- macOS and this NetBSD box both happen to
-;; yield 0.0, but CI's NetBSD produced something else and failed an
-;; earlier version of this assertion that pinned 0.0.  Assert only that
-;; a time object comes back at all: that is the real contrast with the
-;; aborting cases, and it is true wherever the conversion lands.
-(test-assert "TODAY: seconds->time +nan.0 does not abort (value undefined)"
-  (time? (seconds->time +nan.0)))
+;; NaN used to slip through as an undefined-value time object (the one
+;; non-aborting wrong case); post-#1983 it is rejected with the same
+;; catchable error as the infinities, since no time it could denote
+;; exists.
+(test-assert "seconds->time +nan.0 raises catchably (#1983)"
+  (raises? (lambda () (seconds->time +nan.0))))
 
 ;; ---------------------------------------------------------------------
 ;; 8. Timeouts, expressed as bare numbers and as time objects
@@ -923,30 +914,16 @@
 (test-assert "sleep a bignum raises (not a supported spelling)"
   (raises? (lambda () (thread-sleep! (expt 2 70)))))
 
-;; -- BUG: the same unchecked @intFromFloat aborts EVERY timeout entry
-;;    point, not just seconds->time.
-;; timeoutToDeadlineNs (primitives_srfi18.zig:244) does
-;;   const delta_ns: u64 = @intFromFloat(@max(0.0, secs) * 1_000_000_000.0);
-;; and threadSleepFn (:604) does the same for its own duration. Any
-;; timeout above ~1.845e10 seconds (u64 nanoseconds) aborts the process.
-;; timeoutToDeadlineNs is `pub` and is also what (kaappi fibers)
-;; channel-send/channel-receive timeouts parse through, so the blast
-;; radius is wider than SRFI 18.
-;; Cliff measured: 1.8e10 is fine (catchable), 1.9e10 aborts.
-;; FAIL: #1984 (thread-sleep! / mutex-lock! / thread-join! / mutex-unlock!+cv
-;;       panic, exit 134, on +inf.0 or a timeout >= ~1.845e10 seconds)
-;; (test-assert "thread-sleep! +inf.0 raises catchably" (raises? (lambda () (thread-sleep! +inf.0))))
-;; (test-assert "thread-sleep! 1e300 raises catchably"  (raises? (lambda () (thread-sleep! 1e300))))
-;; (test-assert "mutex-lock! +inf.0 timeout raises catchably"
-;;   (raises? (lambda () (let ((m (make-mutex))) (mutex-lock! m) (mutex-lock! m +inf.0)))))
-;; (test-assert "thread-join! +inf.0 timeout raises catchably"
-;;   (raises? (lambda () (thread-join! (make-thread (lambda () 1)) +inf.0 'TV))))
-;; (test-assert "mutex-unlock!+cv +inf.0 timeout raises catchably"
-;;   (raises? (lambda () (mutex-unlock! (make-mutex) (make-condition-variable) +inf.0))))
-;; CONTROL (enabled): just below the cliff the SAME conversion runs and
-;; does not abort — so the failure is the conversion, not the magnitude.
-;; Driven through a thread that has already completed, so the timeout is
-;; parsed but never actually waited out.
+;; The same unchecked @intFromFloat used to abort EVERY timeout entry
+;; point, not just seconds->time — timeoutToDeadlineNs and threadSleepFn
+;; each converted the duration unguarded, with the cliff at ~1.845e10
+;; seconds (the u64 nanosecond clock), and timeoutToDeadlineNs is `pub`
+;; and shared with (kaappi fibers) channel timeouts. Fixed by #1983 with
+;; SATURATION, not a raise: a timeout is a deadline, +inf.0 conventionally
+;; means "never time out" (and #f already means "no timeout"), so a
+;; beyond-range duration becomes a deadline that never fires. These pins
+;; drive the conversion through already-resolved waits, so the saturated
+;; timeout is parsed but never waited out.
 (define to-5 (make-thread (lambda () 'done-immediately)))
 (thread-start! to-5)
 (thread-join! to-5)
@@ -954,20 +931,22 @@
   'done-immediately (thread-join! to-5 1.8e10 'TV))
 (test-equal "CONTROL: 1e9 seconds as a time object parses too"
   'done-immediately (thread-join! to-5 (seconds->time 1e9) 'TV))
+(test-equal "thread-join! +inf.0 timeout saturates (used to abort, #1983)"
+  'done-immediately (thread-join! to-5 +inf.0 'TV))
+(test-equal "thread-join! 1e300 timeout saturates (used to abort, #1983)"
+  'done-immediately (thread-join! to-5 1e300 'TV))
+(test-assert "mutex-lock! +inf.0 timeout on a free mutex saturates (used to abort, #1983)"
+  (let ((m (make-mutex)))
+    (let ((r (mutex-lock! m +inf.0))) (mutex-unlock! m) r)))
 
-;; -- and the TIME-OBJECT branch has its own, separate unguarded arithmetic.
-;; timeoutToDeadlineNs (:234) computes
-;;   const sec_ns: u64 = @as(u64, @intCast(t.seconds)) * 1_000_000_000 + ns_clamped;
-;; which overflows u64 for the same ~1.845e10-second threshold, but panics
-;; "integer overflow" rather than the "integer part of floating point value
-;; out of bounds" the number branch produces -- two distinct sites, one
-;; cliff. Measured: (seconds->time 1.8e10) is fine, (seconds->time 1.9e10)
-;; aborts.
-;; FAIL: #1984 (a time-object timeout whose seconds field exceeds ~1.845e10
-;;       panics with "integer overflow", exit 134, in timeoutToDeadlineNs)
-;; (test-assert "a huge absolute time object raises catchably"
-;;   (raises? (lambda () (thread-join! to-5 (seconds->time 1e18) 'TV))))
-(test-equal "CONTROL: 1.8e10 as a time object is just below that cliff"
+;; The TIME-OBJECT branch had its own, separate unguarded arithmetic: the
+;; u64 seconds*1e9 multiply overflowed ("integer overflow" panic) at the
+;; same ~1.845e10-second threshold. Also fixed by #1983 with saturating
+;; arithmetic — a far-future time object is perfectly legal (its i64
+;; seconds go to ~2.9e11 years) and reads as "never fires".
+(test-equal "a huge absolute time object saturates (used to abort, #1983)"
+  'done-immediately (thread-join! to-5 (seconds->time 1e18) 'TV))
+(test-equal "CONTROL: 1.8e10 as a time object is just below the old cliff"
   'done-immediately (thread-join! to-5 (seconds->time 1.8e10) 'TV))
 
 ;; ---------------------------------------------------------------------

--- a/tests/scheme/audit/primitives_srfi237-audit.scm
+++ b/tests/scheme/audit/primitives_srfi237-audit.scm
@@ -667,14 +667,13 @@
 ;;; ===================================================================
 ;;; Record INSTANTIATION field-count limit
 ;;;
-;;; GC.allocRecordInstance computes its byte size as
+;;; GC.allocRecordInstance used to compute its byte size as
 ;;;   @sizeOf(RecordInstance) + record_type.num_fields * @sizeOf(Value)
 ;;; in u8 arithmetic (num_fields is a u8), so the whole expression
-;;; overflows once 40 + 8n > 255, i.e. at n = 27. The record TYPE is
-;;; created happily; the process aborts on the first instance.
-;;;
-;;; This is an uncatchable Zig panic, not an error, so the failing case
-;;; cannot be left enabled in any form — it would abort the suite.
+;;; overflowed once 40 + 8n > 255, i.e. at n = 27: the record TYPE was
+;;; created happily, and the process aborted (uncatchable Zig panic) on
+;;; the first instance. Fixed by #1973 — the multiplication is widened
+;;; to usize — so the three cases past the old cliff are enabled again.
 ;;; ===================================================================
 
 (test-assert "instantiation: a 26-field record type instantiates (control, just under the cliff)"
@@ -685,36 +684,50 @@
              (record-type-descriptor?
                (make-record-type-descriptor 'N27 #f #f #f #f (fields-vector 27))))
 
-;; FAIL: #1973 (allocRecordInstance sizes in u8 arithmetic — PANICS, uncatchable, at 27 fields)
-;; (test-assert "instantiation: a 27-field record type instantiates"
-;;              (record?
-;;                (apply (root-ctor (make-record-type-descriptor 'N27 #f #f #f #f (fields-vector 27)))
-;;                       (count-up 27))))
-;; FAIL: #1973 (same overflow, reached through inheritance rather than own fields)
-;; (test-assert "instantiation: a 27-field total reached through a parent chain instantiates"
-;;              (let* ((A (make-record-type-descriptor 'A27 #f #f #f #f (fields-vector 20)))
-;;                     (B (make-record-type-descriptor 'B27 A #f #f #f (fields-vector 7))))
-;;                (record? (apply (record-constructor
-;;                                  (make-record-descriptor B (make-record-descriptor A #f #f) #f))
-;;                                (count-up 27)))))
+;; #1973 regression: 27 own fields — the first count past the old u8 cliff.
+(test-assert "instantiation: a 27-field record type instantiates"
+             (record?
+               (apply (root-ctor (make-record-type-descriptor 'N27 #f #f #f #f (fields-vector 27)))
+                      (count-up 27))))
+;; #1973 regression: the same overflow, reached through inheritance.
+(test-assert "instantiation: a 27-field total reached through a parent chain instantiates"
+             (let* ((A (make-record-type-descriptor 'A27 #f #f #f #f (fields-vector 20)))
+                    (B (make-record-type-descriptor 'B27 A #f #f #f (fields-vector 7))))
+               (record? (apply (record-constructor
+                                 (make-record-descriptor B (make-record-descriptor A #f #f) #f))
+                               (count-up 27)))))
 
-;; The same overflow is reachable from plain R7RS `define-record-type` with
+;; The same overflow was reachable from plain R7RS `define-record-type` with
 ;; no SRFI 237 involvement at all — allocRecordInstance is shared by both
 ;; record systems. Kept here because this audit is what found it.
-;; FAIL: #1973 (allocRecordInstance sizes in u8 arithmetic — PANICS on a plain R7RS 27-field record)
-;; (test-assert "instantiation: a plain R7RS 27-field record instantiates"
-;;              (begin
-;;                (define-record-type r7-27
-;;                  (make-r7-27 a b c d e f g h i j k l m n o p q r s t u v w x y z aa)
-;;                  r7-27?
-;;                  (a r7-27-a) (b r7-27-b) (c r7-27-c) (d r7-27-d) (e r7-27-e)
-;;                  (f r7-27-f) (g r7-27-g) (h r7-27-h) (i r7-27-i) (j r7-27-j)
-;;                  (k r7-27-k) (l r7-27-l) (m r7-27-m) (n r7-27-n) (o r7-27-o)
-;;                  (p r7-27-p) (q r7-27-q) (r r7-27-r) (s r7-27-s) (t r7-27-t)
-;;                  (u r7-27-u) (v r7-27-v) (w r7-27-w) (x r7-27-x) (y r7-27-y)
-;;                  (z r7-27-z) (aa r7-27-aa))
-;;                (r7-27? (make-r7-27 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
-;;                                    21 22 23 24 25 26 27))))
+(test-assert "instantiation: a plain R7RS 27-field record instantiates"
+             (begin
+               (define-record-type r7-27
+                 (make-r7-27 a b c d e f g h i j k l m n o p q r s t u v w x y z aa)
+                 r7-27?
+                 (a r7-27-a) (b r7-27-b) (c r7-27-c) (d r7-27-d) (e r7-27-e)
+                 (f r7-27-f) (g r7-27-g) (h r7-27-h) (i r7-27-i) (j r7-27-j)
+                 (k r7-27-k) (l r7-27-l) (m r7-27-m) (n r7-27-n) (o r7-27-o)
+                 (p r7-27-p) (q r7-27-q) (r r7-27-r) (s r7-27-s) (t r7-27-t)
+                 (u r7-27-u) (v r7-27-v) (w r7-27-w) (x r7-27-x) (y r7-27-y)
+                 (z r7-27-z) (aa r7-27-aa))
+               (r7-27? (make-r7-27 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
+                                   21 22 23 24 25 26 27))))
+;; #1973 regression: the widest record that can be CONSTRUCTED. The rtd cap
+;; is 255 (num_fields is a u8), but every construction path passes the rtd
+;; plus all fields through one call, and the call/apply ISA caps at 255
+;; arguments — so 254 fields is the construction ceiling, and a 255-field
+;; construction is rejected loudly (KP3007), never an abort.
+(test-assert "instantiation: a 254-field record type instantiates (construction ceiling)"
+             (let ((inst (apply (root-ctor (make-record-type-descriptor
+                                             'N254 #f #f #f #f (fields-vector 254)))
+                                (count-up 254))))
+               (and (record? inst)
+                    (= 253 ((record-accessor (record-rtd inst) 253) inst)))))
+(test-assert "instantiation: a 255-field construction is rejected catchably (apply arg limit)"
+             (let ((rtd (make-record-type-descriptor 'N255 #f #f #f #f (fields-vector 255))))
+               (and (record-type-descriptor? rtd)
+                    (raises? (lambda () (apply (root-ctor rtd) (count-up 255)))))))
 
 
 ;;; ===================================================================

--- a/tests/scheme/smoke/call-255-args-2185.scm
+++ b/tests/scheme/smoke/call-255-args-2185.scm
@@ -1,0 +1,59 @@
+;; Regression test for #2185: 255 arguments is the call ISA's maximum (nargs
+;; is one byte), and exactly that count aborted the process -- callClosure
+;; sized its register window with `nargs + 1` in u8 arithmetic, and the tail
+;; dispatch paths computed a variadic callee's `arity + 1` rest slot the same
+;; way. A 256-parameter lambda separately overflowed the compiler's u8 arity
+;; counter at definition time. 253/254 arguments always worked, which is what
+;; let this ship: the cliff sat on the last legal call.
+
+(import (scheme base) (scheme eval) (scheme write) (scheme process-context)
+        (srfi 64))
+
+(test-begin "call-255-args-2185")
+
+(define (make-params n)
+  (let loop ((i (- n 1)) (acc '()))
+    (if (< i 0) acc
+        (loop (- i 1)
+              (cons (string->symbol (string-append "p" (number->string i))) acc)))))
+
+(define (count-up n)
+  (let loop ((i (- n 1)) (acc '())) (if (< i 0) acc (loop (- i 1) (cons i acc)))))
+
+(define env (interaction-environment))
+
+;; Exact 255-ary procedure: the very count that overflowed `nargs + 1`.
+(eval `(define f255 (lambda ,(make-params 255) p254)) env)
+
+(test-equal "direct 255-argument call (used to abort the process)"
+            254 (eval `(f255 ,@(count-up 255)) env))
+(test-equal "255-argument tail call"
+            254 (eval `((lambda () (f255 ,@(count-up 255)))) env))
+(test-equal "apply with 255 arguments (the apply limit itself)"
+            254 (apply (eval 'f255 env) (count-up 255)))
+
+;; Variadic with 255 FIXED params: the frame needs arity + 1 = 256 argument
+;; slots (fixed params plus the rest list, necessarily empty here) -- the
+;; quantity the tail paths computed in u8.
+(eval `(define v255 (lambda ,(append (make-params 255) 'rest) (cons p254 rest))) env)
+
+(test-equal "variadic-255 direct call" '(254) (eval `(v255 ,@(count-up 255)) env))
+(test-equal "variadic-255 tail call" '(254) (eval `((lambda () (v255 ,@(count-up 255)))) env))
+(test-equal "variadic-255 via apply" '(254) (apply (eval 'v255 env) (count-up 255)))
+
+;; 256 fixed parameters: uncallable by construction (no call site can encode
+;; a 256th argument), so the definition must fail as a catchable compile
+;; error -- the compiler's own arity counter overflowed here before the fix.
+(test-assert "256-parameter lambda is rejected catchably, not a compile-time abort"
+             (guard (e (#t #t))
+               (eval `(lambda ,(make-params 256) p0) env)
+               #f))
+
+;; Control: one under the cliff keeps working.
+(eval `(define f254 (lambda ,(make-params 254) p253)) env)
+(test-equal "254-argument call (control, always worked)"
+            253 (eval `(f254 ,@(count-up 254)) env))
+
+(let ((runner (test-runner-current)))
+  (test-end "call-255-args-2185")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi170-devfs-1976.scm
+++ b/tests/scheme/srfi/srfi170-devfs-1976.scm
@@ -1,0 +1,42 @@
+;; Regression test for #1976: file-info on devfs paths aborted the process.
+;;
+;; dev_t is signed on macOS and OpenBSD (i32), and devfs reports device ids
+;; with the sign bit set -- macOS's /dev/null stats as st_dev = -1296473318.
+;; doStat's range-checked @intCast into u64 turned that into an uncatchable
+;; Zig panic (exit 134), taking down `(file-info "/dev/null" #t)` and even a
+;; guard wrapped around it. The fix reinterprets the bits as unsigned before
+;; widening (a device id is an opaque identity, not a quantity).
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64)
+        (srfi 170))
+
+(test-begin "srfi170-devfs-1976")
+
+(cond-expand
+  (windows
+   ;; No devfs on Windows -- the signed-dev_t branch is exercised on the
+   ;; POSIX CI legs. Pin only that a missing /dev path stays catchable.
+   (test-assert "file-info on a /dev path succeeds or raises catchably"
+                (guard (e (#t #t)) (file-info "/dev/null" #t) #t)))
+  (else
+   (test-assert "file-info /dev/null returns a file-info (used to abort)"
+                (file-info? (file-info "/dev/null" #t)))
+   (test-assert "file-info:device on /dev/null is a non-negative exact integer"
+                (let ((d (file-info:device (file-info "/dev/null" #t))))
+                  (and (exact-integer? d) (>= d 0))))
+   (test-assert "file-info:rdev on /dev/null is a non-negative exact integer"
+                (let ((r (file-info:rdev (file-info "/dev/null" #t))))
+                  (and (exact-integer? r) (>= r 0))))
+   (test-assert "/dev/null classifies as a device"
+                (file-info-device? (file-info "/dev/null" #t)))
+   ;; /dev/fd is the issue's discriminating control: a *directory* under
+   ;; devfs with st_rdev = 0, so a failure here isolates st_dev. It can be
+   ;; a broken /proc symlink on minimal containers, so accept a catchable
+   ;; stat failure -- the regression being pinned is the uncatchable abort.
+   (test-assert "file-info /dev/fd does not abort"
+                (guard (e (#t 'stat-failed))
+                  (begin (file-info "/dev/fd" #t) #t)))))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi170-devfs-1976")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi18-timeout-saturation-1983.scm
+++ b/tests/scheme/srfi/srfi18-timeout-saturation-1983.scm
@@ -1,0 +1,66 @@
+;; Regression test for #1983: unguarded float->int conversions in SRFI-18
+;; aborted the process (exit 134, uncatchable), and timeoutToDeadlineNs is
+;; shared with (kaappi fibers), so channel timeouts died the same way.
+;;
+;; Post-fix contract:
+;;   - seconds->time RAISES catchably on values no time object can represent
+;;     (it constructs an observable value; clamping would silently lie).
+;;   - timeouts SATURATE: a duration/deadline beyond the u64 nanosecond
+;;     clock means "never times out", matching the SRFI-18 convention that
+;;     +inf.0 as a timeout means wait without bound.
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 18) (srfi 64) (kaappi fibers))
+
+(test-begin "srfi18-timeout-saturation-1983")
+
+;; --- seconds->time: catchable rejection, exact boundary -------------------
+
+(define (rejects? x)
+  (eq? 'caught (guard (e (#t 'caught)) (seconds->time x) 'accepted)))
+
+(test-assert "seconds->time +inf.0 raises catchably (used to abort)" (rejects? +inf.0))
+(test-assert "seconds->time -inf.0 raises catchably" (rejects? -inf.0))
+(test-assert "seconds->time +nan.0 raises catchably" (rejects? +nan.0))
+(test-assert "seconds->time 9.3e18 raises catchably (issue's aborting cliff)" (rejects? 9.3e18))
+;; 2^63 exactly: the first unrepresentable value. A guard written against
+;; @floatFromInt(maxInt(i64)) re-admits it (#1907's off-by-one-ULP shape).
+(test-assert "seconds->time 2^63 raises catchably" (rejects? 9223372036854775808.0))
+
+(test-equal "seconds->time 9.2e18 round-trips (issue's last-safe control)"
+            9.2e18 (time->seconds (seconds->time 9.2e18)))
+(test-equal "seconds->time -2^63 round-trips (minInt IS representable)"
+            -9223372036854775808.0
+            (time->seconds (seconds->time -9223372036854775808.0)))
+(test-approximate "seconds->time ordinary value round-trips" 1.5
+                  (time->seconds (seconds->time 1.5)) 1e-9)
+
+;; --- timeouts: saturate, never abort --------------------------------------
+
+(define m (make-mutex))
+(test-assert "mutex-lock! with the issue's catchable control 1.8e10"
+             (mutex-lock! m 1.8e10))
+(mutex-unlock! m)
+(test-assert "mutex-lock! with a 1e300 timeout (used to abort the process)"
+             (mutex-lock! m 1e300))
+(mutex-unlock! m)
+(test-assert "mutex-lock! with +inf.0 (never times out)"
+             (mutex-lock! m +inf.0))
+(mutex-unlock! m)
+(test-assert "mutex-lock! with a far-future time object (u64 multiply overflowed)"
+             (mutex-lock! m (seconds->time 9.2e18)))
+(mutex-unlock! m)
+
+(define t (thread-start! (make-thread (lambda () 42))))
+(test-equal "thread-join! with +inf.0 timeout" 42 (thread-join! t +inf.0))
+
+;; --- the fibers blast radius ----------------------------------------------
+
+(define ch (make-channel 0))
+(spawn (lambda () (channel-send ch 41)))
+(test-equal "channel-receive with a 1e300 timeout (used to abort)"
+            42 (+ 1 (channel-receive ch 1e300)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi18-timeout-saturation-1983")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Fixes four issues sharing one root cause — unguarded narrow arithmetic or conversion at a representation boundary, each an exit-134 process abort reachable from an ordinary program and invisible to `guard`. One PR per the request; #1907 turned out to already be fixed and is verified here.

## #1973 — record with ≥27 fields aborts on instantiation

`allocRecordInstance` sized its allocation as `num_fields * @sizeOf(Value)` in **u8 arithmetic** (`num_fields` is a u8), overflowing at 27 fields (40 + 8·27 = 256). Widened to `usize`. On the issue's ReleaseFast question: confirmed the overflow would wrap there instead of trapping, silently corrupting GC accounting — the widening fixes both modes, and `gc_sweep.objectSize` (which sizes the same object from `fields.len`, a usize) now agrees with the alloc side.

Adjacent hole closed: `parseRecordSpec` admitted **256-field** specs whose later `@intCast` into the u8 aborted at *definition* time; capped at 255 to match the R6RS parser. The construction ceiling is pinned honestly: **254 fields** is the widest constructible record everywhere (both the syntactic desugar and SRFI-237's `record-constructor` pass rtd+fields through one call, and the call/apply ISA caps at 255 arguments), with 255-field construction a loud KP3007. The three audit assertions disabled against this bug are re-enabled.

## #1976 — `file-info` aborts on devfs paths

`doStat` `@intCast` a signed `dev_t` (i32 on macOS/OpenBSD) into u64; macOS `/dev/null` stats as `st_dev = -1296473318`. New `devToU64` reinterprets the bits as the unsigned same-width type before widening (a device id is an opaque identity, not a quantity), applied to `dev` and `rdev` on both stat branches per the issue's note that `rdev` is the same type and merely lucky. `file-info:device` on `/dev/null` now reports the issue's exact `2998493978`. The audit's disabled devfs assertions (including the discriminating `/dev/fd` directory case) are re-enabled.

## #1983 — SRFI-18 float→int conversions abort; `(kaappi fibers)` too

Two deliberate post-fix behaviors:

- **`seconds->time` raises** a catchable KP3007 outside [-2^63, 2^63), including ±inf.0 and NaN — it constructs an observable value, so clamping would silently build a wrong time. The bound is written `0x1p63` exactly; `@floatFromInt(maxInt(i64))` rounds *up* to 2^63 and would re-admit the first aborting value — the same off-by-one-ULP guard shape #1907 was made of.
- **Timeouts saturate** (`*|`, `+|`, `std.math.lossyCast`): +inf.0 and any beyond-range duration or far-future time object mean "never times out" — the SRFI-18 convention (Gambit's own reading of +inf.0), continuous with `#f`, and it keeps legal far-future time objects (i64 seconds reach ~year 2554+ wall time) usable as deadlines rather than raising on them. NaN stays "no wait", as before. `timeoutToDeadlineNs` is `pub` and shared with `(kaappi fibers)`, so channel-send/receive timeouts are fixed by the same change — the issue's `channel-receive` 1e300 case is a test now.

The audit file's disabled abort cases are re-enabled under this contract (note: its timeout blocks were marked `FAIL: #1984`, but that content matches #1983's sites — the real #1984 is the mutex/terminate state-machine issue and is untouched here). Its stale "TODAY: NaN does not abort (value undefined)" pin — the one suite failure this PR's changes initially caused — is updated to the new catchable rejection.

## #2185 — 255-argument calls and 256-parameter lambdas abort (new issue, found here)

Filed and fixed in this PR: sweeping for sibling sites of #1973's pattern found that `callClosure` computed `nargs + 1` in u8 — aborting **every 255-argument call, the ISA's own maximum** (253/254 worked, which is how it shipped); three tail-dispatch paths computed a variadic callee's `arity + 1` rest-slot count the same way; and both `compileLambda` copies (`compiler_lambda.zig` and the live IR path in `compiler_ir.zig`) overflowed their u8 arity counter on a **256-parameter lambda at compile time** — killing `kaappi check` too. Calls widened to usize; a 256th fixed parameter is now a clean KP2001 (`InvalidSyntax`, deliberately not `TooManyLocals`, which surfaces as a KP9001 "internal error — report this bug" and would blame kaappi for user syntax).

## #1907 — verified fixed, no code needed

The reader `#e`-at-2^63 panic was fixed by #2181 (merged): verified on this branch that `read`, `kaappi check`, `kaappi ast`, and `kaappi fmt` all handle `#e9223372036854775808.0`, and both boundary values (`…296.0` first-crashing, `…784.0` last-safe) are pinned by #2181's tests in `tests_numeric.zig` and `reader-exactness-gaps.scm`.

## Testing

- `zig build test`: 1622 pass, 0 fail (5 new regression tests: record field ladder 27/254/255/256, devfs stat, `seconds->time` bounds + timeout saturation, fiber channel timeout + unbounded-sleep park with fiber progress pinned so the test can't pass vacuously, 255-arg direct/tail/apply × exact/variadic + 256-param rejection).
- `bash tests/scheme/run-all.sh`: **674 pass, 0 fail, 0 timeout** (1 standard wasm-differential skip); R7RS suite 1395/1395. Three new suite files: `srfi170-devfs-1976.scm`, `srfi18-timeout-saturation-1983.scm`, `call-255-args-2185.scm`.
- All original issue repros re-run against the fixed binary, including the discriminating controls (26/27 field cliff, `/dev/fd`, 1.8e10/1.9e10 cliffs, 9.2e18/9.3e18, 253/254/255-param bisect).
- Cross-compiles clean for aarch64-windows, x86_64-linux, aarch64-openbsd (the other signed-`dev_t` platform), aarch64-netbsd, aarch64-freebsd, and wasm.

Closes #1973. Closes #1976. Closes #1983. Closes #2185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)