### PR TITLE
Make the printer exact, iterative, and cycle-safe; unalias write-simple

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,7 +296,8 @@ Exceptions: auto-generated data files (`unicode_tables.zig`) are exempt.
 | `reader.zig` | ~700 | Tokenizer, S-expression parser, Unicode lexing |
 | `expander.zig` | ~1000 | Macro-use expansion engine: expandMacro/expandProceduralMacro, syntax-rules pattern matching, usertext/hygiene-strip walks |
 | `expander_instantiate.zig` | ~1000 | syntax-rules template instantiation + renameForHygiene/scope-table minting (shares expander.zig's threadlocal expansion context) |
-| `printer.zig` | ~300 | Value → string (write mode and display mode) |
+| `printer.zig` | ~1250 | Value → string: iterative label-aware print engine + hashmap cycle/sharing detection (write/display/write-shared/write-simple; exact at any depth) and the bounded diagnostic `printValue` |
+| `printer_pretty.zig` | ~320 | REPL pretty-printer (fits-or-wraps layout over the bounded diagnostic printer; re-exported as `printer.prettyPrint`) |
 
 ### Heap-type domain files (split into 11 files, kaappi#1731)
 
@@ -1210,7 +1211,12 @@ re-export, IR tests, and tail position handling.
    (generational remembered-set check) — and two in `src/gc_sweep.zig`:
    `objectSize` (GC stats) and `freeObject` (free owned memory).
    `types.zig`'s `typeName` also switches on `ObjectTag` for error messages.
-5. Add display in `src/printer.zig`.
+5. Add display in `src/printer.zig` (`printValueOnce`). If the new arm
+   recurses into contained Values, it must ALSO join `isTraversable` +
+   `childAt` there, and push engine tasks instead of recursing — a printed
+   edge invisible to cycle detection is exactly the four-procedure hang of
+   kaappi#1954. Add a self-referential instance to the per-tag termination
+   test in `src/tests_printer.zig` ("every traversable container...").
 
 ## GC safety
 

--- a/build.zig
+++ b/build.zig
@@ -284,6 +284,13 @@ pub fn build(b: *std.Build) void {
         .name = "kaappi",
         .root_module = wasm_mod,
     });
+    // Match the native executables' 64 MB stack (see `exe.stack_size` above).
+    // Without this the module took the 16 MiB linker default, so deep native
+    // recursion (reader nesting, the pretty-printer) ran the wasm32 shadow
+    // stack off the bottom of linear memory — an uncatchable module trap —
+    // before any depth guard calibrated for the native stack could fire
+    // (kaappi#2107).
+    wasm_exe.stack_size = 64 * 1024 * 1024;
     const wasm_install = b.addInstallArtifact(wasm_exe, .{});
     wasm_step.dependOn(&wasm_install.step);
 

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -53,7 +53,7 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "flush-output-port", .func = &flushOutputPort, .arity = .{ .variadic = 0 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "delete-file", .func = &deleteFile, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_file), .sandbox = false },
     .{ .name = "write-shared", .func = &writeShared, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.scheme_write) },
-    .{ .name = "write-simple", .func = &write, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.scheme_write) },
+    .{ .name = "write-simple", .func = &writeSimple, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.scheme_write) },
     .{ .name = "call-with-input-file", .func = &callWithInputFile, .arity = .{ .exact = 2 }, .libs = LS.initMany(&.{ .scheme_file, .scheme_r5rs }), .sandbox = false },
     .{ .name = "call-with-output-file", .func = &callWithOutputFile, .arity = .{ .exact = 2 }, .libs = LS.initMany(&.{ .scheme_file, .scheme_r5rs }), .sandbox = false },
     .{ .name = "call-with-port", .func = &callWithPort, .arity = .{ .exact = 2 }, .libs = LS.initOne(.scheme_base) },
@@ -624,6 +624,27 @@ fn writeShared(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const port = try getOutputPort(args, 1, "write-shared");
     const s = printer.valueToString(gc.allocator, args[0], .shared) catch return PrimitiveError.OutOfMemory;
+    defer gc.allocator.free(s);
+    try portWriteBytes(port, s);
+    return types.VOID;
+}
+
+/// R7RS 6.13.3: same as `write` except shared structure is NEVER represented
+/// with datum labels (kaappi#1955 — this was registered as `&write`, so the
+/// two were indistinguishable). A cycle has no finite label-free rendering;
+/// where the spec anticipates non-termination, raise a catchable error
+/// instead — loud beats a wedged process, and no program can rely on a hang.
+fn writeSimple(args: []const Value) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const port = try getOutputPort(args, 1, "write-simple");
+    const s = printer.valueToStringSimple(gc.allocator, args[0]) catch |err| switch (err) {
+        error.CircularStructure => return primitives.argError(
+            "write-simple",
+            "cannot represent circular structure without datum labels",
+            .{},
+        ),
+        else => return PrimitiveError.OutOfMemory,
+    };
     defer gc.allocator.free(s);
     try portWriteBytes(port, s);
     return types.VOID;

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -17,271 +17,794 @@ pub const PrintMode = enum {
     shared, // write with datum labels for shared/circular structures
 };
 
+/// REPL pretty-printer (moved out under the 1500-line policy; re-exported so
+/// callers keep the `printer.prettyPrint` spelling).
+pub const prettyPrint = @import("printer_pretty.zig").prettyPrint;
+
 // ---------------------------------------------------------------------------
-// Shared-structure detection (write-shared support)
+// Structural traversal
+// ---------------------------------------------------------------------------
+//
+// The printer recurses into exactly SEVEN heap containers. Cycle/sharing
+// detection and the print engine below both enumerate children through
+// `childAt`, so the two can never disagree about which edges exist -- a
+// container the printer walked but detection did not is exactly the
+// four-procedure hang of kaappi#1954 (error-object irritants, mutex and
+// condition-variable names were printed recursively but invisible to the
+// pre-pass, so a cycle through them was never labelled).
+//
+// `.rational` is deliberately NOT here: its numerator/denominator are always
+// exact integers (fixnum or bignum), so the `.rational` print arm renders
+// them inline as atoms. That also removes the depth seam that made a
+// rational at bounded-printer depth 1023 render as `.../...` -- a legal
+// symbol datum with the wrong value (kaappi#1953).
+//
+// `.hash_table` holds Values but prints only its size, so it has no print
+// edges and does not belong here either.
+
+fn isTraversable(obj: *types.Object) bool {
+    return switch (obj.tag) {
+        .pair, .vector, .record_instance, .error_object, .multiple_values, .mutex, .condition_variable => true,
+        else => false,
+    };
+}
+
+/// Child Values of a traversable container in print order; null past the end.
+fn childAt(v: Value, obj: *types.Object, idx: usize) ?Value {
+    switch (obj.tag) {
+        .pair => return switch (idx) {
+            0 => types.car(v),
+            1 => types.cdr(v),
+            else => null,
+        },
+        .vector => {
+            const data = obj.as(types.Vector).data;
+            return if (idx < data.len) data[idx] else null;
+        },
+        .record_instance => {
+            const fields = obj.as(types.RecordInstance).fields;
+            return if (idx < fields.len) fields[idx] else null;
+        },
+        .error_object => {
+            const eo = obj.as(types.ErrorObject);
+            return switch (idx) {
+                0 => eo.message,
+                1 => eo.irritants,
+                else => null,
+            };
+        },
+        .multiple_values => {
+            const vals = obj.as(types.MultipleValues).values;
+            return if (idx < vals.len) vals[idx] else null;
+        },
+        .mutex => return if (idx == 0) obj.as(types.Mutex).name else null,
+        .condition_variable => return if (idx == 0) obj.as(types.ConditionVariable).name else null,
+        else => return null,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Label detection (cycles for write/display, all sharing for write-shared)
 // ---------------------------------------------------------------------------
 
-const MAX_SHARED = 1024;
-const MAX_PRINT_DEPTH: u32 = 1024;
+/// Values that need a datum label, mapped to their assigned label number.
+/// Detection stores -1; the print engine assigns numbers lazily in print
+/// order, so label numbering is independent of traversal order.
+const Labels = struct {
+    map: std.AutoHashMap(Value, i32),
+    next: i32 = 0,
 
-const SharedState = struct {
-    seen: [MAX_SHARED]Value = undefined,
-    seen_count: usize = 0,
-    shared: [MAX_SHARED]Value = undefined, // objects seen more than once
-    shared_count: usize = 0,
-    labels: [MAX_SHARED]i32 = undefined, // -1 = not yet labeled, >= 0 = label number
-    next_label: i32 = 0,
-    depth: u32 = 0,
-
-    fn isShared(self: *SharedState, val: Value) bool {
-        for (self.shared[0..self.shared_count]) |sh| {
-            if (sh == val) return true;
-        }
-        return false;
+    fn init(allocator: std.mem.Allocator) Labels {
+        return .{ .map = std.AutoHashMap(Value, i32).init(allocator) };
     }
-
-    fn getOrAssignLabel(self: *SharedState, val: Value) ?i32 {
-        for (self.shared[0..self.shared_count], 0..) |sh, i| {
-            if (sh == val) {
-                if (self.labels[i] == -1) {
-                    self.labels[i] = self.next_label;
-                    self.next_label += 1;
-                }
-                return self.labels[i];
-            }
-        }
-        return null;
-    }
-
-    fn getLabel(self: *SharedState, val: Value) ?i32 {
-        for (self.shared[0..self.shared_count], 0..) |sh, i| {
-            if (sh == val) {
-                return if (self.labels[i] >= 0) self.labels[i] else null;
-            }
-        }
-        return null;
+    fn deinit(self: *Labels) void {
+        self.map.deinit();
     }
 };
 
-/// Pass 1: Walk the datum and record which heap objects are referenced
-/// more than once (shared structures). Uses a simple two-state approach:
-/// first encounter adds to "seen", second encounter adds to "shared".
-/// We only recurse on first encounter to avoid infinite loops on cycles.
-fn markShared(value: Value, state: *SharedState) void {
-    if (!types.isPointer(value)) return;
-    if (state.depth >= MAX_PRINT_DEPTH) return;
-    state.depth += 1;
-    defer state.depth -= 1;
-    const obj = types.toObject(value);
-    switch (obj.tag) {
-        .pair, .vector, .record_instance => {
-            // Check if already seen
-            for (state.seen[0..state.seen_count]) |s| {
-                if (s == value) {
-                    // Second encounter: mark as shared, don't recurse
-                    for (state.shared[0..state.shared_count]) |sh| {
-                        if (sh == value) return; // already shared
-                    }
-                    if (state.shared_count < MAX_SHARED) {
-                        state.shared[state.shared_count] = value;
-                        state.labels[state.shared_count] = -1;
-                        state.shared_count += 1;
-                    }
-                    return;
-                }
-            }
-            // First encounter: add to seen and recurse into children
-            if (state.seen_count < MAX_SHARED) {
-                state.seen[state.seen_count] = value;
-                state.seen_count += 1;
-            }
-            if (obj.tag == .pair) {
-                markShared(types.car(value), state);
-                markShared(types.cdr(value), state);
-            } else if (obj.tag == .vector) {
-                const vec = obj.as(types.Vector);
-                for (vec.data) |elem| {
-                    markShared(elem, state);
-                }
-            } else if (obj.tag == .record_instance) {
-                const ri = obj.as(types.RecordInstance);
-                for (ri.fields) |elem| {
-                    markShared(elem, state);
-                }
-            }
-        },
-        else => {},
-    }
-}
-
-/// Pass 2: Print with datum labels for the objects recorded in `state.shared`.
-/// `atom_mode` selects write vs display rendering for leaf atoms (strings,
-/// chars); list/vector structure renders identically in both.
-fn printValueShared(writer: anytype, value: Value, state: *SharedState, atom_mode: PrintMode) anyerror!void {
-    if (state.depth >= MAX_PRINT_DEPTH) {
-        try writer.writeAll("#<deep>");
-        return;
-    }
-    state.depth += 1;
-    defer state.depth -= 1;
-    // Check if this value has a label assigned (shared/cyclic reference)
-    if (types.isPointer(value) and state.isShared(value)) {
-        if (state.getLabel(value)) |label| {
-            // Already labeled -- emit back-reference #N#
-            try writer.print("#{d}#", .{label});
-            return;
-        }
-        // First occurrence -- assign label and emit #N=
-        if (state.getOrAssignLabel(value)) |label| {
-            try writer.print("#{d}=", .{label});
-        }
-    }
-    // Print the value itself
-    if (types.isPair(value)) {
-        try printListShared(writer, value, state, atom_mode);
-    } else if (types.isPointer(value) and types.toObject(value).tag == .vector) {
-        const vec = types.toObject(value).as(types.Vector);
-        try writer.writeAll("#(");
-        for (vec.data, 0..) |elem, i| {
-            if (i > 0) try writer.writeByte(' ');
-            try printValueShared(writer, elem, state, atom_mode);
-        }
-        try writer.writeByte(')');
-    } else if (types.isPointer(value) and types.toObject(value).tag == .record_instance) {
-        const ri = types.toObject(value).as(types.RecordInstance);
-        try writer.print("#<{s}", .{ri.record_type.name});
-        for (ri.fields) |field| {
-            try writer.writeByte(' ');
-            try printValueShared(writer, field, state, atom_mode);
-        }
-        try writer.writeByte('>');
-    } else {
-        try printValue(writer, value, atom_mode);
-    }
-}
-
-fn printListShared(writer: anytype, value: Value, state: *SharedState, atom_mode: PrintMode) anyerror!void {
-    try writer.writeByte('(');
-    try printValueShared(writer, types.car(value), state, atom_mode);
-
-    var rest = types.cdr(value);
-    while (rest != types.NIL) {
-        if (types.isPair(rest)) {
-            // If this cdr is shared, print as ". #N#" or ". #N=(...)"
-            if (state.isShared(rest)) {
-                try writer.writeAll(" . ");
-                try printValueShared(writer, rest, state, atom_mode);
-                break;
-            }
-            try writer.writeByte(' ');
-            try printValueShared(writer, types.car(rest), state, atom_mode);
-            rest = types.cdr(rest);
-        } else {
-            try writer.writeAll(" . ");
-            try printValueShared(writer, rest, state, atom_mode);
-            break;
-        }
-    }
-    try writer.writeByte(')');
-}
-
-/// Record `value` as a node that needs a datum label (it closes a cycle).
-fn recordSharedNode(state: *SharedState, value: Value) void {
-    if (state.isShared(value)) return;
-    if (state.shared_count < MAX_SHARED) {
-        state.shared[state.shared_count] = value;
-        state.labels[state.shared_count] = -1;
-        state.shared_count += 1;
-    }
-}
-
-/// Detect heap objects that lie on a cycle (the target of a DFS back-edge) and
-/// record them in `state.shared`. Only cycles need datum labels for `write`/
-/// `display` to terminate; acyclic sharing is printed in full per R7RS.
+/// Record every back-edge target of a DFS from `root` -- the objects that
+/// close a cycle. Only those need datum labels for `write`/`display` to
+/// terminate; acyclic sharing prints in full per R7RS ("Datum labels must
+/// not be used if there are no cycles").
 ///
-/// The list spine is walked iteratively (recursing only into cars and a dotted
-/// tail) so deep proper lists don't overflow the native stack. Traversal sets
-/// live on the heap, so detection terminates on structures of any size.
-fn markCycles(allocator: std.mem.Allocator, value: Value, state: *SharedState) void {
+/// Fully iterative: the DFS stack, visited sets and result all live on the
+/// heap, so detection has no depth limit and uses no native stack -- the
+/// depth-848 wasm32 module abort of kaappi#2107 and the depth-1024 label
+/// loss of kaappi#1902 (D4) were both artifacts of the old native-stack
+/// recursion and its MAX_PRINT_DEPTH guard.
+fn findCycleTargets(allocator: std.mem.Allocator, root: Value, labels: *Labels) !void {
+    if (!types.isPointer(root)) return;
+    if (!isTraversable(types.toObject(root))) return;
+
+    const Frame = struct { v: Value, idx: usize };
+    var stack: std.ArrayList(Frame) = .empty;
+    defer stack.deinit(allocator);
     var on_stack = std.AutoHashMap(Value, void).init(allocator);
     defer on_stack.deinit();
     var done = std.AutoHashMap(Value, void).init(allocator);
     defer done.deinit();
-    markCyclesRec(allocator, value, state, &on_stack, &done, 0);
+
+    try stack.append(allocator, .{ .v = root, .idx = 0 });
+    try on_stack.put(root, {});
+
+    while (stack.items.len > 0) {
+        const top = stack.items.len - 1;
+        const v = stack.items[top].v;
+        const idx = stack.items[top].idx;
+        const obj = types.toObject(v);
+        if (childAt(v, obj, idx)) |child| {
+            stack.items[top].idx = idx + 1;
+            if (!types.isPointer(child)) continue;
+            if (!isTraversable(types.toObject(child))) continue;
+            if (on_stack.contains(child)) {
+                try labels.map.put(child, -1);
+            } else if (!done.contains(child)) {
+                try on_stack.put(child, {});
+                try stack.append(allocator, .{ .v = child, .idx = 0 });
+            }
+        } else {
+            _ = stack.pop();
+            _ = on_stack.remove(v);
+            try done.put(v, {});
+        }
+    }
 }
 
-/// Elements/fields to walk for a heap type whose cycle-detection treatment is
-/// otherwise identical to a vector's: visit each child once, flag a back-edge
-/// as shared. Record instances join vectors here so a cyclic web of records
-/// (e.g. two record types referencing each other, kaappi#1713) gets a datum
-/// label instead of recursing forever -- without this, such a cycle is
-/// invisible to this pre-pass, `state.shared_count` stays 0, and printing
-/// falls through to the plain depth-limited recursion, which merely bounds
-/// depth rather than detecting the cycle: a record type whose field is a
-/// vector of records that each reference it back fans out combinatorially
-/// long before the depth cap is reached.
-fn vectorLikeChildren(obj: *types.Object) ?[]const Value {
-    return switch (obj.tag) {
-        .vector => obj.as(types.Vector).data,
-        .record_instance => obj.as(types.RecordInstance).fields,
-        else => null,
-    };
+/// Record every traversable container encountered more than once from
+/// `root` (write-shared). R7RS mandates labels for repeated pairs and
+/// vectors; repeated instances of the other traversable containers are
+/// labelled too -- they print as unreadable `#<...>` forms either way, and
+/// a cycle whose revisited node is one of them must carry the label for
+/// printing to terminate.
+///
+/// Iterative worklist with hash sets: no capacity cap and no depth cap, so
+/// none of kaappi#1902's three cliffs exist (D1: sharing across a >=1024
+/// spine, D2: first occurrence past 1024 distinct nodes, D3: >1023 labels).
+fn findSharedNodes(allocator: std.mem.Allocator, root: Value, labels: *Labels) !void {
+    if (!types.isPointer(root)) return;
+    if (!isTraversable(types.toObject(root))) return;
+
+    var seen = std.AutoHashMap(Value, void).init(allocator);
+    defer seen.deinit();
+    var work: std.ArrayList(Value) = .empty;
+    defer work.deinit(allocator);
+
+    try work.append(allocator, root);
+    while (work.pop()) |v| {
+        if (!types.isPointer(v)) continue;
+        const obj = types.toObject(v);
+        if (!isTraversable(obj)) continue;
+        const gop = try seen.getOrPut(v);
+        if (gop.found_existing) {
+            // Second encounter: needs a label; children were already queued
+            // the first time.
+            try labels.map.put(v, -1);
+            continue;
+        }
+        if (obj.tag == .pair) {
+            // cdr first, car second: the car pops first and drains before the
+            // spine advances, so a flat list keeps the worklist O(1) deep.
+            try work.append(allocator, types.cdr(v));
+            try work.append(allocator, types.car(v));
+        } else {
+            var i: usize = 0;
+            while (childAt(v, obj, i)) |child| : (i += 1) {
+                try work.append(allocator, child);
+            }
+        }
+    }
 }
 
-fn markCyclesRec(
+// ---------------------------------------------------------------------------
+// Iterative print engine
+// ---------------------------------------------------------------------------
+
+/// Depth budget for the exact printer: effectively none. Structural nesting
+/// (and spine length, which also ticks the counter) cannot reach 2^32 on any
+/// real heap, so `write`/`display`/`write-shared` output is never truncated
+/// -- truncated-but-successful output was kaappi#1902, and the truncation
+/// sentinel reading back as a symbol was kaappi#1953.
+const NO_DEPTH_LIMIT: u32 = std.math.maxInt(u32);
+
+/// Depth cap for the bounded DIAGNOSTIC printer (`printValue`): compiler
+/// diagnostics and the REPL pretty-printer's layout probes, whose output is
+/// human-facing and never re-read. Bounded output uses the `...` sentinel.
+pub const MAX_PRINT_DEPTH: u32 = 1024;
+
+const PrintTask = union(enum) {
+    /// Print one value (label-aware).
+    value: ValDepth,
+    /// Emit literal text (static lifetime).
+    text: []const u8,
+    /// Inside an open '(': print the rest of a list from this tail.
+    list_tail: ValDepth,
+    /// Inside an open "#<error ...": print remaining irritants, then '>'.
+    irritants_tail: ValDepth,
+    /// Elements of a vector / record instance / multiple-values from `idx`.
+    seq: Seq,
+};
+const ValDepth = struct { v: Value, depth: u32 };
+const Seq = struct { v: Value, idx: usize, depth: u32 };
+
+fn labelPending(labels: ?*Labels, v: Value) bool {
+    const lbl = labels orelse return false;
+    return lbl.map.contains(v);
+}
+
+/// The single print loop behind every mode. Fully iterative -- the work
+/// stack lives on the heap, so printing consumes no native stack regardless
+/// of nesting depth (kaappi#2107: 848 frames of the old recursion exhausted
+/// the wasm32 shadow stack before the old depth guard could fire).
+///
+/// `labels` non-null makes it label-aware (datum labels assigned lazily in
+/// print order). With `max_depth` == NO_DEPTH_LIMIT output is exact at any
+/// depth; a real cap (diagnostic printer) truncates values with `...`, and
+/// counts spine elements toward the cap so even an UNlabelled cyclic list
+/// terminates -- the old spine walk had no such tick, which is why a cycle
+/// reached through a container detection didn't cover hung forever
+/// (kaappi#1954) instead of truncating.
+fn printStructured(
     allocator: std.mem.Allocator,
-    value: Value,
-    state: *SharedState,
-    on_stack: *std.AutoHashMap(Value, void),
-    done: *std.AutoHashMap(Value, void),
-    depth: u32,
-) void {
-    if (depth >= MAX_PRINT_DEPTH) return;
-    if (!types.isPointer(value)) return;
-    const obj = types.toObject(value);
+    writer: anytype,
+    root: Value,
+    mode: PrintMode,
+    labels: ?*Labels,
+    max_depth: u32,
+) anyerror!void {
+    var tasks: std.ArrayList(PrintTask) = .empty;
+    defer tasks.deinit(allocator);
+    try tasks.append(allocator, .{ .value = .{ .v = root, .depth = 0 } });
 
-    if (vectorLikeChildren(obj)) |children| {
-        if (on_stack.contains(value)) return recordSharedNode(state, value);
-        if (done.contains(value)) return;
-        on_stack.put(value, {}) catch return;
-        for (children) |elem| markCyclesRec(allocator, elem, state, on_stack, done, depth + 1);
-        _ = on_stack.remove(value);
-        done.put(value, {}) catch {};
+    while (tasks.pop()) |task| {
+        switch (task) {
+            .text => |s| try writer.writeAll(s),
+            .value => |vd| {
+                if (labels) |lbl| {
+                    if (types.isPointer(vd.v)) {
+                        if (lbl.map.getPtr(vd.v)) |slot| {
+                            if (slot.* >= 0) {
+                                // Later occurrence -- emit back-reference #N#.
+                                try writer.print("#{d}#", .{slot.*});
+                                continue;
+                            }
+                            // First occurrence -- assign a label, emit #N=,
+                            // and fall through to print the value itself.
+                            slot.* = lbl.next;
+                            lbl.next += 1;
+                            try writer.print("#{d}=", .{slot.*});
+                        }
+                    }
+                }
+                if (vd.depth >= max_depth) {
+                    try writer.writeAll("...");
+                    continue;
+                }
+                try printValueOnce(allocator, writer, vd.v, vd.depth, mode, &tasks);
+            },
+            .list_tail => |vd| {
+                const t = vd.v;
+                if (t == types.NIL) {
+                    try writer.writeByte(')');
+                    continue;
+                }
+                if (vd.depth >= max_depth) {
+                    try writer.writeAll(" ...)");
+                    continue;
+                }
+                if (types.isPair(t) and !labelPending(labels, t)) {
+                    try writer.writeByte(' ');
+                    try tasks.append(allocator, .{ .list_tail = .{ .v = types.cdr(t), .depth = vd.depth + 1 } });
+                    try tasks.append(allocator, .{ .value = .{ .v = types.car(t), .depth = vd.depth } });
+                } else {
+                    // Dotted tail: either a non-pair, or a labelled pair that
+                    // must restart as ". #N=(..." / ". #N#".
+                    try writer.writeAll(" . ");
+                    try tasks.append(allocator, .{ .text = ")" });
+                    try tasks.append(allocator, .{ .value = .{ .v = t, .depth = vd.depth } });
+                }
+            },
+            .irritants_tail => |vd| {
+                const t = vd.v;
+                if (t == types.NIL) {
+                    try writer.writeByte('>');
+                    continue;
+                }
+                if (vd.depth >= max_depth) {
+                    try writer.writeAll(" ...>");
+                    continue;
+                }
+                if (types.isPair(t) and !labelPending(labels, t)) {
+                    try writer.writeByte(' ');
+                    try tasks.append(allocator, .{ .irritants_tail = .{ .v = types.cdr(t), .depth = vd.depth + 1 } });
+                    try tasks.append(allocator, .{ .value = .{ .v = types.car(t), .depth = vd.depth } });
+                } else if (types.isPair(t)) {
+                    // A labelled irritants tail restarts as a fresh datum;
+                    // mark it dotted so the spine break is visible.
+                    try writer.writeAll(" . ");
+                    try tasks.append(allocator, .{ .text = ">" });
+                    try tasks.append(allocator, .{ .value = .{ .v = t, .depth = vd.depth } });
+                } else {
+                    // Improper irritants tail prints like one more irritant.
+                    try writer.writeByte(' ');
+                    try tasks.append(allocator, .{ .text = ">" });
+                    try tasks.append(allocator, .{ .value = .{ .v = t, .depth = vd.depth } });
+                }
+            },
+            .seq => |sq| {
+                const obj = types.toObject(sq.v);
+                switch (obj.tag) {
+                    .vector => {
+                        const data = obj.as(types.Vector).data;
+                        if (sq.idx >= data.len) {
+                            try writer.writeByte(')');
+                        } else {
+                            if (sq.idx > 0) try writer.writeByte(' ');
+                            try tasks.append(allocator, .{ .seq = .{ .v = sq.v, .idx = sq.idx + 1, .depth = sq.depth } });
+                            try tasks.append(allocator, .{ .value = .{ .v = data[sq.idx], .depth = sq.depth } });
+                        }
+                    },
+                    .record_instance => {
+                        const fields = obj.as(types.RecordInstance).fields;
+                        if (sq.idx >= fields.len) {
+                            try writer.writeByte('>');
+                        } else {
+                            try writer.writeByte(' ');
+                            try tasks.append(allocator, .{ .seq = .{ .v = sq.v, .idx = sq.idx + 1, .depth = sq.depth } });
+                            try tasks.append(allocator, .{ .value = .{ .v = fields[sq.idx], .depth = sq.depth } });
+                        }
+                    },
+                    .multiple_values => {
+                        const vals = obj.as(types.MultipleValues).values;
+                        if (sq.idx >= vals.len) {
+                            try writer.writeByte('>');
+                        } else {
+                            try writer.writeByte(' ');
+                            try tasks.append(allocator, .{ .seq = .{ .v = sq.v, .idx = sq.idx + 1, .depth = sq.depth } });
+                            try tasks.append(allocator, .{ .value = .{ .v = vals[sq.idx], .depth = sq.depth } });
+                        }
+                    },
+                    else => unreachable,
+                }
+            },
+        }
+    }
+}
+
+/// Numerator/denominator of a rational -- always an exact integer.
+fn writeExactIntPart(writer: anytype, v: Value) anyerror!void {
+    if (types.isFixnum(v)) {
+        try writer.print("{d}", .{types.toFixnum(v)});
         return;
     }
-
-    if (obj.tag != .pair) return;
-
-    // Walk the cdr spine iteratively; the spine pairs stay on the DFS stack
-    // until the whole spine is processed, then unwind together.
-    var spine: std.ArrayList(Value) = .empty;
-    defer spine.deinit(allocator);
-
-    var cur = value;
-    while (types.isPointer(cur)) {
-        const o = types.toObject(cur);
-        if (o.tag != .pair) {
-            markCyclesRec(allocator, cur, state, on_stack, done, depth + 1);
-            break;
-        }
-        if (on_stack.contains(cur)) {
-            recordSharedNode(state, cur);
-            break;
-        }
-        if (done.contains(cur)) break;
-        on_stack.put(cur, {}) catch break;
-        spine.append(allocator, cur) catch {};
-        markCyclesRec(allocator, types.car(cur), state, on_stack, done, depth + 1);
-        cur = types.cdr(cur);
+    if (types.isPointer(v) and types.toObject(v).tag == .bignum) {
+        try writeBignum(writer, v);
+        return;
     }
+    try writer.writeAll("#<unknown>");
+}
 
-    var i = spine.items.len;
-    while (i > 0) {
-        i -= 1;
-        _ = on_stack.remove(spine.items[i]);
-        done.put(spine.items[i], {}) catch {};
+fn writeBignum(writer: anytype, v: Value) anyerror!void {
+    const bignum_mod = @import("bignum.zig");
+    const allocator = std.heap.page_allocator;
+    const s = bignum_mod.toString(allocator, v) catch {
+        try writer.writeAll("?bignum?");
+        return;
+    };
+    defer allocator.free(s);
+    try writer.writeAll(s);
+}
+
+/// Emit one value's own rendering. Containers write their opening text and
+/// push continuation tasks; everything else is a leaf written in full.
+fn printValueOnce(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    value: Value,
+    depth: u32,
+    mode: PrintMode,
+    tasks: *std.ArrayList(PrintTask),
+) anyerror!void {
+    if (types.isFixnum(value)) {
+        try writer.print("{d}", .{types.toFixnum(value)});
+    } else if (value == types.NIL) {
+        try writer.writeAll("()");
+    } else if (value == types.TRUE) {
+        try writer.writeAll("#t");
+    } else if (value == types.FALSE) {
+        try writer.writeAll("#f");
+    } else if (value == types.VOID) {
+        // void prints nothing
+    } else if (value == types.EOF) {
+        try writer.writeAll("#<eof>");
+    } else if (value == types.UNDEFINED) {
+        try writer.writeAll("#<undefined>");
+    } else if (types.isChar(value)) {
+        const cp = types.toChar(value);
+        if (mode == .write) {
+            try writer.writeAll("#\\");
+            switch (cp) {
+                0x00 => try writer.writeAll("null"),
+                0x07 => try writer.writeAll("alarm"),
+                0x08 => try writer.writeAll("backspace"),
+                0x09 => try writer.writeAll("tab"),
+                0x0A => try writer.writeAll("newline"),
+                0x0D => try writer.writeAll("return"),
+                0x1B => try writer.writeAll("escape"),
+                0x20 => try writer.writeAll("space"),
+                0x7F => try writer.writeAll("delete"),
+                else => {
+                    if (cp < 0x20 or (cp >= 0x7F and cp <= 0x9F)) {
+                        var hex_buf: [8]u8 = undefined;
+                        var hw: std.Io.Writer = .fixed(&hex_buf);
+                        hw.print("x{x}", .{cp}) catch {};
+                        try writer.writeAll(hw.buffered());
+                    } else {
+                        var buf: [4]u8 = undefined;
+                        const len = std.unicode.utf8Encode(cp, &buf) catch 0;
+                        try writer.writeAll(buf[0..len]);
+                    }
+                },
+            }
+        } else {
+            var buf: [4]u8 = undefined;
+            const len = std.unicode.utf8Encode(cp, &buf) catch 0;
+            try writer.writeAll(buf[0..len]);
+        }
+    } else if (types.isFlonum(value)) {
+        var buf: [64]u8 = undefined;
+        try writer.writeAll(formatFlonum(&buf, types.toFlonum(value)));
+    } else if (types.isPointer(value)) {
+        const obj = types.toObject(value);
+        switch (obj.tag) {
+            .pair => {
+                try writer.writeByte('(');
+                try tasks.append(allocator, .{ .list_tail = .{ .v = types.cdr(value), .depth = depth + 1 } });
+                try tasks.append(allocator, .{ .value = .{ .v = types.car(value), .depth = depth + 1 } });
+            },
+            .symbol => {
+                const sym = obj.as(types.Symbol);
+                if (!sym.interned and mode != .display) {
+                    // SRFI 258: an uninterned symbol has no readable external
+                    // representation. Writing it in this `#<…>` form makes
+                    // `read` reject it (the reader errors on `#<`), deliberately
+                    // breaking write/read invariance (R7RS 6.5). `display` still
+                    // shows the bare name for human-readable output.
+                    try writer.writeAll("#<uninterned-symbol ");
+                    try writer.writeAll(sym.name);
+                    try writer.writeByte('>');
+                } else if (mode != .display and symbolNeedsBars(sym.name)) {
+                    try writer.writeByte('|');
+                    for (sym.name) |c| {
+                        if (c == '|' or c == '\\') {
+                            try writer.writeByte('\\');
+                            try writer.writeByte(c);
+                        } else if (c < 0x20 or c == 0x7F) {
+                            try writer.writeAll("\\x");
+                            const hex = "0123456789abcdef";
+                            try writer.writeByte(hex[c >> 4]);
+                            try writer.writeByte(hex[c & 0x0F]);
+                            try writer.writeByte(';');
+                        } else {
+                            try writer.writeByte(c);
+                        }
+                    }
+                    try writer.writeByte('|');
+                } else {
+                    try writer.writeAll(sym.name);
+                }
+            },
+            .string => {
+                const str = obj.as(types.SchemeString);
+                if (mode == .write) {
+                    try writer.writeByte('"');
+                    for (str.data) |c| {
+                        switch (c) {
+                            '"' => try writer.writeAll("\\\""),
+                            '\\' => try writer.writeAll("\\\\"),
+                            '\n' => try writer.writeAll("\\n"),
+                            '\r' => try writer.writeAll("\\r"),
+                            '\t' => try writer.writeAll("\\t"),
+                            0x07 => try writer.writeAll("\\a"),
+                            0x08 => try writer.writeAll("\\b"),
+                            else => {
+                                if (c < 0x20 or c == 0x7F) {
+                                    try writer.writeAll("\\x");
+                                    const hex = "0123456789abcdef";
+                                    try writer.writeByte(hex[c >> 4]);
+                                    try writer.writeByte(hex[c & 0x0F]);
+                                    try writer.writeByte(';');
+                                } else {
+                                    try writer.writeByte(c);
+                                }
+                            },
+                        }
+                    }
+                    try writer.writeByte('"');
+                } else {
+                    try writer.writeAll(str.data);
+                }
+            },
+            .flonum => {
+                const flo = obj.as(types.Flonum);
+                var buf: [64]u8 = undefined;
+                try writer.writeAll(formatFlonum(&buf, flo.value));
+            },
+            .closure => {
+                const cls = obj.as(types.Closure);
+                if (cls.func.name) |name| {
+                    try writer.print("#<procedure {s}>", .{name});
+                } else {
+                    try writer.writeAll("#<procedure>");
+                }
+            },
+            .native_fn => {
+                const nf = obj.as(types.NativeFn);
+                try writer.print("#<builtin {s}>", .{nf.name});
+            },
+            .native_closure => {
+                // A native closure is the LLVM backend's representation of a
+                // Scheme procedure; print it exactly like an interpreter closure
+                // so native output matches the interpreter (#1500). Native
+                // closures never exist in interpreter mode, so this only affects
+                // native binaries — where a define'd function's value is now a
+                // native closure rather than an eval'd interpreter closure.
+                const nc = obj.as(types.NativeClosure);
+                try writer.print("#<procedure {s}>", .{nc.name});
+            },
+            .function => {
+                try writer.writeAll("#<function>");
+            },
+            .transformer => {
+                try writer.writeAll("#<transformer>");
+            },
+            .error_object => {
+                const eo = obj.as(types.ErrorObject);
+                try writer.writeAll("#<error ");
+                try tasks.append(allocator, .{ .irritants_tail = .{ .v = eo.irritants, .depth = depth + 1 } });
+                try tasks.append(allocator, .{ .value = .{ .v = eo.message, .depth = depth + 1 } });
+            },
+            .port => {
+                const port = obj.as(types.Port);
+                if (port.is_input and port.is_output) {
+                    try writer.print("#<input/output-port {s}>", .{port.name});
+                } else if (port.is_input) {
+                    try writer.print("#<input-port {s}>", .{port.name});
+                } else {
+                    try writer.print("#<output-port {s}>", .{port.name});
+                }
+            },
+            .record_type => {
+                const rt = obj.as(types.RecordType);
+                try writer.print("#<record-type {s}>", .{rt.name});
+            },
+            .record_instance => {
+                const ri = obj.as(types.RecordInstance);
+                try writer.print("#<{s}", .{ri.record_type.name});
+                try tasks.append(allocator, .{ .seq = .{ .v = value, .idx = 0, .depth = depth + 1 } });
+            },
+            .complex => {
+                const c = obj.as(types.Complex);
+                var buf: [64]u8 = undefined;
+                if (c.imag == 0.0 and !std.math.signbit(c.imag)) {
+                    try writer.writeAll(formatFlonum(&buf, c.real));
+                } else {
+                    const has_real = c.real != 0.0 or std.math.signbit(c.real);
+                    if (has_real) try writeComplexPart(writer, c.real, c.exact_real);
+                    const im = c.imag;
+                    if (std.math.isNan(im)) {
+                        try writer.writeAll("+nan.0i");
+                    } else if (std.math.isInf(im)) {
+                        try writer.writeAll(if (im > 0) "+inf.0i" else "-inf.0i");
+                    } else {
+                        try writer.writeByte(if (im < 0 or std.math.signbit(im)) '-' else '+');
+                        const mag = @abs(im);
+                        if (mag != 1.0 or has_real) try writeComplexPart(writer, mag, c.exact_imag);
+                        try writer.writeByte('i');
+                    }
+                }
+            },
+            .vector => {
+                try writer.writeAll("#(");
+                try tasks.append(allocator, .{ .seq = .{ .v = value, .idx = 0, .depth = depth + 1 } });
+            },
+            .bytevector => {
+                const bv = obj.as(types.Bytevector);
+                try writer.writeAll("#u8(");
+                for (bv.data, 0..) |byte, i| {
+                    if (i > 0) try writer.writeByte(' ');
+                    try writer.print("{d}", .{byte});
+                }
+                try writer.writeByte(')');
+            },
+            .numeric_vector => {
+                const nv = obj.as(types.NumericVector);
+                try writer.print("#<{s}vector", .{@tagName(nv.kind)});
+                const width = nv.kind.elementWidth();
+                var buf: [64]u8 = undefined;
+                var i: usize = 0;
+                while (i < nv.data.len) : (i += width) {
+                    try writer.writeByte(' ');
+                    switch (nv.kind) {
+                        .s8 => try writer.print("{d}", .{@as(i8, @bitCast(nv.data[i]))}),
+                        .u16 => try writer.print("{d}", .{std.mem.readInt(u16, nv.data[i..][0..2], native_endian)}),
+                        .s16 => try writer.print("{d}", .{std.mem.readInt(i16, nv.data[i..][0..2], native_endian)}),
+                        .u32 => try writer.print("{d}", .{std.mem.readInt(u32, nv.data[i..][0..4], native_endian)}),
+                        .s32 => try writer.print("{d}", .{std.mem.readInt(i32, nv.data[i..][0..4], native_endian)}),
+                        .u64 => try writer.print("{d}", .{std.mem.readInt(u64, nv.data[i..][0..8], native_endian)}),
+                        .s64 => try writer.print("{d}", .{std.mem.readInt(i64, nv.data[i..][0..8], native_endian)}),
+                        .f32 => {
+                            const bits = std.mem.readInt(u32, nv.data[i..][0..4], native_endian);
+                            try writer.writeAll(formatFlonum(&buf, @as(f32, @bitCast(bits))));
+                        },
+                        .f64 => {
+                            const bits = std.mem.readInt(u64, nv.data[i..][0..8], native_endian);
+                            try writer.writeAll(formatFlonum(&buf, @as(f64, @bitCast(bits))));
+                        },
+                        .c64 => {
+                            const re_bits = std.mem.readInt(u32, nv.data[i..][0..4], native_endian);
+                            const im_bits = std.mem.readInt(u32, nv.data[i + 4 ..][0..4], native_endian);
+                            const im: f32 = @bitCast(im_bits);
+                            try writer.writeAll(formatFlonum(&buf, @as(f32, @bitCast(re_bits))));
+                            try writeImaginaryPart(writer, &buf, im);
+                        },
+                        .c128 => {
+                            const re_bits = std.mem.readInt(u64, nv.data[i..][0..8], native_endian);
+                            const im_bits = std.mem.readInt(u64, nv.data[i + 8 ..][0..8], native_endian);
+                            const im: f64 = @bitCast(im_bits);
+                            try writer.writeAll(formatFlonum(&buf, @as(f64, @bitCast(re_bits))));
+                            try writeImaginaryPart(writer, &buf, im);
+                        },
+                    }
+                }
+                try writer.writeByte('>');
+            },
+            .promise => {
+                try writer.writeAll("#<promise>");
+            },
+            .continuation => {
+                try writer.writeAll("#<continuation>");
+            },
+            .parameter => {
+                try writer.writeAll("#<parameter>");
+            },
+            .multiple_values => {
+                try writer.writeAll("#<values");
+                try tasks.append(allocator, .{ .seq = .{ .v = value, .idx = 0, .depth = depth + 1 } });
+            },
+            .hash_table => {
+                const ht = obj.as(types.HashTable);
+                try writer.print("#<hash-table size={d}>", .{ht.count});
+            },
+            .ffi_library => {
+                const lib = obj.as(types.FfiLibrary);
+                try writer.print("#<ffi-library \"{s}\">", .{lib.name});
+            },
+            .ffi_function => {
+                const ffi_fn = obj.as(types.FfiFunction);
+                try writer.print("#<ffi-function \"{s}\">", .{ffi_fn.name});
+            },
+            .ffi_callback => {
+                const cb = obj.as(types.FfiCallback);
+                if (cb.active) {
+                    try writer.print("#<ffi-callback slot={d}>", .{cb.slot_index});
+                } else {
+                    try writer.writeAll("#<ffi-callback released>");
+                }
+            },
+            .fiber => {
+                const fiber_mod = @import("fiber.zig");
+                const fiber = obj.as(fiber_mod.Fiber);
+                const status_str: []const u8 = switch (fiber.status) {
+                    .created => "created",
+                    .running => "running",
+                    .suspended => "suspended",
+                    .completed => "completed",
+                    .errored => "errored",
+                    .waiting => "waiting",
+                    .io_waiting => "io-waiting",
+                };
+                try writer.print("#<fiber {d} {s}>", .{ fiber.id, status_str });
+            },
+            .channel => {
+                try writer.writeAll("#<channel>");
+            },
+            .mutex => {
+                const m = obj.as(types.Mutex);
+                try writer.writeAll("#<mutex");
+                if (m.name != types.VOID) {
+                    try writer.writeAll(" ");
+                    try tasks.append(allocator, .{ .text = ">" });
+                    try tasks.append(allocator, .{ .value = .{ .v = m.name, .depth = depth + 1 } });
+                } else {
+                    try writer.writeAll(">");
+                }
+            },
+            .condition_variable => {
+                const cv = obj.as(types.ConditionVariable);
+                try writer.writeAll("#<condition-variable");
+                if (cv.name != types.VOID) {
+                    try writer.writeAll(" ");
+                    try tasks.append(allocator, .{ .text = ">" });
+                    try tasks.append(allocator, .{ .value = .{ .v = cv.name, .depth = depth + 1 } });
+                } else {
+                    try writer.writeAll(">");
+                }
+            },
+            .srfi18_time => {
+                const t = obj.as(types.Srfi18Time);
+                const type_name: []const u8 = switch (t.time_type) {
+                    .utc => "time-utc",
+                    .tai => "time-tai",
+                    .monotonic => "time-monotonic",
+                    .duration => "time-duration",
+                };
+                const ns: u64 = if (t.nanoseconds >= 0) @intCast(t.nanoseconds) else 0;
+                try writer.print("#<time {s} {d}.{d:0>9}>", .{ type_name, t.seconds, ns });
+            },
+            .bignum => {
+                try writeBignum(writer, value);
+            },
+            .rational => {
+                // Rendered atomically: both parts are always exact integers,
+                // so no depth accounting can split this leaf into the
+                // symbol-shaped `.../...` of kaappi#1953.
+                const rat = obj.as(types.Rational);
+                try writeExactIntPart(writer, rat.numerator);
+                try writer.writeByte('/');
+                try writeExactIntPart(writer, rat.denominator);
+            },
+            .file_info => {
+                const fi = obj.as(types.FileInfo);
+                const kind = switch (fi.file_type) {
+                    .regular => "regular",
+                    .directory => "directory",
+                    .symlink => "symlink",
+                    .fifo => "fifo",
+                    .socket => "socket",
+                    .char_device => "char-device",
+                    .block_device => "block-device",
+                    .other => "other",
+                };
+                try writer.print("#<file-info {s} size={d} mode={o}>", .{ kind, fi.size, fi.mode });
+            },
+            .user_info => {
+                const ui = obj.as(types.UserInfo);
+                try writer.print("#<user-info \"{s}\" uid={d}>", .{ ui.name, ui.uid });
+            },
+            .group_info => {
+                const gi = obj.as(types.GroupInfo);
+                try writer.print("#<group-info \"{s}\" gid={d}>", .{ gi.name, gi.gid });
+            },
+            .directory_object => {
+                try writer.writeAll("#<directory-object>");
+            },
+            .random_source => {
+                try writer.writeAll("#<random-source>");
+            },
+            .scheme_environment => {
+                try writer.writeAll("#<environment>");
+            },
+            .ephemeron => {
+                const eph = obj.as(types.Ephemeron);
+                try writer.writeAll(if (eph.broken) "#<ephemeron broken>" else "#<ephemeron>");
+            },
+            .guardian => {
+                const g = obj.as(types.Guardian);
+                try writer.writeAll(if (g.is_transport) "#<transport-cell-guardian>" else "#<guardian>");
+            },
+            .transport_cell => {
+                const tc = obj.as(types.TransportCell);
+                try writer.writeAll(if (tc.broken) "#<transport-cell broken>" else "#<transport-cell>");
+            },
+        }
+    } else {
+        try writer.writeAll("#<unknown>");
     }
 }
+
+// ---------------------------------------------------------------------------
+// Atom helpers (shared by the engine and the numeric printers)
+// ---------------------------------------------------------------------------
 
 fn startsWithIgnoreCase(s: []const u8, prefix: []const u8) bool {
     return s.len >= prefix.len and std.ascii.eqlIgnoreCase(s[0..prefix.len], prefix);
@@ -519,651 +1042,57 @@ fn writeImaginaryPart(writer: anytype, buf: []u8, im: f64) !void {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+/// Bounded DIAGNOSTIC printer: no cycle pre-pass, no labels, output truncated
+/// with `...` at MAX_PRINT_DEPTH (spine elements count toward the cap, so
+/// even an unlabelled cyclic list terminates). For compiler diagnostics and
+/// the REPL pretty-printer's layout probes ONLY -- output that a program
+/// could `read` back must go through `valueToString`, whose output is exact
+/// and label-correct at any depth.
 pub fn printValue(writer: anytype, value: Value, mode: PrintMode) anyerror!void {
-    return printValueWithDepth(writer, value, mode, 0);
+    var sfb = std.heap.stackFallback(2048, std.heap.page_allocator);
+    const atom_mode: PrintMode = if (mode == .shared) .write else mode;
+    try printStructured(sfb.get(), writer, value, atom_mode, null, MAX_PRINT_DEPTH);
 }
 
-fn printValueWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u32) anyerror!void {
-    if (mode == .shared) {
-        var state = SharedState{};
-        markShared(value, &state);
-        try printValueShared(writer, value, &state, .write);
-        return;
+/// Render `value` exactly. `write`/`display` label only structure that forms
+/// a cycle (acyclic sharing prints in full, per R7RS); `.shared` labels every
+/// repeated container. Output is never truncated: any depth, any number of
+/// labels, and every container the printer recurses into is covered by the
+/// pre-pass, so printing always terminates.
+pub fn valueToString(allocator: std.mem.Allocator, value: Value, mode: PrintMode) ![]u8 {
+    var labels = Labels.init(allocator);
+    defer labels.deinit();
+    switch (mode) {
+        .write, .display => try findCycleTargets(allocator, value, &labels),
+        .shared => try findSharedNodes(allocator, value, &labels),
     }
-    if (depth >= MAX_PRINT_DEPTH) {
-        try writer.writeAll("...");
-        return;
-    }
-    if (types.isFixnum(value)) {
-        try writer.print("{d}", .{types.toFixnum(value)});
-    } else if (value == types.NIL) {
-        try writer.writeAll("()");
-    } else if (value == types.TRUE) {
-        try writer.writeAll("#t");
-    } else if (value == types.FALSE) {
-        try writer.writeAll("#f");
-    } else if (value == types.VOID) {
-        // void prints nothing
-    } else if (value == types.EOF) {
-        try writer.writeAll("#<eof>");
-    } else if (value == types.UNDEFINED) {
-        try writer.writeAll("#<undefined>");
-    } else if (types.isChar(value)) {
-        const cp = types.toChar(value);
-        if (mode == .write) {
-            try writer.writeAll("#\\");
-            switch (cp) {
-                0x00 => try writer.writeAll("null"),
-                0x07 => try writer.writeAll("alarm"),
-                0x08 => try writer.writeAll("backspace"),
-                0x09 => try writer.writeAll("tab"),
-                0x0A => try writer.writeAll("newline"),
-                0x0D => try writer.writeAll("return"),
-                0x1B => try writer.writeAll("escape"),
-                0x20 => try writer.writeAll("space"),
-                0x7F => try writer.writeAll("delete"),
-                else => {
-                    if (cp < 0x20 or (cp >= 0x7F and cp <= 0x9F)) {
-                        var hex_buf: [8]u8 = undefined;
-                        var hw: std.Io.Writer = .fixed(&hex_buf);
-                        hw.print("x{x}", .{cp}) catch {};
-                        try writer.writeAll(hw.buffered());
-                    } else {
-                        var buf: [4]u8 = undefined;
-                        const len = std.unicode.utf8Encode(cp, &buf) catch 0;
-                        try writer.writeAll(buf[0..len]);
-                    }
-                },
-            }
-        } else {
-            var buf: [4]u8 = undefined;
-            const len = std.unicode.utf8Encode(cp, &buf) catch 0;
-            try writer.writeAll(buf[0..len]);
-        }
-    } else if (types.isFlonum(value)) {
-        var buf: [64]u8 = undefined;
-        try writer.writeAll(formatFlonum(&buf, types.toFlonum(value)));
-    } else if (types.isPointer(value)) {
-        const obj = types.toObject(value);
-        switch (obj.tag) {
-            .pair => try printListWithDepth(writer, value, mode, depth),
-            .symbol => {
-                const sym = obj.as(types.Symbol);
-                if (!sym.interned and mode != .display) {
-                    // SRFI 258: an uninterned symbol has no readable external
-                    // representation. Writing it in this `#<…>` form makes
-                    // `read` reject it (the reader errors on `#<`), deliberately
-                    // breaking write/read invariance (R7RS 6.5). `display` still
-                    // shows the bare name for human-readable output.
-                    try writer.writeAll("#<uninterned-symbol ");
-                    try writer.writeAll(sym.name);
-                    try writer.writeByte('>');
-                } else if (mode != .display and symbolNeedsBars(sym.name)) {
-                    try writer.writeByte('|');
-                    for (sym.name) |c| {
-                        if (c == '|' or c == '\\') {
-                            try writer.writeByte('\\');
-                            try writer.writeByte(c);
-                        } else if (c < 0x20 or c == 0x7F) {
-                            try writer.writeAll("\\x");
-                            const hex = "0123456789abcdef";
-                            try writer.writeByte(hex[c >> 4]);
-                            try writer.writeByte(hex[c & 0x0F]);
-                            try writer.writeByte(';');
-                        } else {
-                            try writer.writeByte(c);
-                        }
-                    }
-                    try writer.writeByte('|');
-                } else {
-                    try writer.writeAll(sym.name);
-                }
-            },
-            .string => {
-                const str = obj.as(types.SchemeString);
-                if (mode == .write) {
-                    try writer.writeByte('"');
-                    for (str.data) |c| {
-                        switch (c) {
-                            '"' => try writer.writeAll("\\\""),
-                            '\\' => try writer.writeAll("\\\\"),
-                            '\n' => try writer.writeAll("\\n"),
-                            '\r' => try writer.writeAll("\\r"),
-                            '\t' => try writer.writeAll("\\t"),
-                            0x07 => try writer.writeAll("\\a"),
-                            0x08 => try writer.writeAll("\\b"),
-                            else => {
-                                if (c < 0x20 or c == 0x7F) {
-                                    try writer.writeAll("\\x");
-                                    const hex = "0123456789abcdef";
-                                    try writer.writeByte(hex[c >> 4]);
-                                    try writer.writeByte(hex[c & 0x0F]);
-                                    try writer.writeByte(';');
-                                } else {
-                                    try writer.writeByte(c);
-                                }
-                            },
-                        }
-                    }
-                    try writer.writeByte('"');
-                } else {
-                    try writer.writeAll(str.data);
-                }
-            },
-            .flonum => {
-                const flo = obj.as(types.Flonum);
-                var buf: [64]u8 = undefined;
-                try writer.writeAll(formatFlonum(&buf, flo.value));
-            },
-            .closure => {
-                const cls = obj.as(types.Closure);
-                if (cls.func.name) |name| {
-                    try writer.print("#<procedure {s}>", .{name});
-                } else {
-                    try writer.writeAll("#<procedure>");
-                }
-            },
-            .native_fn => {
-                const nf = obj.as(types.NativeFn);
-                try writer.print("#<builtin {s}>", .{nf.name});
-            },
-            .native_closure => {
-                // A native closure is the LLVM backend's representation of a
-                // Scheme procedure; print it exactly like an interpreter closure
-                // so native output matches the interpreter (#1500). Native
-                // closures never exist in interpreter mode, so this only affects
-                // native binaries — where a define'd function's value is now a
-                // native closure rather than an eval'd interpreter closure.
-                const nc = obj.as(types.NativeClosure);
-                try writer.print("#<procedure {s}>", .{nc.name});
-            },
-            .function => {
-                try writer.writeAll("#<function>");
-            },
-            .transformer => {
-                try writer.writeAll("#<transformer>");
-            },
-            .error_object => {
-                const err = obj.as(types.ErrorObject);
-                try writer.writeAll("#<error ");
-                try printValueWithDepth(writer, err.message, mode, depth + 1);
-                if (err.irritants != types.NIL) {
-                    try writer.writeByte(' ');
-                    var irr = err.irritants;
-                    while (irr != types.NIL) {
-                        if (types.isPair(irr)) {
-                            try printValueWithDepth(writer, types.car(irr), mode, depth + 1);
-                            irr = types.cdr(irr);
-                            if (irr != types.NIL) try writer.writeByte(' ');
-                        } else {
-                            try printValueWithDepth(writer, irr, mode, depth + 1);
-                            break;
-                        }
-                    }
-                }
-                try writer.writeByte('>');
-            },
-            .port => {
-                const port = obj.as(types.Port);
-                if (port.is_input and port.is_output) {
-                    try writer.print("#<input/output-port {s}>", .{port.name});
-                } else if (port.is_input) {
-                    try writer.print("#<input-port {s}>", .{port.name});
-                } else {
-                    try writer.print("#<output-port {s}>", .{port.name});
-                }
-            },
-            .record_type => {
-                const rt = obj.as(types.RecordType);
-                try writer.print("#<record-type {s}>", .{rt.name});
-            },
-            .record_instance => {
-                const ri = obj.as(types.RecordInstance);
-                try writer.print("#<{s}", .{ri.record_type.name});
-                for (ri.fields) |field| {
-                    try writer.writeByte(' ');
-                    try printValueWithDepth(writer, field, mode, depth + 1);
-                }
-                try writer.writeByte('>');
-            },
-            .complex => {
-                const c = obj.as(types.Complex);
-                var buf: [64]u8 = undefined;
-                if (c.imag == 0.0 and !std.math.signbit(c.imag)) {
-                    try writer.writeAll(formatFlonum(&buf, c.real));
-                } else {
-                    const has_real = c.real != 0.0 or std.math.signbit(c.real);
-                    if (has_real) try writeComplexPart(writer, c.real, c.exact_real);
-                    const im = c.imag;
-                    if (std.math.isNan(im)) {
-                        try writer.writeAll("+nan.0i");
-                    } else if (std.math.isInf(im)) {
-                        try writer.writeAll(if (im > 0) "+inf.0i" else "-inf.0i");
-                    } else {
-                        try writer.writeByte(if (im < 0 or std.math.signbit(im)) '-' else '+');
-                        const mag = @abs(im);
-                        if (mag != 1.0 or has_real) try writeComplexPart(writer, mag, c.exact_imag);
-                        try writer.writeByte('i');
-                    }
-                }
-            },
-            .vector => {
-                const vec = obj.as(types.Vector);
-                try writer.writeAll("#(");
-                for (vec.data, 0..) |elem, i| {
-                    if (i > 0) try writer.writeByte(' ');
-                    try printValueWithDepth(writer, elem, mode, depth + 1);
-                }
-                try writer.writeByte(')');
-            },
-            .bytevector => {
-                const bv = obj.as(types.Bytevector);
-                try writer.writeAll("#u8(");
-                for (bv.data, 0..) |byte, i| {
-                    if (i > 0) try writer.writeByte(' ');
-                    try writer.print("{d}", .{byte});
-                }
-                try writer.writeByte(')');
-            },
-            .numeric_vector => {
-                const nv = obj.as(types.NumericVector);
-                try writer.print("#<{s}vector", .{@tagName(nv.kind)});
-                const width = nv.kind.elementWidth();
-                var buf: [64]u8 = undefined;
-                var i: usize = 0;
-                while (i < nv.data.len) : (i += width) {
-                    try writer.writeByte(' ');
-                    switch (nv.kind) {
-                        .s8 => try writer.print("{d}", .{@as(i8, @bitCast(nv.data[i]))}),
-                        .u16 => try writer.print("{d}", .{std.mem.readInt(u16, nv.data[i..][0..2], native_endian)}),
-                        .s16 => try writer.print("{d}", .{std.mem.readInt(i16, nv.data[i..][0..2], native_endian)}),
-                        .u32 => try writer.print("{d}", .{std.mem.readInt(u32, nv.data[i..][0..4], native_endian)}),
-                        .s32 => try writer.print("{d}", .{std.mem.readInt(i32, nv.data[i..][0..4], native_endian)}),
-                        .u64 => try writer.print("{d}", .{std.mem.readInt(u64, nv.data[i..][0..8], native_endian)}),
-                        .s64 => try writer.print("{d}", .{std.mem.readInt(i64, nv.data[i..][0..8], native_endian)}),
-                        .f32 => {
-                            const bits = std.mem.readInt(u32, nv.data[i..][0..4], native_endian);
-                            try writer.writeAll(formatFlonum(&buf, @as(f32, @bitCast(bits))));
-                        },
-                        .f64 => {
-                            const bits = std.mem.readInt(u64, nv.data[i..][0..8], native_endian);
-                            try writer.writeAll(formatFlonum(&buf, @as(f64, @bitCast(bits))));
-                        },
-                        .c64 => {
-                            const re_bits = std.mem.readInt(u32, nv.data[i..][0..4], native_endian);
-                            const im_bits = std.mem.readInt(u32, nv.data[i + 4 ..][0..4], native_endian);
-                            const im: f32 = @bitCast(im_bits);
-                            try writer.writeAll(formatFlonum(&buf, @as(f32, @bitCast(re_bits))));
-                            try writeImaginaryPart(writer, &buf, im);
-                        },
-                        .c128 => {
-                            const re_bits = std.mem.readInt(u64, nv.data[i..][0..8], native_endian);
-                            const im_bits = std.mem.readInt(u64, nv.data[i + 8 ..][0..8], native_endian);
-                            const im: f64 = @bitCast(im_bits);
-                            try writer.writeAll(formatFlonum(&buf, @as(f64, @bitCast(re_bits))));
-                            try writeImaginaryPart(writer, &buf, im);
-                        },
-                    }
-                }
-                try writer.writeByte('>');
-            },
-            .promise => {
-                try writer.writeAll("#<promise>");
-            },
-            .continuation => {
-                try writer.writeAll("#<continuation>");
-            },
-            .parameter => {
-                try writer.writeAll("#<parameter>");
-            },
-            .multiple_values => {
-                const mv = obj.as(types.MultipleValues);
-                try writer.writeAll("#<values");
-                for (mv.values) |val| {
-                    try writer.writeByte(' ');
-                    try printValueWithDepth(writer, val, mode, depth + 1);
-                }
-                try writer.writeByte('>');
-            },
-            .hash_table => {
-                const ht = obj.as(types.HashTable);
-                try writer.print("#<hash-table size={d}>", .{ht.count});
-            },
-            .ffi_library => {
-                const lib = obj.as(types.FfiLibrary);
-                try writer.print("#<ffi-library \"{s}\">", .{lib.name});
-            },
-            .ffi_function => {
-                const ffi_fn = obj.as(types.FfiFunction);
-                try writer.print("#<ffi-function \"{s}\">", .{ffi_fn.name});
-            },
-            .ffi_callback => {
-                const cb = obj.as(types.FfiCallback);
-                if (cb.active) {
-                    try writer.print("#<ffi-callback slot={d}>", .{cb.slot_index});
-                } else {
-                    try writer.writeAll("#<ffi-callback released>");
-                }
-            },
-            .fiber => {
-                const fiber_mod = @import("fiber.zig");
-                const fiber = obj.as(fiber_mod.Fiber);
-                const status_str: []const u8 = switch (fiber.status) {
-                    .created => "created",
-                    .running => "running",
-                    .suspended => "suspended",
-                    .completed => "completed",
-                    .errored => "errored",
-                    .waiting => "waiting",
-                    .io_waiting => "io-waiting",
-                };
-                try writer.print("#<fiber {d} {s}>", .{ fiber.id, status_str });
-            },
-            .channel => {
-                try writer.writeAll("#<channel>");
-            },
-            .mutex => {
-                const m = obj.as(types.Mutex);
-                try writer.writeAll("#<mutex");
-                if (m.name != types.VOID) {
-                    try writer.writeAll(" ");
-                    try printValueWithDepth(writer, m.name, mode, depth + 1);
-                }
-                try writer.writeAll(">");
-            },
-            .condition_variable => {
-                const cv = obj.as(types.ConditionVariable);
-                try writer.writeAll("#<condition-variable");
-                if (cv.name != types.VOID) {
-                    try writer.writeAll(" ");
-                    try printValueWithDepth(writer, cv.name, mode, depth + 1);
-                }
-                try writer.writeAll(">");
-            },
-            .srfi18_time => {
-                const t = obj.as(types.Srfi18Time);
-                const type_name: []const u8 = switch (t.time_type) {
-                    .utc => "time-utc",
-                    .tai => "time-tai",
-                    .monotonic => "time-monotonic",
-                    .duration => "time-duration",
-                };
-                const ns: u64 = if (t.nanoseconds >= 0) @intCast(t.nanoseconds) else 0;
-                try writer.print("#<time {s} {d}.{d:0>9}>", .{ type_name, t.seconds, ns });
-            },
-            .bignum => {
-                const bignum_mod = @import("bignum.zig");
-                const allocator = std.heap.page_allocator;
-                const s = bignum_mod.toString(allocator, value) catch {
-                    try writer.writeAll("?bignum?");
-                    return;
-                };
-                defer allocator.free(s);
-                try writer.writeAll(s);
-            },
-            .rational => {
-                const rat = obj.as(types.Rational);
-                try printValueWithDepth(writer, rat.numerator, mode, depth + 1);
-                try writer.writeByte('/');
-                try printValueWithDepth(writer, rat.denominator, mode, depth + 1);
-            },
-            .file_info => {
-                const fi = obj.as(types.FileInfo);
-                const kind = switch (fi.file_type) {
-                    .regular => "regular",
-                    .directory => "directory",
-                    .symlink => "symlink",
-                    .fifo => "fifo",
-                    .socket => "socket",
-                    .char_device => "char-device",
-                    .block_device => "block-device",
-                    .other => "other",
-                };
-                try writer.print("#<file-info {s} size={d} mode={o}>", .{ kind, fi.size, fi.mode });
-            },
-            .user_info => {
-                const ui = obj.as(types.UserInfo);
-                try writer.print("#<user-info \"{s}\" uid={d}>", .{ ui.name, ui.uid });
-            },
-            .group_info => {
-                const gi = obj.as(types.GroupInfo);
-                try writer.print("#<group-info \"{s}\" gid={d}>", .{ gi.name, gi.gid });
-            },
-            .directory_object => {
-                try writer.writeAll("#<directory-object>");
-            },
-            .random_source => {
-                try writer.writeAll("#<random-source>");
-            },
-            .scheme_environment => {
-                try writer.writeAll("#<environment>");
-            },
-            .ephemeron => {
-                const eph = obj.as(types.Ephemeron);
-                try writer.writeAll(if (eph.broken) "#<ephemeron broken>" else "#<ephemeron>");
-            },
-            .guardian => {
-                const g = obj.as(types.Guardian);
-                try writer.writeAll(if (g.is_transport) "#<transport-cell-guardian>" else "#<guardian>");
-            },
-            .transport_cell => {
-                const tc = obj.as(types.TransportCell);
-                try writer.writeAll(if (tc.broken) "#<transport-cell broken>" else "#<transport-cell>");
-            },
-        }
-    } else {
-        try writer.writeAll("#<unknown>");
-    }
-}
 
-fn printList(writer: anytype, value: Value, mode: PrintMode) anyerror!void {
-    return printListWithDepth(writer, value, mode, 0);
-}
-
-fn printListWithDepth(writer: anytype, value: Value, mode: PrintMode, depth: u32) anyerror!void {
-    try writer.writeByte('(');
-    try printValueWithDepth(writer, types.car(value), mode, depth + 1);
-
-    var rest = types.cdr(value);
-    while (rest != types.NIL) {
-        if (types.isPair(rest)) {
-            try writer.writeByte(' ');
-            try printValueWithDepth(writer, types.car(rest), mode, depth + 1);
-            rest = types.cdr(rest);
-        } else {
-            try writer.writeAll(" . ");
-            try printValueWithDepth(writer, rest, mode, depth + 1);
-            break;
-        }
-    }
-    try writer.writeByte(')');
-}
-
-pub fn prettyPrint(allocator: std.mem.Allocator, value: Value, width: u16) ![]u8 {
-    const flat = try valueToString(allocator, value, .write);
-    if (flat.len <= width) return flat;
-    allocator.free(flat);
     var aw: std.Io.Writer.Allocating = .init(allocator);
-    try ppValue(&aw.writer, value, 0, width, 0);
+    errdefer aw.deinit();
+    const atom_mode: PrintMode = if (mode == .shared) .write else mode;
+    const lbl: ?*Labels = if (labels.map.count() > 0) &labels else null;
+    try printStructured(allocator, &aw.writer, value, atom_mode, lbl, NO_DEPTH_LIMIT);
     return aw.toOwnedSlice();
 }
 
-fn ppValue(writer: anytype, value: Value, indent: u16, width: u16, depth: u32) anyerror!void {
-    if (depth >= MAX_PRINT_DEPTH) {
-        try writer.writeAll("...");
-        return;
-    }
+/// `write-simple` (R7RS 6.13.3): "shared structure is never represented
+/// using datum labels". Acyclic input renders exactly like `write`; cyclic
+/// input has no finite label-free representation, so rather than the
+/// non-termination the spec anticipates, this reports CircularStructure and
+/// the primitive raises a catchable error.
+pub fn valueToStringSimple(allocator: std.mem.Allocator, value: Value) ![]u8 {
+    var labels = Labels.init(allocator);
+    defer labels.deinit();
+    try findCycleTargets(allocator, value, &labels);
+    if (labels.map.count() > 0) return error.CircularStructure;
 
-    // Atoms — always single-line
-    if (!types.isPair(value) and !types.isVector(value) and !types.isBytevector(value)) {
-        try printValue(writer, value, .write);
-        return;
-    }
-
-    // Anything that fits on one line — print flat
-    const flat_len = exactFlatLen(value);
-    if (indent + flat_len <= width) {
-        try printValue(writer, value, .write);
-        return;
-    }
-
-    // Vectors — one element per line when too wide
-    if (types.isVector(value)) {
-        const vec = types.toObject(value).as(types.Vector);
-        try writer.writeAll("#(");
-        const new_indent = indent + 2;
-        for (vec.data, 0..) |elem, i| {
-            if (i > 0) {
-                try writer.writeByte('\n');
-                try writeIndent(writer, new_indent);
-            }
-            try ppValue(writer, elem, new_indent, width, depth + 1);
-        }
-        try writer.writeByte(')');
-        return;
-    }
-
-    // Bytevectors — flow-wrap (multiple bytes per line)
-    if (types.isBytevector(value)) {
-        const bv = types.toObject(value).as(types.Bytevector);
-        try writer.writeAll("#u8(");
-        const new_indent = indent + 4;
-        var col: u16 = indent + 4;
-        for (bv.data, 0..) |byte, i| {
-            var num_buf: [4]u8 = undefined;
-            var nw: std.Io.Writer = .fixed(&num_buf);
-            nw.print("{d}", .{byte}) catch {};
-            const num_str = nw.buffered();
-            const elem_w: u16 = @intCast(num_str.len + @as(usize, if (i > 0) 1 else 0));
-            if (i > 0 and col + elem_w > width) {
-                try writer.writeByte('\n');
-                try writeIndent(writer, new_indent);
-                col = new_indent;
-            } else if (i > 0) {
-                try writer.writeByte(' ');
-                col += 1;
-            }
-            try writer.writeAll(num_str);
-            col += @intCast(num_str.len);
-        }
-        try writer.writeByte(')');
-        return;
-    }
-
-    // Lists — special-form-aware indentation
-    const style = specialFormStyle(value);
-    try writer.writeByte('(');
-    const body_indent = indent + 2;
-
-    switch (style) {
-        .body => {
-            // (head arg1\n  body...) — head + first arg on line 1
-            try ppValue(writer, types.car(value), body_indent, width, depth + 1);
-            var cur = types.cdr(value);
-            if (cur != types.NIL and types.isPair(cur)) {
-                try writer.writeByte(' ');
-                try ppValue(writer, types.car(cur), body_indent, width, depth + 1);
-                cur = types.cdr(cur);
-            }
-            try ppListTail(writer, cur, body_indent, width, depth);
-        },
-        .clause => {
-            // (head\n  clause...) — head alone on line 1
-            try ppValue(writer, types.car(value), body_indent, width, depth + 1);
-            try ppListTail(writer, types.cdr(value), body_indent, width, depth);
-        },
-        .none => {
-            // Default: each element on its own line
-            try ppValue(writer, types.car(value), body_indent, width, depth + 1);
-            try ppListTail(writer, types.cdr(value), body_indent, width, depth);
-        },
-    }
-    try writer.writeByte(')');
-}
-
-fn ppListTail(writer: anytype, tail: Value, indent: u16, width: u16, depth: u32) anyerror!void {
-    var cur = tail;
-    var count: u32 = 0;
-    while (cur != types.NIL) {
-        if (count >= MAX_PRINT_DEPTH) {
-            try writer.writeAll(" ...");
-            break;
-        }
-        if (!types.isPair(cur)) {
-            try writer.writeByte('\n');
-            try writeIndent(writer, indent);
-            try writer.writeAll(". ");
-            try ppValue(writer, cur, indent, width, depth + 1);
-            break;
-        }
-        try writer.writeByte('\n');
-        try writeIndent(writer, indent);
-        try ppValue(writer, types.car(cur), indent, width, depth + 1);
-        cur = types.cdr(cur);
-        count += 1;
-    }
-}
-
-fn writeIndent(writer: anytype, n: u16) !void {
-    var i: u16 = 0;
-    while (i < n) : (i += 1) try writer.writeByte(' ');
-}
-
-const FormStyle = enum { body, clause, none };
-
-fn specialFormStyle(value: Value) FormStyle {
-    if (!types.isPair(value)) return .none;
-    const head = types.car(value);
-    if (!types.isSymbol(head)) return .none;
-    const name = types.symbolName(head);
-    for (body_forms) |f| {
-        if (std.mem.eql(u8, name, f)) return .body;
-    }
-    for (clause_forms) |f| {
-        if (std.mem.eql(u8, name, f)) return .clause;
-    }
-    return .none;
-}
-
-const body_forms = [_][]const u8{
-    "define",               "define-syntax",        "define-record-type",
-    "define-library",       "define-values",        "lambda",
-    "let",                  "let*",                 "letrec",
-    "letrec*",              "let-values",           "let*-values",
-    "when",                 "unless",               "begin",
-    "guard",                "parameterize",         "do",
-    "syntax-rules",         "dynamic-wind",         "with-exception-handler",
-    "call-with-port",       "call-with-input-file", "call-with-output-file",
-    "with-input-from-file", "with-output-to-file",
-};
-
-const clause_forms = [_][]const u8{ "cond", "case", "case-lambda" };
-
-fn exactFlatLen(value: Value) u16 {
-    var discard_buf: [64]u8 = undefined;
-    var dw: std.Io.Writer.Discarding = .init(&discard_buf);
-    printValue(&dw.writer, value, .write) catch return std.math.maxInt(u16);
-    const count = dw.fullCount();
-    return if (count > std.math.maxInt(u16)) std.math.maxInt(u16) else @intCast(count);
-}
-
-pub fn valueToString(allocator: std.mem.Allocator, value: Value, mode: PrintMode) ![]u8 {
     var aw: std.Io.Writer.Allocating = .init(allocator);
-
-    // For `write`/`display`, R7RS requires labeling only structure that forms a
-    // cycle (so output terminates) while leaving acyclic sharing in full. Detect
-    // cycles up front; if none exist, take the plain fast path so non-cyclic
-    // output is byte-for-byte unchanged.
-    if (mode == .write or mode == .display) {
-        var state = SharedState{};
-        markCycles(allocator, value, &state);
-        if (state.shared_count > 0) {
-            try printValueShared(&aw.writer, value, &state, mode);
-            return aw.toOwnedSlice();
-        }
-    }
-
-    try printValue(&aw.writer, value, mode);
+    errdefer aw.deinit();
+    try printStructured(allocator, &aw.writer, value, .write, null, NO_DEPTH_LIMIT);
     return aw.toOwnedSlice();
 }
 
@@ -1320,115 +1249,4 @@ test "write-shared circular record instance" {
     const s = try valueToString(std.testing.allocator, ri, .shared);
     defer std.testing.allocator.free(s);
     try std.testing.expectEqualStrings("#0=#<cell #0#>", s);
-}
-
-test "prettyPrint short list stays single-line" {
-    const memory = @import("memory.zig");
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-
-    const items = [_]Value{ types.makeFixnum(1), types.makeFixnum(2), types.makeFixnum(3) };
-    const list_val = try gc.makeList(&items);
-
-    const s = try prettyPrint(std.testing.allocator, list_val, 80);
-    defer std.testing.allocator.free(s);
-    try std.testing.expectEqualStrings("(1 2 3)", s);
-}
-
-test "prettyPrint long list wraps" {
-    const memory = @import("memory.zig");
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-
-    var items: [20]Value = undefined;
-    for (&items, 0..) |*slot, i| slot.* = types.makeFixnum(@intCast(i + 1));
-    const list_val = try gc.makeList(&items);
-
-    const s = try prettyPrint(std.testing.allocator, list_val, 40);
-    defer std.testing.allocator.free(s);
-    // Should wrap — check it contains newlines and starts/ends correctly
-    try std.testing.expect(std.mem.indexOf(u8, s, "\n") != null);
-    try std.testing.expect(std.mem.startsWith(u8, s, "(1\n"));
-    try std.testing.expect(std.mem.endsWith(u8, s, "20)"));
-}
-
-test "prettyPrint vector wraps when too wide" {
-    const memory = @import("memory.zig");
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-
-    var data: [15]Value = undefined;
-    for (&data, 0..) |*slot, i| slot.* = types.makeFixnum(@intCast(i + 1));
-    const vec = try gc.allocVector(&data);
-
-    const s = try prettyPrint(std.testing.allocator, vec, 30);
-    defer std.testing.allocator.free(s);
-    try std.testing.expect(std.mem.indexOf(u8, s, "\n") != null);
-    try std.testing.expect(std.mem.startsWith(u8, s, "#(1\n"));
-    try std.testing.expect(std.mem.endsWith(u8, s, "15)"));
-}
-
-test "prettyPrint short vector stays single-line" {
-    const memory = @import("memory.zig");
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-
-    const data = [_]Value{ types.makeFixnum(1), types.makeFixnum(2), types.makeFixnum(3) };
-    const vec = try gc.allocVector(&data);
-
-    const s = try prettyPrint(std.testing.allocator, vec, 80);
-    defer std.testing.allocator.free(s);
-    try std.testing.expectEqualStrings("#(1 2 3)", s);
-}
-
-test "prettyPrint body form indentation" {
-    const memory = @import("memory.zig");
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-
-    // (define name (+ 1 2 3 4 5 6 7 8 9 10))
-    var body_items: [10]Value = undefined;
-    for (&body_items, 0..) |*slot, i| slot.* = types.makeFixnum(@intCast(i + 1));
-    const plus_sym = try gc.allocSymbol("+");
-    var plus_args: [11]Value = undefined;
-    plus_args[0] = plus_sym;
-    for (plus_args[1..], 0..) |*slot, i| slot.* = body_items[i];
-    var body = try gc.makeList(&plus_args);
-    // Root across the allocations below — unrooted locals are swept under
-    // -Dgc-stress=true (#1682).
-    gc.pushRoot(&body);
-    defer gc.popRoot();
-
-    const define_sym = try gc.allocSymbol("define");
-    const name_sym = try gc.allocSymbol("name");
-    const define_items = [_]Value{ define_sym, name_sym, body };
-    const form = try gc.makeList(&define_items);
-
-    const s = try prettyPrint(std.testing.allocator, form, 30);
-    defer std.testing.allocator.free(s);
-    // Should start with "(define name" on line 1
-    try std.testing.expect(std.mem.startsWith(u8, s, "(define name\n"));
-}
-
-test "prettyPrint clause form indentation" {
-    const memory = @import("memory.zig");
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-
-    // (cond (#t 1) (#f 2))
-    const cond_sym = try gc.allocSymbol("cond");
-    const clause1_items = [_]Value{ types.TRUE, types.makeFixnum(1) };
-    var clause1 = try gc.makeList(&clause1_items);
-    // clause1 must stay rooted while the next makeList allocates: under
-    // -Dgc-stress=true that collection sweeps unrooted locals (#1682).
-    gc.pushRoot(&clause1);
-    defer gc.popRoot();
-    const clause2_items = [_]Value{ types.FALSE, types.makeFixnum(2) };
-    const clause2 = try gc.makeList(&clause2_items);
-    const cond_items = [_]Value{ cond_sym, clause1, clause2 };
-    const form = try gc.makeList(&cond_items);
-
-    const s = try prettyPrint(std.testing.allocator, form, 15);
-    defer std.testing.allocator.free(s);
-    try std.testing.expectEqualStrings("(cond\n  (#t 1)\n  (#f 2))", s);
 }

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -371,21 +371,20 @@ fn printStructured(
 }
 
 /// Numerator/denominator of a rational -- always an exact integer.
-fn writeExactIntPart(writer: anytype, v: Value) anyerror!void {
+fn writeExactIntPart(allocator: std.mem.Allocator, writer: anytype, v: Value) anyerror!void {
     if (types.isFixnum(v)) {
         try writer.print("{d}", .{types.toFixnum(v)});
         return;
     }
     if (types.isPointer(v) and types.toObject(v).tag == .bignum) {
-        try writeBignum(writer, v);
+        try writeBignum(allocator, writer, v);
         return;
     }
     try writer.writeAll("#<unknown>");
 }
 
-fn writeBignum(writer: anytype, v: Value) anyerror!void {
+fn writeBignum(allocator: std.mem.Allocator, writer: anytype, v: Value) anyerror!void {
     const bignum_mod = @import("bignum.zig");
-    const allocator = std.heap.page_allocator;
     const s = bignum_mod.toString(allocator, v) catch {
         try writer.writeAll("?bignum?");
         return;
@@ -742,16 +741,16 @@ fn printValueOnce(
                 try writer.print("#<time {s} {d}.{d:0>9}>", .{ type_name, t.seconds, ns });
             },
             .bignum => {
-                try writeBignum(writer, value);
+                try writeBignum(allocator, writer, value);
             },
             .rational => {
                 // Rendered atomically: both parts are always exact integers,
                 // so no depth accounting can split this leaf into the
                 // symbol-shaped `.../...` of kaappi#1953.
                 const rat = obj.as(types.Rational);
-                try writeExactIntPart(writer, rat.numerator);
+                try writeExactIntPart(allocator, writer, rat.numerator);
                 try writer.writeByte('/');
-                try writeExactIntPart(writer, rat.denominator);
+                try writeExactIntPart(allocator, writer, rat.denominator);
             },
             .file_info => {
                 const fi = obj.as(types.FileInfo);
@@ -1208,15 +1207,17 @@ test "write-shared shared substructure" {
     try std.testing.expectEqualStrings("(#0=(1) #0#)", s);
 }
 
-// Regression tests for #1713: record instances were invisible to both the
-// `write`/`display` cycle-detection pre-pass and the `write-shared`
+// Regression tests for #1713: record instances were once invisible to both
+// the `write`/`display` cycle-detection pre-pass and the `write-shared`
 // shared-structure pre-pass, so a self-referential record fell through to
-// the plain depth-limited recursive printer instead of getting a datum
-// label. A single direct self-reference "only" recurses ~1024 times before
-// hitting the depth cap, but a fan-out cycle (a record field that's a
-// vector of records each pointing back) blows up combinatorially at every
-// level of that recursion -- see the Scheme-level regression test
-// tests/scheme/smoke/cyclic-record-printer-1713.scm for that shape.
+// the (since-removed) depth-limited recursive printer instead of getting a
+// datum label -- and a fan-out cycle (a record field that's a vector of
+// records each pointing back) blew up combinatorially before that depth cap
+// could stop it. Records now sit in `isTraversable`/`childAt` like every
+// other printed container; these tests pin the labelled rendering, the
+// per-tag lock lives in tests_printer.zig ("every traversable
+// container..."), and tests/scheme/smoke/cyclic-record-printer-1713.scm
+// pins the fan-out shape end to end.
 
 test "write circular record instance" {
     const memory = @import("memory.zig");

--- a/src/printer_pretty.zig
+++ b/src/printer_pretty.zig
@@ -1,0 +1,323 @@
+//! REPL pretty-printer (split from printer.zig under the 1500-line policy).
+//!
+//! Human-facing layout only: `prettyPrint` first renders the value exactly
+//! via `printer.valueToString` (cycle-labelled, never truncated) and returns
+//! that when it fits the terminal width. Only the multi-line layout fallback
+//! below uses the bounded diagnostic `printer.printValue`, whose
+//! MAX_PRINT_DEPTH cap (and per-element spine tick) keeps layout probing
+//! cheap and terminating even on cyclic sub-structure -- `exactFlatLen` on a
+//! cdr-cyclic value looped forever before the printer rework (the tail of
+//! kaappi#859, noted in tests/scheme/compliance/printer-gaps.scm).
+
+const std = @import("std");
+const types = @import("types.zig");
+const printer = @import("printer.zig");
+const Value = types.Value;
+const MAX_PRINT_DEPTH = printer.MAX_PRINT_DEPTH;
+const printValue = printer.printValue;
+
+pub fn prettyPrint(allocator: std.mem.Allocator, value: Value, width: u16) ![]u8 {
+    const flat = try printer.valueToString(allocator, value, .write);
+    if (flat.len <= width) return flat;
+    allocator.free(flat);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    errdefer aw.deinit();
+    try ppValue(&aw.writer, value, 0, width, 0);
+    return aw.toOwnedSlice();
+}
+
+fn ppValue(writer: anytype, value: Value, indent: u16, width: u16, depth: u32) anyerror!void {
+    if (depth >= MAX_PRINT_DEPTH) {
+        try writer.writeAll("...");
+        return;
+    }
+
+    // Atoms — always single-line
+    if (!types.isPair(value) and !types.isVector(value) and !types.isBytevector(value)) {
+        try printValue(writer, value, .write);
+        return;
+    }
+
+    // Anything that fits on one line — print flat
+    const flat_len = exactFlatLen(value);
+    if (indent + flat_len <= width) {
+        try printValue(writer, value, .write);
+        return;
+    }
+
+    // Vectors — one element per line when too wide
+    if (types.isVector(value)) {
+        const vec = types.toObject(value).as(types.Vector);
+        try writer.writeAll("#(");
+        const new_indent = indent + 2;
+        for (vec.data, 0..) |elem, i| {
+            if (i > 0) {
+                try writer.writeByte('\n');
+                try writeIndent(writer, new_indent);
+            }
+            try ppValue(writer, elem, new_indent, width, depth + 1);
+        }
+        try writer.writeByte(')');
+        return;
+    }
+
+    // Bytevectors — flow-wrap (multiple bytes per line)
+    if (types.isBytevector(value)) {
+        const bv = types.toObject(value).as(types.Bytevector);
+        try writer.writeAll("#u8(");
+        const new_indent = indent + 4;
+        var col: u16 = indent + 4;
+        for (bv.data, 0..) |byte, i| {
+            var num_buf: [4]u8 = undefined;
+            var nw: std.Io.Writer = .fixed(&num_buf);
+            nw.print("{d}", .{byte}) catch {};
+            const num_str = nw.buffered();
+            const elem_w: u16 = @intCast(num_str.len + @as(usize, if (i > 0) 1 else 0));
+            if (i > 0 and col + elem_w > width) {
+                try writer.writeByte('\n');
+                try writeIndent(writer, new_indent);
+                col = new_indent;
+            } else if (i > 0) {
+                try writer.writeByte(' ');
+                col += 1;
+            }
+            try writer.writeAll(num_str);
+            col += @intCast(num_str.len);
+        }
+        try writer.writeByte(')');
+        return;
+    }
+
+    // Lists — special-form-aware indentation
+    const style = specialFormStyle(value);
+    try writer.writeByte('(');
+    const body_indent = indent + 2;
+
+    switch (style) {
+        .body => {
+            // (head arg1\n  body...) — head + first arg on line 1
+            try ppValue(writer, types.car(value), body_indent, width, depth + 1);
+            var cur = types.cdr(value);
+            if (cur != types.NIL and types.isPair(cur)) {
+                try writer.writeByte(' ');
+                try ppValue(writer, types.car(cur), body_indent, width, depth + 1);
+                cur = types.cdr(cur);
+            }
+            try ppListTail(writer, cur, body_indent, width, depth);
+        },
+        .clause => {
+            // (head\n  clause...) — head alone on line 1
+            try ppValue(writer, types.car(value), body_indent, width, depth + 1);
+            try ppListTail(writer, types.cdr(value), body_indent, width, depth);
+        },
+        .none => {
+            // Default: each element on its own line
+            try ppValue(writer, types.car(value), body_indent, width, depth + 1);
+            try ppListTail(writer, types.cdr(value), body_indent, width, depth);
+        },
+    }
+    try writer.writeByte(')');
+}
+
+fn ppListTail(writer: anytype, tail: Value, indent: u16, width: u16, depth: u32) anyerror!void {
+    var cur = tail;
+    var count: u32 = 0;
+    while (cur != types.NIL) {
+        if (count >= MAX_PRINT_DEPTH) {
+            try writer.writeAll(" ...");
+            break;
+        }
+        if (!types.isPair(cur)) {
+            try writer.writeByte('\n');
+            try writeIndent(writer, indent);
+            try writer.writeAll(". ");
+            try ppValue(writer, cur, indent, width, depth + 1);
+            break;
+        }
+        try writer.writeByte('\n');
+        try writeIndent(writer, indent);
+        try ppValue(writer, types.car(cur), indent, width, depth + 1);
+        cur = types.cdr(cur);
+        count += 1;
+    }
+}
+
+fn writeIndent(writer: anytype, n: u16) !void {
+    var i: u16 = 0;
+    while (i < n) : (i += 1) try writer.writeByte(' ');
+}
+
+const FormStyle = enum { body, clause, none };
+
+fn specialFormStyle(value: Value) FormStyle {
+    if (!types.isPair(value)) return .none;
+    const head = types.car(value);
+    if (!types.isSymbol(head)) return .none;
+    const name = types.symbolName(head);
+    for (body_forms) |f| {
+        if (std.mem.eql(u8, name, f)) return .body;
+    }
+    for (clause_forms) |f| {
+        if (std.mem.eql(u8, name, f)) return .clause;
+    }
+    return .none;
+}
+
+const body_forms = [_][]const u8{
+    "define",               "define-syntax",        "define-record-type",
+    "define-library",       "define-values",        "lambda",
+    "let",                  "let*",                 "letrec",
+    "letrec*",              "let-values",           "let*-values",
+    "when",                 "unless",               "begin",
+    "guard",                "parameterize",         "do",
+    "syntax-rules",         "dynamic-wind",         "with-exception-handler",
+    "call-with-port",       "call-with-input-file", "call-with-output-file",
+    "with-input-from-file", "with-output-to-file",
+};
+
+const clause_forms = [_][]const u8{ "cond", "case", "case-lambda" };
+
+fn exactFlatLen(value: Value) u16 {
+    var discard_buf: [64]u8 = undefined;
+    var dw: std.Io.Writer.Discarding = .init(&discard_buf);
+    printValue(&dw.writer, value, .write) catch return std.math.maxInt(u16);
+    const count = dw.fullCount();
+    return if (count > std.math.maxInt(u16)) std.math.maxInt(u16) else @intCast(count);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "prettyPrint short list stays single-line" {
+    const memory = @import("memory.zig");
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    const items = [_]Value{ types.makeFixnum(1), types.makeFixnum(2), types.makeFixnum(3) };
+    const list_val = try gc.makeList(&items);
+
+    const s = try prettyPrint(std.testing.allocator, list_val, 80);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("(1 2 3)", s);
+}
+
+test "prettyPrint long list wraps" {
+    const memory = @import("memory.zig");
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    var items: [20]Value = undefined;
+    for (&items, 0..) |*slot, i| slot.* = types.makeFixnum(@intCast(i + 1));
+    const list_val = try gc.makeList(&items);
+
+    const s = try prettyPrint(std.testing.allocator, list_val, 40);
+    defer std.testing.allocator.free(s);
+    // Should wrap — check it contains newlines and starts/ends correctly
+    try std.testing.expect(std.mem.indexOf(u8, s, "\n") != null);
+    try std.testing.expect(std.mem.startsWith(u8, s, "(1\n"));
+    try std.testing.expect(std.mem.endsWith(u8, s, "20)"));
+}
+
+test "prettyPrint vector wraps when too wide" {
+    const memory = @import("memory.zig");
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    var data: [15]Value = undefined;
+    for (&data, 0..) |*slot, i| slot.* = types.makeFixnum(@intCast(i + 1));
+    const vec = try gc.allocVector(&data);
+
+    const s = try prettyPrint(std.testing.allocator, vec, 30);
+    defer std.testing.allocator.free(s);
+    try std.testing.expect(std.mem.indexOf(u8, s, "\n") != null);
+    try std.testing.expect(std.mem.startsWith(u8, s, "#(1\n"));
+    try std.testing.expect(std.mem.endsWith(u8, s, "15)"));
+}
+
+test "prettyPrint short vector stays single-line" {
+    const memory = @import("memory.zig");
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    const data = [_]Value{ types.makeFixnum(1), types.makeFixnum(2), types.makeFixnum(3) };
+    const vec = try gc.allocVector(&data);
+
+    const s = try prettyPrint(std.testing.allocator, vec, 80);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("#(1 2 3)", s);
+}
+
+test "prettyPrint body form indentation" {
+    const memory = @import("memory.zig");
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    // (define name (+ 1 2 3 4 5 6 7 8 9 10))
+    var body_items: [10]Value = undefined;
+    for (&body_items, 0..) |*slot, i| slot.* = types.makeFixnum(@intCast(i + 1));
+    const plus_sym = try gc.allocSymbol("+");
+    var plus_args: [11]Value = undefined;
+    plus_args[0] = plus_sym;
+    for (plus_args[1..], 0..) |*slot, i| slot.* = body_items[i];
+    var body = try gc.makeList(&plus_args);
+    // Root across the allocations below — unrooted locals are swept under
+    // -Dgc-stress=true (#1682).
+    gc.pushRoot(&body);
+    defer gc.popRoot();
+
+    const define_sym = try gc.allocSymbol("define");
+    const name_sym = try gc.allocSymbol("name");
+    const define_items = [_]Value{ define_sym, name_sym, body };
+    const form = try gc.makeList(&define_items);
+
+    const s = try prettyPrint(std.testing.allocator, form, 30);
+    defer std.testing.allocator.free(s);
+    // Should start with "(define name" on line 1
+    try std.testing.expect(std.mem.startsWith(u8, s, "(define name\n"));
+}
+
+test "prettyPrint clause form indentation" {
+    const memory = @import("memory.zig");
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    // (cond (#t 1) (#f 2))
+    const cond_sym = try gc.allocSymbol("cond");
+    const clause1_items = [_]Value{ types.TRUE, types.makeFixnum(1) };
+    var clause1 = try gc.makeList(&clause1_items);
+    // clause1 must stay rooted while the next makeList allocates: under
+    // -Dgc-stress=true that collection sweeps unrooted locals (#1682).
+    gc.pushRoot(&clause1);
+    defer gc.popRoot();
+    const clause2_items = [_]Value{ types.FALSE, types.makeFixnum(2) };
+    const clause2 = try gc.makeList(&clause2_items);
+    const cond_items = [_]Value{ cond_sym, clause1, clause2 };
+    const form = try gc.makeList(&cond_items);
+
+    const s = try prettyPrint(std.testing.allocator, form, 15);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("(cond\n  (#t 1)\n  (#f 2))", s);
+}
+
+test "prettyPrint terminates on a cyclic value at narrow width" {
+    // Pre-rework, `exactFlatLen` fed a cdr-cyclic value to a printer with no
+    // spine bound and never returned (kaappi#859's surviving tail; the REPL
+    // wedged at narrow COLUMNS). The bounded printer now ticks the cap per
+    // spine element, so layout probing terminates.
+    const memory = @import("memory.zig");
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    const items = [_]Value{ types.makeFixnum(1), types.makeFixnum(2), types.makeFixnum(3) };
+    var cyc = try gc.makeList(&items);
+    gc.pushRoot(&cyc);
+    defer gc.popRoot();
+    // (1 2 3 . <self>)
+    const third = types.cdr(types.cdr(cyc));
+    types.setCdr(third, cyc);
+
+    const s = try prettyPrint(std.testing.allocator, cyc, 5);
+    defer std.testing.allocator.free(s);
+    try std.testing.expect(s.len > 0);
+}

--- a/src/printer_pretty.zig
+++ b/src/printer_pretty.zig
@@ -2,12 +2,18 @@
 //!
 //! Human-facing layout only: `prettyPrint` first renders the value exactly
 //! via `printer.valueToString` (cycle-labelled, never truncated) and returns
-//! that when it fits the terminal width. Only the multi-line layout fallback
-//! below uses the bounded diagnostic `printer.printValue`, whose
-//! MAX_PRINT_DEPTH cap (and per-element spine tick) keeps layout probing
-//! cheap and terminating even on cyclic sub-structure -- `exactFlatLen` on a
-//! cdr-cyclic value looped forever before the printer rework (the tail of
-//! kaappi#859, noted in tests/scheme/compliance/printer-gaps.scm).
+//! that whenever it fits the terminal width. The multi-line fallback below
+//! -- all of `ppValue`, its layout probes AND its flat emissions -- runs on
+//! the bounded diagnostic `printer.printValue` instead, deliberately: the
+//! fit decisions and the emitted text must come from the same renderer (an
+//! exact emission behind a bounded measurement could be arbitrarily wider
+//! than the width the layout just budgeted for), and MAX_PRINT_DEPTH plus
+//! the per-element spine tick keep both cheap and terminating even on
+//! cyclic sub-structure. So wrapped REPL output truncates past
+//! MAX_PRINT_DEPTH with `...`, exactly as it did before the printer rework;
+//! `write` is the exact channel. `exactFlatLen` on a cdr-cyclic value
+//! looped forever before the rework (the tail of kaappi#859, noted in
+//! tests/scheme/compliance/printer-gaps.scm).
 
 const std = @import("std");
 const types = @import("types.zig");
@@ -38,9 +44,13 @@ fn ppValue(writer: anytype, value: Value, indent: u16, width: u16, depth: u32) a
         return;
     }
 
-    // Anything that fits on one line — print flat
+    // Anything that fits on one line — print flat. Widened add:
+    // `exactFlatLen` saturates at maxInt(u16), so u16 arithmetic overflowed
+    // (a ReleaseSafe panic, reachable from the REPL) for any nested subtree
+    // whose flat form reaches 64 KiB — pre-existing, caught in review of
+    // kaappi#2190.
     const flat_len = exactFlatLen(value);
-    if (indent + flat_len <= width) {
+    if (@as(u32, indent) + flat_len <= width) {
         try printValue(writer, value, .write);
         return;
     }
@@ -300,6 +310,34 @@ test "prettyPrint clause form indentation" {
     try std.testing.expectEqualStrings("(cond\n  (#t 1)\n  (#f 2))", s);
 }
 
+test "prettyPrint survives a subtree whose flat form exceeds 64 KiB" {
+    // `exactFlatLen` saturates at maxInt(u16); the fits-check used to add it
+    // to `indent` in u16 arithmetic, so any nested (indent > 0) subtree with
+    // a >=64 KiB flat rendering panicked with integer overflow in
+    // ReleaseSafe — reachable by echoing ((<70000-char string>)) in the
+    // REPL, on the pre-rework printer too (caught in review of kaappi#2190).
+    const memory = @import("memory.zig");
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    const big = try std.testing.allocator.alloc(u8, 70000);
+    defer std.testing.allocator.free(big);
+    @memset(big, 'a');
+    var str = try gc.allocString(big);
+    gc.pushRoot(&str);
+    defer gc.popRoot();
+    const inner_items = [_]Value{str};
+    var inner = try gc.makeList(&inner_items);
+    gc.pushRoot(&inner);
+    defer gc.popRoot();
+    const outer_items = [_]Value{inner};
+    const outer = try gc.makeList(&outer_items);
+
+    const s = try prettyPrint(std.testing.allocator, outer, 30);
+    defer std.testing.allocator.free(s);
+    try std.testing.expect(s.len > 70000);
+}
+
 test "prettyPrint terminates on a cyclic value at narrow width" {
     // Pre-rework, `exactFlatLen` fed a cdr-cyclic value to a printer with no
     // spine bound and never returned (kaappi#859's surviving tail; the REPL
@@ -316,6 +354,7 @@ test "prettyPrint terminates on a cyclic value at narrow width" {
     // (1 2 3 . <self>)
     const third = types.cdr(types.cdr(cyc));
     types.setCdr(third, cyc);
+    gc.writeBarrier(types.toObject(third), cyc);
 
     const s = try prettyPrint(std.testing.allocator, cyc, 5);
     defer std.testing.allocator.free(s);

--- a/src/tests_printer.zig
+++ b/src/tests_printer.zig
@@ -1,0 +1,374 @@
+//! Printer regression tests for the audit-v2 Phase 1D family:
+//!   #1953 — a rational leaf at nesting depth 1023 rendered as `.../...`,
+//!           a legal symbol datum with the wrong value
+//!   #1954 — cycles reached only through error-object irritants or
+//!           mutex/condition-variable names hung all four output procedures
+//!   #1955 — write-simple was registered as `&write`, so it emitted datum
+//!           labels on circular structure
+//!   #1902 — (closed, decomposed) the fixed 1024-entry seen[]/shared[]
+//!           arrays and MAX_PRINT_DEPTH silently truncated output and
+//!           dropped write-shared labels; three distinct cliffs (D1-D4)
+//!   #2107 — printing recursed on the native stack, so wasm32 (16 MiB
+//!           default stack) trapped at depth 848 before the depth guard
+//!           calibrated for the native 64 MB stack could fire
+//!
+//! The printer is now a single iterative engine over heap-allocated work
+//! stacks with hashmap-based cycle/sharing detection: exact output at any
+//! depth, any number of labels, and detection covers every container the
+//! printer recurses into. The Scheme-level round-trip half of these lives in
+//! tests/scheme/compliance/printer-gaps.scm.
+
+const std = @import("std");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const printer = @import("printer.zig");
+const Value = types.Value;
+const build_options = @import("build_options");
+
+/// n nested one-element lists around `leaf`: nest(3, x) = (((x)))
+fn nest(gc: *memory.GC, n: usize, leaf: Value) !Value {
+    var acc = leaf;
+    var i: usize = 0;
+    // allocPair auto-roots its Value arguments, and nothing else allocates
+    // between iterations, so `acc` needs no manual root here.
+    while (i < n) : (i += 1) acc = try gc.allocPair(acc, types.NIL);
+    return acc;
+}
+
+/// The exact expected rendering of nest(n, leaf): n opens, leaf, n closes.
+fn expectNested(allocator: std.mem.Allocator, s: []const u8, n: usize, leaf: []const u8) !void {
+    try std.testing.expectEqual(2 * n + leaf.len, s.len);
+    const expected = try allocator.alloc(u8, 2 * n + leaf.len);
+    defer allocator.free(expected);
+    @memset(expected[0..n], '(');
+    @memcpy(expected[n .. n + leaf.len], leaf);
+    @memset(expected[n + leaf.len ..], ')');
+    try std.testing.expectEqualStrings(expected, s);
+}
+
+fn countLabelDefs(s: []const u8) usize {
+    // Datum-label definitions are the only '=' the printer emits in these
+    // tests' inputs.
+    var n: usize = 0;
+    for (s) |c| {
+        if (c == '=') n += 1;
+    }
+    return n;
+}
+
+// -- #1902 / #2107: exact output at and far past the old 1024 depth cap ----
+
+test "write is exact at the old depth cliff (1023, 1024, 1025)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    inline for (.{ 1023, 1024, 1025 }) |n| {
+        const deep = try nest(&gc, n, types.makeFixnum(42));
+        const s = try printer.valueToString(std.testing.allocator, deep, .write);
+        defer std.testing.allocator.free(s);
+        try expectNested(std.testing.allocator, s, n, "42");
+    }
+}
+
+test "write is exact far past the old depth cap" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    // 200k pairs is the #49 / #2107 regression shape; keep the unit-test
+    // copy cheap under -Dgc-stress=true (the Scheme suite runs the big one).
+    const n: usize = if (build_options.gc_stress) 2000 else 20000;
+    const deep = try nest(&gc, n, types.NIL);
+    const s = try printer.valueToString(std.testing.allocator, deep, .write);
+    defer std.testing.allocator.free(s);
+    try expectNested(std.testing.allocator, s, n, "()");
+}
+
+// -- #1953: two-part numeric leaves must never split across a depth seam ---
+
+test "rational leaf at depth 1023 prints exactly (#1953)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    const rat = try gc.allocRational(types.makeFixnum(3), types.makeFixnum(4));
+    const deep = try nest(&gc, 1023, rat);
+    const s = try printer.valueToString(std.testing.allocator, deep, .write);
+    defer std.testing.allocator.free(s);
+    try expectNested(std.testing.allocator, s, 1023, "3/4");
+}
+
+test "negative rational leaf at depth 1024 prints exactly (#1953)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    const rat = try gc.allocRational(types.makeFixnum(-7), types.makeFixnum(9));
+    const deep = try nest(&gc, 1024, rat);
+    const s = try printer.valueToString(std.testing.allocator, deep, .write);
+    defer std.testing.allocator.free(s);
+    try expectNested(std.testing.allocator, s, 1024, "-7/9");
+}
+
+// -- #1954: cycles reached only through non-pair/vector/record containers --
+
+fn makeCyclicList(gc: *memory.GC) !Value {
+    // (1 2 3 . <self>)
+    const items = [_]Value{ types.makeFixnum(1), types.makeFixnum(2), types.makeFixnum(3) };
+    const c = try gc.makeList(&items);
+    const third = types.cdr(types.cdr(c));
+    types.setCdr(third, c);
+    gc.writeBarrier(types.toObject(third), c);
+    return c;
+}
+
+test "write terminates and labels a cyclic error-object irritant (#1954)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    var msg = try gc.allocString("boom");
+    gc.pushRoot(&msg);
+    defer gc.popRoot();
+    var cyc = try makeCyclicList(&gc);
+    gc.pushRoot(&cyc);
+    const irritants = try gc.allocPair(cyc, types.NIL);
+    gc.popRoot();
+    const err = try gc.allocErrorObject(msg, irritants);
+
+    const s = try printer.valueToString(std.testing.allocator, err, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("#<error \"boom\" #0=(1 2 3 . #0#)>", s);
+
+    // display has the same R7RS termination obligation.
+    const d = try printer.valueToString(std.testing.allocator, err, .display);
+    defer std.testing.allocator.free(d);
+    try std.testing.expectEqualStrings("#<error boom #0=(1 2 3 . #0#)>", d);
+
+    // write-shared had the same blind spot in its own pre-pass.
+    const sh = try printer.valueToString(std.testing.allocator, err, .shared);
+    defer std.testing.allocator.free(sh);
+    try std.testing.expectEqualStrings("#<error \"boom\" #0=(1 2 3 . #0#)>", sh);
+}
+
+test "write terminates on a cyclic mutex / condition-variable name (#1954)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    var cyc = try makeCyclicList(&gc);
+    gc.pushRoot(&cyc);
+    const m = try gc.allocMutex(cyc);
+    gc.popRoot();
+    const ms = try printer.valueToString(std.testing.allocator, m, .write);
+    defer std.testing.allocator.free(ms);
+    try std.testing.expectEqualStrings("#<mutex #0=(1 2 3 . #0#)>", ms);
+
+    var cyc2 = try makeCyclicList(&gc);
+    gc.pushRoot(&cyc2);
+    const cv = try gc.allocConditionVariable(cyc2);
+    gc.popRoot();
+    const cs = try printer.valueToString(std.testing.allocator, cv, .write);
+    defer std.testing.allocator.free(cs);
+    try std.testing.expectEqualStrings("#<condition-variable #0=(1 2 3 . #0#)>", cs);
+}
+
+test "every traversable container terminates when it closes a cycle itself" {
+    // The mutation lock for "detection covers what printing walks": one
+    // self-referential instance per traversable tag. A new recursive print
+    // arm added without its detection edge fails here by hanging (caught by
+    // the suite timeout) rather than by silently shipping #1954 again.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    // vector: v = #(v)
+    {
+        const elems = [_]Value{types.NIL};
+        const v = try gc.allocVector(&elems);
+        types.toObject(v).as(types.Vector).data[0] = v;
+        gc.writeBarrier(types.toObject(v), v);
+        const s = try printer.valueToString(std.testing.allocator, v, .write);
+        defer std.testing.allocator.free(s);
+        try std.testing.expectEqualStrings("#0=#(#0#)", s);
+    }
+    // error object: e = #<error "m" e>
+    {
+        var msg = try gc.allocString("m");
+        gc.pushRoot(&msg);
+        defer gc.popRoot();
+        var irritants = try gc.allocPair(types.NIL, types.NIL);
+        gc.pushRoot(&irritants);
+        const e = try gc.allocErrorObject(msg, irritants);
+        gc.popRoot();
+        types.setCar(irritants, e);
+        gc.writeBarrier(types.toObject(irritants), e);
+        const s = try printer.valueToString(std.testing.allocator, e, .write);
+        defer std.testing.allocator.free(s);
+        try std.testing.expectEqualStrings("#0=#<error \"m\" #0#>", s);
+    }
+    // multiple values: mv = #<values #(mv)>
+    {
+        const elems = [_]Value{types.NIL};
+        var vec = try gc.allocVector(&elems);
+        gc.pushRoot(&vec);
+        defer gc.popRoot();
+        const mvs = [_]Value{vec};
+        const mv = try gc.allocMultipleValues(&mvs);
+        types.toObject(vec).as(types.Vector).data[0] = mv;
+        gc.writeBarrier(types.toObject(vec), mv);
+        const s = try printer.valueToString(std.testing.allocator, mv, .write);
+        defer std.testing.allocator.free(s);
+        try std.testing.expectEqualStrings("#0=#<values #(#0#)>", s);
+    }
+    // mutex named by a pair that points back at the mutex
+    {
+        var p = try gc.allocPair(types.NIL, types.NIL);
+        gc.pushRoot(&p);
+        defer gc.popRoot();
+        const m = try gc.allocMutex(p);
+        types.setCar(p, m);
+        gc.writeBarrier(types.toObject(p), m);
+        const s = try printer.valueToString(std.testing.allocator, m, .write);
+        defer std.testing.allocator.free(s);
+        try std.testing.expectEqualStrings("#0=#<mutex (#0#)>", s);
+    }
+    // condition variable, same shape
+    {
+        var p = try gc.allocPair(types.NIL, types.NIL);
+        gc.pushRoot(&p);
+        defer gc.popRoot();
+        const cv = try gc.allocConditionVariable(p);
+        types.setCar(p, cv);
+        gc.writeBarrier(types.toObject(p), cv);
+        const s = try printer.valueToString(std.testing.allocator, cv, .write);
+        defer std.testing.allocator.free(s);
+        try std.testing.expectEqualStrings("#0=#<condition-variable (#0#)>", s);
+    }
+}
+
+// -- #1902 D2/D3: sharing detection has no capacity or position limits -----
+
+test "write-shared labels all of 1200 repeated cells (old cap: 1023)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    const n: usize = if (build_options.gc_stress) 300 else 1200;
+    const data = try std.testing.allocator.alloc(Value, 2 * n);
+    defer std.testing.allocator.free(data);
+    @memset(data, types.NIL);
+    var vec = try gc.allocVector(data);
+    gc.pushRoot(&vec);
+    defer gc.popRoot();
+    var i: usize = 0;
+    while (i < n) : (i += 1) {
+        const cell = try gc.allocPair(types.makeFixnum(@intCast(i)), types.NIL);
+        const vd = types.toObject(vec).as(types.Vector).data;
+        vd[2 * i] = cell;
+        vd[2 * i + 1] = cell;
+        gc.writeBarrier(types.toObject(vec), cell);
+    }
+
+    const s = try printer.valueToString(std.testing.allocator, vec, .shared);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqual(n, countLabelDefs(s));
+}
+
+test "write-shared detects a first occurrence past 1024 distinct nodes (D2)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    // 1100 distinct filler cells, with one shared cell first met at index
+    // 1050 and repeated at the end — positionally invisible to the old
+    // fixed seen[] array.
+    const size: usize = 1100;
+    const data = try std.testing.allocator.alloc(Value, size);
+    defer std.testing.allocator.free(data);
+    @memset(data, types.NIL);
+    var vec = try gc.allocVector(data);
+    gc.pushRoot(&vec);
+    defer gc.popRoot();
+    var i: usize = 0;
+    while (i < size) : (i += 1) {
+        const cell = try gc.allocPair(types.makeFixnum(@intCast(i)), types.NIL);
+        types.toObject(vec).as(types.Vector).data[i] = cell;
+        gc.writeBarrier(types.toObject(vec), cell);
+    }
+    const vd = types.toObject(vec).as(types.Vector).data;
+    vd[size - 1] = vd[1050];
+    gc.writeBarrier(types.toObject(vec), vd[1050]);
+
+    const s = try printer.valueToString(std.testing.allocator, vec, .shared);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqual(@as(usize, 1), countLabelDefs(s));
+}
+
+// -- #1902 D4: a cycle whose back-edge sits past the old depth cap ---------
+
+test "a 2000-deep nested cycle keeps its datum label (D4)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    const depth: usize = if (build_options.gc_stress) 1200 else 2000;
+    var outer = try gc.allocPair(types.NIL, types.NIL);
+    gc.pushRoot(&outer);
+    defer gc.popRoot();
+    // outer = ( ( ( ... (inner) ... ) ) ); then inner's car -> outer.
+    var inner = outer;
+    var i: usize = 1;
+    while (i < depth) : (i += 1) {
+        const next = try gc.allocPair(types.NIL, types.NIL);
+        types.setCar(inner, next);
+        gc.writeBarrier(types.toObject(inner), next);
+        inner = next;
+    }
+    types.setCar(inner, outer);
+    gc.writeBarrier(types.toObject(inner), outer);
+
+    const s = try printer.valueToString(std.testing.allocator, outer, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expect(std.mem.startsWith(u8, s, "#0=("));
+    try std.testing.expect(std.mem.indexOf(u8, s, "#0#") != null);
+    // Exact shape: #0= + depth opens + #0# + depth closes.
+    try std.testing.expectEqual(3 + depth + 3 + depth, s.len);
+}
+
+// -- #1955: write-simple never labels; cyclic input is a loud error --------
+
+test "write-simple output has no labels on acyclic sharing, errors on cycles" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    // (d d) with d = (1 2 3): acyclic sharing prints in full, unlabelled.
+    const items = [_]Value{ types.makeFixnum(1), types.makeFixnum(2), types.makeFixnum(3) };
+    var d = try gc.makeList(&items);
+    gc.pushRoot(&d);
+    const shared_items = [_]Value{ d, d };
+    const both = try gc.makeList(&shared_items);
+    gc.popRoot();
+
+    const s = try printer.valueToStringSimple(std.testing.allocator, both);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("((1 2 3) (1 2 3))", s);
+
+    const cyc = try makeCyclicList(&gc);
+    try std.testing.expectError(error.CircularStructure, printer.valueToStringSimple(std.testing.allocator, cyc));
+}
+
+// -- Bounded diagnostic printer stays terminating and bounded --------------
+
+test "printValue (diagnostic) truncates deep values and terminates on cycles" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    // Past the cap it truncates with the `...` sentinel rather than
+    // recursing (this is the human-facing diagnostic path only).
+    const deep = try nest(&gc, 1500, types.makeFixnum(1));
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    try printer.printValue(&aw.writer, deep, .write);
+    const out = try aw.toOwnedSlice();
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "...") != null);
+
+    // An UNlabelled cyclic list terminates: the spine ticks the cap.
+    const cyc = try makeCyclicList(&gc);
+    var aw2: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    try printer.printValue(&aw2.writer, cyc, .write);
+    const out2 = try aw2.toOwnedSlice();
+    defer std.testing.allocator.free(out2);
+    try std.testing.expect(std.mem.endsWith(u8, out2, " ...)"));
+}

--- a/src/tests_printer.zig
+++ b/src/tests_printer.zig
@@ -170,12 +170,23 @@ test "write terminates on a cyclic mutex / condition-variable name (#1954)" {
 
 test "every traversable container terminates when it closes a cycle itself" {
     // The mutation lock for "detection covers what printing walks": one
-    // self-referential instance per traversable tag. A new recursive print
-    // arm added without its detection edge fails here by hanging (caught by
-    // the suite timeout) rather than by silently shipping #1954 again.
+    // self-referential instance per traversable tag — all SEVEN of
+    // `isTraversable`, so this one test alone owns the checklist CLAUDE.md
+    // points new-container authors at. A new recursive print arm added
+    // without its detection edge fails here by hanging (caught by the suite
+    // timeout) rather than by silently shipping #1954 again.
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
 
+    // pair: p = (p) — its own car
+    {
+        const p = try gc.allocPair(types.NIL, types.NIL);
+        types.setCar(p, p);
+        gc.writeBarrier(types.toObject(p), p);
+        const s = try printer.valueToString(std.testing.allocator, p, .write);
+        defer std.testing.allocator.free(s);
+        try std.testing.expectEqualStrings("#0=(#0#)", s);
+    }
     // vector: v = #(v)
     {
         const elems = [_]Value{types.NIL};
@@ -185,6 +196,19 @@ test "every traversable container terminates when it closes a cycle itself" {
         const s = try printer.valueToString(std.testing.allocator, v, .write);
         defer std.testing.allocator.free(s);
         try std.testing.expectEqualStrings("#0=#(#0#)", s);
+    }
+    // record instance: r = #<cell r> (the #1713 shape; repeated here so the
+    // lock alone covers the full isTraversable set)
+    {
+        const rt_val = try gc.allocRecordType("cell", 1);
+        const rt = types.toObject(rt_val).as(types.RecordType);
+        const placeholder = [_]Value{types.NIL};
+        const ri = try gc.allocRecordInstance(rt, &placeholder);
+        types.toObject(ri).as(types.RecordInstance).fields[0] = ri;
+        gc.writeBarrier(types.toObject(ri), ri);
+        const s = try printer.valueToString(std.testing.allocator, ri, .write);
+        defer std.testing.allocator.free(s);
+        try std.testing.expectEqualStrings("#0=#<cell #0#>", s);
     }
     // error object: e = #<error "m" e>
     {

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -12,6 +12,8 @@ test {
     _ = @import("tests_exceptions.zig");
     _ = @import("tests_records.zig");
     _ = @import("tests_io.zig");
+    _ = @import("tests_printer.zig");
+    _ = @import("printer_pretty.zig");
     _ = @import("tests_reader_incremental.zig");
     _ = @import("tests_continuations.zig");
     _ = @import("tests_advanced.zig");

--- a/tests/scheme/compliance/printer-gaps.scm
+++ b/tests/scheme/compliance/printer-gaps.scm
@@ -28,35 +28,38 @@
 ;;   pairs, vectors, or records.  Thus if the normal write representation is
 ;;   used, datum labels are needed to represent cycles as in write."
 ;;
-;; The two fixed-size arrays under test (src/printer.zig:24-25):
+;; HISTORY.  This file originally pinned the printer's fixed 1024-entry
+;; arrays (MAX_SHARED seen[]/shared[]/labels[] and MAX_PRINT_DEPTH), whose
+;; silent truncation was kaappi#1902 (closed, decomposed into #1953/#1954/
+;; #1955) and whose native-stack recursion was the wasm32 module abort of
+;; kaappi#2107.  The printer is now a single iterative engine over
+;; heap-allocated work stacks with hashmap-based cycle/sharing detection:
 ;;
-;;   const MAX_SHARED = 1024;            // seen[] / shared[] / labels[]
-;;   const MAX_PRINT_DEPTH: u32 = 1024;
+;;   - `write'/`display'/`write-shared' output is EXACT at any depth and for
+;;     any number of labels -- no truncation sentinel exists on this path.
+;;   - Cycle/sharing detection covers every container the printer recurses
+;;     into (pairs, vectors, records, error objects, multiple-values, mutex
+;;     and condition-variable names), so printing always terminates.
+;;   - `write-simple' never emits labels; on cyclic input it raises a
+;;     catchable error instead of the non-termination R7RS anticipates.
+;;   - The READER's own nesting limit (Reader.MAX_NESTING_DEPTH = 1024)
+;;     remains, and remains LOUD: output deeper than 1023 nesting levels is
+;;     exact but fails at read time with a read error.  Section B pins that
+;;     boundary from both sides.
 ;;
-;; Every disabled assertion below was reproduced against a fresh ReleaseSafe
-;; build with an isolated KAAPPI_HOME, and each is paired with an ENABLED
-;; control -- a near-identical input that behaves differently -- so the file
-;; keeps proving the neighbouring path still works.
+;; The formerly-disabled assertions below (each marked with the issue that
+;; kept it off) are all enabled; each keeps its ENABLED control -- a
+;; near-identical input that always worked -- so the file still proves the
+;; neighbouring path as well.
 ;;
-;; NON-TERMINATION WARNING.  Several findings here are HANGS, not wrong
-;; values.  Those assertions are commented out rather than marked
-;; `test-expect-fail': an expected-fail case that never returns wedges the
-;; whole suite.  Do not re-enable one without a fix in hand.
-;;
-;; NOT TESTABLE FROM SCHEME (documented here so it is not lost): `prettyPrint'
-;; (src/printer.zig:904) is reachable only from the interactive REPL under a
-;; TTY.  It hangs on ANY cyclic value whose labelled flat form is wider than
-;; the terminal, because `ppValue' calls `exactFlatLen' (src/printer.zig:1064)
-;; -> the cycle-unaware `printValue'.  Reproduce with a pty driver:
-;;   (define c (list 1 2 3)) (set-cdr! (cddr c) c) c
-;; at COLUMNS=12 wedges the REPL; at COLUMNS=80 it prints "#0=(1 2 3 . #0#)".
-;; This is closed issue kaappi#859 still live: commit a74137c1 added the
-;; MAX_PRINT_DEPTH guard to `ppValue', which fixed the unbounded memory growth
-;; (RSS now stays flat at ~4.3 MB) but not the hang, which has moved into
-;; `exactFlatLen'.
+;; The prettyPrint REPL hang once noted here (kaappi#859's tail: exactFlatLen
+;; fed a cyclic value to a printer with no spine bound) is fixed by the same
+;; rework and pinned by a Zig unit test ("prettyPrint terminates on a cyclic
+;; value at narrow width", src/printer_pretty.zig) -- prettyPrint is only
+;; reachable from a TTY REPL, so it stays untestable from this file.
 
 (import (scheme base) (scheme write) (scheme lazy) (scheme eval) (scheme repl)
-        (scheme process-context) (srfi 64) (srfi 258))
+        (scheme process-context) (srfi 18) (srfi 64) (srfi 258))
 
 (test-begin "printer-gaps")
 
@@ -130,9 +133,9 @@
 (test-assert "vector of strings round-trips"
              (round-trips? (vector "" "\"" "\\" "\n")))
 
-;; A list's cdr spine costs no printer depth (printListWithDepth walks it
-;; iteratively), so length is unbounded where nesting is not.  This is the
-;; control that makes section B's cliff about DEPTH, not size.
+;; A list's cdr spine never overflowed even under the old printer (it was
+;; walked iteratively), so length was always unbounded where nesting was not.
+;; These controls keep section B about DEPTH, not size.
 (test-assert "flat list of 5000 round-trips" (round-trips? (flat 5000)))
 (test-assert "flat list of 50000 round-trips" (round-trips? (flat 50000)))
 (test-assert "vector of 20000 round-trips"
@@ -154,12 +157,14 @@
 (test-assert "newline-bearing symbol round-trips" (round-trips? (string->symbol "a\nb")))
 
 ;; ---------------------------------------------------------------------------
-;; B. MAX_PRINT_DEPTH -- the nesting cliff (kaappi#1902)
+;; B. Nesting depth -- the printer is exact; the reader's limit stays loud
 ;; ---------------------------------------------------------------------------
 ;;
-;; Both the printer and the reader stop at 1024 levels, so 1023 is the last
-;; depth that survives a round trip.  The asymmetry is the point: the READER
-;; raises a read error; the PRINTER emits "..." and returns success.
+;; The printer no longer has a depth limit (kaappi#1902): output is exact at
+;; any nesting.  The READER keeps MAX_NESTING_DEPTH = 1024 and raises a read
+;; error past it, so 1023 remains the last depth that survives a round trip
+;; -- but the failure past it is now LOUD, at read time, instead of the
+;; printer silently emitting truncated output with unbalanced parens.
 
 (test-assert "list nested 100 deep round-trips" (round-trips? (nest 100 'leaf)))
 (test-assert "list nested 1000 deep round-trips" (round-trips? (nest 1000 'leaf)))
@@ -168,12 +173,8 @@
              (round-trips? (let loop ((i 0) (a 'leaf))
                              (if (= i 1023) a (loop (+ i 1) (vector a))))))
 
-;; The reader is loud about its own limit -- this is the control proving the
-;; printer's silence (below) is a choice, not a shared inevitability.  The
-;; shape below is exactly what the printer emits: N opens, an atom, N closes.
-;; The reader accepts that to N=1023 and raises at N=1024, i.e. the two limits
-;; coincide for plain nesting -- which is why section B2's rational case, where
-;; they do NOT coincide, is the only readable-corruption window.
+;; The reader's limit, pinned from both sides.  The shape below is exactly
+;; what the printer emits: N opens, an atom, N closes.
 (define (parens n inner)
   (string-append (make-string n #\() inner (make-string n #\))))
 
@@ -185,35 +186,29 @@
                (read (open-input-string (parens 1024 "x")))
                #f))
 
-;; The printer, by contrast, reports success and truncates.
-(test-equal "write of a 1024-deep nest succeeds but is truncated to 2051 chars"
-            2051 (string-length (wr (nest 1024 'leaf))))
-(test-equal "write output stops growing past the depth cap"
-            (string-length (wr (nest 1024 'leaf)))
-            (string-length (wr (nest 5000 'leaf))))
+;; The printer is exact past the reader's limit: N opens + the leaf + N
+;; closes, at every depth (#1902 -- it used to saturate at 2051 chars with
+;; unbalanced parens and report success).
+(test-equal "write of a 1024-deep nest is exact"
+            (+ (* 2 1024) 4) (string-length (wr (nest 1024 'leaf))))
+(test-equal "write of a 5000-deep nest is exact"
+            (+ (* 2 5000) 4) (string-length (wr (nest 5000 'leaf))))
+(test-equal "write of a 2000-deep nest is its own parens shape"
+            (parens 2000 "leaf") (wr (nest 2000 'leaf)))
+;; ...so past the reader's limit the round trip fails LOUDLY at read time.
+(test-assert "a 1024-deep nest fails loudly at READ time, not silently at write"
+             (reader-rejects? (nest 1024 'leaf)))
 
-;; FAIL: #1902 (write of a >1024-deep nest emits truncated output with no error)
-;; (test-assert "list nested 1024 deep round-trips" (round-trips? (nest 1024 'leaf)))
-;; FAIL: #1902 (same, well past the cliff)
-;; (test-assert "list nested 2000 deep round-trips" (round-trips? (nest 2000 'leaf)))
-
-;; --- B2: the truncation sentinel is itself a legal datum -------------------
+;; --- B2: two-part numeric leaves near the boundary (kaappi#1953) -----------
 ;;
-;; The plain printer truncates with "...", which READS BACK as the ellipsis
-;; symbol; the shared printer truncates with "#<deep>", which the reader
-;; rejects.  Where the printer's depth counter outruns the reader's paren
-;; nesting, that difference turns silent truncation into silent CORRUPTION.
-;;
-;; The `.rational' arm (src/printer.zig:826-831) recurses into numerator and
-;; denominator with `depth + 1', so at nesting depth 1023 -- still inside what
-;; the reader accepts -- an exact rational prints as ".../..." and reads back
-;; as a SYMBOL.
+;; The old `.rational' arm recursed into numerator and denominator with
+;; `depth + 1', so at nesting depth 1023 -- still inside what the reader
+;; accepts -- an exact rational printed as ".../..." and read back as a
+;; SYMBOL: the one depth where truncation was silent AND legal.  Rationals
+;; now render atomically (both parts are always exact integers), so no depth
+;; seam can split them.
 
-(test-assert "write-shared truncates with the unreadable #<deep>"
-             (reader-rejects? (nest 1100 'leaf)))
-
-;; Controls: at the SAME depth 1023, every other leaf type round-trips
-;; exactly.  Only the two-part numeric prints wrong.
+;; Controls: at the same depth 1023, every leaf type round-trips exactly.
 (test-assert "fixnum leaf at depth 1023 round-trips" (round-trips? (nest 1023 42)))
 (test-assert "flonum leaf at depth 1023 round-trips" (round-trips? (nest 1023 1.5)))
 (test-assert "symbol leaf at depth 1023 round-trips" (round-trips? (nest 1023 'abc)))
@@ -222,21 +217,17 @@
              (round-trips? (nest 1023 123456789012345678901234567890)))
 (test-assert "bytevector leaf at depth 1023 round-trips"
              (round-trips? (nest 1023 (bytevector 1 2))))
-;; Control on the OTHER side of the boundary: one level shallower is exact.
 (test-assert "rational leaf at depth 1022 round-trips" (round-trips? (nest 1022 1/3)))
-;; Control on the far side: at 1024 the reader refuses, i.e. loudly.
+;; At 1024 the READER refuses (its own nesting limit), i.e. loudly.
 (test-assert "rational leaf at depth 1024 is REJECTED by the reader"
              (reader-rejects? (nest 1024 1/3)))
 
-;; FAIL: #1953 (exact rational at nesting depth 1023 prints as "..." "/" "..." and
-;; FAIL: #1953  reads back as the symbol |.../...| -- readable, silent, wrong type)
-;; (test-assert "rational leaf at depth 1023 round-trips" (round-trips? (nest 1023 1/3)))
-;; FAIL: #1953 (same, negative)
-;; (test-assert "negative rational leaf at depth 1023 round-trips"
-;;             (round-trips? (nest 1023 -7/9)))
-;; FAIL: #1953 (the corrupted leaf is accepted by the reader as a symbol)
-;; (test-assert "depth-1023 rational does not silently become a symbol"
-;;             (not (symbol? (unnest 1023 (round-trip (nest 1023 1/3))))))
+;; Re-enabled: #1953.
+(test-assert "rational leaf at depth 1023 round-trips" (round-trips? (nest 1023 1/3)))
+(test-assert "negative rational leaf at depth 1023 round-trips"
+             (round-trips? (nest 1023 -7/9)))
+(test-assert "depth-1023 rational does not silently become a symbol"
+             (not (symbol? (unnest 1023 (round-trip (nest 1023 1/3))))))
 
 ;; ---------------------------------------------------------------------------
 ;; C. write / display / write-shared / write-simple -- four different contracts
@@ -265,31 +256,40 @@
 (test-equal "write-shared labels a cycle" "#0=(1 2 3 . #0#)" (wsh (make-cycle)))
 
 ;; write-simple: "shared structure is NEVER represented using datum labels."
-;; It is registered as `.func = &write' (src/primitives_io.zig:56), so on
-;; acyclic input it agrees with write (correct) and on cyclic input it emits
-;; labels (a spec violation).  The enabled control is the acyclic half.
+;; It was registered as `.func = &write' (kaappi#1955), making the two
+;; procedures indistinguishable.  It now has its own implementation: acyclic
+;; input renders exactly like write (which never labels acyclic sharing), and
+;; cyclic input -- for which R7RS anticipates non-termination -- raises a
+;; catchable error rather than either hanging or (the old bug) labelling.
 (test-equal "write-simple does NOT label acyclic sharing"
             "((1 2 3) (1 2 3))" (out write-simple (make-acyclic-sharing)))
 (test-assert "write-simple agrees with write on acyclic input"
              (equal? (wr (make-acyclic-sharing))
                      (out write-simple (make-acyclic-sharing))))
 
-;; FAIL: #1955 (write-simple is registered as &write, so it emits datum labels on a
-;; FAIL: #1955  circular structure; R7RS 6.13.3 says it never may)
-;; (test-assert "write-simple emits NO datum label on a cycle"
-;;             (not (has-label? (out write-simple (make-cycle)))))
+;; Re-enabled: #1955.  A cycle never produces a label: the call raises (a
+;; catchable error object) instead of emitting anything.
+(test-assert "write-simple never emits a datum label on a cycle -- it raises"
+             (guard (e (#t (error-object? e)))
+               (out write-simple (make-cycle))
+               #f))
+(test-assert "write-simple leaves the port untouched when it raises"
+             (let ((p (open-output-string)))
+               (guard (e (#t #t)) (write-simple (make-cycle) p))
+               (string=? "" (get-output-string p))))
 
 ;; ---------------------------------------------------------------------------
-;; D. Sharing detection -- three independent failure modes, one constant
+;; D. Sharing detection -- the three old cliffs (kaappi#1902), all removed
 ;; ---------------------------------------------------------------------------
 ;;
-;; kaappi#1902 reports "write-shared loses labels".  There are three distinct
-;; mechanisms behind that, all bounded by MAX_SHARED = 1024, and each has its
-;; own cliff.  Separating them matters: a fix for one leaves the other two.
+;; The old fixed MAX_SHARED = 1024 arrays had three distinct failure modes,
+;; each with its own cliff.  Detection is hashmap-based now; each subsection
+;; keeps its just-below-the-cliff control and its re-enabled beyond-the-cliff
+;; assertion, so a regression to any bounded mechanism shows up here.
 
-;; --- D1: markShared recurses down the cdr spine, incrementing `depth' ------
-;; A pair shared between position 0 and position L-1 of a list is detected
-;; only while L <= 1023, because the tail is past MAX_PRINT_DEPTH.
+;; --- D1: the old markShared recursed down the cdr spine, ticking `depth' ---
+;; A pair shared between position 0 and position L-1 of a list was detected
+;; only while L <= 1023, the tail beyond that being past the old depth cap.
 (define (d1 L)
   (let* ((x (list 'X))
          (mid (let loop ((i 0) (a (list x)))
@@ -301,10 +301,11 @@
 (test-assert "D1 control: sharing across a 1023-long list is labelled"
              (has-label? (wsh (d1 1023))))
 
-;; FAIL: #1902 (markShared's cdr-spine recursion hits MAX_PRINT_DEPTH: sharing
-;; FAIL: #1902  across a list of 1024+ is silently unlabelled)
-;; (test-assert "D1: sharing across a 1024-long list is labelled"
-;;             (has-label? (wsh (d1 1024))))
+;; Re-enabled: #1902 D1 (the cdr-spine depth tick in the old markShared).
+(test-assert "D1: sharing across a 1024-long list is labelled"
+             (has-label? (wsh (d1 1024))))
+(test-assert "D1: sharing across a 5000-long list is labelled"
+             (has-label? (wsh (d1 5000))))
 
 ;; --- D2: the seen[] array fills, so LATE-FIRST-SEEN objects are invisible --
 ;; Vector elements all sit at the same depth, so D1's mechanism is excluded.
@@ -322,10 +323,11 @@
 (test-assert "D2 control: first occurrence at index 1022 is labelled"
              (has-label? (wsh (d2 1100 1022))))
 
-;; FAIL: #1902 (seen[] is full at MAX_SHARED, so a pair first met at index 1023
-;; FAIL: #1902  is never recorded and its repeat is never detected)
-;; (test-assert "D2: first occurrence at index 1023 is labelled"
-;;             (has-label? (wsh (d2 1100 1023))))
+;; Re-enabled: #1902 D2 (the positional seen[] capacity).
+(test-assert "D2: first occurrence at index 1023 is labelled"
+             (has-label? (wsh (d2 1100 1023))))
+(test-assert "D2: first occurrence at index 1090 is labelled"
+             (has-label? (wsh (d2 1100 1090))))
 
 ;; --- D3: the shared[] array caps the NUMBER of labels ---------------------
 (define (d3 n)
@@ -341,9 +343,8 @@
 (test-equal "D3 control: 400 shared objects get 400 labels" 400 (label-count (wsh (d3 400))))
 (test-equal "D3 control: 600 shared objects get 600 labels" 600 (label-count (wsh (d3 600))))
 
-;; FAIL: #1902 (shared[] holds at most MAX_SHARED entries, so only 1023 of 1200
-;; FAIL: #1902  repeated objects are labelled; the other 177 print twice, silently)
-;; (test-equal "D3: 1200 shared objects get 1200 labels" 1200 (label-count (wsh (d3 1200))))
+;; Re-enabled: #1902 D3 (the shared[] label capacity).
+(test-equal "D3: 1200 shared objects get 1200 labels" 1200 (label-count (wsh (d3 1200))))
 
 ;; --- D4: a cycle whose back-edge is deeper than MAX_PRINT_DEPTH -----------
 ;; A car-nested cycle loses its label entirely past 1024.  A FLAT cdr-cycle of
@@ -362,25 +363,25 @@
 (test-assert "D4 control: a FLAT cdr-cycle of 5000 keeps its label"
              (has-label? (wr (let ((c (flat 5000))) (set-cdr! (list-tail c 4999) c) c))))
 
-;; FAIL: #1902 (markCycles returns at MAX_PRINT_DEPTH, so a car-nested cycle at
-;; FAIL: #1902  1024+ is never recorded and prints unlabelled and truncated)
-;; (test-assert "D4: a 1024-deep chain cycle keeps its label"
-;;             (has-label? (wr (chain-cycle 1024))))
+;; Re-enabled: #1902 D4 (the depth guard on the old markCycles recursion).
+(test-assert "D4: a 1024-deep chain cycle keeps its label"
+             (has-label? (wr (chain-cycle 1024))))
+(test-assert "D4: a 2000-deep chain cycle keeps its label"
+             (has-label? (wr (chain-cycle 2000))))
 
 ;; ---------------------------------------------------------------------------
-;; E. Cycles reachable only through a container the pre-pass does not walk
+;; E. Cycles reached only through error objects / mutex / condvar names
 ;; ---------------------------------------------------------------------------
 ;;
-;; NON-TERMINATING -- every assertion in this section HANGS.  Do not enable.
-;;
-;; `markCycles'/`markShared' descend into `.pair', `.vector' and
-;; `.record_instance' only (src/printer.zig:223-229, 76-114).  An error
-;; object's message/irritants, and a mutex's or condition variable's name, are
-;; printed recursively by `printValueWithDepth' but are never visited by the
-;; cycle pre-pass.  `printListWithDepth' then walks the cdr spine with no depth
-;; increment and no cycle guard (src/printer.zig:889-900), so the loop never
-;; ends.  All four output procedures are affected, including `display', whose
-;; spec text says it "must not loop forever on self-referencing pairs".
+;; Formerly the NON-TERMINATING section (kaappi#1954): the old cycle pre-pass
+;; descended into `.pair', `.vector' and `.record_instance' only, while the
+;; printer also recursed into error-object message/irritants and mutex /
+;; condition-variable names -- so a cycle reached only through one of those
+;; hung all four output procedures, `display' included, whose spec text says
+;; it "must not loop forever on self-referencing pairs".  Detection and the
+;; print engine now enumerate children through one shared `childAt', so the
+;; two cannot disagree again (the per-tag self-cycle lock lives in
+;; src/tests_printer.zig).
 
 (define (cyclic-list) (let ((c (list 1 2 3))) (set-cdr! (cddr c) c) c))
 (define (err-with irritant) (guard (x (#t x)) (error "boom" irritant)))
@@ -391,62 +392,62 @@
             "(#<error \"boom\" plain> #0=(1 2 3 . #0#))"
             (wr (list (err-with 'plain) (cyclic-list))))
 
-;; Control 2 -- a cyclic VECTOR irritant does terminate, because the vector arm
-;; recurses with `depth + 1' and so is caught by MAX_PRINT_DEPTH.  This
-;; isolates the hang to the depth-free cdr-spine walk specifically.
-(test-assert "E control: a cyclic VECTOR irritant terminates (truncated)"
-             (string? (wr (err-with (let ((v (vector 1 2 3)))
+;; Control 2 -- a cyclic VECTOR irritant.  Under the old printer this
+;; terminated only by depth-cap truncation; it now gets a real datum label.
+(test-assert "E control: a cyclic VECTOR irritant terminates, labelled"
+             (let ((s (wr (err-with (let ((v (vector 1 2 3)))
                                       (vector-set! v 0 v) v)))))
+               (and (string? s) (has-label? s))))
 
 ;; Control 3 -- an acyclic irritant prints normally.
 (test-equal "E control: an acyclic list irritant prints normally"
             "#<error \"boom\" (1 2 3)>" (wr (err-with (list 1 2 3))))
 
-;; FAIL: #1954 (write of an error object whose irritant is a cdr-cyclic list never
-;; FAIL: #1954  returns -- markCycles does not traverse .error_object)
-;; (test-assert "E: write of a cyclic-irritant error object terminates"
-;;             (string? (wr (err-with (cyclic-list)))))
-;; FAIL: #1954 (display, same hang -- R7RS: "display must not loop forever on
-;; FAIL: #1954  self-referencing pairs, vectors, or records")
-;; (test-assert "E: display of a cyclic-irritant error object terminates"
-;;             (string? (dsp (err-with (cyclic-list)))))
-;; FAIL: #1954 (write-shared, same hang -- markShared has the same blind spot)
-;; (test-assert "E: write-shared of a cyclic-irritant error object terminates"
-;;             (string? (wsh (err-with (cyclic-list)))))
-;; FAIL: #1954 (a mutex NAMED by a cyclic list hangs identically; needs (srfi 18))
-;; (test-assert "E: write of a mutex named by a cyclic list terminates"
-;;             (string? (wr (make-mutex (cyclic-list)))))
-;; FAIL: #1954 (a condition variable named by a cyclic list, same; needs (srfi 18).
-;; FAIL: #1954  Its acyclic control prints "#<condition-variable (1 2 3)>" fine.)
-;; (test-assert "E: write of a condition variable named by a cyclic list terminates"
-;;             (string? (wr (make-condition-variable (cyclic-list)))))
+;; Re-enabled: #1954 -- all four output procedures, plus the two SRFI-18
+;; containers.  Exact output is asserted where the rendering is pinned by the
+;; Zig unit tests too, so a hang OR a formatting regression both show here.
+(test-equal "E: write of a cyclic-irritant error object terminates"
+            "#<error \"boom\" #0=(1 2 3 . #0#)>" (wr (err-with (cyclic-list))))
+(test-equal "E: display of a cyclic-irritant error object terminates"
+            "#<error boom #0=(1 2 3 . #0#)>" (dsp (err-with (cyclic-list))))
+(test-equal "E: write-shared of a cyclic-irritant error object terminates"
+            "#<error \"boom\" #0=(1 2 3 . #0#)>" (wsh (err-with (cyclic-list))))
+(test-equal "E: write of a mutex named by a cyclic list terminates"
+            "#<mutex #0=(1 2 3 . #0#)>" (wr (make-mutex (cyclic-list))))
+(test-equal "E: write of a condition variable named by a cyclic list terminates"
+            "#<condition-variable #0=(1 2 3 . #0#)>"
+            (wr (make-condition-variable (cyclic-list))))
+;; A cyclic irritants SPINE, not merely a cyclic irritant: the live list
+;; error-object-irritants returns is the error object's own, so tying it
+;; into a cycle makes the printer's irritants walk itself cyclic.  The
+;; labelled head restarts as a dotted datum.
+(test-equal "E: a cyclic irritants SPINE terminates"
+            "#<error \"boom\" . #0=(1 2 3 . #0#)>"
+            (let* ((e (guard (x (#t x)) (error "boom" 1 2 3)))
+                   (irr (error-object-irritants e)))
+              (set-cdr! (cddr irr) irr)
+              (wr e)))
 ;;
-;; The complete set of `printValueWithDepth' arms that recurse into contained
-;; Values is: .pair, .vector, .record_instance, .error_object,
-;; .multiple_values, .mutex, .condition_variable, .rational.  The cycle
-;; pre-pass covers only the first three.  Of the rest, .error_object, .mutex
-;; and .condition_variable are reachable from portable Scheme and all three
-;; hang (above); .rational cannot cycle (its parts are always integers); and
-;; .multiple_values is latent -- a MultipleValues object is consumed by
-;; call-with-values before it can reach the printer, so it is unreachable
-;; today but would hang the same way if it ever became printable.
-;;
-;; kaappi#1713 fixed exactly this shape for ONE container: it added
-;; .record_instance to `vectorLikeChildren' so a cyclic record gets a datum
-;; label.  The other four arms were not brought along.
+;; The complete set of print arms that recurse into contained Values is:
+;; .pair, .vector, .record_instance, .error_object, .multiple_values,
+;; .mutex, .condition_variable.  Detection walks the same seven via the
+;; shared `childAt`.  `.rational' renders atomically (its parts are always
+;; integers), and `.multiple_values' stays latent from portable Scheme -- a
+;; MultipleValues object is consumed by call-with-values before it can reach
+;; the printer -- but is covered by a self-cycle unit test anyway.
 
 ;; ---------------------------------------------------------------------------
-;; F. write-shared must be linear -- the seen[] cap makes it exponential
+;; F. write-shared must be linear regardless of traversal order
 ;; ---------------------------------------------------------------------------
 ;;
 ;; A binary DAG of depth d has d+1 distinct pairs but 2^d leaves when written
 ;; unshared.  `write' is REQUIRED to unfold it ("Datum labels must not be used
 ;; if there are no cycles"), so `(write dag)' is astronomical BY SPEC and is
 ;; not a bug.  `write-shared' is required to label it, and must therefore stay
-;; linear -- but only does so while the DAG's nodes fit in seen[].
-;;
-;; The discriminating control is order: the same two objects in a two-element
-;; vector print instantly one way round and never terminate the other.
+;; linear.  Under the old fixed seen[] the SAME two objects in a two-element
+;; vector printed instantly one way round and never terminated the other
+;; (kaappi#1902): once the filler exhausted the array, the DAG's nodes could
+;; no longer be recorded as shared.
 
 (define (dag d) (if (= d 0) 'leaf (let ((x (dag (- d 1)))) (cons x x))))
 (define (filler n)
@@ -459,11 +460,9 @@
 (test-assert "F control: DAG BEFORE the filler stays linear"
              (< (string-length (wsh (vector (dag 40) (filler 1200)))) 20000))
 
-;; FAIL: #1902 (seen[] is full after the 1200-element filler, so the DAG's nodes are
-;; FAIL: #1902  never recorded as shared and write-shared unfolds 2^40 leaves -- the
-;; FAIL: #1902  SAME two objects, only swapped)
-;; (test-assert "F: DAG AFTER the filler stays linear"
-;;             (< (string-length (wsh (vector (filler 1200) (dag 40)))) 20000))
+;; Re-enabled: #1902 (order-dependence of the old positional seen[] cap).
+(test-assert "F: DAG AFTER the filler stays linear"
+             (< (string-length (wsh (vector (filler 1200) (dag 40)))) 20000))
 
 ;; ---------------------------------------------------------------------------
 ;; G. Types with no external representation -- deliberately unreadable

--- a/tests/scheme/differential/probes/deep-print-depth.scm
+++ b/tests/scheme/differential/probes/deep-print-depth.scm
@@ -1,0 +1,45 @@
+;; Probe: printing depth across execution tiers (kaappi#2107).
+;;
+;; write/display of an 848-deep car-nested structure aborted the whole wasm32
+;; module (out-of-bounds shadow-stack access) while native printed it fine:
+;; the printer recursed on the native stack and its depth guard was
+;; calibrated to the native 64 MB stack, which the wasm module did not have.
+;; The printer is iterative now and the wasm module carries the same 64 MB
+;; stack, so both tiers must produce byte-identical output at every depth
+;; here — 847/848 straddle the old wasm cliff, 1023/1024/1025 the old
+;; MAX_PRINT_DEPTH truncation cliff, and 20000 is far past both.
+;;
+;; No imports: (scheme base)/(scheme write) bindings are ambient in a main
+;; script, and this probe must stay runnable on the wasm tier, where
+;; file-backed .sld imports are unavailable (kaappi#2108).
+
+(define (nest n acc) (if (= n 0) acc (nest (- n 1) (list acc))))
+
+(define (probe n)
+  (let ((p (open-output-string)))
+    (write (nest n '()) p)
+    (let ((s (get-output-string p)))
+      (display n) (display " -> len=") (display (string-length s)) (newline))))
+
+(probe 10)
+(probe 847)
+(probe 848)
+(probe 1023)
+(probe 1024)
+(probe 1025)
+(probe 20000)
+
+;; The guard-visibility half of the finding: on wasm the abort was
+;; uncatchable, so this printed nothing past "before".  Both tiers must
+;; agree on the full transcript now.
+(display "before") (newline)
+(display (guard (e (#t "CAUGHT"))
+  (let ((p (open-output-string))) (write (nest 2000 '()) p) "no-error")))
+(newline)
+(display "after") (newline)
+
+;; Cyclic structure through an error object (kaappi#1954) — same output on
+;; both tiers, and terminates on both.
+(define c (list 1 2 3))
+(set-cdr! (cddr c) c)
+(write (guard (e (#t e)) (error "boom" c))) (newline)


### PR DESCRIPTION
One PR for the four open printer issues from audit v2 Phase 1D/4D — they were four symptoms of one design problem, so one rework closes them together. #1902 was already closed as decomposed into the first three; its mechanisms (D1–D4) are all covered here too.

## The four failures

- **#1953** — an exact rational at nesting depth 1023 printed as `.../...`: each component was truncated separately by the depth guard, and the result is a *legal symbol datum* with the wrong value — the one depth where truncation was silent and readable.
- **#1954** — a cycle reached only through an error-object irritant or a mutex/condition-variable name hung `write`, `display`, `write-shared`, and `write-simple` forever: those arms recursed in the printer but were invisible to the cycle pre-pass, and the cdr-spine walk had no depth tick.
- **#1955** — `write-simple` was registered as `.func = &write`, so it emitted datum labels R7RS says it never may.
- **#2107** (critical) — on wasm32 the printer's native-stack recursion ran the 16 MiB default shadow stack off the bottom of linear memory at depth **848** — an uncatchable module abort on the tier that backs the playground — while `MAX_PRINT_DEPTH`'s guard sat at 1024, calibrated to the native 64 MB stack `build.zig` never gave the wasm module.

## The fix

**One iterative, label-aware print engine** (`printStructured`) over a heap-allocated task stack, with **hashmap-based detection** — cycle targets (DFS back-edges) for `write`/`display`, all repeated containers for `write-shared`. Detection and the engine enumerate children through the same `childAt`, so they can never again disagree about which edges exist (the #1954 class). Consequences:

- Output is **exact at any depth and for any number of labels** — no truncation sentinel exists on the `write`/`display`/`write-shared` path (kills #1902 D1–D4 and #1953; rationals additionally render atomically since their parts are always exact integers).
- **No native stack is consumed** regardless of nesting, which closes #2107 at the root; `wasm_exe` additionally gets the same 64 MB `stack_size` as every native executable so the remaining native-stack recursions (reader nesting, REPL layout) keep the headroom their guards assume — the module's `__stack_pointer` now initialises to 64 MiB, verified.
- **`write-simple` gets its own implementation**: acyclic input renders exactly like `write` (which never labels acyclic sharing), and cyclic input — where the spec anticipates non-termination — raises a **catchable error** instead of hanging or (the old bug) labelling.
- The bounded `printValue` survives as the **diagnostic printer** (compiler messages, REPL layout probes), now iterative and spine-ticking — which also ends the REPL wedge on cyclic values at narrow widths (the surviving tail of #859 noted in printer-gaps.scm).
- The reader's own `MAX_NESTING_DEPTH = 1024` is untouched and **loud**: output deeper than 1023 is exact but fails at read time with a read error, instead of the printer lying first.

`prettyPrint` and its helpers move to `printer_pretty.zig` under the 1500-line policy (printer.zig lands at ~1250).

## Verification

- **`zig build test`** green, plus a `-Dgc-stress=true` spot run of the new tests.
- **Full Scheme suite: 2070 pass, 0 fail** (675 files + 1395 R7RS), including both differential harnesses.
- **All 16 formerly-disabled assertions in `tests/scheme/compliance/printer-gaps.scm` re-enabled** (reworded where the old expectation pinned the bug itself, e.g. the truncated-length golden and write-simple's labelling); the file's suite is at 99 assertions, 0 fail.
- **New unit tests** (`src/tests_printer.zig`): depth-cliff exactness (1023/1024/1025/20k), rational-at-1023, cyclic irritants/mutex/cv names with exact labelled renderings, a **per-tag self-cycle termination lock** over every traversable container, D2/D3/D4 sharing exactness, `write-simple` error path, and prettyPrint-on-cyclic-value termination.
- **#2107 reproductions on wasmtime 46.0.0**: depth 848 and 2000 print fine (`before`/`no-error`/`after` matches native); the depth-200000 `deep-nesting-print.scm` (#49's regression file, which itself aborted on wasm) now prints `length=400002` **identically on both tiers**. A new probe (`tests/scheme/differential/probes/deep-print-depth.scm`) pins native/wasm byte-agreement at the old cliff depths, import-free so it runs on the wasm tier despite #2108.
- **A/B against the pre-change binary**: byte-identical output across a broad battery (atoms, strings, chars, records, cycles, shared structure, complex/rational/bignum, error objects) — non-cyclic behaviour is unchanged.
- **Perf**: `write` of a 32k-node tree unchanged within noise (16→14 ms); `write-shared` ~4x faster (13→3 ms — hashmaps replace the linear array scans); flat 100k-element list 12→14 ms.

## Behaviour notes reviewers may care about

- `write-shared` now labels repeated instances of *any* traversable container (error objects, mutexes, …), not just pairs/vectors/records: R7RS mandates the first two, records were already labelled, and a cycle whose revisited node is one of the others *must* carry the label for printing to terminate. All are unreadable `#<…>` forms either way.
- `write-simple` raising on cycles is a deliberate choice where the spec anticipates non-termination; the error is a catchable `KP3007` naming the procedure, and the port is left untouched (asserted).
- Uncaught-exception diagnostics that embed a deep value now print it in full rather than truncated at ~2051 chars — the same was always true of *wide* values, so the depth/breadth asymmetry is simply gone.

Fixes #1953
Fixes #1954
Fixes #1955
Fixes #2107

🤖 Generated with [Claude Code](https://claude.com/claude-code)