### PR TITLE
Reject non-positive segment sizes across SRFIs 152/160/178/196

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,9 +316,15 @@ jobs:
           #              GC-owned strings, so a nongenerative uid stops
           #              resolving once its string is collected (19 assertions)
           #
-          # All eleven still run stressed in the nightly fuzz.yml legs' unit
-          # phase where applicable, and unstressed under run-all.sh on every
-          # other leg here, so nothing is untested -- only unstressed.
+          # Listing a file here removes its stressed Scheme run entirely --
+          # fuzz.yml's gc-stress legs run fuzz targets and the Zig unit
+          # suite, never this corpus. Every listed file still runs plain
+          # under run-all.sh on every other leg, so nothing is untested,
+          # only unstressed; where the guarded behavior has a counterpart,
+          # that half keeps stress coverage (tests_reader_incremental.zig in
+          # the gc-stress unit job for reader-port-refill-gaps.scm, and
+          # srfi178-audit.scm, still in this run, for the n = 0 half of
+          # srfi178-segment-stack-2084.scm).
           #
           # The script FAILS if a name here matches no file, so this list
           # cannot rot into a silent no-op.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,12 @@ jobs:
           #     the 900 s stress timeout on this job's first run against it,
           #     PR #2174); the incomplete-input reader mode it guards gets its
           #     stress coverage from src/tests_reader_incremental.zig in the
-          #     gc-stress unit job instead.
+          #     gc-stress unit job instead. srfi178-segment-stack-2084.scm
+          #     builds a 200,000-element bitvector list to pin #2084's
+          #     tail-recursion fix past the 32,768 frame cap -- ~0.1 s plain,
+          #     exit 124 stressed (measured quadratic: ~3 min at 40k on a
+          #     fast machine); the n = 0 guard half of #2084 stays stressed
+          #     in srfi178-audit.scm.
           #
           # (b) REAL BUGS THIS GATE FOUND ON ITS FIRST RUN -- excluded so the
           #     gate is green for everything else, exactly as the campaign
@@ -311,7 +316,7 @@ jobs:
           #              GC-owned strings, so a nongenerative uid stops
           #              resolving once its string is collected (19 assertions)
           #
-          # All ten still run stressed in the nightly fuzz.yml legs' unit
+          # All eleven still run stressed in the nightly fuzz.yml legs' unit
           # phase where applicable, and unstressed under run-all.sh on every
           # other leg here, so nothing is untested -- only unstressed.
           #
@@ -319,7 +324,7 @@ jobs:
           # cannot rot into a silent no-op.
           KAAPPI_GC_STRESS_SKIP: >-
             trampoline-polish-1375.scm srfi14.scm srfi264.scm
-            reader-port-refill-gaps.scm
+            reader-port-refill-gaps.scm srfi178-segment-stack-2084.scm
             primitives_srfi1-audit.scm srfi1-ext.scm srfi1-gc-stress.scm
             primitives_srfi237-audit.scm srfi237.scm srfi240-audit.scm
 

--- a/lib/srfi/152.sld
+++ b/lib/srfi/152.sld
@@ -200,6 +200,10 @@
             (write-char (string-ref s (+ start (modulo i slen))) out)))))
 
     (define (string-segment s k)
+      ;; No finite list of length-0 substrings covers a non-empty string, and
+      ;; k = 0 would never advance the loop below (#2172) — reject it up front.
+      (unless (and (exact-integer? k) (positive? k))
+        (error "string-segment: size must be an exact positive integer" k))
       (let ((len (string-length s)))
         (let loop ((i 0) (result '()))
           (if (>= i len)

--- a/lib/srfi/160/base.sld
+++ b/lib/srfi/160/base.sld
@@ -355,6 +355,12 @@
     (define (%uvec-drop-right kind v n) (%uvec-copy kind v 0 (- (%uvec-length v) n)))
 
     (define (%uvec-segment kind v n)
+      ;; "It is an error if n is not an exact positive integer." n = 0 would
+      ;; never advance the loop below (#1949), so reject it up front.
+      (unless (and (exact-integer? n) (positive? n))
+        (error (string-append (symbol->string kind)
+                              "vector-segment: size must be an exact positive integer")
+               n))
       (let ((len (%uvec-length v)))
         (let loop ((start 0) (acc '()))
           (if (>= start len) (reverse acc)

--- a/lib/srfi/178.sld
+++ b/lib/srfi/178.sld
@@ -164,12 +164,17 @@
     (define (bitvector-drop-right bv n) (bitvector-copy bv 0 (- (%len bv) n)))
 
     (define (bitvector-segment bv n)
+      ;; "It is an error if n is not an exact positive integer." n = 0 would
+      ;; never advance the loop below (#2084), so reject it up front. The loop
+      ;; accumulates in tail position — a cons around the recursive call costs
+      ;; one frame per segment and overflows uncatchably on large inputs.
+      (unless (and (exact-integer? n) (positive? n))
+        (error "bitvector-segment: size must be an exact positive integer" n))
       (let ((len (%len bv)))
-        (let loop ((i 0))
+        (let loop ((i 0) (acc '()))
           (if (>= i len)
-              '()
-              (cons (bitvector-copy bv i (min len (+ i n)))
-                    (loop (+ i n)))))))
+              (reverse acc)
+              (loop (+ i n) (cons (bitvector-copy bv i (min len (+ i n))) acc))))))
 
     (define (%refs bvs i) (map (lambda (bv) (bitvector-ref/int bv i)) bvs))
 

--- a/lib/srfi/196.sld
+++ b/lib/srfi/196.sld
@@ -103,6 +103,10 @@
       (%make-range (- end start) (lambda (i) (range-ref r (+ start i)))))
 
     (define (range-segment r len)
+      ;; No finite list of length-0 subranges covers a non-empty range, and
+      ;; len = 0 would never advance the loop below (#2172) — reject it up front.
+      (unless (and (exact-integer? len) (positive? len))
+        (error "range-segment: length must be an exact positive integer" len))
       (let ((total (range-length r)))
         (let loop ((i 0) (result '()))
           (if (>= i total) (reverse result)

--- a/tests/scheme/audit/primitives_srfi160-audit.scm
+++ b/tests/scheme/audit/primitives_srfi160-audit.scm
@@ -716,6 +716,17 @@
             'ERR (try (lambda () (s8vector-segment (s8vector) 0))))
 (test-equal "segment with an inexact n raises"
             'ERR (try (lambda () (s8vector-segment (s8vector 1 2) 2.0))))
+;; The guard lives once in %uvec-segment, so s8/u8 above already prove both
+;; dispatch branches — this sweep pins that every public wrapper reaches it,
+;; so a future per-kind split cannot drop the guard for one kind unnoticed.
+(for-each
+ (lambda (row seg)
+   (test-equal (nm (k-name row) "vector-segment rejects n = 0") 'ERR
+               (try (lambda () (seg ((k-make row) 2) 0)))))
+ all-kinds
+ (list s8vector-segment u8vector-segment u16vector-segment s16vector-segment
+       u32vector-segment s32vector-segment u64vector-segment s64vector-segment
+       f32vector-segment f64vector-segment c64vector-segment c128vector-segment))
 
 ;;; ------------------------------------------------------------------
 ;;; 11. Comparators

--- a/tests/scheme/audit/primitives_srfi160-audit.scm
+++ b/tests/scheme/audit/primitives_srfi160-audit.scm
@@ -702,21 +702,20 @@
 (test-equal '((1) (2)) (map s8vector->list (s8vector-segment (s8vector 1 2) 1)))
 (test-equal '() (s8vector-segment (s8vector) 2))
 ;; SRFI 160: "It is an error if n is not an exact positive integer."
-;; n = -1 raises; n = 0 does not — see the disabled case below.
-(test-equal 'ERR (try (lambda () (s8vector-segment (s8vector 1 2) -1))))
-;; Discriminating control for the hang below: with an EMPTY vector the
-;; loop's (>= start len) guard is true on entry, so n = 0 terminates.
-(test-equal '() (s8vector-segment (s8vector) 0))
-
-;;; FAIL: #1949 (Uvector-segment with n = 0 never terminates)
-;;; %uvec-segment (lib/srfi/160/base.sld:357) advances with
-;;;   (loop (min len (+ start n)) ...)
-;;; so n = 0 leaves `start` unchanged forever while consing a fresh
-;;; zero-length copy each iteration — an unbounded-allocation infinite
-;;; loop, on all 12 kinds. SRFI 160 makes n = 0 "an error", so any raise
-;;; would conform; a hang does not. Controls above: n = -1 raises, n = 1
-;;; and n = 3 work, and an empty vector with n = 0 returns ().
-;;; (test-equal 'ERR (try (lambda () (s8vector-segment (s8vector 1 2 3 4) 0))))
+;; Regression, #1949: %uvec-segment used to advance with
+;; (min len (+ start n)), so n = 0 looped forever on any non-empty vector
+;; while consing a fresh zero-length copy each iteration — on all 12 kinds.
+;; It now rejects a non-positive (or inexact, or non-integer) n at entry,
+;; before the loop, so even the empty vector raises rather than answering.
+(test-equal "segment n = -1 raises" 'ERR (try (lambda () (s8vector-segment (s8vector 1 2) -1))))
+(test-equal "segment n = 0 raises catchably (NumericVector branch)"
+            'ERR (try (lambda () (s8vector-segment (s8vector 1 2 3 4) 0))))
+(test-equal "segment n = 0 raises catchably (bytevector branch)"
+            'ERR (try (lambda () (u8vector-segment (u8vector 1 2 3 4) 0))))
+(test-equal "segment n = 0 raises even on the empty vector"
+            'ERR (try (lambda () (s8vector-segment (s8vector) 0))))
+(test-equal "segment with an inexact n raises"
+            'ERR (try (lambda () (s8vector-segment (s8vector 1 2) 2.0))))
 
 ;;; ------------------------------------------------------------------
 ;;; 11. Comparators

--- a/tests/scheme/srfi/srfi152-audit.scm
+++ b/tests/scheme/srfi/srfi152-audit.scm
@@ -154,6 +154,9 @@
 (test-equal "string-split on a delimiter" '("a" "b") (s152:string-split "a,b" ","))
 (test-equal "string-segment chops into fixed-size pieces" '("ab" "cd" "e")
             (s152:string-segment "abcde" 2))
+;; Regression, #2172: k = 0 hung forever; it must raise catchably.
+(test-equal "string-segment rejects k = 0 catchably" 'caught
+            (guard (e (#t 'caught)) (s152:string-segment "abcde" 0) 'no-error))
 (test-equal "string-take-while" "ab" (s152:string-take-while "abZd" (lambda (c) (char-lower-case? c))))
 (test-equal "string-drop-while" "Zd" (s152:string-drop-while "abZd" (lambda (c) (char-lower-case? c))))
 (test-equal "string-span returns the matching prefix"

--- a/tests/scheme/srfi/srfi152.scm
+++ b/tests/scheme/srfi/srfi152.scm
@@ -175,6 +175,12 @@
 (test-equal '("ab" "cd" "e") (string-segment "abcde" 2))
 (test-equal '("abc") (string-segment "abc" 5))
 (test-equal '() (string-segment "" 3))
+;; Regression, #2172: k = 0 never advanced the loop, hanging forever on any
+;; non-empty string. It must raise a catchable error instead.
+(test-equal "string-segment k=0 raises catchably"
+            'caught (guard (e (#t 'caught)) (string-segment "abcdef" 0) 'no-error))
+(test-equal "string-segment k=-1 raises catchably"
+            'caught (guard (e (#t 'caught)) (string-segment "abcdef" -1) 'no-error))
 
 ;;; --- splitting ---
 (test-equal '("a" "b" "c") (string-split "a,b,c" ","))

--- a/tests/scheme/srfi/srfi152.scm
+++ b/tests/scheme/srfi/srfi152.scm
@@ -181,6 +181,12 @@
             'caught (guard (e (#t 'caught)) (string-segment "abcdef" 0) 'no-error))
 (test-equal "string-segment k=-1 raises catchably"
             'caught (guard (e (#t 'caught)) (string-segment "abcdef" -1) 'no-error))
+(test-equal "string-segment inexact k=2.0 raises catchably"
+            'caught (guard (e (#t 'caught)) (string-segment "abcdef" 2.0) 'no-error))
+;; Guard runs before the length check: the empty string — which used to
+;; return () under k=0, the loop's only terminating case — raises too.
+(test-equal "string-segment k=0 raises even on the empty string"
+            'caught (guard (e (#t 'caught)) (string-segment "" 0) 'no-error))
 
 ;;; --- splitting ---
 (test-equal '("a" "b" "c") (string-split "a,b,c" ","))

--- a/tests/scheme/srfi/srfi178-audit.scm
+++ b/tests/scheme/srfi/srfi178-audit.scm
@@ -443,14 +443,14 @@
             '((1 0)) (map L (bitvector-segment (bitvector 1 0) 9)))
 (test-equal "segment of the empty bitvector" '() (bitvector-segment (bitvector) 2))
 
-;; FAIL: #2084 (bitvector-segment recurses once per segment; a legal call on a
-;;              200,000-bit vector overflows the stack, and n=0 recurses without
-;;              bound into an uncatchable KP3008)
-;; (test-equal "segment of a 200,000-bit vector with n=1"
-;;             200000 (length (bitvector-segment (make-bitvector 200000 1) 1)))
-;; FAIL: #2084
-;; (test-assert "segment with n=0 raises a catchable error"
-;;              (raises? (lambda () (bitvector-segment (bitvector 1 0 1) 0))))
+;; Regression, #2084: the loop now accumulates in tail position (one frame
+;; total, not one per segment) and rejects a non-positive n at entry.
+(test-equal "segment of a 200,000-bit vector with n=1"
+            200000 (length (bitvector-segment (make-bitvector 200000 1) 1)))
+(test-assert "segment with n=0 raises a catchable error"
+             (raises? (lambda () (bitvector-segment (bitvector 1 0 1) 0))))
+(test-assert "segment with an inexact n raises a catchable error"
+             (raises? (lambda () (bitvector-segment (bitvector 1 0 1) 2.0))))
 
 ;; Discriminating control: the same shape at a size the recursion survives.
 (test-equal "segment of a 1,000-bit vector with n=1 does terminate"

--- a/tests/scheme/srfi/srfi178-audit.scm
+++ b/tests/scheme/srfi/srfi178-audit.scm
@@ -451,11 +451,20 @@
 ;; skipping this file's assertions.
 (test-assert "segment with n=0 raises a catchable error"
              (raises? (lambda () (bitvector-segment (bitvector 1 0 1) 0))))
+(test-assert "segment with n=-1 raises a catchable error"
+             (raises? (lambda () (bitvector-segment (bitvector 1 0 1) -1))))
 (test-assert "segment with an inexact n raises a catchable error"
              (raises? (lambda () (bitvector-segment (bitvector 1 0 1) 2.0))))
+;; The guard runs before the length check, so the empty bitvector — which
+;; used to return () under n=0, the loop's only terminating case — raises too.
+(test-assert "segment with n=0 raises even on the empty bitvector"
+             (raises? (lambda () (bitvector-segment (bitvector) 0))))
 
-;; Discriminating control: the same shape at a size the recursion survives.
-(test-equal "segment of a 1,000-bit vector with n=1 does terminate"
+;; Smaller n=1 case kept here (and under gc-stress): with the accumulate-
+;; then-reverse loop every size costs one frame, so this is a plain smoke
+;; check — the cap-exceeding depth case lives in
+;; srfi178-segment-stack-2084.scm.
+(test-equal "segment of a 1,000-bit vector with n=1"
             1000 (length (bitvector-segment (make-bitvector 1000 1) 1)))
 
 ;;; ------------------------------------------------------------------

--- a/tests/scheme/srfi/srfi178-audit.scm
+++ b/tests/scheme/srfi/srfi178-audit.scm
@@ -444,9 +444,11 @@
 (test-equal "segment of the empty bitvector" '() (bitvector-segment (bitvector) 2))
 
 ;; Regression, #2084: the loop now accumulates in tail position (one frame
-;; total, not one per segment) and rejects a non-positive n at entry.
-(test-equal "segment of a 200,000-bit vector with n=1"
-            200000 (length (bitvector-segment (make-bitvector 200000 1) 1)))
+;; total, not one per segment) and rejects a non-positive n at entry. The
+;; full-depth 200,000-segment case lives in srfi178-segment-stack-2084.scm —
+;; its own file so the gc-stress leg can skip just it (building 200k
+;; bitvectors is quadratic in the live heap under stress collection) without
+;; skipping this file's assertions.
 (test-assert "segment with n=0 raises a catchable error"
              (raises? (lambda () (bitvector-segment (bitvector 1 0 1) 0))))
 (test-assert "segment with an inexact n raises a catchable error"

--- a/tests/scheme/srfi/srfi178-segment-stack-2084.scm
+++ b/tests/scheme/srfi/srfi178-segment-stack-2084.scm
@@ -1,0 +1,26 @@
+;; Regression test for #2084: bitvector-segment recursed once per segment
+;; with the cons outside the recursive call, so this legal call consumed one
+;; frame per segment and died past the 32,768 frame cap with an uncatchable
+;; KP3008. The loop now accumulates in tail position; this file pins that at
+;; full, cap-exceeding depth.
+;;
+;; Its own file, apart from srfi178-audit.scm, deliberately: under
+;; -Dgc-stress=true a collection runs on every allocation, so building
+;; 200,000 bitvectors is quadratic in the live heap (measured ~3 min at 40k
+;; on a fast machine, extrapolating to over an hour at 200k). ci.yml's
+;; KAAPPI_GC_STRESS_SKIP lists this file (reason (a), too slow under stress)
+;; so the stress leg can skip exactly the deep case without losing the
+;; audit file's other assertions — including the n = 0 guard half of #2084,
+;; which stays stressed there. run-all.sh runs this plain on every PR,
+;; where it takes well under a second.
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64) (srfi 178))
+
+(test-begin "srfi178-segment-stack-2084")
+
+(test-equal "segment of a 200,000-bit vector with n=1 (no frame per segment)"
+            200000 (length (bitvector-segment (make-bitvector 200000 1) 1)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi178-segment-stack-2084")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi196.scm
+++ b/tests/scheme/srfi/srfi196.scm
@@ -76,6 +76,14 @@
 (check "segment length=-1 raises catchably"
        (guard (e (#t 'caught)) (range-segment (numeric-range 0 6) -1) 'no-error)
        'caught)
+(check "segment inexact length=2.0 raises catchably"
+       (guard (e (#t 'caught)) (range-segment (numeric-range 0 6) 2.0) 'no-error)
+       'caught)
+;; Guard runs before the length check: the empty range — which used to
+;; return () under length=0, the loop's only terminating case — raises too.
+(check "segment length=0 raises even on an empty range"
+       (guard (e (#t 'caught)) (range-segment (numeric-range 0 0) 0) 'no-error)
+       'caught)
 
 ;; Append
 (let ((r (range-append (numeric-range 0 3) (numeric-range 10 13))))

--- a/tests/scheme/srfi/srfi196.scm
+++ b/tests/scheme/srfi/srfi196.scm
@@ -68,6 +68,14 @@
   (check "segment count" (length segs) 3)
   (check "segment 0" (range->list (car segs)) '(0 1 2))
   (check "segment 2" (range->list (caddr segs)) '(6)))
+;; Regression, #2172: length = 0 never advanced the loop, hanging forever on
+;; any non-empty range. It must raise a catchable error instead.
+(check "segment length=0 raises catchably"
+       (guard (e (#t 'caught)) (range-segment (numeric-range 0 6) 0) 'no-error)
+       'caught)
+(check "segment length=-1 raises catchably"
+       (guard (e (#t 'caught)) (range-segment (numeric-range 0 6) -1) 'no-error)
+       'caught)
 
 ;; Append
 (let ((r (range-append (numeric-range 0 3) (numeric-range 10 13))))


### PR DESCRIPTION
Fixes #1949, fixes #2084, fixes #2172.

Four `segment` procedures across four SRFIs shared the same missing precondition: none rejected a non-positive size, and their loops advance by that size per iteration, so `n = 0` never advanced — an unbounded-allocation hang (`%uvec-segment`, `string-segment`, `range-segment`) or unbounded recursion into an uncatchable `KP3008` (`bitvector-segment`). SRFI 171's `tsegment` was the one family member that already rejected `n = 0` at entry; this PR makes the other four do the same.

## Changes

**Guards** — each procedure now rejects a size that is not an exact positive integer at entry, with a catchable error, before touching the input:

- `lib/srfi/160/base.sld` `%uvec-segment` (#1949) — one guard covers all 12 kinds and both dispatch branches (bytevector and NumericVector). The error message names the user-facing procedure via the `kind` tag (`s8vector-segment: …`). SRFI 160: *"It is an error if n is not an exact positive integer."*
- `lib/srfi/178.sld` `bitvector-segment` (#2084) — same spec sentence in SRFI 178.
- `lib/srfi/152.sld` `string-segment` and `lib/srfi/196.sld` `range-segment` (#2172) — neither spec defines behavior for a non-positive size, and no finite list of length-0 pieces covers a non-empty input, so raising is the only sane behavior (matching `tsegment`).

**Stack safety** (#2084's second half) — `bitvector-segment` recursed once per segment with the `cons` outside the recursive call, so a legal call on a 200,000-bit vector died with an uncatchable `KP3008`. It now accumulates in tail position and reverses, the same shape the other three already had.

Behavior change worth noting: `(s8vector-segment (s8vector) 0)` previously returned `()` (the empty vector was the one input where `n = 0` terminated); it now raises like every other `n = 0` call, since the guard runs before the loop. The audit test asserting the old behavior was updated — SRFI 160 makes `n = 0` an error regardless of the vector.

## Tests

- `tests/scheme/srfi/srfi178-audit.scm` — the two assertions disabled with `;; FAIL: #2084` are re-enabled, plus an inexact-`n` case. The 200,000-segment depth case lives in a new file, `tests/scheme/srfi/srfi178-segment-stack-2084.scm`, listed in `KAAPPI_GC_STRESS_SKIP` (reason (a)): under stress collection, building 200k bitvectors is quadratic in the live heap (measured ~3 min at 40k; the first CI run timed out at 200k), and any count that still exceeds the 32,768 frame cap is already minutes. `run-all.sh` runs it plain on every PR (~0.1 s); the audit file's other 369 assertions — including the `n = 0` guard — stay stressed (5.3 s under the stress binary).
- `tests/scheme/audit/primitives_srfi160-audit.scm` — the assertion disabled with `;;; FAIL: #1949` is re-enabled, plus: the bytevector-branch (`u8`) case, the empty-vector `n = 0` case (now expects a raise), and an inexact-`n` case.
- `tests/scheme/srfi/srfi152.scm`, `tests/scheme/srfi/srfi152-audit.scm`, `tests/scheme/srfi/srfi196.scm` — new regression assertions that `n = 0` (and `n = -1`) raises catchably.

Verified: all five modified test files pass; family-wide grep for `segment`/`chunk` found no fifth member (`chunk` appears only in comments); full `tests/scheme/run-all.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
