### PR TITLE
Refuse three cross-heap uses that the owner checks were missing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1469,16 +1469,29 @@ pinned by `tests/scheme/srfi/srfi18-sharing-model.scm`.
 fiber, mutex, condition variable, ffi-callback, the four SRFI-170 record
 types, environment, and the three SRFI-254 weak references). Channels are
 the exception: their arm promotes and aliases, which is what makes lexical
-capture the supported way to share one.
+capture the supported way to share one — subject to one entitlement check,
+applied in the **export** direction only (a copy out of the running heap
+into an `Envelope`, which must be a channel the running thread owns) and
+never on the import back out of an envelope an entitled thread already
+built. That check used to be skipped whenever the channel happened to be
+already promoted, so a thread could hand a globals-route channel down to a
+child that then held a perfectly working stub (#1934).
 
 **The globals route.** `VM.initForThread` shares the parent's `globals`
 map **by pointer**, so a thunk that *names* a top-level binding captures
 nothing — the child resolves it at run time and gets the parent's own
-object, uncopied. That list of 14 does not apply here, and 13 of the 14
-are freely usable this way. Only two types defend themselves, by comparing
+object, uncopied. That list of 14 does not apply here, and 11 of the 14
+are freely usable this way. Four types defend themselves, by comparing
 `Object.owner` against the running `GC.id`: channels
-(`primitives_fiber.zig`) and thread handles
-(`primitives_srfi18.checkThreadOwner`).
+(`primitives_fiber.zig`), thread handles
+(`primitives_srfi18.checkThreadOwner`), fibers (`fiber-join`, #2001 — it
+was returning the parent's own heap object to the child as its result, and
+calling another thread's still-running fiber a deadlock) and guardians
+(`vm_calls.invokeGuardian`, #2008 — `Guardian.registered`/`ready` are the
+only raw Zig containers Scheme can mutate across a heap boundary, and a
+child appending to the parent's list with the child's allocator aborted
+the process with no diagnostic at all). `channel?`, `thread?` and `fiber?`
+stay exempt: a total predicate answers rather than raising.
 
 So threads **can** share mutable heap state, and for mutexes and condition
 variables a global is the *only* supported way to share one — exactly

--- a/docs/dev/thread-value-sharing.md
+++ b/docs/dev/thread-value-sharing.md
@@ -11,12 +11,12 @@ routes, and they have separate, unrelated enforcement:
 | route | how a value travels | what enforces the rules |
 |---|---|---|
 | **copy** | deep-copied into the other heap | the uncopyable-tag list, one central check |
-| **globals** | reached by pointer, no copy | per-type owner checks in individual primitives — present for exactly two types |
+| **globals** | reached by pointer, no copy | per-type owner checks in individual primitives — present for exactly four types |
 
 The tag list is not a statement about what can cross a thread boundary.
-It is a statement about what can be *copied*. Thirteen of the fourteen
-tags on it are freely reachable through a top-level `define`, and for two
-of them that is the only supported way to share them at all.
+It is a statement about what can be *copied*. Eleven of the fourteen tags
+on it are freely reachable through a top-level `define`, and for two of
+them that is the only supported way to share them at all.
 
 ## The copy route
 
@@ -54,6 +54,18 @@ Channels are **not** on that list. Their arm promotes the channel to a
 shared representation and aliases it, which is what makes a lexically
 captured channel the supported way to share one (KEP-0002 §2).
 
+That arm carries the globals-route check too, in the one direction where
+it means something. A copy **out of** the running thread's heap — into
+the private `Envelope` heap every cross-thread hand-off goes through — is
+refused unless the running thread owns the channel; a copy **in**, out of
+an envelope some entitled thread already built, is not re-checked, since
+the envelope's objects belong to that private heap rather than to the
+importer. The direction, not the channel's promotion state, is what
+decides: until kaappi#1934 an already-promoted channel skipped the check
+its unpromoted twin failed, so a thread that read one out of a shared
+global could still hand it down to a child, and that child got a working
+stub for a channel nobody gave it.
+
 A refusal surfaces as `error.UncopyableType`, which the boundary turns
 into a catchable error naming neither the type nor the offending value:
 
@@ -68,13 +80,30 @@ uncaught exception in thread: thread thunk contains an uncopyable type
 child thread reading a top-level binding gets the parent's object itself,
 in the parent's heap, with no copy and no check at the point of access.
 
-Two types defend themselves at the primitive level, by comparing
+Four types defend themselves at the primitive level, by comparing
 `Object.owner` against the running thread's `GC.id`:
 
 | type | check | sites |
 |---|---|---|
 | channel | `channel belongs to another thread; pass it through the thread thunk to share it` | `primitives_fiber.zig` — `channel-send`, `channel-receive`, `channel-close!`, `channel-closed?` |
 | thread handle | `thread belongs to another OS thread; a thread handle may only be used by the thread that created it` | `primitives_srfi18.zig` `checkThreadOwner` — `thread-name`, `thread-specific`, `thread-specific-set!`, `thread-start!`, `thread-terminate!`, `thread-join!` |
+| fiber | `fiber-join: fiber belongs to another thread; a fiber may only be joined by the thread that spawned it` | `primitives_fiber.zig` — `fiber-join` (kaappi#2001) |
+| guardian | `guardian belongs to another thread; a guardian may only be used by the thread that created it` | `vm_calls.zig` `invokeGuardian` — both the register and the retrieve call shapes, object and transport-cell guardians alike (kaappi#2008) |
+
+The last two were added because their damage was not the general
+mutate-a-shared-global hazard. `fiber-join` *returned* the parent's own
+heap object to the child as its documented result — a `set-car!` in the
+child was observed by the parent — and reported a nonexistent deadlock
+for a still-running foreign fiber. A guardian's `registered`/`ready` are
+raw Zig `ArrayList`s, the only ones reachable for mutation from Scheme
+across a heap boundary: a child appended to the parent's list with the
+child's own allocator and no lock, which aborted the process with an
+empty stdout and stderr, and registered child-heap objects the parent's
+collector later read out of the freed child arena.
+
+The three predicates that take these types — `channel?`, `thread?`,
+`fiber?` — are deliberately exempt: a total predicate must answer, not
+raise.
 
 Nothing else is checked. Every other type on the uncopyable list is fully
 usable from a child thread through a global.
@@ -88,6 +117,7 @@ with a top-level `define` and named by the thunk.
 | type | capture | global | status |
 |---|---|---|---|
 | thread handle (fiber) | refused | refused | **coherent** — usable only by its creating thread |
+| fiber (`spawn`) | refused | refused (kaappi#2001) | **coherent** — same rule, arrived at later |
 | channel | **aliased — the supported way** | refused | **coherent** — one supported route, and it is checked |
 | mutex | refused | works | **inverted** — the only way to share one is the route the list refuses |
 | condition variable | refused | works | **inverted** — same |
@@ -96,7 +126,8 @@ with a top-level `define` and named by the thunk.
 | `scheme-environment` | refused | works (`eval` in it succeeds) | unchecked |
 | `file-info` / `user-info` / `group-info` | refused | works | unchecked |
 | directory object | refused | works | unchecked |
-| ephemeron / guardian | refused | works | unchecked — these are bound to one GC's collection cycle |
+| guardian | refused | refused (kaappi#2008) | **coherent** — the raw-container mutation made a check mandatory |
+| ephemeron | refused | works | unchecked — bound to one GC's collection cycle, but nothing mutates a raw container through it |
 | transport cell | refused | — | unreachable from Scheme: on this non-moving collector a transport-cell guardian always yields `#f` |
 | ffi-callback | refused | not probed | needs a loaded FFI library to construct |
 
@@ -154,8 +185,17 @@ Ports through globals would break too, and the issue itself argues that
 case is fine. A per-type check is possible — `Object.owner` is on every
 heap object, so the mechanism is already there and the channel and thread
 cases show the shape — but it is a per-type decision about a per-type
-idiom, not one sweep, and the two known-unsound cases have their own
-issues (kaappi#1924, kaappi#1936).
+idiom, not one sweep, and the remaining unsound case has its own issue
+(kaappi#1924, kaappi#1936).
+
+Two rows have since been decided that way, one each: the fiber
+(kaappi#2001) and the guardian (kaappi#2008). Both had a route-specific
+failure no general mutation rule covers — an API that hands the foreign
+object back as its result, and a raw Zig container mutated from two
+allocators — and neither had a competing idiom to protect, since the copy
+route refuses them outright. That is the bar for adding a check here: not
+"is the globals route unsound for this type" (it broadly is), but "does
+this type have damage of its own, and no supported idiom to lose".
 
 What this document fixes is the narrower thing that made the state
 misleading: the tag list read as a guarantee it never provided.
@@ -178,11 +218,11 @@ finding that motivated this file.
 
 ## Keeping it honest
 
-`tests/scheme/srfi/srfi18-sharing-model.scm` pins both routes for the nine
+`tests/scheme/srfi/srfi18-sharing-model.scm` pins both routes for the ten
 types that cover every distinct enforcement shape in the matrix: thread
-handle, channel, mutex, condition variable, port (both directions),
-continuation, environment, ephemeron, guardian. It is deliberately a
-*characterisation* test — it asserts what the engine does today, including
+handle, fiber, channel, mutex, condition variable, port (both
+directions), continuation, environment, ephemeron, guardian. It is
+deliberately a *characterisation* test — it asserts what the engine does today, including
 the rows this document calls unchecked, so that a change to any of them
 fails visibly and lands here rather than silently widening the gap between
 the code and this table.

--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -493,20 +493,49 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
         // reached with a mismatched owner when a channel is reached through
         // a shared global instead of being captured by a thunk or message
         // (Motivation Path 2), which is exactly the case this error exists
-        // to catch.
+        // to catch -- promoted or not (#1934).
         .channel => {
             const ch = obj.as(types.Channel);
-            // Aliasing an already-promoted stub needs no ownership check
-            // (and no memory_mod.gc_instance at all) -- any thread that
-            // legitimately holds a stub Value may pass it along further.
-            // Only a not-yet-promoted channel needs the current-thread
-            // check, since promoting is the operation invariant 4 restricts.
+            const current_gc = memory_mod.gc_instance;
+
+            // Entitlement (#1934), decided BEFORE `ch.shared` is read, so
+            // promotion state can no longer be what selects whether the
+            // invariant applies at all -- and so a foreign heap's `shared`
+            // field, which another thread may be writing, is never read on
+            // this path.
+            //
+            // The direction is what distinguishes the two cases, not the
+            // promotion state:
+            //
+            //   export (`gc` is some *other* heap -- always a private
+            //     Envelope heap in production): this is a value leaving the
+            //     running thread, so it must be one the running thread owns.
+            //     A promoted channel read out of a shared global is exactly
+            //     the escape this rejects; before it, an already-promoted
+            //     channel skipped the check that its unpromoted twin failed,
+            //     and a grandchild could reach a channel nobody handed it.
+            //
+            //   import (`gc` IS the running thread's heap): the source is an
+            //     Envelope built by a thread that already passed the export
+            //     check -- the thunk copy-in at thread-start!, the result at
+            //     thread-join!, a received message -- so its objects are
+            //     owned by that private heap, not by the importer, and
+            //     re-checking here would reject every legal message. All
+            //     three import sites set `gc_instance` to `gc` first.
+            if (current_gc) |cur| {
+                if (gc != cur and obj.owner != cur.id) return error.UncopyableType;
+            }
+
+            // Promotion additionally mutates the source object in place, so
+            // it stays restricted to the owner on every direction (KEP-0002
+            // invariant 4). An envelope only ever carries already-promoted
+            // stubs, so this never fires on an import.
             const sc = if (ch.shared) |s|
                 @as(*shared_channel.SharedChannel, @ptrCast(@alignCast(s)))
             else blk: {
-                const current_gc = memory_mod.gc_instance orelse return error.UncopyableType;
-                if (obj.owner != current_gc.id) return error.UncopyableType;
-                break :blk try shared_channel.promoteChannel(current_gc, ch);
+                const owner_gc = current_gc orelse return error.UncopyableType;
+                if (obj.owner != owner_gc.id) return error.UncopyableType;
+                break :blk try shared_channel.promoteChannel(owner_gc, ch);
             };
             // Allocate before retaining: if allocChannelStub fails, no new
             // stub exists to own the +1, and the source stub's own count

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -67,6 +67,22 @@ fn fiberJoinFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFiber(args[0]))
         return primitives.typeError("fiber-join", "fiber", args[0]);
 
+    // A fiber belongs to the scheduler of the thread that spawned it, and
+    // gc_deep_copy.zig refuses the `.fiber` tag outright -- so no thunk
+    // capture, join result or channel message can ever legally carry one to
+    // another thread. The globals route can (a top-level binding is shared
+    // by pointer, never copied), and without this check fiber-join then
+    // *hands the parent's own heap object to the child*, uncopied: a
+    // set-car! in the child is observed by the parent (#2001). A still-
+    // running foreign fiber was worse than wrong -- it reported a deadlock
+    // that does not exist, since another thread's scheduler is what would
+    // complete it. Same shape as the four channel entry points below and
+    // primitives_srfi18.checkThreadOwner; `fiber?` stays exempt as a total
+    // predicate, exactly like `channel?`.
+    const owner_gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    if (types.toObject(args[0]).owner != owner_gc.id)
+        return raiseFiberError("fiber-join: fiber belongs to another thread; a fiber may only be joined by the thread that spawned it");
+
     const target = types.toObject(args[0]).as(fiber_mod.Fiber);
 
     if (target.status == .completed) return target.result;

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -171,9 +171,61 @@ test "deepCopy .channel arm rejects a foreign, unpromoted channel" {
     try std.testing.expect(types.toObject(ch_val).as(types.Channel).shared == null);
 }
 
+test "deepCopy .channel arm rejects a foreign PROMOTED channel too (#1934)" {
+    const baseline = shared_object.liveCount();
+    var gc1 = memory.GC.init(std.testing.allocator);
+    var gc2 = memory.GC.init(std.testing.allocator);
+    var gc3 = memory.GC.init(std.testing.allocator);
+
+    const saved_gc = memory.gc_instance;
+    defer memory.gc_instance = saved_gc;
+
+    var ch_val = try gc1.allocChannel();
+    gc1.pushRoot(&ch_val);
+
+    // Promote it legitimately: gc1 owns it, and gc1 is the running heap.
+    // In Scheme this is a first child capturing the channel in its thunk.
+    memory.gc_instance = &gc1;
+    var stub2 = try gc2.deepCopy(ch_val);
+    gc2.pushRoot(&stub2); // held across gc2's later allocations (-Dgc-stress)
+    try std.testing.expect(types.toObject(ch_val).as(types.Channel).shared != null);
+
+    // Now a thread that owns neither copies it out. Promotion state used to
+    // decide whether the ownership check applied at all, so this succeeded
+    // where the byte-identical unpromoted program above was refused -- and a
+    // grandchild ended up with a working stub for a channel nobody handed it.
+    memory.gc_instance = &gc3;
+    try std.testing.expectError(error.UncopyableType, gc2.deepCopy(ch_val));
+
+    // A thread holding a stub of its OWN may still pass it along: that is the
+    // legal hand-off (a received message, a thunk copy-in) and must not be
+    // caught by the same check.
+    memory.gc_instance = &gc2;
+    const stub3 = try gc3.deepCopy(stub2);
+    try std.testing.expectEqual(
+        types.toObject(stub2).as(types.Channel).shared,
+        types.toObject(stub3).as(types.Channel).shared,
+    );
+
+    gc2.popRoot(); // stub2
+    gc1.popRoot(); // ch_val
+    gc1.deinit();
+    gc2.deinit();
+    gc3.deinit();
+    try std.testing.expectEqual(baseline, shared_object.liveCount());
+}
+
 test "re-entrant promotion: a channel whose own queue contains itself (and the documented cycle leak)" {
     const baseline = shared_object.liveCount();
     var gc1 = memory.GC.init(std.testing.allocator);
+
+    // The drain below copies the queued channel OUT into an envelope, which
+    // is an export: gc1 must be the running thread's gc for that to be
+    // entitled (#1934). Set explicitly rather than inherited from whatever
+    // an earlier test left behind.
+    const saved_gc = memory.gc_instance;
+    defer memory.gc_instance = saved_gc;
+    memory.gc_instance = &gc1;
 
     var ch_val = try gc1.allocChannel();
     gc1.pushRoot(&ch_val);
@@ -276,10 +328,15 @@ test "reply-to worked example (§1): the received half, with the rc 1->2->3->2 p
     try std.testing.expect(reply_ch.shared != null); // promoted as a side effect of the send
     const reply_sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(reply_ch.shared.?));
 
-    // Receive on a *different* heap: the copied-out value's alias arm runs
-    // against an envelope-owned stub (obj.owner = the envelope GC's id, not
-    // memory.gc_instance) -- exactly why the alias path deliberately skips
-    // the ownership check.
+    // Receive on a *different* heap, which in production means a different
+    // thread -- so the threadlocal moves with it, exactly as
+    // channelReceiveFn's own `memory.gc_instance` binding does. The
+    // copied-out value's alias arm then runs against an envelope-owned stub
+    // (obj.owner = the envelope GC's id, neither heap's), which is why the
+    // entitlement check is an export-direction one: on this import the
+    // destination IS the running heap, so the stub is copied in unchecked
+    // (#1934).
+    memory.gc_instance = &dest_gc;
     const recv_outcome = try shared_channel.receive(tasks_sc, &dest_gc, null, false);
     const received_val = switch (recv_outcome) {
         .value => |v| v,

--- a/src/tests_srfi254.zig
+++ b/src/tests_srfi254.zig
@@ -9,6 +9,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
+const vm_calls = @import("vm_calls.zig");
 const th = @import("testing_helpers.zig");
 
 const GC = memory.GC;
@@ -317,6 +318,55 @@ test "srfi 254: transport cell guardian and current-hash" {
     try expect(types.isTruthy(try ctx.vm.eval("(integer? (current-hash o))")));
     try expect(types.isTruthy(try ctx.vm.eval("(= (current-hash o) (current-hash o))")));
     try expect(types.isTruthy(try ctx.vm.eval("(>= (current-hash o) 0)")));
+}
+
+test "srfi 254: a guardian owned by another heap is refused, both paths (#2008)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // A guardian allocated by a *different* GC is exactly what a child thread
+    // sees through the shared globals map: the parent's own object, by
+    // pointer, never copied. Registering into it would grow the parent's raw
+    // ArrayList with this heap's allocator (#2008's silent abort), and its
+    // ready queue would hand back objects from a heap this VM does not own.
+    var other = GC.init(std.testing.allocator);
+    defer other.deinit();
+    // Nothing roots this heap's objects, so no collection may run in it --
+    // the same discipline the GC-semantics tests at the top of this file use.
+    other.enabled = false;
+    const foreign = try other.allocGuardian(false);
+
+    // Register path.
+    try std.testing.expectError(
+        error.InvalidArgument,
+        vm_calls.invokeGuardian(ctx.vm, foreign, &.{types.makeFixnum(1)}),
+    );
+    // Retrieve path (zero arguments) -- the check sits ahead of both.
+    try std.testing.expectError(
+        error.InvalidArgument,
+        vm_calls.invokeGuardian(ctx.vm, foreign, &.{}),
+    );
+    // Nothing was appended to the foreign heap's list.
+    try expectEqual(@as(usize, 0), types.toGuardian(foreign).registered.items.len);
+
+    // A transport cell guardian takes the same append path and is refused
+    // the same way.
+    const foreign_tg = try other.allocGuardian(true);
+    try std.testing.expectError(
+        error.InvalidArgument,
+        vm_calls.invokeGuardian(ctx.vm, foreign_tg, &.{ types.makeFixnum(1), types.makeFixnum(2) }),
+    );
+
+    // Control: this VM's own guardian still registers. Counted across both
+    // queues, since a collection between here and the read -- guaranteed
+    // under -Dgc-stress=true -- resurrects the entry from `registered` into
+    // `ready`, which is the guardian working, not the registration failing.
+    _ = try ctx.vm.eval("(import (srfi 254))");
+    _ = try ctx.vm.eval("(define g (make-guardian))");
+    _ = try ctx.vm.eval("(g (list 'live))");
+    const own = types.toGuardian(try ctx.vm.eval("g"));
+    try expectEqual(@as(usize, 1), own.registered.items.len + own.ready.items.len);
 }
 
 test "srfi 254: component libraries import in isolation" {

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -35,6 +35,23 @@ pub fn invokeGuardian(vm: *VM, guardian: Value, args: []const Value) VMError!Val
     var self_val = guardian;
     vm.gc.pushRoot(&self_val);
     defer vm.gc.popRoot();
+
+    // `registered`/`ready` are raw Zig ArrayLists owned by the heap that
+    // allocated the guardian, and `vm.gc` below is the *calling* thread's GC.
+    // gc_deep_copy.zig refuses the `.guardian` tag, so a guardian reaches
+    // another thread only through the globals route (a top-level binding,
+    // shared by pointer) -- where, without this check, a child thread grows
+    // the parent's list with the child's own allocator and no lock at all
+    // (#2008: a deterministic abort with empty stdout and stderr), and
+    // registers child-heap objects the parent's collector later reads out of
+    // the freed child arena. Mirrors primitives_srfi18.checkThreadOwner and
+    // the channel checks in primitives_fiber.zig, and covers both the
+    // register and the retrieve path; `guardian?` stays a total predicate.
+    if (types.toObject(self_val).owner != vm.gc.id) {
+        vm.setErrorDetail("guardian belongs to another thread; a guardian may only be used by the thread that created it", .{});
+        return VMError.InvalidArgument;
+    }
+
     const g = types.toGuardian(self_val);
 
     if (args.len == 0) {

--- a/tests/scheme/audit/primitives_fiber-audit.scm
+++ b/tests/scheme/audit/primitives_fiber-audit.scm
@@ -516,24 +516,34 @@
 (test-equal "channel? does not apply the owner check (total predicate)"
     '(allowed #t) (child-does (lambda () (channel? shared-ch))))
 
-;;; --- D6: fiber-join has no owner check (#2001) ---
-;; Every channel operation above rejects a foreign-heap object. fiber-join
-;; performs no such check, so a child thread reaches straight into the
-;; parent's heap through a top-level fiber binding.
+;;; --- D6: fiber-join applies the owner check too (#2001) ---
+;; Every channel operation above rejects a foreign-heap object, and so does
+;; fiber-join: without that check a child thread reached straight into the
+;; parent's heap through a top-level fiber binding, and fiber-join *returned*
+;; the parent's object uncopied.
 (define shared-fiber (spawn (lambda () (list 1 2 3))))
 (define parent-view (fiber-join shared-fiber))
 (test-equal "CONTROL: the parent's own fiber-join returns the thunk's value"
     '(1 2 3) parent-view)
-;; FAIL: #2001 (a child thread's fiber-join on a parent-heap fiber is allowed,
-;; and returns the parent's heap object uncopied — a cross-thread set-car! in
-;; the child is observed by the parent)
-;; (test-equal "fiber-join through a shared global is refused, like every channel op"
-;;     '(refused #t) (child-does (lambda () (fiber-join shared-fiber))))
-;; FAIL: #2001 (the value a child gets from a foreign fiber-join is an alias)
-;; (test-equal "a foreign fiber-join result is not aliased into the parent's heap"
-;;     '(1 2 3)
-;;     (begin (child-does (lambda () (set-car! (fiber-join shared-fiber) 'MUTATED)))
-;;            parent-view))
+(test-equal "fiber-join through a shared global is refused, like every channel op"
+    '(refused #t) (child-does (lambda () (fiber-join shared-fiber))))
+(test-equal "a foreign fiber-join result is not aliased into the parent's heap"
+    '(1 2 3)
+    (begin (child-does (lambda () (set-car! (fiber-join shared-fiber) 'MUTATED)))
+           parent-view))
+;; A still-running foreign fiber used to report a deadlock that does not
+;; exist — the fiber belongs to another thread's scheduler, and no cycle is
+;; involved. It must be refused with the ownership message instead.
+(define running-fiber (spawn (lambda () (channel-receive (make-channel)))))
+(test-assert "a foreign fiber-join says 'another thread', not 'deadlock'"
+    (let ((t (make-thread (lambda ()
+                            (msg-has? (lambda () (fiber-join running-fiber))
+                                      "another thread")))))
+      (thread-start! t)
+      (thread-join! t)))
+;; fiber? stays a total predicate, exactly like channel? above.
+(test-equal "fiber? does not apply the owner check (total predicate)"
+    '(allowed #t) (child-does (lambda () (fiber? shared-fiber))))
 
 ;;; --- deadlock detection (each leaks a parked fiber; that is inherent) ---
 ;; joining a fiber blocked on a never-sent channel raises, not hangs

--- a/tests/scheme/audit/primitives_srfi254-audit.scm
+++ b/tests/scheme/audit/primitives_srfi254-audit.scm
@@ -475,33 +475,55 @@
 
 ;; A guardian reached through the GLOBALS route is *not* deep-copied: top-level
 ;; bindings are shared by pointer (docs/dev/thread-value-sharing.md), so a child
-;; gets the parent's own guardian object. invokeGuardian has no owner check —
-;; unlike channels (primitives_fiber.zig) and thread handles
-;; (primitives_srfi18.checkThreadOwner) — and the result is memory corruption.
-;; See #2008. Both shapes below are disabled: the first is nondeterministic
-;; (silent #f in ReleaseSafe, a type-confused live object under -Dgc-stress),
-;; the second aborts the process outright with no diagnostic at all.
-;;
-;; FAIL: #2008 (a child registering into a parent-shared guardian leaves a dangling watched pointer)
-;; (define uaf-g (make-guardian))
-;; (test-assert "cross-heap: an object registered by a child is resurrected as itself"
-;;              (let ((t (make-thread (lambda () (uaf-g (vector 'child)) 'ok))))
-;;                (thread-start! t) (thread-join! t)
-;;                (churn-rounds! 4)
-;;                (vector? (uaf-g))))
-;;
-;; FAIL: #2008 (concurrent registration on a shared guardian aborts, exit 133/134, no message)
-;; (define race-g (make-guardian))
-;; (test-assert "cross-heap: concurrent registration on one guardian survives"
-;;              (let ((t (make-thread (lambda ()
-;;                                      (do ((i 0 (+ i 1))) ((= i 2000)) (race-g (list 'c i)))
-;;                                      'done))))
-;;                (thread-start! t)
-;;                (do ((i 0 (+ i 1))) ((= i 2000)) (race-g (list 'p i)))
-;;                (eq? 'done (thread-join! t))))
+;; gets the parent's own guardian object. invokeGuardian therefore carries the
+;; same Object.owner check channels (primitives_fiber.zig) and thread handles
+;; (primitives_srfi18.checkThreadOwner) do (#2008). Without it, the first shape
+;; below left a dangling watched pointer (silent #f in ReleaseSafe, a
+;; type-confused live object under -Dgc-stress) and the second aborted the
+;; process outright — exit 133/134, empty stdout, empty stderr.
+(define uaf-g (make-guardian))
+(test-equal "cross-heap: a child registering into a parent's guardian is refused"
+            'refused
+            (let ((t (make-thread (lambda ()
+                                    (guard (e (#t 'refused))
+                                      (uaf-g (vector 'child)) 'registered)))))
+              (thread-start! t)
+              (thread-join! t)))
+(test-assert "cross-heap: the refused registration left nothing behind"
+             (begin (churn-rounds! 4) (not (uaf-g))))
+(test-assert "cross-heap: the refusal names the ownership rule"
+             (let ((t (make-thread
+                       (lambda ()
+                         (substring? "another thread"
+                                     (or (raised-message (lambda () (uaf-g (list 'x)))) ""))))))
+               (thread-start! t)
+               (thread-join! t)))
+(define race-g (make-guardian))
+(test-equal "cross-heap: concurrent registration on one guardian is refused, not aborted"
+            'refused
+            (let ((t (make-thread (lambda ()
+                                    (guard (e (#t 'refused))
+                                      (do ((i 0 (+ i 1))) ((= i 2000)) (race-g (list 'c i)))
+                                      'done)))))
+              (thread-start! t)
+              (do ((i 0 (+ i 1))) ((= i 2000)) (race-g (list 'p i)))
+              (thread-join! t)))
+;; The retrieve path is checked by the same guard, ahead of both branches.
+(test-equal "cross-heap: a child *reading* a parent's guardian is refused too"
+            'refused
+            (let ((t (make-thread (lambda () (guard (e (#t 'refused)) (race-g))))))
+              (thread-start! t)
+              (thread-join! t)))
+;; A transport cell guardian takes the same append path and is refused alike.
+(define race-tg (make-transport-cell-guardian))
+(test-equal "cross-heap: a shared transport cell guardian is refused"
+            'refused
+            (let ((t (make-thread (lambda () (guard (e (#t 'refused)) (race-tg 'k 'v) 'made)))))
+              (thread-start! t)
+              (thread-join! t)))
 
-;; Control for the disabled pair above: one guardian per thread, no sharing,
-;; is safe — which is what identifies the shared-guardian case as the defect.
+;; Control for the pair above: one guardian per thread, no sharing, is safe —
+;; which is what identifies the shared-guardian case as the defect.
 (test-equal "cross-heap control: a per-thread guardian is safe under contention" 'done
             (let ((t (make-thread (lambda ()
                                     (let ((h (make-guardian)))

--- a/tests/scheme/smoke/channel-promoted-owner-1934.scm
+++ b/tests/scheme/smoke/channel-promoted-owner-1934.scm
@@ -1,0 +1,73 @@
+;; Regression test for #1934: the channel ownership check must not depend on
+;; whether the channel happens to be promoted.
+;;
+;; KEP-0002 invariant 4 says the only legal cross-thread channel handle is a
+;; locally owned stub deepCopy made from a thunk capture or a message. The
+;; unpromoted arm of gc_deep_copy.zig's `.channel` case enforced that; the
+;; promoted arm skipped it entirely, so *promotion state alone* decided
+;; whether the invariant applied. A thread that reached a promoted channel
+;; through a shared global — which every primitive refuses it directly — could
+;; still hand it to a child, and that child got a working stub for a channel
+;; nobody ever gave it.
+;;
+;; The check now runs before `shared` is even read, in the export direction (a
+;; value leaving the running thread's heap into an envelope). The import
+;; direction — draining an envelope built by a thread that already passed the
+;; export check — stays unchecked, which is what keeps the legal hand-off at
+;; the bottom of this file working.
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 18) (kaappi fibers) (srfi 64))
+
+(test-begin "channel-promoted-owner-1934")
+
+;; A top-level channel, promoted the legal way: a first child captures it
+;; lexically (`c`, not the global name), so thread-start!'s copy runs on the
+;; owning thread and promotes it there.
+(define ch (make-channel))
+(define first-child
+  (let ((c ch))
+    (make-thread (lambda () (channel-send c 'from-first) 'ok))))
+(test-assert "the first child starts" (thread? (thread-start! first-child)))
+(test-equal "its message arrives — ch is promoted now" 'from-first (channel-receive ch))
+(test-equal "the first child joins" 'ok (thread-join! first-child))
+
+;; The escape. This child's thunk captures NOTHING: it names the top-level
+;; binding, so it reads the parent's own promoted channel object out of the
+;; shared globals map at run time. Handing that to a grandchild is the copy
+;; the promoted arm used to wave through.
+(define escaper
+  (make-thread
+   (lambda ()
+     (let ((stolen ch))
+       (guard (e (#t 'refused))
+         (let ((gt (make-thread (lambda () (channel-send stolen 'from-grandchild) 'sent))))
+           (thread-start! gt)
+           (list 'escaped (thread-join! gt))))))))
+(test-assert "the escaping child starts" (thread? (thread-start! escaper)))
+(test-equal "a grandchild cannot be handed a channel reached through a global"
+            'refused (thread-join! escaper))
+(test-equal "and nothing was sent into the main thread's channel"
+            'nothing (channel-receive ch 0 'nothing))
+
+;; Discriminating control for the whole fix: the same three-generation shape,
+;; but with the channel handed down legally at every step. The child owns the
+;; stub thread-start! copied in for it, so passing it on is entitled and must
+;; keep working — this is the case an owner check written without the
+;; direction distinction would break.
+(define ch2 (make-channel))
+(define relay
+  (let ((c ch2))
+    (make-thread
+     (lambda ()
+       (let ((gt (make-thread (lambda () (channel-send c 'from-grandchild) 'sent))))
+         (thread-start! gt)
+         (thread-join! gt))))))
+(test-assert "the relaying child starts" (thread? (thread-start! relay)))
+(test-equal "a legally captured channel still reaches a grandchild"
+            'from-grandchild (channel-receive ch2))
+(test-equal "the relaying child joins" 'sent (thread-join! relay))
+
+(let ((runner (test-runner-current)))
+  (test-end "channel-promoted-owner-1934")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi18-sharing-model.scm
+++ b/tests/scheme/srfi/srfi18-sharing-model.scm
@@ -7,7 +7,8 @@
 ;; copy at all. The two routes have separate, unrelated enforcement:
 ;; gc_deep_copy.zig's fourteen-tag uncopyable list governs the copy route
 ;; only, and the globals route is checked by individual primitives for
-;; exactly two types (channels and thread handles).
+;; exactly four types (channels, thread handles, fibers and guardians —
+;; the last two added by #2001 and #2008).
 ;;
 ;; This file pins BOTH routes for each type, which is the pairing that makes
 ;; the asymmetry visible -- and it is deliberately a characterisation test,
@@ -92,12 +93,20 @@
 (define g-guardian (make-guardian))
 (define g-channel (make-channel))
 (define g-thread (make-thread (lambda () 'never-started)))
+(define g-fiber (spawn (lambda () (list 1 2 3))))
 
-;; Checked on this route -- the only two types that are.
+;; Checked on this route -- the only four types that are. A fiber and a
+;; guardian joined the list with #2001 and #2008: fiber-join was handing the
+;; child the parent's own heap object as its documented result value, and
+;; invokeGuardian was growing the parent's raw ArrayList from the child.
 (test-assert "global refused: channel"
   (refused? (on-child (lambda () (channel-send g-channel 'hi)))))
 (test-assert "global refused: thread handle"
   (refused? (on-child (lambda () (thread-name g-thread)))))
+(test-assert "global refused: fiber"
+  (refused? (on-child (lambda () (fiber-join g-fiber)))))
+(test-assert "global refused: guardian"
+  (refused? (on-child (lambda () (g-guardian (list 1 2))))))
 
 ;; Unchecked on this route. Mutexes and condition variables are not merely
 ;; tolerated here: a global is the ONLY way to share one, since the line
@@ -130,12 +139,12 @@
 (test-equal "global works: environment (eval succeeds in it)"
   3
   (on-child (lambda () (eval '(+ 1 2) g-env))))
+;; An ephemeron is still unchecked: it is bound to one GC's collection cycle
+;; the same way a guardian is, but nothing mutates a raw Zig container through
+;; it, so it stays a characterisation row rather than a fix.
 (test-equal "global works: ephemeron"
   'k
   (on-child (lambda () (ephemeron-key g-ephemeron))))
-(test-equal "global works: guardian"
-  'ok
-  (on-child (lambda () (g-guardian (list 1 2)) 'ok)))
 
 ;; ---------------------------------------------------------------------------
 ;; The copy route also governs the two boundaries that are not the thunk.


### PR DESCRIPTION
Three issues, one shape: an object used by a thread that does not own it, on
a route where nothing checked. `VM.initForThread` shares the globals map **by
pointer**, so a thunk that merely *names* a top-level binding hands the child
the parent's own object — and only channels and thread handles compared
`Object.owner` against the running `GC.id`.

Closes #2001.
Closes #2008.
Closes #1934.

## `fiber-join` (#2001)

The worst of the three, because the API itself performs the hand-off:
`fiber-join` returned the parent's heap object to the child as its documented
result value, so a `set-car!` in the child was observed by the parent. A
still-running foreign fiber was reported as a *deadlock*, sending the reader
to look for a cycle that does not exist — the fiber simply belongs to another
thread's scheduler.

`gc_deep_copy` refuses the `.fiber` tag outright, so no thunk capture, join
result or channel message can legally carry a fiber anywhere. Nothing legal
is now refused. `fiber?` stays a total predicate, like `channel?`.

## `invokeGuardian` (#2008)

`Guardian.registered`/`ready` are raw `std.ArrayList`s — the only Zig
containers Scheme can grow across a heap boundary. A child appended to the
parent's list with the **child's** allocator and no lock: two threads
registering into one shared guardian aborted the process 5/5 with empty
stdout *and* empty stderr, no `KP` code. Registering a child-heap object left
the parent holding a pointer into the freed child arena, which `weakReachable`
then read for an owner id — silently `#f` in ReleaseSafe, an unrelated live
parent-heap pair under `-Dgc-stress`.

One check ahead of both the register and the retrieve branch closes both
reproductions; object and transport-cell guardians share it.

## `gc_deep_copy`'s channel arm (#1934)

Ownership was checked only on the *unpromoted* branch, so promotion state
alone decided whether KEP-0002 invariant 4 applied. A thread could read a
promoted channel out of a shared global — which every channel primitive
refuses it directly — and hand it to a child, which then held a perfectly
working stub.

The naive fix (copy the same `obj.owner != gc_instance.id` onto the promoted
branch) **breaks every legal channel message**: a cross-thread value travels
through an `Envelope`, a private mini-heap with its own `GC.id`, so the
receiver's `deepCopy` reads objects owned by *that* heap, never by itself. The
check therefore keys off **direction**:

- **export** (`gc != gc_instance` — the destination is an envelope): the
  channel must be one the running thread owns.
- **import** (`gc == gc_instance`): unchecked. The source is an envelope built
  by a thread that already passed the export check. All three import sites
  (`threadEntryFn`'s thunk copy-in, `thread-join!`'s result, `receive`'s
  `dest_gc`) set `gc_instance` to the destination first.

It also runs *before* `ch.shared` is read, so a foreign heap's field — which
another thread may be writing, the issue's second, unreproduced risk — is
never read on this path at all. Promotion keeps its own owner check on top,
since it mutates the source object.

## Tests

Every assertion below was A/B'd against a baseline binary with all three
source files stashed.

- `src/tests_shared_channel.zig` — a foreign **promoted** channel is refused,
  and the legal hand-off (a thread passing on a stub it owns) still works.
  Green under `-Dgc-stress=true`.
- `src/tests_srfi254.zig` — a guardian owned by another heap is refused on
  both the register and the retrieve path, transport-cell guardians included,
  with nothing appended to the foreign list.
- `tests/scheme/audit/primitives_fiber-audit.scm` — the two `;; FAIL: #2001`
  assertions are enabled, plus the "another thread, not deadlock" message and
  the `fiber?` total-predicate exemption.
- `tests/scheme/audit/primitives_srfi254-audit.scm` — section 8's two disabled
  `;; FAIL: #2008` blocks are re-enabled as refusal assertions (the second one
  used to kill the process).
- `tests/scheme/smoke/channel-promoted-owner-1934.scm` — the three-generation
  escape, and the same shape handed down legally as its control.
- `tests/scheme/srfi/srfi18-sharing-model.scm` — the characterisation matrix
  moves the guardian row from "works" to "refused" and gains a fiber row.

Two existing unit tests modelled a thread boundary without moving the
threadlocal with it (`receive` on a second heap while `gc_instance` still
named the sender). They now set it the way the production path does.

Full local runs: `zig build test`, `bash tests/scheme/run-all.sh` (2072 pass,
0 fail), and the touched unit tests under `-Dgc-stress=true`.

## Docs

`docs/dev/thread-value-sharing.md` and `CLAUDE.md`: the globals route is now
checked for **four** types, not two, with the bar for adding a fifth stated
explicitly — not "is this route unsound for the type" (it broadly is) but
"does this type have damage of its own, and no supported idiom to lose".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
