### PR TITLE
Stop compile-only commands running program code, and name the real cache reason

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,10 @@ zero overhead when absent — see `docs/dev/timings.md`),
 `--completions <shell>`.
 Subcommands: `kaappi compile <file> [-o output]` compiles to a native binary
 via LLVM; `kaappi check <file>` runs compile-only static analysis (reads,
-expands, compiles, executes nothing) reporting read/compile errors plus the
+expands, compiles, executes no program code — only the five
+`vm_eval.TopLevelHead.isEnvSetup()` declarations later forms are compiled
+*against*, which `--compile` and `--disassemble` share since kaappi#2156)
+reporting read/compile errors plus the
 `KP4xxx` lint findings — unknown top-level variable (warning), and arity or
 wrong-type-literal on direct built-in calls (errors); honors
 `--diagnostics=json` and `--deny-warnings` — see `docs/dev/check.md`;

--- a/docs/dev/cache.md
+++ b/docs/dev/cache.md
@@ -124,9 +124,29 @@ to* the source as `file.sbc`. A central store is what makes `cache status` /
 - **Not cached — top-level forms the VM handles directly:** one occurrence of
   any of `import`, `define-library`, `include`, `include-ci`,
   `define-record-type`, `define-values`, `begin`, or `cond-expand` at top
-  level skips caching for the whole file (reason: `imports`). Library loading
-  can free collected function pointers, so these files' top-level functions
-  are not safe to serialize after the fact.
+  level skips caching for the whole file — every other form in it included.
+  These eight are `vm_eval.TopLevelHead`, the set `handleTopLevelForm`
+  claims; `--timings` names the one that fired (`not cached: top-level
+  cond-expand`). Until
+  [#2114](https://github.com/kaappi/kaappi/issues/2114) it reported all eight
+  as `imports`, so a file with no `import` in it was told an import was the
+  cause.
+
+  They are refused for one shared reason: `handleTopLevelForm` *interprets*
+  such a form and appends no `Function` to the run's compiled list, so a HIT —
+  which compiles nothing — would skip that form's work entirely. (The separate
+  hazard that library loading can free collected function pointers is real,
+  but specific to the three heads that load libraries.)
+
+  The rule is **top-level head position only**. The same constructs nested
+  inside a body are ordinary code and leave caching alive:
+
+  ```scheme
+  (define (a) (begin 1 2 3))                     ; still cacheable
+  (define (b) (cond-expand (else 'chosen)))
+  (define (c) (define-values (x y) (values 1 2)) (+ x y))
+  ```
+
 - **Not cached — compile-time registrations
   ([#2112](https://github.com/kaappi/kaappi/issues/2112)):** a top-level
   `define-syntax` or `define-property` (or a macro use expanding into one)
@@ -151,6 +171,21 @@ to* the source as `file.sbc`. A central store is what makes `cache status` /
   binary via `zig build -Dbundle=out.sbc`, not for the auto-run path. It is
   never read as the run-cache, so `--no-ir-opt --compile` can't poison a plain
   run.
+
+  `--compile` does **not** run the program. Of the eight heads above it
+  evaluates only the five `TopLevelHead.isEnvSetup()` names — the declarations
+  later forms are compiled *against* (`import`, `include`, `include-ci`,
+  `define-library`, `define-record-type`) — and records them in the artifact's
+  preamble for replay. `begin` and `cond-expand` are spliced into the form
+  stream so their bodies are compiled (only a `cond-expand`'s branch
+  *selection* is a compile-time question), and a `define-values` is recorded
+  without its producer expression being evaluated. Until
+  [#2156](https://github.com/kaappi/kaappi/issues/2156) all three were
+  evaluated for real, so `(begin (delete-file "x"))` deleted the file while
+  producing the `.sbc` and again at run time from the preamble — and, because
+  the preamble replays entirely *before* the compiled forms, a top-level
+  `begin` also ran out of program order in the artifact. `--disassemble`
+  follows the same discipline.
 - `.sld` library loads are never cached in either direction.
 
 ## Inspect, clear, bypass

--- a/docs/dev/cache.md
+++ b/docs/dev/cache.md
@@ -182,10 +182,30 @@ to* the source as `file.sbc`. A central store is what makes `cache status` /
   without its producer expression being evaluated. Until
   [#2156](https://github.com/kaappi/kaappi/issues/2156) all three were
   evaluated for real, so `(begin (delete-file "x"))` deleted the file while
-  producing the `.sbc` and again at run time from the preamble — and, because
-  the preamble replays entirely *before* the compiled forms, a top-level
-  `begin` also ran out of program order in the artifact. `--disassemble`
-  follows the same discipline.
+  producing the `.sbc` and again at run time from the preamble.
+  `--disassemble` follows the same discipline.
+
+  **The preamble replays in full before any compiled form**, so a recorded
+  declaration does not keep its position in the program. Splicing puts `begin`
+  and `cond-expand` bodies into the compiled stream, which is what restores
+  their order; the other six heads still replay first. For `import`,
+  `include`, `include-ci`, `define-library` and `define-record-type` that is
+  harmless — they are declarations, and hoisting them is what a preamble is
+  for. For `define-values` it is not, because its producer is arbitrary
+  program code that can depend on earlier forms:
+
+  ```scheme
+  (define x 1)
+  (define-values (a b) (values x 2))   ; replayed first, with x unbound
+  (display (list a b))
+  ```
+
+  The interpreter prints `(1 2)`; the standalone binary fails with
+  `preamble error[KP3001]: undefined variable 'x'` and exits 1. This
+  pre-dates #2156 and is unchanged by it — tracked separately as
+  [#2200](https://github.com/kaappi/kaappi/issues/2200), since fixing it needs
+  either an order-preserving preamble in the `.sbc` format or a compilable
+  `define-values`.
 - `.sld` library loads are never cached in either direction.
 
 ## Inspect, clear, bypass

--- a/docs/dev/timings.md
+++ b/docs/dev/timings.md
@@ -56,7 +56,7 @@ The cache line is never blank. When caching was not even attempted it says why:
 
 ```text
 cache: off (--no-ir-opt)     # or (sandbox), or (no home dir)
-cache: MISS (not cached: imports)   # imported programs are never cached (#1516)
+cache: MISS (not cached: top-level import)   # one of the eight top-level heads (#1516, #2114)
 ```
 
 ### Stages

--- a/src/check.zig
+++ b/src/check.zig
@@ -30,7 +30,6 @@ const reader = @import("reader.zig");
 const compiler = @import("compiler.zig");
 const vm_mod = @import("vm.zig");
 const vm_library = @import("vm_library.zig");
-const vm_eval = @import("vm_eval.zig");
 const ir_mod = @import("ir.zig");
 const diagnostics = @import("diagnostics.zig");
 const lsp_diagnostic = @import("lsp_diagnostic.zig");
@@ -195,13 +194,31 @@ fn checkForm(vm: *VM, ctx: *check_lint.Context, arena: std.mem.Allocator, expr: 
         // Environment setup that later forms depend on: run it (suppressing lint
         // over the library/record code it compiles), so imported names/macros and
         // record accessors are in scope for the rest of the file.
-        if (isEnvSetupForm(name)) {
-            ctx.suppress_depth += 1;
-            defer ctx.suppress_depth -= 1;
-            if (vm.handleTopLevelForm(expr)) |result| {
-                _ = result catch |err| addRuntimeOrCompileError(vm, ctx, arena, err, line, col);
+        //
+        // Classify through `vm.topLevelHead`, not the head's spelling: it also
+        // answers null when a macro shadows `define-record-type` (SRFI 57/131/
+        // 136/150 each bind that name), which is exactly when the form must
+        // fall through to ordinary compilation. Matching on the name alone
+        // sent a shadowed use into this branch, where `handleTopLevelForm` —
+        // which does consult the macro table — declined it, and the `return`
+        // below dropped the form uncompiled. That cost diagnostics in both
+        // directions: a malformed shadowed use reported nothing and `check`
+        // exited 0, while every *later* form depending on what the dropped
+        // form was supposed to bind reported a phantom error. Real instance:
+        // `tests/scheme/srfi/srfi136.scm` — a valid, passing file — drew 3
+        // KP2001 "invalid syntax" errors plus an unknown-variable warning,
+        // because SRFI 136 binds each type name to a CPS introspection macro
+        // that the dropped form never registered. Pre-dates #2114; found
+        // reviewing that PR, whose enum makes the VM-aware answer available
+        // here.
+        if (vm.topLevelHead(expr)) |head| {
+            if (head.isEnvSetup()) {
+                ctx.suppress_depth += 1;
+                defer ctx.suppress_depth -= 1;
+                _ = vm.runTopLevelHead(head, expr) catch |err|
+                    addRuntimeOrCompileError(vm, ctx, arena, err, line, col);
+                return;
             }
-            return;
         }
     }
 
@@ -212,18 +229,6 @@ fn checkForm(vm: *VM, ctx: *check_lint.Context, arena: std.mem.Allocator, expr: 
     _ = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, line, path, false) catch |err| {
         addCompileError(ctx, arena, err, line, col);
     };
-}
-
-/// Forms `check` processes for their environment effect rather than compiling as
-/// ordinary expressions. `define-values` is deliberately absent: it is compiled
-/// (so its initializer is linted) and its names are gathered structurally.
-/// Derived from `vm_eval.TopLevelHead` so this shares one classification with
-/// `kaappi --compile` and `--disassemble`, which need exactly the same split
-/// between declarations a compile-only command must run and program code it
-/// must not (#2114/#2156).
-fn isEnvSetupForm(name: []const u8) bool {
-    const head = vm_eval.TopLevelHead.fromKeyword(name) orelse return false;
-    return head.isEnvSetup();
 }
 
 // ── Structural collection of top-level define names ────────────────────────

--- a/src/check.zig
+++ b/src/check.zig
@@ -30,6 +30,7 @@ const reader = @import("reader.zig");
 const compiler = @import("compiler.zig");
 const vm_mod = @import("vm.zig");
 const vm_library = @import("vm_library.zig");
+const vm_eval = @import("vm_eval.zig");
 const ir_mod = @import("ir.zig");
 const diagnostics = @import("diagnostics.zig");
 const lsp_diagnostic = @import("lsp_diagnostic.zig");
@@ -216,12 +217,13 @@ fn checkForm(vm: *VM, ctx: *check_lint.Context, arena: std.mem.Allocator, expr: 
 /// Forms `check` processes for their environment effect rather than compiling as
 /// ordinary expressions. `define-values` is deliberately absent: it is compiled
 /// (so its initializer is linted) and its names are gathered structurally.
+/// Derived from `vm_eval.TopLevelHead` so this shares one classification with
+/// `kaappi --compile` and `--disassemble`, which need exactly the same split
+/// between declarations a compile-only command must run and program code it
+/// must not (#2114/#2156).
 fn isEnvSetupForm(name: []const u8) bool {
-    return std.mem.eql(u8, name, "import") or
-        std.mem.eql(u8, name, "define-library") or
-        std.mem.eql(u8, name, "include") or
-        std.mem.eql(u8, name, "include-ci") or
-        std.mem.eql(u8, name, "define-record-type");
+    const head = vm_eval.TopLevelHead.fromKeyword(name) orelse return false;
+    return head.isEnvSetup();
 }
 
 // ── Structural collection of top-level define names ────────────────────────

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,6 +11,7 @@ pub const reader = @import("reader.zig");
 pub const compiler = @import("compiler.zig");
 pub const compiler_forms = @import("compiler_forms.zig");
 pub const vm_mod = @import("vm.zig");
+pub const vm_eval = @import("vm_eval.zig");
 pub const primitives = @import("primitives.zig");
 pub const primitives_arithmetic = @import("primitives_arithmetic.zig");
 pub const primitives_io = @import("primitives_io.zig");
@@ -766,7 +767,9 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
 
     var compiled_funcs: std.ArrayList(*types.Function) = .empty;
     defer compiled_funcs.deinit(allocator);
-    var has_imports = false;
+    // The first top-level declaration head seen, if any — it both disables the
+    // cache and names the reason `--timings` prints (#2114).
+    var first_toplevel_decl: ?vm_eval.TopLevelHead = null;
     var defines_syntax = false;
     var had_compile_error = false;
 
@@ -795,13 +798,17 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
         vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
 
-        // A top-level import/define-library/include runs library code here.
-        crash.noteStage(.executing);
-        timings.begin(.execute);
-        const maybe_top = vm.handleTopLevelForm(expr);
-        timings.end();
-        if (maybe_top) |top_result| {
-            has_imports = true;
+        // A top-level declaration — import/define-library/include runs library
+        // code here; the other five heads are interpreted directly. Classify
+        // before dispatching: evaluating one form can change how the next is
+        // classified, so the head and its handler must be read from the same
+        // moment (#2114).
+        if (vm.topLevelHead(expr)) |head| {
+            if (first_toplevel_decl == null) first_toplevel_decl = head;
+            crash.noteStage(.executing);
+            timings.begin(.execute);
+            const top_result = vm.runTopLevelHead(head, expr);
+            timings.end();
             const result = top_result catch |err| {
                 script_had_error = true;
                 toplevel_driver.reportRuntimeError(vm, err, .{ .source = path, .line = datum_lc.line });
@@ -855,15 +862,23 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
         printTopLevelResult(allocator, result);
     }
 
-    // Cache compiled bytecode. Skipped when imports are used (GC may have
-    // freed collected function pointers during library loading), when a form
-    // registered a macro or syntax property at compile time (a HIT would not
-    // replay the registration and run-time `eval` would diverge — kaappi#2112),
-    // and when any form failed to compile (a HIT would silently run the
-    // partial program with exit 0 where the cold run reported the error with
-    // exit 1). Best-effort: a failed write (read-only home, etc.) just means
-    // the next run recompiles.
-    if (!has_imports and !defines_syntax and !had_compile_error and compiled_funcs.items.len > 0) {
+    // Cache compiled bytecode. Skipped in three cases.
+    //
+    // Any of the eight top-level declaration heads (kaappi#2114 — see
+    // `vm_eval.TopLevelHead` and `docs/dev/cache.md`): `handleTopLevelForm`
+    // consumes such a form and appends no Function here, so a HIT — which
+    // compiles nothing — would skip its work entirely. That, not the
+    // library-loading rationale this comment used to give, is why all eight
+    // disable the cache; the GC hazard is real but specific to the three that
+    // load libraries.
+    //
+    // A form that registered a macro or syntax property at compile time (a HIT
+    // would not replay the registration and run-time `eval` would diverge —
+    // kaappi#2112), and any form that failed to compile (a HIT would silently
+    // run the partial program with exit 0 where the cold run reported the error
+    // with exit 1). Best-effort: a failed write (read-only home, etc.) just
+    // means the next run recompiles.
+    if (first_toplevel_decl == null and !defines_syntax and !had_compile_error and compiled_funcs.items.len > 0) {
         if (sbc_path) |sp| {
             cache.ensureDir();
             if (bytecode_file.writeFileWithTopLevel(allocator, compiled_funcs.items, source_hash, path, sp)) |_| {
@@ -878,9 +893,12 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
             }
         }
     } else if (sbc_path != null) {
-        // A miss was recorded but nothing will be written — say why.
-        if (has_imports) {
-            timings.cacheReason("imports");
+        // A miss was recorded but nothing will be written — say why. Name the
+        // head that actually disabled it: every one of the eight used to be
+        // reported as `imports`, including files containing no import at all
+        // (#2114).
+        if (first_toplevel_decl) |head| {
+            timings.cacheReason(head.cacheReason());
         } else if (defines_syntax) {
             timings.cacheReason("define-syntax");
         } else if (had_compile_error) {
@@ -1022,22 +1040,36 @@ fn disassembleFile(vm: *vm_mod.VM, path: []const u8) !void {
         vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
 
-        if (vm.handleTopLevelForm(expr)) |top_result| {
-            _ = top_result catch |err| {
+        // Same compile-only discipline as `--compile` (#2156): splice
+        // `begin` / `cond-expand` so their bodies are disassembled rather than
+        // run, and evaluate only the declarations the compiler depends on.
+        var forms = toplevel_driver.TopLevelForms.init(vm, allocator, expr);
+        defer forms.deinit();
+        while (forms.next()) |form_result| {
+            const form = form_result catch |err| {
                 script_had_error = true;
                 toplevel_driver.reportRuntimeError(vm, err, .{ .source = path, .line = datum_lc.line });
+                continue;
             };
-            continue;
+
+            if (vm.topLevelHead(form)) |head| {
+                if (!head.isEnvSetup()) continue;
+                _ = vm.runTopLevelHead(head, form) catch |err| {
+                    script_had_error = true;
+                    toplevel_driver.reportRuntimeError(vm, err, .{ .source = path, .line = datum_lc.line });
+                };
+                continue;
+            }
+
+            const func = compiler.compileExpressionWithMacrosAt(vm.gc, form, &vm.macros, vm.globals, datum_lc.line, path, false) catch |err| {
+                toplevel_driver.reportCompileError(path, datum_lc.line, datum_lc.col, err);
+                script_had_error = true;
+                continue;
+            };
+
+            const disasm = @import("disassembler.zig");
+            disasm.disassemble(func, allocator);
         }
-
-        const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, datum_lc.line, path, false) catch |err| {
-            toplevel_driver.reportCompileError(path, datum_lc.line, datum_lc.col, err);
-            script_had_error = true;
-            continue;
-        };
-
-        const disasm = @import("disassembler.zig");
-        disasm.disassemble(func, allocator);
     }
 }
 
@@ -1102,25 +1134,48 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
         vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
 
-        if (vm.handleTopLevelForm(expr)) |top_result| {
-            const form_src = printer.valueToString(allocator, expr, .write) catch continue;
-            _ = top_result catch |err| {
+        // Splice top-level `begin` / `cond-expand` instead of evaluating them:
+        // their bodies are ordinary program code and belong in the bytecode,
+        // not in this process (#2156).
+        var forms = toplevel_driver.TopLevelForms.init(vm, allocator, expr);
+        defer forms.deinit();
+        while (forms.next()) |form_result| {
+            const form = form_result catch |err| {
                 script_had_error = true;
                 toplevel_driver.reportRuntimeError(vm, err, .{ .source = path, .line = datum_lc.line });
+                continue;
             };
-            preamble.append(allocator, form_src) catch {
-                allocator.free(form_src);
+
+            if (vm.topLevelHead(form)) |head| {
+                // Record every declaration for replay when the artifact runs...
+                const form_src = printer.valueToString(allocator, form, .write) catch continue;
+                preamble.append(allocator, form_src) catch {
+                    allocator.free(form_src);
+                    continue;
+                };
+                // ...but evaluate only those the *compiler* depends on. A
+                // `define-values` needs nothing at compile time, and evaluating
+                // it ran its producer expression's side effects for real while
+                // writing the `.sbc`, on top of the replay just recorded — so
+                // `(define-values (a) (values (delete-file "x")))` deleted the
+                // file twice (#2156). `begin` and `cond-expand` never reach
+                // here; TopLevelForms already spliced them.
+                if (!head.isEnvSetup()) continue;
+                _ = vm.runTopLevelHead(head, form) catch |err| {
+                    script_had_error = true;
+                    toplevel_driver.reportRuntimeError(vm, err, .{ .source = path, .line = datum_lc.line });
+                };
+                continue;
+            }
+
+            const func = compiler.compileExpressionWithMacrosAt(vm.gc, form, &vm.macros, vm.globals, datum_lc.line, path, false) catch |err| {
+                toplevel_driver.reportCompileError(path, datum_lc.line, datum_lc.col, err);
+                script_had_error = true;
+                continue;
             };
-            continue;
+
+            compiled_funcs.append(allocator, func) catch {};
         }
-
-        const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, datum_lc.line, path, false) catch |err| {
-            toplevel_driver.reportCompileError(path, datum_lc.line, datum_lc.col, err);
-            script_had_error = true;
-            continue;
-        };
-
-        compiled_funcs.append(allocator, func) catch {};
     }
 
     if (compiled_funcs.items.len > 0 or preamble.items.len > 0) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1147,11 +1147,15 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
             };
 
             if (vm.topLevelHead(form)) |head| {
-                // Record every declaration for replay when the artifact runs...
-                const form_src = printer.valueToString(allocator, form, .write) catch continue;
+                // Record every declaration for replay when the artifact runs.
+                // Propagate an allocation failure rather than dropping the
+                // form: silently continuing here writes an artifact missing an
+                // `import`, then prints `Compiled ... -> ...` and exits 0.
+                // `runFile`'s equivalent site returns error.OutOfMemory too.
+                const form_src = try printer.valueToString(allocator, form, .write);
                 preamble.append(allocator, form_src) catch {
                     allocator.free(form_src);
-                    continue;
+                    return error.OutOfMemory;
                 };
                 // ...but evaluate only those the *compiler* depends on. A
                 // `define-values` needs nothing at compile time, and evaluating
@@ -1174,7 +1178,9 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
                 continue;
             };
 
-            compiled_funcs.append(allocator, func) catch {};
+            // Likewise: dropping a compiled top-level form here would emit an
+            // artifact silently missing that code.
+            compiled_funcs.append(allocator, func) catch return error.OutOfMemory;
         }
     }
 

--- a/src/timings.zig
+++ b/src/timings.zig
@@ -77,7 +77,7 @@ pub const CacheOutcome = enum { none, hit, miss, off };
 
 var cache_outcome: CacheOutcome = .none;
 var cache_written: bool = false;
-/// A static-lifetime reason ("sandbox", "--no-ir-opt", "imports", …) — safe to
+/// A static-lifetime reason ("sandbox", "--no-ir-opt", "top-level import", …) — safe to
 /// alias since callers pass string literals.
 var cache_reason: []const u8 = "";
 var cache_path_buf: [max_path]u8 = undefined;

--- a/src/toplevel_driver.zig
+++ b/src/toplevel_driver.zig
@@ -251,6 +251,68 @@ pub fn printStackTrace(vm: *vm_mod.VM) void {
     }
 }
 
+/// Iterates one top-level datum as the sequence of top-level forms it
+/// contributes: a `begin` or a matched `cond-expand` contributes its body's
+/// forms, recursively; every other form contributes just itself.
+///
+/// Compile-only drivers (`kaappi --compile`, `kaappi --disassemble`) use this
+/// so those bodies are **compiled** rather than **evaluated**. Routing them
+/// through `handleTopLevelForm` ran user code while producing the artifact, so
+/// `(begin (delete-file "x"))` deleted the file at compile time — and again at
+/// run time from the preamble the artifact records (#2156). `check.zig` splices
+/// the same two heads for the same reason, by hand.
+///
+/// Every Value handed out is reachable from the `expr` the caller passed, so
+/// the caller's single root over `expr` keeps the whole traversal alive and the
+/// iterator roots nothing itself. Nesting is held on the heap rather than the
+/// native stack, so arbitrarily deep `(begin (begin ...))` cannot overflow it.
+pub const TopLevelForms = struct {
+    vm: *vm_mod.VM,
+    allocator: std.mem.Allocator,
+    /// The not-yet-visited tail of each spliced body, innermost last.
+    stack: std.ArrayList(types.Value),
+    /// The datum the caller passed, before its first `next()`.
+    root: ?types.Value,
+
+    pub fn init(vm: *vm_mod.VM, allocator: std.mem.Allocator, expr: types.Value) TopLevelForms {
+        return .{ .vm = vm, .allocator = allocator, .stack = .empty, .root = expr };
+    }
+
+    pub fn deinit(self: *TopLevelForms) void {
+        self.stack.deinit(self.allocator);
+    }
+
+    /// The next form, or null once the datum is exhausted. An error means a
+    /// malformed `cond-expand` — the same error `eval` reports for it.
+    pub fn next(self: *TopLevelForms) ?(vm_mod.VMError!types.Value) {
+        while (self.take()) |form| {
+            const spliced = self.vm.topLevelSpliceBody(form) orelse return form;
+            const body = spliced catch |err| return err;
+            self.stack.append(self.allocator, body) catch return vm_mod.VMError.OutOfMemory;
+        }
+        return null;
+    }
+
+    fn take(self: *TopLevelForms) ?types.Value {
+        if (self.root) |r| {
+            self.root = null;
+            return r;
+        }
+        while (self.stack.items.len > 0) {
+            const tail = &self.stack.items[self.stack.items.len - 1];
+            if (types.isPair(tail.*)) {
+                const form = types.car(tail.*);
+                // An improper body tail is silently ignored, matching the
+                // leniency of the `handleTopLevelBegin` this mirrors.
+                tail.* = types.cdr(tail.*);
+                return form;
+            }
+            _ = self.stack.pop();
+        }
+        return null;
+    }
+};
+
 pub fn printSourceSnippet(source: []const u8, line: u32) void {
     if (diagnostic_format == .json) return;
     if (line == 0 or source.len == 0) return;

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -1175,6 +1175,18 @@ pub const VM = struct {
         return vm_eval.handleTopLevelForm(self, expr);
     }
 
+    pub fn topLevelHead(self: *VM, expr: Value) ?vm_eval.TopLevelHead {
+        return vm_eval.topLevelHead(self, expr);
+    }
+
+    pub fn runTopLevelHead(self: *VM, head: vm_eval.TopLevelHead, expr: Value) VMError!Value {
+        return vm_eval.runTopLevelHead(self, head, expr);
+    }
+
+    pub fn topLevelSpliceBody(self: *VM, expr: Value) ?VMError!Value {
+        return vm_eval.topLevelSpliceBody(self, expr);
+    }
+
     pub fn compileCachedForm(self: *VM, source: []const u8) VMError!Value {
         return vm_eval.compileCachedForm(self, source);
     }

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -69,12 +69,103 @@ pub fn eval(vm: *VM, source: []const u8) VMError!Value {
     return last_result;
 }
 
-pub fn handleTopLevelForm(vm: *VM, expr: Value) ?VMError!Value {
+/// The eight top-level heads `handleTopLevelForm` claims: forms `eval()`
+/// interprets directly instead of compiling to a reusable Function.
+///
+/// This enum is the single source of truth for that set. Four consumers read
+/// it — the dispatch chain in `runTopLevelHead` (an exhaustive `switch`, so a
+/// new head cannot reach the VM without a handler), the `.sbc` cache's decline
+/// predicate `isSpecialTopLevelForm`, `--timings`' "not cached: ..." reason,
+/// and `check.zig`'s env-setup allowlist. Until #2114 those were four
+/// hand-kept lists, and `--timings` reported every one of them as `imports`.
+pub const TopLevelHead = enum {
+    import,
+    define_library,
+    define_record_type,
+    define_values,
+    include,
+    include_ci,
+    begin,
+    cond_expand,
+
+    pub fn keyword(self: TopLevelHead) []const u8 {
+        return switch (self) {
+            .import => "import",
+            .define_library => "define-library",
+            .define_record_type => "define-record-type",
+            .define_values => "define-values",
+            .include => "include",
+            .include_ci => "include-ci",
+            .begin => "begin",
+            .cond_expand => "cond-expand",
+        };
+    }
+
+    pub fn fromKeyword(name: []const u8) ?TopLevelHead {
+        inline for (@typeInfo(TopLevelHead).@"enum".fields) |f| {
+            const cand: TopLevelHead = @enumFromInt(f.value);
+            if (std.mem.eql(u8, name, comptime cand.keyword())) return cand;
+        }
+        return null;
+    }
+
+    /// Static string naming this head in `--timings`' "not cached: ..." line.
+    /// Every one of the eight disables the `.sbc` cache for the same reason:
+    /// `handleTopLevelForm` consumes the form and appends no Function to the
+    /// run's `compiled_funcs`, so a HIT — which compiles nothing — would skip
+    /// the form's work entirely. See `docs/dev/cache.md`.
+    pub fn cacheReason(self: TopLevelHead) []const u8 {
+        return switch (self) {
+            inline else => |h| "top-level " ++ comptime h.keyword(),
+        };
+    }
+
+    /// Whether a *compile-only* driver has to evaluate this head for real.
+    /// True for the declarations that establish the environment later forms
+    /// are compiled against — `import`/`include`/`include-ci`/`define-library`
+    /// bring in bindings, macros and library code, and `define-record-type`
+    /// registers a type. False for the rest, whose bodies are ordinary program
+    /// code a compile-only command must never run (#2156): `begin` and
+    /// `cond-expand` splice (see `topLevelSpliceBody`), and `define-values`
+    /// only needs its *names*, never its producer expression's effects.
+    pub fn isEnvSetup(self: TopLevelHead) bool {
+        return switch (self) {
+            .import, .define_library, .include, .include_ci, .define_record_type => true,
+            .define_values, .begin, .cond_expand => false,
+        };
+    }
+};
+
+/// The `TopLevelHead` claiming `expr`, or null if `eval` would compile it as an
+/// ordinary expression. Callers that then dispatch should pass the result to
+/// `runTopLevelHead` rather than re-deriving it: evaluating one form (an
+/// `import` bringing a shadowing macro into scope) can change the answer for
+/// the next, so the two must be read from the same moment.
+pub fn topLevelHead(vm: *VM, expr: Value) ?TopLevelHead {
     if (!types.isPair(expr)) return null;
     const head = types.car(expr);
     if (!types.isSymbol(head)) return null;
-    const name = types.symbolName(head);
+    const found = TopLevelHead.fromKeyword(types.symbolName(head)) orelse return null;
 
+    // R7RS has no reserved words: an imported macro may shadow a special
+    // form keyword (compiler.zig's compileForm already honors this for
+    // every non-top-level use, e.g. SRFI-219 redefining `define` -- see
+    // its own comment). SRFI 136/131/57 each define their own
+    // define-record-type macro (extended record-type syntax reusing the
+    // same name); when one is in scope, report no head at all so the form
+    // reaches ordinary macro-aware compilation, exactly like every other
+    // top-level form does.
+    if (found == .define_record_type and isMacroShadowed(vm, "define-record-type")) return null;
+    return found;
+}
+
+pub fn handleTopLevelForm(vm: *VM, expr: Value) ?VMError!Value {
+    const head = topLevelHead(vm, expr) orelse return null;
+    return runTopLevelHead(vm, head, expr);
+}
+
+/// Evaluate a form already classified by `topLevelHead`.
+pub fn runTopLevelHead(vm: *VM, head: TopLevelHead, expr: Value) VMError!Value {
     // Root the form across the handlers: import/define-library load, compile,
     // and execute entire libraries (GC runs many times) while still walking
     // this datum, and most callers pass a freshly read, unrooted expr. Without
@@ -83,31 +174,41 @@ pub fn handleTopLevelForm(vm: *VM, expr: Value) ?VMError!Value {
     vm.gc.pushRoot(&expr_root);
     defer vm.gc.popRoot();
 
-    if (std.mem.eql(u8, name, "import")) return vm_library.handleImport(vm, types.cdr(expr));
-    if (std.mem.eql(u8, name, "define-library")) return vm_library.handleDefineLibrary(vm, types.cdr(expr));
-    // R7RS has no reserved words: an imported macro may shadow a special
-    // form keyword (compiler.zig's compileForm already honors this for
-    // every non-top-level use, e.g. SRFI-219 redefining `define` -- see
-    // its own comment). SRFI 136/131/57 each define their own
-    // define-record-type macro (extended record-type syntax reusing the
-    // same name); when one is in scope, fall through instead of returning
-    // here so the form reaches ordinary macro-aware compilation below,
-    // exactly like every other top-level form does.
-    if (std.mem.eql(u8, name, "define-record-type") and !isMacroShadowed(vm, "define-record-type"))
-        return vm_records.handleDefineRecordType(vm, types.cdr(expr));
-    if (std.mem.eql(u8, name, "define-values")) return handleDefineValues(vm, types.cdr(expr));
-    if (std.mem.eql(u8, name, "include")) return vm_library.handleTopLevelInclude(vm, types.cdr(expr), false);
-    if (std.mem.eql(u8, name, "include-ci")) return vm_library.handleTopLevelInclude(vm, types.cdr(expr), true);
+    const args = types.cdr(expr);
+    return switch (head) {
+        .import => vm_library.handleImport(vm, args),
+        .define_library => vm_library.handleDefineLibrary(vm, args),
+        .define_record_type => vm_records.handleDefineRecordType(vm, args),
+        .define_values => handleDefineValues(vm, args),
+        .include => vm_library.handleTopLevelInclude(vm, args, false),
+        .include_ci => vm_library.handleTopLevelInclude(vm, args, true),
+        // R7RS 5.1: top-level begin splices its body as top-level forms.
+        .begin => handleTopLevelBegin(vm, args),
+        // R7RS 4.2.1: a top-level cond-expand expands to the selected clause's
+        // forms in a top-level context, so its body may contain declarations
+        // (import, define-library, ...) that only work at top level (#1661).
+        .cond_expand => handleTopLevelCondExpand(vm, args),
+    };
+}
 
-    // R7RS 5.1: top-level begin splices its body as top-level forms
-    if (std.mem.eql(u8, name, "begin")) return handleTopLevelBegin(vm, types.cdr(expr));
-
-    // R7RS 4.2.1: a top-level cond-expand expands to the selected clause's forms
-    // in a top-level context, so its body may contain declarations (import,
-    // define-library, ...) that only work at top level (#1661).
-    if (std.mem.eql(u8, name, "cond-expand")) return handleTopLevelCondExpand(vm, types.cdr(expr));
-
-    return null;
+/// The forms a top-level `begin` or `cond-expand` splices into the enclosing
+/// top-level sequence, or null when `expr` is neither. The returned list is a
+/// sublist of `expr`, so a single root over `expr` keeps it alive.
+///
+/// This is the *non-evaluating* half of what `runTopLevelHead` does for those
+/// two heads, for drivers that must compile a body rather than run it: only a
+/// `cond-expand`'s branch **selection** is a compile-time question, its body is
+/// ordinary program code. `kaappi --compile` and `--disassemble` route every
+/// claimed head through the evaluator, so `(begin (delete-file "x"))` deleted
+/// the file while producing the `.sbc` — and again at run time from the
+/// recorded preamble (#2156).
+pub fn topLevelSpliceBody(vm: *VM, expr: Value) ?VMError!Value {
+    const head = topLevelHead(vm, expr) orelse return null;
+    switch (head) {
+        .begin => return types.cdr(expr),
+        .cond_expand => return selectCondExpandBody(vm, types.cdr(expr)),
+        else => return null,
+    }
 }
 
 // Whether `name` is shadowed by a macro in the currently-relevant scope: the
@@ -127,24 +228,13 @@ fn isMacroShadowed(vm: *VM, name: []const u8) bool {
     return vm.macros.get(name) != null;
 }
 
-// Predicate mirror of the dispatch chain in handleTopLevelForm: true for the
-// top-level-only forms that eval() interprets specially rather than compiling
-// to a single reusable Function. compileCachedForm (#1494) consults this to
-// decline caching such a form — the caller falls back to a plain eval(). Keep
-// this list in sync with handleTopLevelForm above.
+// True for the top-level-only forms that eval() interprets specially rather
+// than compiling to a single reusable Function. compileCachedForm (#1494)
+// consults this to decline caching such a form — the caller falls back to a
+// plain eval(). Derived from TopLevelHead, so it can no longer drift from the
+// dispatch chain the way the hand-kept mirror it replaced had (#2114).
 fn isSpecialTopLevelForm(vm: *VM, expr: Value) bool {
-    if (!types.isPair(expr)) return false;
-    const head = types.car(expr);
-    if (!types.isSymbol(head)) return false;
-    const name = types.symbolName(head);
-    return std.mem.eql(u8, name, "import") or
-        std.mem.eql(u8, name, "define-library") or
-        (std.mem.eql(u8, name, "define-record-type") and !isMacroShadowed(vm, "define-record-type")) or
-        std.mem.eql(u8, name, "define-values") or
-        std.mem.eql(u8, name, "include") or
-        std.mem.eql(u8, name, "include-ci") or
-        std.mem.eql(u8, name, "begin") or
-        std.mem.eql(u8, name, "cond-expand");
+    return topLevelHead(vm, expr) != null;
 }
 
 /// Compile a single expression for the native eval-fallback cache (#1494):
@@ -249,6 +339,16 @@ fn handleTopLevelBegin(vm: *VM, body: Value) VMError!Value {
 // `(cond-expand (else 1 . junk))`). Both are validated here so cond-expand's own
 // structure matches the compiler; begin's own leniency is left untouched.
 fn handleTopLevelCondExpand(vm: *VM, clauses_val: Value) VMError!Value {
+    // An unmatched cond-expand selects no body; splicing the empty list yields
+    // void, exactly as returning void directly did.
+    return handleTopLevelBegin(vm, try selectCondExpandBody(vm, clauses_val));
+}
+
+/// The selected clause's body, or nil when no clause matched. Split out of
+/// `handleTopLevelCondExpand` so a compile-only driver can make the same
+/// branch selection without running the body (#2156) — selection is the only
+/// part of a `cond-expand` that is a compile-time question.
+fn selectCondExpandBody(vm: *VM, clauses_val: Value) VMError!Value {
     var clauses = clauses_val;
     while (types.isPair(clauses)) : (clauses = types.cdr(clauses)) {
         const clause = types.car(clauses);
@@ -258,11 +358,11 @@ fn handleTopLevelCondExpand(vm: *VM, clauses_val: Value) VMError!Value {
         if (is_else or vm_library.evalLibFeatureReq(vm, feature_req)) {
             const body = types.cdr(clause);
             if (!isProperList(body)) return VMError.CompileError;
-            return handleTopLevelBegin(vm, body);
+            return body;
         }
     }
     if (clauses != types.NIL) return VMError.CompileError;
-    return types.VOID;
+    return types.NIL;
 }
 
 // A proper (nil-terminated) list? Used to reject improper clause bodies before

--- a/tests/scheme/cache/cache-decline-reason-2114.sh
+++ b/tests/scheme/cache/cache-decline-reason-2114.sh
@@ -60,10 +60,18 @@ cache_line() {
         grep '^cache:' || echo "(no cache line)"
 }
 
-# expect_reason <head-name> <program-source>
-expect_reason() {
-    local head="$1" line
-    line="$(cache_line "$2")"
+# cache_line_for <program-path>: as cache_line, for a program that already
+# exists on disk (include/include-ci need a sibling file to include).
+cache_line_for() {
+    local home
+    home="$(mktemp -d "$WORK/home.XXXXXX")"
+    KAAPPI_HOME="$home" "$KAAPPI_ABS" --timings "$1" 2>&1 > /dev/null |
+        grep '^cache:' || echo "(no cache line)"
+}
+
+# assert_decline_reason <head-name> <cache-line>
+assert_decline_reason() {
+    local head="$1" line="$2"
     if [ "$line" == "cache: MISS (not cached: top-level $head)" ]; then
         ok "top-level $head is named as the reason"
     else
@@ -71,6 +79,11 @@ expect_reason() {
             "expected: cache: MISS (not cached: top-level $head)" \
             "actual:   $line"
     fi
+}
+
+# expect_reason <head-name> <program-source>
+expect_reason() {
+    assert_decline_reason "$1" "$(cache_line "$2")"
 }
 
 echo "=== each top-level head names itself ==="
@@ -92,20 +105,11 @@ cat > "$WORK/inc-body.scm" <<'SCM'
 (define included 7)
 SCM
 for head in include include-ci; do
-    home="$(mktemp -d "$WORK/home.XXXXXX")"
     cat > "$WORK/uses-$head.scm" <<SCM
 ($head "inc-body.scm")
 (display included)(newline)
 SCM
-    line="$(KAAPPI_HOME="$home" "$KAAPPI_ABS" --timings "$WORK/uses-$head.scm" 2>&1 > /dev/null |
-        grep '^cache:' || echo "(no cache line)")"
-    if [ "$line" == "cache: MISS (not cached: top-level $head)" ]; then
-        ok "top-level $head is named as the reason"
-    else
-        bad "top-level $head is named as the reason" \
-            "expected: cache: MISS (not cached: top-level $head)" \
-            "actual:   $line"
-    fi
+    assert_decline_reason "$head" "$(cache_line_for "$WORK/uses-$head.scm")"
 done
 
 echo "=== control: nested in a body, the same forms do not disable the cache ==="

--- a/tests/scheme/cache/cache-decline-reason-2114.sh
+++ b/tests/scheme/cache/cache-decline-reason-2114.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# Regression test for #2114: `--timings` must name the top-level head that
+# actually disabled the `.sbc` cache.
+#
+# The documented rule named one construct, `import`. The implemented rule is
+# every head `vm_eval.handleTopLevelForm` claims — all eight of them, listed in
+# `vm_eval.TopLevelHead` — and `--timings` reported all eight as `imports`, so a
+# file containing no `import` at all was told its cache miss was caused by one.
+#
+# What this pins:
+#   * each of the eight heads is named for itself in the "not cached: ..." line;
+#   * the rule is top-level *head position only* — the same four non-library
+#     constructs nested inside a body leave caching alive, which is what makes
+#     this `handleTopLevelForm`'s dispatch set rather than "these forms are
+#     unserialisable";
+#   * a plain program with none of them still populates the cache and HITs.
+#
+# Hermetic: one isolated KAAPPI_HOME per case, so no probe can see another's
+# entry (or the real user cache).
+#
+# Usage: bash tests/scheme/cache/cache-decline-reason-2114.sh [path-to-kaappi]
+
+set -euo pipefail
+
+. "$(dirname "$0")/../shell-common.sh"
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+if [ ! -x "$KAAPPI" ]; then
+    echo "FAIL: no kaappi binary at '$KAAPPI' — build it first (zig build)"
+    exit 1
+fi
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+PASS=0
+FAIL=0
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+ok() {
+    echo "PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+bad() {
+    echo "FAIL: $1"
+    shift
+    for line in "$@"; do echo "  $line"; done
+    FAIL=$((FAIL + 1))
+}
+
+# cache_line <program-source>: the `cache:` line of a cold `--timings` run, in
+# an isolated cache home.
+cache_line() {
+    local home prog
+    home="$(mktemp -d "$WORK/home.XXXXXX")"
+    prog="$(mktemp "$WORK/prog.XXXXXX")"
+    printf '%s\n' "$1" > "$prog"
+    KAAPPI_HOME="$home" "$KAAPPI_ABS" --timings "$prog" 2>&1 > /dev/null |
+        grep '^cache:' || echo "(no cache line)"
+}
+
+# expect_reason <head-name> <program-source>
+expect_reason() {
+    local head="$1" line
+    line="$(cache_line "$2")"
+    if [ "$line" == "cache: MISS (not cached: top-level $head)" ]; then
+        ok "top-level $head is named as the reason"
+    else
+        bad "top-level $head is named as the reason" \
+            "expected: cache: MISS (not cached: top-level $head)" \
+            "actual:   $line"
+    fi
+}
+
+echo "=== each top-level head names itself ==="
+expect_reason import '(import (scheme base))
+(display 1)(newline)'
+expect_reason define-library '(define-library (probe lib) (export p) (begin (define (p) 1)))
+(display 1)(newline)'
+expect_reason define-record-type '(define-record-type <p> (mk a) p? (a p-a))
+(display (p-a (mk 5)))(newline)'
+expect_reason define-values '(define-values (a b) (values 1 2))
+(display (+ a b))(newline)'
+expect_reason begin '(begin (display 1))
+(newline)'
+expect_reason cond-expand '(cond-expand (else (display 1)))
+(newline)'
+
+# include / include-ci need a file to include; both share one fixture.
+cat > "$WORK/inc-body.scm" <<'SCM'
+(define included 7)
+SCM
+for head in include include-ci; do
+    home="$(mktemp -d "$WORK/home.XXXXXX")"
+    cat > "$WORK/uses-$head.scm" <<SCM
+($head "inc-body.scm")
+(display included)(newline)
+SCM
+    line="$(KAAPPI_HOME="$home" "$KAAPPI_ABS" --timings "$WORK/uses-$head.scm" 2>&1 > /dev/null |
+        grep '^cache:' || echo "(no cache line)")"
+    if [ "$line" == "cache: MISS (not cached: top-level $head)" ]; then
+        ok "top-level $head is named as the reason"
+    else
+        bad "top-level $head is named as the reason" \
+            "expected: cache: MISS (not cached: top-level $head)" \
+            "actual:   $line"
+    fi
+done
+
+echo "=== control: nested in a body, the same forms do not disable the cache ==="
+# All four non-library heads at once, none of them at top level. If any of them
+# were matched structurally rather than in head position, this would miss.
+nested='(define (a) (begin 1 2 3))
+(define (b) (cond-expand (else (quote chosen))))
+(define (c) (define-values (x y) (values 10 20)) (+ x y))
+(define (d) (define-record-type <pt> (mk x) pt? (x pt-x)) (pt-x (mk 7)))
+(display (+ (a) (c) (d)))(newline)'
+line="$(cache_line "$nested")"
+case "$line" in
+    "cache: MISS"*"not cached"*)
+        bad "nested begin/cond-expand/define-values/define-record-type still cache" \
+            "actual: $line" ;;
+    "cache: MISS"*) ok "nested begin/cond-expand/define-values/define-record-type still cache" ;;
+    *) bad "nested begin/cond-expand/define-values/define-record-type still cache" \
+        "expected a plain MISS that then writes the cache" "actual: $line" ;;
+esac
+
+echo "=== control: a cacheable program misses cold, then hits warm ==="
+HOME_HIT="$(mktemp -d "$WORK/home.XXXXXX")"
+cat > "$WORK/plain.scm" <<'SCM'
+(define (square x) (* x x))
+(display (square 9))
+(newline)
+SCM
+cold="$(KAAPPI_HOME="$HOME_HIT" "$KAAPPI_ABS" --timings "$WORK/plain.scm" 2>&1 > /dev/null | grep '^cache:')"
+warm="$(KAAPPI_HOME="$HOME_HIT" "$KAAPPI_ABS" --timings "$WORK/plain.scm" 2>&1 > /dev/null | grep '^cache:')"
+case "$cold" in
+    "cache: MISS"*"not cached"*) bad "cold run misses without a decline reason" "actual: $cold" ;;
+    "cache: MISS"*) ok "cold run misses without a decline reason" ;;
+    *) bad "cold run misses without a decline reason" "actual: $cold" ;;
+esac
+case "$warm" in
+    "cache: HIT"*) ok "warm run hits" ;;
+    *) bad "warm run hits" "actual: $warm" ;;
+esac
+
+echo
+echo "Passed: $PASS, Failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/scheme/compile/compile-toplevel-side-effects-2156.sh
+++ b/tests/scheme/compile/compile-toplevel-side-effects-2156.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# Regression test for #2156: `kaappi --compile` and `kaappi --disassemble` are
+# compile-only commands, and must not run the program's own code.
+#
+# Both routed every form `vm_eval.handleTopLevelForm` claims through the
+# *evaluator*. Three of those eight heads carry ordinary program code —
+# `begin`, `cond-expand` and `define-values` — so a `(delete-file ...)` inside
+# one really deleted the file while the `.sbc` was being produced. The form was
+# then also recorded in the artifact's preamble, so across compile + run the
+# effect happened twice.
+#
+# The discriminating control is a *bare* top-level `(delete-file ...)`, which
+# was never executed at compile time: this is not "compiling runs the program",
+# it is specific to those heads.
+#
+# The fix splices top-level `begin` / `cond-expand` into the form stream (their
+# bodies are compiled, not run — only a `cond-expand`'s branch *selection* is a
+# compile-time question) and records `define-values` for replay without
+# evaluating it. That also repaired an ordering divergence: a top-level `begin`
+# used to reach the artifact via the preamble, which replays entirely *before*
+# the compiled forms, so `one / (begin two) / three` printed `two one three`.
+#
+# Hermetic: KAAPPI_HOME points at a throwaway dir; every probe file lives in a
+# temp dir. Only the last section needs a Zig toolchain (it builds a standalone
+# binary to prove the effect still happens exactly once at run time).
+#
+# Usage: bash tests/scheme/compile/compile-toplevel-side-effects-2156.sh [path-to-kaappi]
+
+set -euo pipefail
+
+. "$(dirname "$0")/../shell-common.sh"
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+# Every probe below asserts that a file *survives* a command, so a command that
+# never ran would pass every one of them. Resolve and verify the binary up
+# front, and fail loudly rather than silently testing nothing.
+if [ ! -x "$KAAPPI" ]; then
+    echo "FAIL: no kaappi binary at '$KAAPPI' — build it first (zig build)"
+    exit 1
+fi
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+PASS=0
+FAIL=0
+
+HOMEDIR="$(mktemp -d)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$HOMEDIR" "$WORK"' EXIT
+export KAAPPI_HOME="$HOMEDIR"
+
+ok() {
+    echo "PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+bad() {
+    echo "FAIL: $1"
+    shift
+    for line in "$@"; do echo "  $line"; done
+    FAIL=$((FAIL + 1))
+}
+
+# probe_survives <label> <scheme-form> <kaappi-args...>
+#
+# Writes a one-form program whose VICTIM placeholder is the path of a file that
+# exists, runs the given compile-only command over it, and asserts the file is
+# still there afterwards.
+probe_survives() {
+    local label="$1" form="$2"
+    shift 2
+    local victim="$WORK/victim.txt"
+    local prog="$WORK/probe.scm"
+    echo hi > "$victim"
+    printf '%s\n(display "compiled")(newline)\n' "${form//VICTIM/$victim}" > "$prog"
+    local status=0
+    "$KAAPPI_ABS" "$@" "$prog" > /dev/null 2>&1 || status=$?
+    if [ "$status" -ne 0 ]; then
+        bad "$label" "the command itself failed (exit $status) — the probe proves nothing"
+    elif [ -f "$victim" ]; then
+        ok "$label"
+    else
+        bad "$label" "the compile-only command deleted $victim"
+    fi
+}
+
+echo "=== --compile does not execute top-level bodies ==="
+probe_survives "--compile leaves a cond-expand body unrun" \
+    '(cond-expand (else (delete-file "VICTIM")))' --compile -o "$WORK/out.sbc"
+probe_survives "--compile leaves a begin body unrun" \
+    '(begin (delete-file "VICTIM"))' --compile -o "$WORK/out.sbc"
+probe_survives "--compile leaves a define-values producer unrun" \
+    '(define-values (a) (values (delete-file "VICTIM")))' --compile -o "$WORK/out.sbc"
+
+echo "=== --disassemble does not execute top-level bodies ==="
+probe_survives "--disassemble leaves a cond-expand body unrun" \
+    '(cond-expand (else (delete-file "VICTIM")))' --disassemble
+probe_survives "--disassemble leaves a begin body unrun" \
+    '(begin (delete-file "VICTIM"))' --disassemble
+probe_survives "--disassemble leaves a define-values producer unrun" \
+    '(define-values (a) (values (delete-file "VICTIM")))' --disassemble
+
+echo "=== control: a bare top-level form was never executed either ==="
+probe_survives "--compile leaves a bare delete-file unrun (control)" \
+    '(delete-file "VICTIM")' --compile -o "$WORK/out.sbc"
+
+echo "=== control: the declarations a compiler depends on still run ==="
+# `include` must still be evaluated at compile time — the included file's
+# definitions are what later forms are compiled against. Its inclusion is the
+# discriminating control for isEnvSetup(): a compile-only command is allowed to
+# read the filesystem for declarations, just not to run the program.
+cat > "$WORK/inc-body.scm" <<'SCM'
+(define (from-include) 'included)
+SCM
+cat > "$WORK/uses-include.scm" <<'SCM'
+(include "inc-body.scm")
+(display (from-include))
+(newline)
+SCM
+if "$KAAPPI_ABS" --compile -o "$WORK/inc.sbc" "$WORK/uses-include.scm" > /dev/null 2>&1 &&
+    [ -f "$WORK/inc.sbc" ]; then
+    ok "--compile still evaluates a top-level include"
+else
+    bad "--compile still evaluates a top-level include" "compiling the file failed"
+fi
+
+echo "=== the artifact still runs the bodies, once, in program order ==="
+skip_without_zig "the standalone-binary check needs a Zig toolchain"
+
+VICTIM="$WORK/run-victim.txt"
+echo hi > "$VICTIM"
+cat > "$WORK/prog.scm" <<SCM
+(display "one")(newline)
+(begin (display "two")(newline))
+(cond-expand (else (display "three")(newline)))
+(define-values (a b) (values 4 5))
+(display (+ a b))(newline)
+(begin (delete-file "$VICTIM"))
+SCM
+
+expected="$("$KAAPPI_ABS" "$WORK/prog.scm")"
+if [ "$expected" != "one
+two
+three
+9" ]; then
+    bad "interpreted run has the expected output" "actual: $expected"
+else
+    ok "interpreted run has the expected output"
+fi
+# The interpreted run consumed the victim; restore it for the compiled run.
+echo hi > "$VICTIM"
+
+"$KAAPPI_ABS" --compile -o "$WORK/prog.sbc" "$WORK/prog.scm" > /dev/null
+
+if [ -f "$VICTIM" ]; then
+    ok "producing the .sbc left the victim alone"
+else
+    bad "producing the .sbc left the victim alone" "compile deleted $VICTIM"
+fi
+
+# -p isolates the install prefix so a concurrent suite's zig-out is untouched.
+(cd "$REPO_ROOT" && zig build -Dbundle="$WORK/prog.sbc" -p "$WORK/bundle" > /dev/null 2>&1)
+actual="$("$WORK/bundle/bin/kaappi")"
+
+if [ "$actual" == "$expected" ]; then
+    ok "the standalone binary's output matches the interpreted run"
+else
+    bad "the standalone binary's output matches the interpreted run" \
+        "expected: $(printf '%s' "$expected" | tr '\n' '|')" \
+        "actual:   $(printf '%s' "$actual" | tr '\n' '|')"
+fi
+
+if [ ! -f "$VICTIM" ]; then
+    ok "running the standalone binary performed the effect (exactly once)"
+else
+    bad "running the standalone binary performed the effect (exactly once)" \
+        "$VICTIM still exists — the begin body never ran"
+fi
+
+echo
+echo "Passed: $PASS, Failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/scheme/compile/compile-toplevel-side-effects-2156.sh
+++ b/tests/scheme/compile/compile-toplevel-side-effects-2156.sh
@@ -139,14 +139,21 @@ cat > "$WORK/prog.scm" <<SCM
 (begin (delete-file "$VICTIM"))
 SCM
 
-expected="$("$KAAPPI_ABS" "$WORK/prog.scm")"
-if [ "$expected" != "one
+# The interpreter is this tier's oracle (tests/scheme/CLAUDE.md). The golden
+# string stays as a second assertion *against the interpreter*, so a bug both
+# tiers share is still caught — but it is not the only thing standing between a
+# wrong artifact and a green run. This program has no bare top-level expression
+# and no top-level error, so none of the three by-design tier differences apply.
+interp_status=0
+interp_out="$(interp_stdout "$KAAPPI_ABS" "$WORK" "$WORK/prog.scm")" || interp_status=$?
+
+if [ "$interp_out" == "one
 two
 three
 9" ]; then
-    bad "interpreted run has the expected output" "actual: $expected"
-else
     ok "interpreted run has the expected output"
+else
+    bad "interpreted run has the expected output" "actual: $interp_out"
 fi
 # The interpreted run consumed the victim; restore it for the compiled run.
 echo hi > "$VICTIM"
@@ -161,14 +168,14 @@ fi
 
 # -p isolates the install prefix so a concurrent suite's zig-out is untouched.
 (cd "$REPO_ROOT" && zig build -Dbundle="$WORK/prog.sbc" -p "$WORK/bundle" > /dev/null 2>&1)
-actual="$("$WORK/bundle/bin/kaappi")"
+native_status=0
+native_out="$("$WORK/bundle/bin/kaappi" 2> /dev/null)" || native_status=$?
 
-if [ "$actual" == "$expected" ]; then
-    ok "the standalone binary's output matches the interpreted run"
+if assert_tiers_agree "standalone binary vs interpreter" \
+    "$interp_out" "$interp_status" "$native_out" "$native_status"; then
+    ok "the standalone binary agrees with the interpreter on stdout and exit status"
 else
-    bad "the standalone binary's output matches the interpreted run" \
-        "expected: $(printf '%s' "$expected" | tr '\n' '|')" \
-        "actual:   $(printf '%s' "$actual" | tr '\n' '|')"
+    FAIL=$((FAIL + 1))
 fi
 
 if [ ! -f "$VICTIM" ]; then

--- a/tests/scheme/differential/probes/cache-compile-error.scm
+++ b/tests/scheme/differential/probes/cache-compile-error.scm
@@ -4,7 +4,8 @@
 ;;
 ;; `runFile` reports a compile error, skips the failed form, and keeps going —
 ;; so `compiled_funcs` holds only the forms that DID compile.  The cache write
-;; used to be gated only on `has_imports`, so this file wrote an entry holding
+;; used to be gated only on the top-level-declaration check (`has_imports` at
+;; the time, `first_toplevel_decl` since kaappi#2114), so this file wrote an entry holding
 ;; the partial program.  The warm run then HIT, executed the partial program
 ;; with no diagnostic at all, and exited 0:
 ;;

--- a/tests/scheme/differential/probes/sbc-population.scm
+++ b/tests/scheme/differential/probes/sbc-population.scm
@@ -12,25 +12,31 @@
 ;;   1. caching is enabled at all — not `--sandbox`, not `--no-ir-opt`, and a
 ;;      home directory resolves (`cache.pathForSource`);
 ;;   2. at least one top-level form compiled to a Function; and
-;;   3. `has_imports` stayed false — i.e. NO top-level form was claimed by
-;;      `vm_eval.handleTopLevelForm`.
+;;   3. `first_toplevel_decl` stayed null — i.e. NO top-level form was claimed
+;;      by `vm_eval.handleTopLevelForm`.
 ;;
-;; Condition 3 is the one that matters, and it is much broader than its name
-;; and than docs/dev/cache.md ("a program that does not `import`").
-;; `handleTopLevelForm` claims EIGHT head symbols:
+;; Condition 3 is the one that matters, and it is much broader than
+;; docs/dev/cache.md used to say ("a program that does not `import`").
+;; `handleTopLevelForm` claims EIGHT head symbols — the `vm_eval.TopLevelHead`
+;; enum, which is now the single source of truth all the consumers derive from:
 ;;
 ;;     import   define-library   define-record-type   define-values
 ;;     include  include-ci       begin                cond-expand
 ;;
 ;; Any one of them, once, anywhere at top level, makes the WHOLE file
-;; uncacheable — including the forms that have nothing to do with library
-;; loading, which is the rationale the source comment gives.  `--timings` then
-;; reports `cache: MISS (not cached: imports)` even for a file containing no
-;; `import` at all.  Measured over the harness's own default corpus: 40 of 345
+;; uncacheable.  They share one reason: `handleTopLevelForm` interprets such a
+;; form and appends no Function to the run's compiled list, so a HIT — which
+;; compiles nothing — would skip its work entirely.  (The library-loading
+;; rationale the source comment used to give covers only three of the eight.)
+;; Measured over the harness's own default corpus: 40 of 345
 ;; files populate the cache; of the 305 that do not, 303 have a top-level
 ;; `import` and the other two are disabled by a top-level `begin` and a
-;; top-level `define-values` respectively.  Tracked as kaappi#2114; the import
-;; half is kaappi#1888.
+;; top-level `define-values` respectively.  The import half is kaappi#1888.
+;;
+;; kaappi#2114 fixed the reporting: `--timings` names the head that actually
+;; fired (`cache: MISS (not cached: top-level begin)`) instead of blaming
+;; `imports` for all eight.  tests/scheme/cache/cache-decline-reason-2114.sh
+;; pins one case per head.
 ;;
 ;; This file therefore contains NONE of the eight at top level — and, as the
 ;; control, uses four of them in NESTED position, where they are ordinary

--- a/tests/scheme/differential/run-differential.sh
+++ b/tests/scheme/differential/run-differential.sh
@@ -77,8 +77,9 @@
 # WHICH FILES POPULATE THE CACHE.  `src/main.zig`'s `runFile` writes an entry
 # iff caching is enabled (no `--sandbox`, no `--no-ir-opt`, a home directory
 # resolves), at least one top-level form compiled to a Function, and none of
-# three refusal flags fired.  `has_imports` is set by ANY top-level form
-# `vm_eval.handleTopLevelForm` claims, which is eight head symbols, not one:
+# three refusal flags fired.  `first_toplevel_decl` is set by ANY top-level
+# form `vm_eval.handleTopLevelForm` claims, which is eight head symbols, not
+# one — the set is `vm_eval.TopLevelHead`:
 #
 #     import   define-library   define-record-type   define-values
 #     include  include-ci       begin                cond-expand
@@ -90,7 +91,8 @@
 # failed to compile, since a HIT would silently run the partial program with
 # exit 0 where the cold run reported the error with exit 1.  One occurrence of
 # any of these, anywhere at top level, makes the whole file uncacheable — and
-# `--timings` reports `not cached: imports` / `define-syntax` /
+# `--timings` reports `not cached: top-level <head>` (kaappi#2114 — it used to
+# report all eight as `imports`) / `define-syntax` /
 # `compile error`.  MEASURED over the default corpus: 40 of 345 files populate
 # the cache; of the 305 that do not, 303 have a top-level `import`, one is
 # disabled by a top-level `begin` and one by a top-level `define-values`.

--- a/tests/scheme/errors/check.sh
+++ b/tests/scheme/errors/check.sh
@@ -89,6 +89,53 @@ echo "== digit-led identifier reclassifies to KP1004 under check (kaappi#1723) =
 assert_out "3-state is KP1004, not KP1002"       'error\[KP1004\]' '(define (3-state x) x) x'
 assert_out "3-state message echoes the token"    "invalid number literal '3-state'" '(define (3-state x) x) x'
 
+echo "== a macro-shadowed define-record-type is compiled, not dropped (#2114 review) =="
+# R7RS has no reserved words, and SRFI 57/131/136/150 each bind
+# `define-record-type` as a macro. `check` classified by head *name*, so a
+# shadowed use entered the env-setup branch, `handleTopLevelForm` declined it
+# (it does consult the macro table), and the form was dropped uncompiled.
+# Diagnostics were lost in both directions.
+#
+# False negative: a use the shadowing macro cannot match is a real syntax
+# error, and `check` reported nothing and exited 0.
+assert_exit "malformed shadowed define-record-type use is an error" 1 \
+    '(define-syntax define-record-type
+       (syntax-rules () ((_ one-only) (display one-only))))
+     (define-record-type too many args here)'
+assert_out "...and reports KP2001" 'error\[KP2001\]' \
+    '(define-syntax define-record-type
+       (syntax-rules () ((_ one-only) (display one-only))))
+     (define-record-type too many args here)'
+
+# False positive, the more damaging half: dropping the form also dropped
+# whatever it was meant to bind, so every later form depending on it drew a
+# phantom diagnostic. A synthetic probe can't show this — `check` gathers
+# top-level define names structurally and so never sees a binding introduced by
+# any macro expansion, shadowed or not. The real SRFI files are the honest
+# guard, in the style of the R7RS conformance check below: both bind
+# `define-record-type` as a macro, both pass their own suites, and both drew
+# hard errors from `check` — srfi136 three KP2001 "invalid syntax" (its type
+# names are CPS introspection macros the dropped form never registered) plus a
+# phantom KP4001, srfi150 a KP2002.
+for probe in srfi136 srfi150; do
+    status=0
+    "$KAAPPI" check "$SCRIPT_DIR/../srfi/$probe.scm" > "$TMP/probe.out" 2>&1 || status=$?
+    if [[ "$status" -eq 0 ]]; then
+        echo "PASS: $probe.scm passes check with zero errors"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $probe.scm failed check (exit $status)"
+        grep -E 'error\[KP' "$TMP/probe.out" | head -5 || true
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+# The unshadowed form must still be run for its effect, so its accessors are in
+# scope for later forms — the behaviour the env-setup branch exists for.
+assert_exit "unshadowed define-record-type still establishes accessors" 0 \
+    '(define-record-type <pt> (mk x) pt? (x pt-x))
+     (display (pt-x (mk 1)))'
+
 echo "== --diagnostics=json parity =="
 printf '(car 5)\n' > "$TMP/j.scm"
 JSON="$("$KAAPPI" check --diagnostics=json "$TMP/j.scm" 2>&1 || true)"

--- a/tests/scheme/timings/timings-1515.sh
+++ b/tests/scheme/timings/timings-1515.sh
@@ -123,7 +123,10 @@ json="$(stderr_of "$KAAPPI" --timings=json "$IMP")"
 check_json_parses "imports json" "$json"
 check "imports json: recorded as a miss" '"status":"miss"' "$json"
 check "imports json: not written to cache" '"written":false' "$json"
-check "imports json: reason names imports" '"reason":"imports"' "$json"
+# kaappi#2114: the reason names the top-level head that actually fired, not a
+# blanket "imports" that also covered seven other heads. The full per-head
+# matrix lives in tests/scheme/cache/cache-decline-reason-2114.sh.
+check "imports json: reason names the import head" '"reason":"top-level import"' "$json"
 
 # ── 5b. Other honest not-cached reasons (kaappi#2112, #2113) ───────────────
 # A top-level define-syntax registers its transformer at compile time, which a


### PR DESCRIPTION
Both issues are the same root cause: `vm_eval.handleTopLevelForm` claims **eight**
top-level heads — `import`, `define-library`, `define-record-type`,
`define-values`, `include`, `include-ci`, `begin`, `cond-expand` — and three
consumers each carried a hand-kept copy of that list. Both defects are a copy
disagreeing with what the dispatcher actually does.

## #2156 — `--compile` deletes files (priority: high, wrong-result)

`--compile` and `--disassemble` routed every claimed head through the
*evaluator*. Three of the eight carry ordinary program code, so a `delete-file`
inside a top-level `begin`, `cond-expand` or `define-values` ran for real while
the `.sbc` was produced — and the form was also recorded in the preamble, so
across compile + run the effect happened **twice**. Reproduced against
`07cceb25`; a bare top-level `(delete-file ...)` was never executed, which is
what makes this the dispatcher's fault rather than "compiling runs the program".

The fix splices `begin` / `cond-expand` into the driver's form stream
(`toplevel_driver.TopLevelForms`) so their bodies are **compiled** — only a
`cond-expand`'s branch *selection* is a compile-time question — and evaluates
only `TopLevelHead.isEnvSetup()`, the five declarations later forms are compiled
*against*. `define-values` is recorded for replay without running its producer.
`check.zig` already worked this way; `--compile` and `--disassemble` now share
its classification instead of having their own.

**`--disassemble` was not named in the issue** but had the identical defect in
the adjacent loop, so it is fixed the same way. Its bodies are now disassembled
rather than silently executed.

### A second defect the same fix closes

The preamble replays *entirely before* the compiled forms, so a top-level
`begin` also ran **out of program order** in the artifact. A/B against a
pre-fix build:

| `one / (begin two) / three` | interpreted | standalone binary |
|---|---|---|
| before | `one two three` | `two one three` |
| after | `one two three` | `one two three` |

## #2114 — `--timings` blames `imports` for all eight (priority: low, doc-truth)

All eight heads legitimately disable the `.sbc` cache, but not for the reason
the code and docs gave. The real invariant: `handleTopLevelForm` consumes such a
form and appends no `Function`, so a HIT — which compiles nothing — would skip
its work entirely. The library-loading/GC rationale is real but covers only the
three heads that load libraries. `--timings` now names the head that fired:

```text
cache: MISS (not cached: top-level define-record-type)   # was: imports
```

`has_imports` is gone in favour of `first_toplevel_decl: ?TopLevelHead`, which
both gates the write and supplies the reason, so the two can't disagree.
`docs/dev/cache.md` states the shared reason and the top-level-head-position
rule; `docs/dev/timings.md`, the differential harness header and two probe
headers are corrected too.

## One list instead of four

`vm_eval.TopLevelHead` is now the single source of truth. Dispatch is an
exhaustive `switch`, so a ninth head cannot reach the VM without a handler.
`isSpecialTopLevelForm` — whose own comment read *"Keep this list in sync with
handleTopLevelForm above"* — is now one line over the enum, as is `check.zig`'s
`isEnvSetupForm`.

## Tests

Two new suites, both verified to **fail against a pre-fix build** and pass
after:

- `tests/scheme/compile/compile-toplevel-side-effects-2156.sh` — 12 assertions.
  Six probes (3 heads × `--compile`/`--disassemble`), the bare-`delete-file`
  control, the `include`-still-runs control, and an end-to-end standalone-binary
  check that the effect happens exactly once and output matches the interpreted
  run. Pre-fix: 7 failures.
- `tests/scheme/cache/cache-decline-reason-2114.sh` — 11 assertions: one per
  head, the nested-position control, and cold-MISS-then-warm-HIT. Pre-fix: 8
  failures.

`tests/scheme/timings/timings-1515.sh` updated for the new reason string.

Full suite: **2074 pass, 0 fail** (`zig build test`, `tests/scheme/run-all.sh`,
R7RS 1395/1395). Differential harness unchanged at 45/361 files writing an entry,
0 divergences. `zig fmt --check` and markdownlint clean.

Closes #2156.
Closes #2114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)