### PR TITLE
Point CONTRIBUTING.md at kaappi/community for get-involved content

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,25 +7,10 @@ the essentials: how to get involved, building, testing, and submitting changes.
 
 ## How to get involved
 
-**[GitHub Discussions](https://github.com/orgs/kaappi/discussions)** is the
-front door for new contributors. Start there to ask questions, propose ideas,
-report bugs, or introduce yourself.
-
-Issues and pull requests are restricted to members of the
-[kaappi GitHub org](https://github.com/kaappi). This keeps the signal-to-noise
-ratio high while the project grows. If you'd like to contribute code or file
-issues directly, ask for an invite in
-[Discussions](https://github.com/orgs/kaappi/discussions) — we're happy to
-add anyone who's genuinely interested.
-
-### Typical path for a new contributor
-
-1. **Explore** — try Kaappi, read the docs, poke around the source.
-2. **Join the conversation** — post in Discussions (questions, bug reports,
-   ideas — all welcome).
-3. **Get org access** — mention that you'd like to contribute and we'll send
-   an invite.
-4. **Submit a PR** — fork, branch, test, open a pull request.
+See [kaappi/community's CONTRIBUTING.md](https://github.com/kaappi/community/blob/main/CONTRIBUTING.md)
+for how to join the conversation, request org access, and the typical path
+for a new contributor. The rest of this document covers this repo's
+build/test/PR workflow specifically.
 
 ---
 


### PR DESCRIPTION
## Summary
- The "How to get involved" section here duplicated kaappi/community's new CONTRIBUTING.md (and kaappi.github.io/docs/community.md) almost verbatim.
- Replace it with a link to the canonical version so Discussions/org-access/contributor-path guidance has one place to update.
- The rest of this file (build/test/PR workflow, architecture docs) is unchanged.

## Test plan
- [x] `npx markdownlint-cli2 CONTRIBUTING.md` passes
- [x] No other page anchors into the removed section