### PR TITLE
Validate arity in the two call paths that build their frames by hand

### DIFF
--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -397,12 +397,27 @@ pub const FiberScheduler = struct {
 
     pub fn spawnFiber(self: *FiberScheduler, thunk: Value) !*Fiber {
         var thunk_val = thunk;
+
+        // Both checks precede allocFiber: a rejected thunk used to leave a
+        // fiber (and an id) already allocated behind it.
+        if (!types.isProcedure(thunk_val)) return VMError.NotAProcedure;
+        // A fiber thunk is called with no arguments, and the first frame is
+        // built by hand below — so the arity check the `call` opcode performs
+        // has to happen here. Without it a non-thunk ran anyway, with its
+        // parameters reading the hand-staged register file (#1999).
+        if (!types.acceptsArgCount(thunk_val, 0)) {
+            if (types.procedureName(thunk_val)) |name| {
+                self.vm.setErrorDetail("spawn: fiber thunk '{s}' does not accept zero arguments", .{name});
+            } else {
+                self.vm.setErrorDetail("spawn: fiber thunk does not accept zero arguments", .{});
+            }
+            return VMError.ArityMismatch;
+        }
+
         self.vm.gc.pushRoot(&thunk_val);
         const fiber = try self.vm.gc.allocFiber(thunk_val, self.next_id);
         self.vm.gc.popRoot();
         self.next_id += 1;
-
-        if (!types.isProcedure(thunk_val)) return VMError.NotAProcedure;
 
         var closure: *types.Closure = undefined;
         if (types.isClosure(thunk_val)) {
@@ -418,7 +433,20 @@ pub const FiberScheduler = struct {
         }
 
         @memset(fiber.registers, types.UNDEFINED);
-        fiber.registers[0] = types.makePointer(&closure.header);
+        // r0 is the callee's *first local*, not a callee slot: `base = 0`
+        // below, and a re-entrant frame's base is where argument zero goes
+        // (unlike callClosure, where the callee sits at base and arguments
+        // start at base + 1). Writing the closure here therefore bound it to
+        // the thunk's first parameter, so `(spawn (lambda (x) ...))` saw its
+        // own thunk as x (#1999) — and nothing needed it there: the closure is
+        // kept alive by frames[0].closure and fiber.thunk, both of which the
+        // GC traces (gc_collect.zig, markFiberState).
+        //
+        // A pure-variadic thunk is legal and takes the rest list in r0; the
+        // arity check above has already refused every other shape, so this is
+        // the whole of the binding an ordinary call would do for zero
+        // arguments.
+        if (closure.func.is_variadic) fiber.registers[0] = types.NIL;
         fiber.frames[0] = .{
             .closure = closure,
             .code = closure.func.code.items,

--- a/src/primitives_control.zig
+++ b/src/primitives_control.zig
@@ -187,6 +187,16 @@ fn withExceptionHandlerFn(args: []const Value) PrimitiveError!Value {
 
     if (!types.isProcedure(handler)) return primitives.typeError("with-exception-handler", "procedure", args[0]);
     if (!types.isProcedure(thunk)) return primitives.typeError("with-exception-handler", "procedure", args[1]);
+    // R7RS 6.11: "It is an error if thunk does not accept zero arguments."
+    // Checked here rather than left to callThunk's own check because the
+    // handler is installed below: a thunk of the wrong arity would raise
+    // *inside* this handler's extent, and the handler would then be handed
+    // the report of its own caller's malformed call (#2034). The handler's
+    // "does not accept one argument" is deliberately left to callHandler,
+    // where the call actually happens — a handler that is never invoked has
+    // nothing to report about.
+    if (!types.acceptsArgCount(thunk, 0))
+        return primitives.argError("with-exception-handler", "thunk does not accept zero arguments", .{});
 
     // Push the handler onto the handler stack. A failure here is the handler
     // stack hitting MAX_HANDLER_LIMIT — propagate it as the StackOverflow it
@@ -266,6 +276,9 @@ fn callWithUnwindHandlerFn(args: []const Value) PrimitiveError!Value {
 
     if (!types.isProcedure(handler)) return primitives.typeError("%call-with-unwind-handler", "procedure", args[0]);
     if (!types.isProcedure(thunk)) return primitives.typeError("%call-with-unwind-handler", "procedure", args[1]);
+    // Before the handler goes on the stack — see withExceptionHandlerFn (#2034).
+    if (!types.acceptsArgCount(thunk, 0))
+        return primitives.argError("%call-with-unwind-handler", "thunk does not accept zero arguments", .{});
 
     try vm.pushHandlerSticky(handler);
 

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -40,7 +40,14 @@ fn spawnFn(args: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const ctx = try fiber_mod.ensureScheduler(vm);
 
-    const fiber = ctx.sched.spawnFiber(proc) catch return PrimitiveError.OutOfMemory;
+    // A wrong-arity thunk is refused by spawnFiber with its own detail
+    // message (#1999); pass that through rather than relabelling every
+    // failure OutOfMemory, which would report a memory problem for what is
+    // an argument problem.
+    const fiber = ctx.sched.spawnFiber(proc) catch |err| return switch (err) {
+        error.ArityMismatch => PrimitiveError.ArityMismatch,
+        else => PrimitiveError.OutOfMemory,
+    };
     return types.makePointer(&fiber.header);
 }
 

--- a/src/tests_exceptions.zig
+++ b/src/tests_exceptions.zig
@@ -447,3 +447,93 @@ test "isUncatchable covers limits and signals but not program faults" {
     // Overloaded: also the payload-size cap. See isUncatchable's doc comment.
     try std.testing.expect(!errors.isUncatchable(error.OutOfMemory));
 }
+
+// #2034: callHandler and callThunk built their callee's frame by hand and
+// jumped straight into it, skipping the arity check callClosure performs for
+// the `call` opcode. A wrong-arity handler, thunk, producer or receiver
+// therefore ran anyway, and its surplus parameters read whatever the register
+// file happened to hold. Both are now bound through the one validating helper
+// (vm_calls.bindReentrantArgs), so every entry point below reports arity.
+test "a wrong-arity exception handler is rejected (#2034)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    try std.testing.expectError(VMError.ArityMismatch, vm.eval(
+        \\(with-exception-handler (lambda (a b) (list a b))
+        \\  (lambda () (raise-continuable 'x)))
+    ));
+    try std.testing.expectError(VMError.ArityMismatch, vm.eval(
+        \\(with-exception-handler (lambda () 'h) (lambda () (raise-continuable 'x)))
+    ));
+}
+
+test "a surplus handler parameter never reads a neighbouring register (#2034)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The sharpest form of the bug: the 3-argument handler's third parameter
+    // came back as the `list` procedure itself -- a live value out of the
+    // enclosing frame, not merely an undefined slot -- because the hand-built
+    // frame also never cleared the registers past the argument it staged.
+    try std.testing.expectError(VMError.ArityMismatch, vm.eval(
+        \\(with-exception-handler (lambda (a b c) (list a b c))
+        \\  (lambda () (raise-continuable 'x)))
+    ));
+}
+
+test "a wrong-arity with-exception-handler thunk is rejected before the handler is installed (#2034)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The report must escape rather than being delivered to the very handler
+    // whose caller is malformed: with the check inside callThunk the handler
+    // caught its own thunk's arity error and the form quietly returned 'h.
+    try std.testing.expectError(VMError.InvalidArgument, vm.eval(
+        \\(with-exception-handler (lambda (e) 'h) (lambda (x) x))
+    ));
+}
+
+test "a wrong-arity call-with-values producer and call/cc receiver are rejected (#2034)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The producer went through callThunk while the consumer went through
+    // callWithArgs, so one half of one call was checked and the other was not.
+    try std.testing.expectError(VMError.ArityMismatch, vm.eval("(call-with-values (lambda (x) 1) list)"));
+    // Non-tail position: the tail-position superinstruction has always had its
+    // own check, so only this half was ever wrong.
+    try std.testing.expectError(VMError.ArityMismatch, vm.eval("(list (call/cc (lambda (a b) 1)))"));
+    try std.testing.expectError(VMError.ArityMismatch, vm.eval("(call/ec (lambda (a b) 1))"));
+}
+
+test "variadic handlers and thunks still bind correctly (#2034)" {
+    // A variadic callee is legal at these arities and must keep working: the
+    // rest list is built from the caller's own argument before any register is
+    // written, so these exercise the new binder's other branch.
+    try th.expectEvalTrue("(equal? '(x) (with-exception-handler (lambda args args) (lambda () (raise-continuable 'x))))");
+    try th.expectEvalTrue("(equal? '(x ()) (with-exception-handler (lambda (a . r) (list a r)) (lambda () (raise-continuable 'x))))");
+    try th.expectEvalTrue("(equal? '(0) (call-with-values (lambda args (length args)) list))");
+}
+
+test "a variadic callee needing more than one argument is still rejected (#2034)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // `is_variadic` alone did not make the old code correct: it staged the
+    // single argument and ran the body regardless of how many the callee
+    // required, so `b` and `r` read leftover registers.
+    try std.testing.expectError(VMError.ArityMismatch, vm.eval(
+        \\(with-exception-handler (lambda (a b . r) (list a b r))
+        \\  (lambda () (raise-continuable 'x)))
+    ));
+}

--- a/src/tests_fibers.zig
+++ b/src/tests_fibers.zig
@@ -575,3 +575,58 @@ test "thread-sleep! with an unbounded duration parks without aborting (#1983)" {
     const got = try vm.eval("progress");
     try std.testing.expectEqual(@as(i64, 2), types.toFixnum(got));
 }
+
+// #1999: spawnFiber builds the fiber's first call frame by hand and performed
+// neither the arity check nor the rest-list construction an ordinary call
+// does. `registers[0]` held the thunk closure itself while `base = 0` made r0
+// the callee's first parameter, so a one-argument procedure ran with its own
+// thunk bound to that parameter and any further parameter reading the
+// UNDEFINED register fill.
+test "spawn rejects a procedure that is not a thunk (#1999)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    try std.testing.expectError(vm_mod.VMError.ArityMismatch, vm.eval("(spawn (lambda (x) 'body-ran))"));
+    try std.testing.expectError(vm_mod.VMError.ArityMismatch, vm.eval("(spawn (lambda (a b c) (list a b c)))"));
+    // A required parameter plus a rest parameter is not a thunk either: the
+    // rest list would be empty, but `a` has nothing to bind to. This shape
+    // used to bind UNDEFINED to both, making (list? r) and (null? r) BOTH #f
+    // in violation of R7RS 4.1.4's "newly allocated list".
+    try std.testing.expectError(vm_mod.VMError.ArityMismatch, vm.eval("(spawn (lambda (a . r) (list a r)))"));
+    // A native procedure of arity >= 1 used to reach the fiber and fail there
+    // with the contentless "fiber error (no exception value)".
+    try std.testing.expectError(vm_mod.VMError.ArityMismatch, vm.eval("(spawn car)"));
+}
+
+test "spawn runs a pure-variadic thunk with an empty rest list (#1999)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The most natural way to write "ignore my arguments" failed outright
+    // before the fix, because r0 held the thunk closure rather than the '()
+    // an ordinary zero-argument call would have built.
+    const result = try vm.eval("(fiber-join (spawn (lambda args (length args))))");
+    try std.testing.expectEqual(@as(i64, 0), types.toFixnum(result));
+
+    const shape = try vm.eval("(fiber-join (spawn (lambda args (list (list? args) (null? args)))))");
+    try std.testing.expect(types.isPair(shape));
+    try std.testing.expectEqual(types.TRUE, types.toObject(shape).as(types.Pair).car);
+}
+
+test "a rejected spawn allocates no fiber and leaves the scheduler usable (#1999)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The checks now precede allocFiber, which used to run first -- a refused
+    // thunk left a fiber and a consumed id behind it.
+    _ = try vm.eval("(define before (spawn (lambda () 'first)))");
+    try std.testing.expectError(vm_mod.VMError.ArityMismatch, vm.eval("(spawn (lambda (x) x))"));
+    const result = try vm.eval("(list (fiber-join before) (fiber-join (spawn (lambda () 'after))))");
+    try std.testing.expect(types.isPair(result));
+}

--- a/src/types.zig
+++ b/src/types.zig
@@ -654,6 +654,47 @@ pub fn isProcedure(v: Value) bool {
     return isClosure(v) or isNativeFn(v) or isNativeClosure(v) or isContinuation(v) or isParameter(v) or isFfiFunction(v) or isGuardian(v);
 }
 
+/// Answer whether `v` — assumed to satisfy `isProcedure` — can be called with
+/// `nargs` arguments, without building a frame or observing anything.
+///
+/// For the call sites that must refuse a wrong-arity procedure *before* doing
+/// something they cannot take back: installing the very exception handler that
+/// would otherwise intercept the failure (#2034), or allocating a fiber
+/// (#1999). The ordinary call path reports arity from the frame it is about to
+/// build; these cannot wait that long.
+///
+/// Only closures, native procedures and FFI functions declare an arity. A
+/// continuation accepts any number of arguments, and a parameter object or a
+/// guardian accepts a small range including zero, so those answer true and are
+/// left to the call itself to check.
+pub fn acceptsArgCount(v: Value, nargs: usize) bool {
+    if (isClosure(v)) {
+        const func = toObject(v).as(Closure).func;
+        return if (func.is_variadic) nargs >= func.arity else nargs == func.arity;
+    }
+    if (isNativeFn(v)) {
+        return switch (toObject(v).as(NativeFn).arity) {
+            .exact => |n| nargs == n,
+            .variadic => |min| nargs >= min,
+        };
+    }
+    if (isNativeClosure(v)) return nargs == toObject(v).as(NativeClosure).arity;
+    if (isFfiFunction(v)) return nargs == toObject(v).as(FfiFunction).param_count;
+    return true;
+}
+
+/// The name `v` was defined under, when it has one — for naming the offending
+/// procedure in a diagnostic without allocating or printing it. An anonymous
+/// `lambda`, and every procedure kind that carries no name at all, answers
+/// null; a caller phrases its message so that reads naturally.
+pub fn procedureName(v: Value) ?[]const u8 {
+    if (isClosure(v)) return toObject(v).as(Closure).func.name;
+    if (isNativeFn(v)) return toObject(v).as(NativeFn).name;
+    if (isNativeClosure(v)) return toObject(v).as(NativeClosure).name;
+    if (isFfiFunction(v)) return toObject(v).as(FfiFunction).name;
+    return null;
+}
+
 pub fn isContinuation(v: Value) bool {
     return isPointer(v) and toObject(v).tag == .continuation;
 }

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -683,7 +683,53 @@ fn computeReentrantBase(vm: *VM) u32 {
     return 0;
 }
 
-fn callReentrant(vm: *VM, closure: *types.Closure, base: u32, dst: u8, returns_to_native: bool) VMError!Value {
+/// Bind `args` into the parameter registers of a hand-built frame at `base`,
+/// validating arity exactly as `callClosure` does for the `call` opcode and
+/// folding surplus arguments into a variadic callee's rest list.
+///
+/// This lives on the `callReentrant` path rather than in each of its callers
+/// because a caller that stages its own arguments is a caller that can forget
+/// the check — and two of the three did. `callHandler` and `callThunk` wrote
+/// their argument straight into the register file and jumped to
+/// `callReentrant`, so a wrong-arity exception handler, `with-exception-handler`
+/// thunk, `call-with-values` producer or non-tail `call/cc` receiver ran
+/// anyway, with its surplus parameters reading whatever the register file
+/// happened to hold — including live values from a neighbouring frame (#2034).
+fn bindReentrantArgs(vm: *VM, func: *types.Function, base: u32, args: []const Value) VMError!void {
+    if (!func.is_variadic) {
+        if (args.len != func.arity) {
+            if (func.name) |name| {
+                vm.setErrorDetail("'{s}': expected {d} arguments, got {d}", .{ name, func.arity, args.len });
+            } else {
+                vm.setErrorDetail("expected {d} arguments, got {d}", .{ func.arity, args.len });
+            }
+            return VMError.ArityMismatch;
+        }
+        for (args, 0..) |a, i| vm.registers[base + i] = a;
+        return;
+    }
+
+    if (args.len < func.arity) {
+        if (func.name) |name| {
+            vm.setErrorDetail("'{s}': expected at least {d} arguments, got {d}", .{ name, func.arity, args.len });
+        } else {
+            vm.setErrorDetail("expected at least {d} arguments, got {d}", .{ func.arity, args.len });
+        }
+        return VMError.ArityMismatch;
+    }
+
+    // Build the rest list from the caller's own `args` before writing any
+    // register: `base` sits past the topmost frame's marking window, so a
+    // value staged there is not yet a GC root (markVMRoots walks
+    // [f.base, f.base + frameWindow) per live frame). Nothing allocates
+    // between the build and the stores below, so `rest` needs no root.
+    const vm_dispatch = @import("vm_dispatch.zig");
+    const rest = try vm_dispatch.buildRestList(vm.gc, args[func.arity..]);
+    for (args[0..func.arity], 0..) |a, i| vm.registers[base + i] = a;
+    vm.registers[base + func.arity] = rest;
+}
+
+fn callReentrant(vm: *VM, closure: *types.Closure, base: u32, args: []const Value, dst: u8, returns_to_native: bool) VMError!Value {
     const max_native_depth: u16 = if (@import("builtin").mode == .Debug) 200 else 3000;
     if (vm.native_reentry_depth >= max_native_depth or
         vm.gc.root_count > memory.GC.MAX_ROOT_CAPACITY - 32)
@@ -695,6 +741,14 @@ fn callReentrant(vm: *VM, closure: *types.Closure, base: u32, dst: u8, returns_t
 
     const func = closure.func;
     const used: usize = if (func.is_variadic) @as(usize, func.arity) + 1 else @as(usize, func.arity);
+    // Room for the callee's locals *and* for every slot bindReentrantArgs is
+    // about to write. The compiler counts a variadic rest parameter among the
+    // locals, so `used` is normally the smaller of the two — but a register
+    // write past the end of the file is memory unsafety, so derive the bound
+    // from what is actually written rather than trusting that.
+    try vm.ensureRegisterCapacity(@as(usize, base) + @max(@as(usize, func.locals_count), used) + 1);
+    try bindReentrantArgs(vm, func, base, args);
+
     clearFrameLocals(vm, base, used, func.locals_count);
 
     vm.native_reentry_depth += 1;
@@ -758,21 +812,7 @@ pub fn callHandler(vm: *VM, handler_val: Value, arg: Value, return_dst: u8) VMEr
     }
     if (types.isClosure(handler_val)) {
         const closure = types.toObject(handler_val).as(types.Closure);
-        const func = closure.func;
-
-        const base = computeReentrantBase(vm);
-        try vm.ensureRegisterCapacity(@as(usize, base) + @as(usize, func.locals_count) + 1);
-
-        if (func.is_variadic and func.arity == 0) {
-            vm.registers[base] = vm.gc.allocPair(arg, types.NIL) catch return VMError.OutOfMemory;
-        } else if (func.is_variadic and func.arity == 1) {
-            vm.registers[base] = arg;
-            vm.registers[base + 1] = types.NIL;
-        } else {
-            vm.registers[base] = arg;
-        }
-
-        return callReentrant(vm, closure, base, return_dst, false);
+        return callReentrant(vm, closure, computeReentrantBase(vm), &[_]Value{arg}, return_dst, false);
     } else if (types.isNativeFn(handler_val)) {
         const native = types.toObject(handler_val).as(types.NativeFn);
         const args = [1]Value{arg};
@@ -794,16 +834,7 @@ pub fn callHandler(vm: *VM, handler_val: Value, arg: Value, return_dst: u8) VMEr
 pub fn callThunk(vm: *VM, thunk_val: Value) VMError!Value {
     if (types.isClosure(thunk_val)) {
         const closure = types.toObject(thunk_val).as(types.Closure);
-        const func = closure.func;
-
-        const base = computeReentrantBase(vm);
-        try vm.ensureRegisterCapacity(@as(usize, base) + @as(usize, func.locals_count) + 1);
-
-        if (func.is_variadic and func.arity == 0) {
-            vm.registers[base] = types.NIL;
-        }
-
-        return callReentrant(vm, closure, base, 0, false);
+        return callReentrant(vm, closure, computeReentrantBase(vm), &.{}, 0, false);
     } else if (types.isNativeFn(thunk_val)) {
         const native = types.toObject(thunk_val).as(types.NativeFn);
         const empty_args: []const Value = &.{};
@@ -861,33 +892,13 @@ pub fn callWithArgs(vm: *VM, proc: Value, args: []const Value) VMError!Value {
     }
     if (types.isClosure(proc)) {
         const closure = types.toObject(proc).as(types.Closure);
-        const func = closure.func;
-
-        const base = computeReentrantBase(vm);
-        try vm.ensureRegisterCapacity(@as(usize, base) + @as(usize, func.locals_count) + 1);
-
-        if (args.len > std.math.maxInt(u8)) return VMError.ArityMismatch;
-        const nargs: u8 = @intCast(args.len);
-        if (!func.is_variadic) {
-            if (nargs != func.arity) return VMError.ArityMismatch;
-        } else {
-            if (nargs < func.arity) return VMError.ArityMismatch;
-            const rest_start = func.arity;
-            const vm_dispatch = @import("vm_dispatch.zig");
-            const rest_list = try vm_dispatch.buildRestList(vm.gc, args[rest_start..nargs]);
-            for (0..rest_start) |ri| {
-                vm.registers[base + ri] = args[ri];
-            }
-            vm.registers[base + rest_start] = rest_list;
+        // 255 arguments is the ISA's maximum, so a longer call cannot be
+        // expressed as a frame at all; arity itself is bindReentrantArgs's.
+        if (args.len > std.math.maxInt(u8)) {
+            vm.setErrorDetail("too many arguments: {d} (maximum {d})", .{ args.len, std.math.maxInt(u8) });
+            return VMError.ArityMismatch;
         }
-
-        if (!func.is_variadic) {
-            for (args, 0..) |a, i| {
-                vm.registers[base + i] = a;
-            }
-        }
-
-        return callReentrant(vm, closure, base, 0, true);
+        return callReentrant(vm, closure, computeReentrantBase(vm), args, 0, true);
     } else if (types.isNativeClosure(proc)) {
         const nc = types.toObject(proc).as(types.NativeClosure);
         return callNativeClosure(vm, nc, args);

--- a/tests/scheme/audit/primitives_control-audit.scm
+++ b/tests/scheme/audit/primitives_control-audit.scm
@@ -782,32 +782,45 @@
 ;;; ------------------------------------------------------------------
 ;;;
 ;;; The ordinary call path (callClosure / callWithArgs) validates arity; the
-;;; native re-entrancy helpers callHandler / callThunk do not, so a
-;;; wrong-arity handler, receiver or thunk runs anyway with its surplus
+;;; native re-entrancy helpers callHandler / callThunk did not, so a
+;;; wrong-arity handler, receiver or thunk ran anyway with its surplus
 ;;; parameters bound to whatever the register file happened to hold.
 ;;; dynamic-wind's three thunks — invoked from bootstrapped Scheme through the
 ;;; ordinary path — are the discriminating control, and are asserted above.
+;;; Fixed in #2034: every hand-built re-entrant frame now binds its arguments
+;;; through one validating helper (vm_calls.bindReentrantArgs), and the two
+;;; handler-installing primitives check their thunk *before* the handler goes
+;;; on the stack, so the failure is not delivered to the handler it describes.
 
-;; FAIL: #2034 (callHandler/callThunk skip the arity check)
-;; (test-assert "arity: a 2-argument exception handler is rejected"
-;;              (raises? (with-exception-handler (lambda (a b) 'h)
-;;                         (lambda () (raise-continuable 'x)))))
-;; (test-assert "arity: a 0-argument exception handler is rejected"
-;;              (raises? (with-exception-handler (lambda () 'h)
-;;                         (lambda () (raise-continuable 'x)))))
-;; (test-assert "arity: a 3-argument exception handler is rejected"
-;;              (raises? (with-exception-handler (lambda (a b c) (list a b c))
-;;                         (lambda () (raise-continuable 'x)))))
-;; (test-assert "arity: a 1-argument with-exception-handler thunk is rejected"
-;;              (raises? (with-exception-handler (lambda (e) 'h) (lambda (x) x))))
-;; (test-assert "arity: a 1-argument call-with-values producer is rejected"
-;;              (raises? (call-with-values (lambda (x) 1) list)))
-;; (test-assert "arity: a 2-argument call/cc receiver is rejected in non-tail position"
-;;              (raises? (list (call/cc (lambda (a b) 1)))))
-;; (test-assert "arity: a 2-argument call/ec receiver is rejected"
-;;              (raises? (call/ec (lambda (a b) 1))))
-;; (test-assert "arity: a 2-argument SRFI 248 unwind-handler thunk is rejected"
-;;              (raises? (%call-with-unwind-handler (lambda (o) 'h) (lambda (x) x))))
+(test-assert "arity: a 2-argument exception handler is rejected"
+             (raises? (with-exception-handler (lambda (a b) 'h)
+                        (lambda () (raise-continuable 'x)))))
+(test-assert "arity: a 0-argument exception handler is rejected"
+             (raises? (with-exception-handler (lambda () 'h)
+                        (lambda () (raise-continuable 'x)))))
+(test-assert "arity: a 3-argument exception handler is rejected"
+             (raises? (with-exception-handler (lambda (a b c) (list a b c))
+                        (lambda () (raise-continuable 'x)))))
+(test-assert "arity: a 1-argument with-exception-handler thunk is rejected"
+             (raises? (with-exception-handler (lambda (e) 'h) (lambda (x) x))))
+(test-assert "arity: a 1-argument call-with-values producer is rejected"
+             (raises? (call-with-values (lambda (x) 1) list)))
+(test-assert "arity: a 2-argument call/cc receiver is rejected in non-tail position"
+             (raises? (list (call/cc (lambda (a b) 1)))))
+(test-assert "arity: a 2-argument call/ec receiver is rejected"
+             (raises? (call/ec (lambda (a b) 1))))
+(test-assert "arity: a 2-argument SRFI 248 unwind-handler thunk is rejected"
+             (raises? (%call-with-unwind-handler (lambda (o) 'h) (lambda (x) x))))
+;; The same defect in the shape that made it worst: with a live procedure in a
+;; neighbouring register, the 3-argument handler's third parameter came back as
+;; `#<builtin list>` — the caller's own register, deterministically, not merely
+;; an undefined slot — because the hand-built frame never cleared past the one
+;; argument it staged.  Rejecting the call is what removes the leak, so this
+;; pins the leak's exact register layout rather than a second mechanism.
+(test-assert "arity: a rejected handler cannot surface a caller's register"
+             (raises? (list list (with-exception-handler
+                                     (lambda (a b c) (list a b c))
+                                   (lambda () (raise-continuable 'x))))))
 
 ;; A variadic handler is legal at any arity and must keep working.
 (test-equal "arity: a variadic exception handler receives exactly one argument"

--- a/tests/scheme/audit/primitives_fiber-audit.scm
+++ b/tests/scheme/audit/primitives_fiber-audit.scm
@@ -276,10 +276,13 @@
 
 ;;; --- spawn thunk arity (#1999) ---
 ;; spawnFiber (src/fiber.zig) builds the fiber's first call frame by hand and
-;; never performs the arity check or the rest-list construction an ordinary
-;; call does, so a non-thunk runs anyway with its parameters bound to
-;; internal values. Controls: the same procedure called directly with zero
-;; arguments raises, and SRFI-18's make-thread rejects the same mismatch.
+;; performed neither the arity check nor the rest-list construction an ordinary
+;; call does, so a non-thunk ran anyway with its parameters bound to internal
+;; values — the thunk closure itself in r0, `#<undefined>` beyond it. Controls:
+;; the same procedure called directly with zero arguments raises, and SRFI-18's
+;; make-thread rejects the same mismatch. Fixed in #1999: the arity is checked
+;; before the fiber is even allocated, and r0 is left to the variadic rest list
+;; (or cleared) rather than holding the callee.
 (test-assert "CONTROL: calling a 1-argument procedure with no arguments raises"
     (raises? (lambda () ((lambda (x) 'body-ran)))))
 (test-assert "CONTROL: make-thread with a 1-argument thunk fails the thread"
@@ -290,18 +293,29 @@
     '() ((lambda args args)))
 (test-equal "CONTROL: make-thread runs a pure-variadic thunk correctly"
     0 (let ((t (make-thread (lambda args (length args))))) (thread-start! t) (thread-join! t)))
-;; FAIL: #1999 (spawn runs a 1-argument procedure instead of raising an arity error)
-;; (test-assert "spawn rejects a procedure that is not a thunk"
-;;     (raises? (lambda () (fiber-join (spawn (lambda (x) 'body-ran))))))
-;; FAIL: #1999 (a spawned lambda's rest parameter is #<undefined>, not a list)
-;; (test-equal "a spawned procedure's rest parameter is a list"
-;;     '(#t #t) (fiber-join (spawn (lambda (a . rest) (list (list? rest) (null? rest))))))
-;; FAIL: #1999 (a pure-variadic spawn thunk errors with "fiber error (no exception value)")
-;; (test-equal "spawn runs a pure-variadic thunk with no arguments"
-;;     0 (fiber-join (spawn (lambda args (length args)))))
-;; FAIL: #1999 (a native procedure of arity >= 1 errors with no exception value)
-;; (test-assert "spawn of a native procedure needing arguments raises a described error"
-;;     (msg-has? (lambda () (fiber-join (spawn car))) "car"))
+(test-assert "spawn rejects a procedure that is not a thunk"
+    (raises? (lambda () (fiber-join (spawn (lambda (x) 'body-ran))))))
+;; A required parameter plus a rest parameter is still not a thunk: the rest
+;; list is empty, but `a` has nothing to bind to.  It used to bind
+;; `#<undefined>` to both, so `(list? rest)` and `(null? rest)` were BOTH #f.
+(test-assert "spawn rejects a procedure with a required parameter and a rest parameter"
+    (raises? (lambda () (fiber-join (spawn (lambda (a . rest) (list (list? rest) (null? rest))))))))
+(test-equal "spawn runs a pure-variadic thunk with no arguments"
+    0 (fiber-join (spawn (lambda args (length args)))))
+(test-assert "spawn of a native procedure needing arguments raises a described error"
+    (msg-has? (lambda () (fiber-join (spawn car))) "car"))
+;; A pure-variadic thunk is the one legal shape that still binds a parameter,
+;; so it is also the probe for what r0 holds.  R7RS 4.1.4 wants "a newly
+;; allocated list"; r0 used to hold the fiber's own thunk closure, live and
+;; callable, which made every one of these three answers wrong at once.
+(test-equal "a spawned pure-variadic thunk's rest parameter is the empty list"
+    '(#t #t #f)
+    (fiber-join (spawn (lambda args (list (list? args) (null? args) (procedure? args))))))
+;; spawn rejects before allocating: a refused thunk must not consume a fiber,
+;; and the scheduler must still be usable afterwards.
+(test-equal "a rejected spawn leaves the scheduler working"
+    'ok (begin (guard (e (#t #f)) (spawn (lambda (x) x)))
+               (fiber-join (spawn (lambda () 'ok)))))
 
 ;;; --- errors inside fibers ---
 ;; join re-raises the fiber's exception, with the error object intact


### PR DESCRIPTION
`callClosure` checks arity for the `call` opcode. Three other places construct a
frame themselves and inherited none of that: `callHandler`, `callThunk`
(`vm_calls.zig`) and `FiberScheduler.spawnFiber` (`fiber.zig`). Two of them
skipped the check entirely.

`docs/audit-strategy.md` had already triaged these as "same bug *class*, no
shared code … Two patches, one narrative" — hence one PR.

## What was wrong

A wrong-arity procedure ran anyway, with its surplus parameters reading whatever
the register file held. Not merely an undefined slot: the hand-built frames also
never cleared past the argument they staged, so a live value from a neighbouring
frame surfaced in user Scheme.

```scheme
(write (with-exception-handler (lambda (a b c) (list a b c))
         (lambda () (raise-continuable 'x))))
;; before: (x #<undefined> #<builtin list>)   <- the caller's own `list`
;; after:  error: expected 3 arguments, got 1

(write (fiber-join (spawn (lambda (a . r) (list (list? r) (null? r))))))
;; before: (#f #f)   <- r was #<undefined>, so neither predicate held
;; after:  error: spawn: fiber thunk does not accept zero arguments
```

## The fix

Rather than add the same check in each caller — which is how it went missing —
every re-entrant frame now binds its arguments through **one** helper on the
`callReentrant` path, `bindReentrantArgs`, which validates arity and folds
surplus arguments into a variadic callee's rest list. `callHandler`, `callThunk`
and `callWithArgs` each collapse to a single call and cannot skip it. `callHandler`
loses 12 lines of bespoke variadic staging that only handled arity 0 and 1 and
silently mis-bound arity ≥ 2.

That covers the `with-exception-handler` handler, the `call-with-values`
producer, and the `call/cc` / `call/ec` receivers in non-tail position — the
tail-position superinstruction always had its own check, which is why the same
expression was diagnosed or not depending only on tail position.

**`with-exception-handler` and `%call-with-unwind-handler` additionally check
their thunk before installing the handler.** Left to `callThunk`, the thunk's
arity error is raised *inside* the extent of the handler being installed, so the
handler catches the report of its own caller's malformed call and the form
quietly returns the handler's value. Their *handler's* arity is deliberately
still checked at the call, since a handler that is never invoked has nothing to
report about.

`spawnFiber` had the same gap plus a second defect: with `base = 0`, r0 is the
thunk's **first parameter**, not a callee slot (unlike `callClosure`, where the
callee sits *at* base and arguments start at base + 1). Writing the closure
there bound a fiber's own thunk to its first parameter. r0 is now left to the
variadic rest list; the closure stays reachable through `frames[0].closure` and
`fiber.thunk`, both already GC-traced. Both checks moved ahead of `allocFiber`,
which used to run first, so a refused thunk no longer leaves a fiber and a
consumed id behind. `spawn` also stops relabelling every `spawnFiber` failure
`OutOfMemory`, which reported a memory problem for an argument problem and
discarded the diagnostic.

A pure-variadic thunk — the natural way to write "ignore my arguments" — now
works in both places instead of failing outright.

Two small shared helpers land in `types.zig` next to `isProcedure`:
`acceptsArgCount` (answer arity without building a frame, for the sites that
must refuse *before* doing something they cannot take back) and
`procedureName`.

## Tests

- **23 assertions enabled or added.** The 12 `;; FAIL:` assertions the two
  issues named (8 in `primitives_control-audit.scm`, 4 in
  `primitives_fiber-audit.scm`) are uncommented, plus 3 new audit assertions
  and 8 new Zig unit tests in `tests_exceptions.zig` / `tests_fibers.zig`.
- **Mutation-checked.** With the five source files reverted and the tests kept,
  all 8 new unit tests and all 15 audit assertions fail; with the fix they pass.
- `zig build test`, `zig build test -Dgc-stress=true`, and
  `bash tests/scheme/run-all.sh` (679 files + 1395 R7RS) all green.

One assertion pins the leak's exact register layout rather than a second
mechanism: with a live procedure in a neighbouring register, the 3-argument
handler must still be rejected instead of returning a list built from it.

## Noticed but out of scope

A VM-level fault inside a fiber body (`(car 5)`) still loses its diagnostic
entirely — `fiber-join` reports `"fiber error (no exception value)"` from
`reraiseFiberError`'s null-exception fallback, because the fiber run path never
converts a `VMError` into a condition. #1999 cited that message as one of its
symptoms; this fix removes that trigger, but the reporting hole is independent
and needs its own issue.

Closes #2034
Closes #1999

🤖 Generated with [Claude Code](https://claude.com/claude-code)