### PR TITLE
Check arity on the native branches of the re-entrancy helpers too

### DIFF
--- a/src/tests_exceptions.zig
+++ b/src/tests_exceptions.zig
@@ -537,3 +537,57 @@ test "a variadic callee needing more than one argument is still rejected (#2034)
         \\  (lambda () (raise-continuable 'x)))
     ));
 }
+
+// #2034, native half: the same two helpers reach a *native* procedure through
+// their own branches, which had no arity check at all. A NativeFn body indexes
+// args[0], args[1], ... without bounds checks of its own -- the VM is supposed
+// to have validated arity first -- so a wrong-arity native handler or thunk read
+// past the end of a fixed-size argument array. Under the default ReleaseSafe
+// build that is a panic: a process abort out of five lines of ordinary Scheme,
+// not a catchable error. All four native call sites now share checkNativeArity.
+test "a wrong-arity native call-with-values producer is rejected, not aborted (#2034)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // `cons` has exact arity 2 and callThunk called it with zero arguments.
+    try std.testing.expectError(VMError.ArityMismatch, vm.eval("(call-with-values cons list)"));
+}
+
+test "a wrong-arity native exception handler is rejected, not aborted (#2034)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // callHandler builds a 1-element argument array; `cons` read args[1].
+    try std.testing.expectError(VMError.ArityMismatch, vm.eval(
+        \\(with-exception-handler cons (lambda () (raise-continuable 'x)))
+    ));
+}
+
+test "a wrong-arity native dynamic-wind after-thunk does not abort the process (#2034)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // `-` is variadic with a minimum of 1 and the unwind ran it with zero
+    // arguments, reading args[0] of an empty slice. The unwind loop discards a
+    // failing after-thunk, so the correct outcome is the ORIGINAL raise
+    // surviving -- what must not happen is the process dying on the way out.
+    try std.testing.expectError(VMError.ExceptionRaised, vm.eval(
+        \\(dynamic-wind (lambda () 1) (lambda () (raise 'x)) -)
+    ));
+}
+
+test "legal native handlers and thunks still run (#2034)" {
+    // Arity-correct natives on the same branches: `car` as a 1-argument
+    // handler, and variadic/0-argument producers.
+    try th.expectEval("(with-exception-handler car (lambda () (raise-continuable '(9))))", 9);
+    try th.expectEvalTrue("(equal? '(1 2) (call-with-values (lambda () (values 1 2)) list))");
+    // The variadic native producer yields one value, the empty list, which the
+    // consumer then wraps -- so the answer is (()), not ().
+    try th.expectEvalTrue("(equal? '(()) (call-with-values list list))");
+}

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -616,14 +616,17 @@ pub fn callClosure(vm: *VM, closure: *types.Closure, base: u32, nargs: u8) VMErr
     }
 }
 
-pub fn callNative(vm: *VM, native: *types.NativeFn, base: u32, nargs: u8) VMError!void {
-    if (vm.profile_mode) {
-        native.profile_calls += 1;
-    }
-
-    if (@as(usize, base) + @as(usize, nargs) + 1 > vm.registers.len)
-        return VMError.StackOverflow;
-
+/// Validate `nargs` against a native procedure's declared arity.
+///
+/// A `NativeFn` body indexes `args[0]`, `args[1]`, … without bounds checks of
+/// its own, because the VM is expected to have validated arity before the call.
+/// Every site that hands one an argument slice therefore has to run this — and
+/// the two re-entrancy helpers did not, so a wrong-arity *native* handler or
+/// thunk read past the end of a fixed-size argument array. Under the default
+/// ReleaseSafe build that is a panic, i.e. a process abort out of ordinary
+/// Scheme (`(call-with-values cons list)` was enough), not the catchable
+/// ArityMismatch the closure path produces.
+fn checkNativeArity(vm: *VM, native: *types.NativeFn, nargs: usize) VMError!void {
     switch (native.arity) {
         .exact => |expected| {
             if (nargs != expected) {
@@ -638,6 +641,17 @@ pub fn callNative(vm: *VM, native: *types.NativeFn, base: u32, nargs: u8) VMErro
             }
         },
     }
+}
+
+pub fn callNative(vm: *VM, native: *types.NativeFn, base: u32, nargs: u8) VMError!void {
+    if (vm.profile_mode) {
+        native.profile_calls += 1;
+    }
+
+    if (@as(usize, base) + @as(usize, nargs) + 1 > vm.registers.len)
+        return VMError.StackOverflow;
+
+    try checkNativeArity(vm, native, nargs);
 
     const saved_alloc_target = vm.gc.profile_alloc_target;
     if (vm.profile_mode) {
@@ -815,6 +829,7 @@ pub fn callHandler(vm: *VM, handler_val: Value, arg: Value, return_dst: u8) VMEr
         return callReentrant(vm, closure, computeReentrantBase(vm), &[_]Value{arg}, return_dst, false);
     } else if (types.isNativeFn(handler_val)) {
         const native = types.toObject(handler_val).as(types.NativeFn);
+        try checkNativeArity(vm, native, 1);
         const args = [1]Value{arg};
         vm.last_error_detail_len = 0;
         vm.native_call_was_tail = false; // SRFI 248: re-entrant, not a tail call
@@ -837,6 +852,7 @@ pub fn callThunk(vm: *VM, thunk_val: Value) VMError!Value {
         return callReentrant(vm, closure, computeReentrantBase(vm), &.{}, 0, false);
     } else if (types.isNativeFn(thunk_val)) {
         const native = types.toObject(thunk_val).as(types.NativeFn);
+        try checkNativeArity(vm, native, 0);
         const empty_args: []const Value = &.{};
         vm.native_call_was_tail = false; // SRFI 248: re-entrant, not a tail call
         const result = native.func(empty_args) catch |err| {
@@ -904,20 +920,7 @@ pub fn callWithArgs(vm: *VM, proc: Value, args: []const Value) VMError!Value {
         return callNativeClosure(vm, nc, args);
     } else if (types.isNativeFn(proc)) {
         const native = types.toObject(proc).as(types.NativeFn);
-        switch (native.arity) {
-            .exact => |expected| {
-                if (args.len != expected) {
-                    vm.setErrorDetail("'{s}': expected {d} arguments, got {d}", .{ native.name, expected, args.len });
-                    return VMError.ArityMismatch;
-                }
-            },
-            .variadic => |min| {
-                if (args.len < min) {
-                    vm.setErrorDetail("'{s}': expected at least {d} arguments, got {d}", .{ native.name, min, args.len });
-                    return VMError.ArityMismatch;
-                }
-            },
-        }
+        try checkNativeArity(vm, native, args.len);
         vm.last_error_detail_len = 0;
         const result = native.func(args) catch |err| {
             return mapNativeError(vm, err, native.name, args);

--- a/tests/scheme/audit/primitives_control-audit.scm
+++ b/tests/scheme/audit/primitives_control-audit.scm
@@ -822,6 +822,29 @@
                                      (lambda (a b c) (list a b c))
                                    (lambda () (raise-continuable 'x))))))
 
+;; The same two helpers reach a *native* procedure through their own branches,
+;; which had no arity check at all.  A NativeFn body indexes args[0], args[1],
+;; ... trusting the VM to have validated arity, so these three read past the end
+;; of a fixed-size argument array and PANICKED under ReleaseSafe -- a process
+;; abort out of ordinary Scheme, which is why they could not be written as
+;; disabled assertions next to the closure cases.  All four native call sites
+;; now share vm_calls.checkNativeArity.
+(test-assert "arity: a native call-with-values producer of the wrong arity is rejected"
+             (raises? (call-with-values cons list)))
+(test-assert "arity: a native exception handler of the wrong arity is rejected"
+             (raises? (with-exception-handler cons (lambda () (raise-continuable 'x)))))
+;; A failing after-thunk is discarded by the unwind loop, so the correct outcome
+;; is the ORIGINAL condition arriving intact -- the point is that the process
+;; survives the trip.
+(test-equal "arity: a wrong-arity native dynamic-wind after-thunk keeps the original raise"
+            'x (guard (e (#t e))
+                 (dynamic-wind (lambda () 1) (lambda () (raise 'x)) -)))
+;; Arity-correct natives on those same branches must still run.
+(test-equal "arity: a legal native handler receives the condition"
+            9 (with-exception-handler car (lambda () (raise-continuable '(9)))))
+(test-equal "arity: a legal native producer is called with no arguments"
+            '(()) (call-with-values list list))
+
 ;; A variadic handler is legal at any arity and must keep working.
 (test-equal "arity: a variadic exception handler receives exactly one argument"
             '(x) (with-exception-handler (lambda args args)


### PR DESCRIPTION
Follow-up to #2203. That PR fixed the **closure** branches of `callHandler` and
`callThunk`; their **`NativeFn`** branches had no arity check at all, and that
one aborts the process rather than returning a wrong result.

Found by CodeRabbit in review of #2203 — after it had already auto-merged.

## The bug

A `NativeFn` body indexes `args[0]`, `args[1]`, … without bounds checks of its
own, because the VM is expected to have validated arity first. Both helpers hand
one a **fixed-size** argument array, so a native requiring more reads past its
end. Three one-liners of plain `(scheme base)`, each of which printed
`kaappi internal error — this is a bug in kaappi` and died:

```scheme
(call-with-values cons list)                                     ; callThunk: 0 args, cons needs 2
(with-exception-handler cons (lambda () (raise-continuable 'x)))  ; callHandler: 1 arg, cons needs 2
(dynamic-wind (lambda () 1) (lambda () (raise 'x)) -)             ; unwind: 0 args, - needs >= 1
```

The ordinary call path checks, the closure re-entrancy path checks (since
#2203), and only the native re-entrancy path did not.

## The fix

The check already existed **twice, verbatim** — in `callNative` and in
`callWithArgs`' own `NativeFn` branch. Rather than add a third and fourth copy
(the duplication #2203 was otherwise removing), it moves to `checkNativeArity`
and all four native call sites share it. Messages are unchanged, so no existing
diagnostic moves.

That is the same "one choke point instead of per-caller copies" shape #2203 used
for closures — and the reason these two were missed is precisely that the native
check was a copy rather than a choke point.

## Behaviour after the fix

| | before | after |
|---|---|---|
| `(call-with-values cons list)` | process abort | `'cons': expected 2 arguments, got 0` |
| `(with-exception-handler cons …)` | process abort | `'cons': expected 2 arguments, got 1` |
| `(dynamic-wind … (raise 'x) -)` | process abort | the original `x`, raised |

The `dynamic-wind` case is worth spelling out: the unwind loop deliberately
discards a failing after-thunk, so the correct outcome is the **original**
condition arriving intact. What changes is that the process gets there at all.

## Tests

- 4 new unit tests in `src/tests_exceptions.zig` (the three aborts, plus a
  legal-natives control) and 5 new assertions in
  `tests/scheme/audit/primitives_control-audit.scm`, beside #2034's own.
- These could not be added as disabled `;; FAIL:` assertions when #2034 was
  filed: pre-fix they **panic**, which takes the whole audit file down rather
  than failing one assertion. Their pre-fix behaviour is recorded in #2205
  instead, verified directly.
- `zig build test`, `zig build test -Dgc-stress=true`, and
  `bash tests/scheme/run-all.sh` (679 files + 1395 R7RS) all green on this
  branch.

## Note on scope

Pre-existing, not a regression from #2203 — that PR does not touch the native
branches (`git diff` over `src/vm_calls.zig` confirms it). It is inside #2034's
stated scope, whose table lists the `with-exception-handler` handler reached via
`callHandler` as unchecked; every case #2034 actually tested used a closure,
which is how the native half survived both the audit and the fix.

Closes #2205

🤖 Generated with [Claude Code](https://claude.com/claude-code)