### PR TITLE
Give the native backend's re-lowered bodies their lexical scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,31 @@ name that escapes the gate; a deliberately stricter runtime test in
 `tests_native.zig` fails if `derived_exclusions` gains an entry at all, so
 weakening the gate takes two edits, not one quiet line.
 
+A third thing the backend re-derives is **lexical scope**. It does not emit
+from the IR tree it was handed: every lambda/closure/`let` body is still a raw
+S-expression there and is re-lowered during emission through a scratch `ir.IR`
+that has no `Compiler` — so `IR.bound_names` and `IR.set_targets` stand in for
+`Compiler.isLexicallyBound` and the per-form `set!` pre-scan. Both feed two
+*different* decisions (`lowerFormWithMacros`'s special-form-vs-call dispatch
+and `isRedefined`'s fold gate), and until kaappi#2117/#2118 both were
+under-supplied: `bound_names` held only the immediate frame's parameter names
+and `set_targets` was never passed at all. A binding one level out was
+therefore invisible, so `(define (outer +) (lambda () (+ 5 2)))` printed 7,
+`(define (f) (set! + -) (+ 5 2))` printed 7, and `(define (f if) (if 1 2))`
+lowered `if` as the special form — each a plausible number the interpreter
+disagrees with. `LLVMEmitter.lexicalNames` now **derives** the name set from
+the same four maps `emitGlobalRef` resolves against rather than keeping a
+parallel list, and `LLVMEmitter.lowerScoped` is the one way to re-lower a
+sub-form (a bare `ir.lowerSingleExpr*` in `llvm_emit*.zig` drops both fields
+and reopens the bug). See `docs/dev/llvm-backend.md`.
+
+The lesson worth carrying: `tests/scheme/smoke/lambda-param-shadows-keyword-788.scm`
+and its two siblings were the regression tests for exactly these bugs and
+passed the whole time — no suite ran them through `kaappi compile`. A `.scm`
+regression test is interpreter-only evidence;
+`tests/scheme/compile/native-lexical-scope-fold-2117-2118.sh` now compiles
+those three files too.
+
 **Always use `zig cc` (not `clang`) for linking native binaries against
 `libkaappi_rt.a`.** The Zig-compiled static library references
 `__zig_probe_stack` and other Zig compiler-rt intrinsics that `clang`

--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -183,6 +183,55 @@ The emitter (`src/llvm_emit.zig`) walks IR nodes and produces LLVM IR text
 | `letrec`, `letrec*`, `guard`, quasiquote, named `let` | Serialize to source text, `call @kaappi_eval_cached(...)` (see [Cached eval fallback](#cached-eval-fallback)) |
 | `passthrough` | Serialize to source text, `call @kaappi_eval_cached(...)` |
 
+### Lexical scope in a re-lowered body (kaappi#2117, kaappi#2118)
+
+The backend does not emit from the IR tree it was handed. Every `lambda`,
+closure and `let` body is a raw S-expression at that point, **re-lowered**
+during emission through a scratch `ir.IR` — `LLVMEmitter.lowerScoped`, and the
+three `body_ir` instances in `llvm_emit_lambda.zig`. A scratch IR has no
+`Compiler`, and `IR` asks the `Compiler` two separate questions while lowering:
+
+- **is this name lexically bound?** (`lowerFormWithMacros`'s `is_shadowed`) —
+  decides whether `(if 1 2)` is the special form or a call to a binding named
+  `if`. R7RS has no reserved words (§4.3.1).
+- **may this name's value change?** (`isRedefined`) — gates constant folding,
+  from both a shadowing binding and a `set!` elsewhere in the form.
+
+Two `IR` fields stand in for the Compiler on this path, and **both must be
+supplied at every lowering site** or the tiers silently disagree:
+
+| Field | Native source | What it replaces |
+|-------|---------------|------------------|
+| `bound_names` | `LLVMEmitter.lexicalNames(extra)` | `Compiler.isLexicallyBound` |
+| `set_targets` | `LLVMEmitter.set_targets`, from `native_compiler.zig` | `Compiler.compile`'s per-form `set!` pre-scan |
+
+`lexicalNames` is **derived**, not maintained: it reads the same
+`locals`/`boxes`/`rest_param_name`/`params`/`upvalues` maps `emitGlobalRef`
+resolves against, in that order, plus an `extra` list for a frame whose scope
+is not installed yet (a lambda body is lowered before `emitLambdaFunction`
+swaps `params` in). A hand-kept parallel list is exactly what drifted: the
+backend passed only the immediate frame's parameter names, so a binding one
+level out was invisible to *both* questions, and `set_targets` was never
+passed at all. `(define (outer +) (lambda () (+ 5 2)))` folded to 7,
+`(define (f) (set! + -) (+ 5 2))` folded to 7, and `(define (f if) (if 1 2))`
+lowered as the special form — each a plausible number from a binary whose
+interpreter run gives a different one.
+
+`set_targets` is whole-program here rather than per-top-level-form: the
+emitter runs only after the read loop has seen every form, and every form of a
+compiled binary runs in one process anyway. It is strictly more conservative
+than the interpreter's own pre-scan, which costs folding and never
+correctness. `compiler.scanSetTargetsWithoutMacros` is that pre-scan minus
+macro expansion (which needs a `Compiler`); the backend already declines
+native compilation of any body containing a macro use (kaappi#1807), so the
+two limits line up.
+
+`tests/scheme/compile/native-lexical-scope-fold-2117-2118.sh` runs the three
+`.scm` regression suites these bugs already owned — `#788`, `#790`,
+`set-redefine-fold` — through `kaappi compile`. Nothing had, which is why all
+three passed under the interpreter while failing 9, 1 and 6 assertions
+natively.
+
 ### Internal defines in a `let` body
 
 An internal `(define <symbol> <expr>)` in a natively emitted `let` body is a
@@ -723,6 +772,15 @@ backends support `tailcc`/`musttail`. Other hosts keep the uniform-only ABI
 unchanged; RISC-V can be enabled once its `musttail` support is confirmed.
 
 ## Testing
+
+Per-issue native regressions live in `tests/scheme/compile/*.sh`, each
+comparing the compiled binary against the interpreter as oracle (see the
+"interpreter as the native tier's oracle" block in
+`tests/scheme/shell-common.sh`). A `.scm` regression test that only ever runs
+under the interpreter proves nothing about this tier — three of them silently
+regressed that way (kaappi#2117/#2118), so a fix here that already has a `.scm`
+suite should get a `compile/` script that runs *that file* through
+`kaappi compile` rather than a fresh hand-typed golden value.
 
 End-to-end tests live in `tests/e2e/`:
 

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1035,7 +1035,12 @@ const SetScanBudget = struct {
 /// macro is encountered, it is expanded and the expansion is scanned
 /// (#1250). Only the top-level pre-scan expands; the per-expansion Part B
 /// scan passes null (see scanSetTargets).
-fn collectSetTargets(self: *Compiler, expr: Value, out: *std.StringHashMap(void), depth: u16, budget: ?*SetScanBudget) CompileError!void {
+///
+/// `self` is needed only to expand macros, i.e. only when `budget` is
+/// non-null — a null `budget` makes the whole walk a pure function of `expr`,
+/// which is what `scanSetTargetsWithoutMacros` below exposes to the LLVM
+/// native backend (it has no Compiler at all).
+fn collectSetTargets(self: ?*Compiler, expr: Value, out: *std.StringHashMap(void), depth: u16, budget: ?*SetScanBudget) CompileError!void {
     // This is the scan's *own* recursion cap, deliberately not shared with
     // compiler_macro.MAX_MACRO_EXPANSION_DEPTH despite both being 256: they
     // count different things. That one bounds the real expansion of code that
@@ -1064,34 +1069,39 @@ fn collectSetTargets(self: *Compiler, expr: Value, out: *std.StringHashMap(void)
                     }
                 }
             } else if (budget) |b| {
-                if (self.lookupMacro(types.symbolName(head))) |transformer| {
+                // Only a budgeted scan expands, and only a budgeted scan is
+                // ever handed a Compiler — so `self.?` below is reached only
+                // when `maybe_macro` was non-null, which requires one.
+                const maybe_macro = if (self) |c| c.lookupMacro(types.symbolName(head)) else null;
+                if (maybe_macro) |transformer| {
                     if (b.expansions_left == 0) {
                         b.truncated = true;
                         return;
                     }
                     b.expansions_left -= 1;
+                    const c = self.?;
                     // Best-effort expansion: uses an empty UseSiteBindingCheck
                     // (no locals exist at pre-scan time), so patterns with
                     // literals may diverge from the real expansion.  Part B
                     // (scanSetTargets in expandAndCompileMacroUse) corrects
                     // any misses at real-expansion time.
-                    self.gc.no_collect += 1;
+                    c.gc.no_collect += 1;
                     const expanded = expander.expandMacro(
-                        self.gc,
+                        c.gc,
                         cur,
                         transformer,
-                        self.globals,
-                        &self.macros,
+                        c.globals,
+                        &c.macros,
                         .{},
                     ) catch {
-                        self.gc.no_collect -= 1;
+                        c.gc.no_collect -= 1;
                         cur = types.cdr(cur);
                         continue;
                     };
                     var expanded_root = expanded;
-                    self.gc.pushRoot(&expanded_root);
-                    defer self.gc.popRoot();
-                    self.gc.no_collect -= 1;
+                    c.gc.pushRoot(&expanded_root);
+                    defer c.gc.popRoot();
+                    c.gc.no_collect -= 1;
                     // Fixed point (e.g. SRFI-219 rule 3: (define x e) →
                     // (define x e)): the expansion is the input, so scanning
                     // it again can only repeat what this pass already did.
@@ -1162,6 +1172,16 @@ fn collectSetTargets(self: *Compiler, expr: Value, out: *std.StringHashMap(void)
         try collectSetTargets(self, head, out, depth, budget);
         cur = types.cdr(cur);
     }
+}
+
+/// The `set!`-target scan for callers with no Compiler — the LLVM native
+/// backend, which re-lowers each lambda/let body through a scratch IR and
+/// needs the same suppression set the interpreter's per-form pre-scan builds
+/// (#2117). Macros are not expanded (that needs a Compiler); the backend
+/// declines native compilation of any body containing a macro use anyway
+/// (`sexprHasMacroUse`, #1807), so the two limits line up.
+pub fn scanSetTargetsWithoutMacros(expr: Value, out: *std.StringHashMap(void)) CompileError!void {
+    return collectSetTargets(null, expr, out, 0, null);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1177,9 +1177,21 @@ fn collectSetTargets(self: ?*Compiler, expr: Value, out: *std.StringHashMap(void
 /// The `set!`-target scan for callers with no Compiler — the LLVM native
 /// backend, which re-lowers each lambda/let body through a scratch IR and
 /// needs the same suppression set the interpreter's per-form pre-scan builds
-/// (#2117). Macros are not expanded (that needs a Compiler); the backend
-/// declines native compilation of any body containing a macro use anyway
-/// (`sexprHasMacroUse`, #1807), so the two limits line up.
+/// (#2117). Macros are not expanded, since that needs a Compiler.
+///
+/// For the body case that limit costs nothing: the backend declines native
+/// compilation of any body containing a macro use (`sexprHasMacroUse`,
+/// #1807), so a `set!` only a macro would reveal is in a body the
+/// interpreter — and its macro-expanding pre-scan — has already taken over.
+///
+/// At *top level across forms* the same is NOT true, and this scan does not
+/// close that: a macro use in form N that expands to `(set! + -)` leaves `+`
+/// unrecorded, so form N+1 can still fold it. That is kaappi#2212 — the
+/// pre-existing macro-blindness of #822's `collectRedefinedNames`, which this
+/// scan runs alongside rather than replaces. The interpreter is immune for an
+/// unrelated reason (it has already *executed* form N, so the globals check in
+/// isRedefined sees the rebound value), which is why only the compiled tier
+/// diverges.
 pub fn scanSetTargetsWithoutMacros(expr: Value, out: *std.StringHashMap(void)) CompileError!void {
     return collectSetTargets(null, expr, out, 0, null);
 }

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -318,9 +318,15 @@ pub const IR = struct {
     // (issues #788, #790). Null for standalone lowering, where only the
     // globals check applies.
     compiler: ?*const compiler_mod.Compiler = null,
-    // Extra lexically-bound names that shadow primitives, for lowering paths
-    // that have no Compiler (the LLVM native backend passes a lambda's own
-    // parameter names here). Also consulted by isRedefined (issue #790).
+    // Extra lexically-bound names, for lowering paths that have no Compiler
+    // (the LLVM native backend passes every name visible at the emission
+    // point — this frame's parameters plus the enclosing frames' params,
+    // upvalues, locals and boxes — see LLVMEmitter.lexicalNames). Stands in
+    // for `compiler.isLexicallyBound` at BOTH places that consult it: the
+    // fold gate in isRedefined (#790/#2117) and the special-form-vs-call
+    // decision in lowerFormWithMacros (#788/#2118). Feeding it only the
+    // immediate frame's parameters, as the native backend once did, left a
+    // shadowing binding one level out invisible to both.
     bound_names: ?[]const []const u8 = null,
     // Names that are the target of a `set!` somewhere in the enclosing form
     // being compiled. Folding a call to such a name is unsound: the `set!`
@@ -346,12 +352,31 @@ pub const IR = struct {
         };
     }
 
+    /// True when `name` is lexically bound according to the scope this
+    /// lowering was given: the enclosing Compiler's own scope, or the
+    /// `bound_names` list a Compiler-less path (the LLVM native backend)
+    /// supplies in its place. The single answer to "does a binding hide the
+    /// keyword/primitive spelled `name` here?", shared by the fold gate
+    /// (isRedefined) and the special-form dispatch (lowerFormWithMacros) so
+    /// the two can never disagree about the same binding again (#2117/#2118).
+    pub fn isLexicallyBound(self: *const IR, name: []const u8) bool {
+        if (self.compiler) |c| {
+            if (c.isLexicallyBound(name)) return true;
+        }
+        if (self.bound_names) |names| {
+            for (names) |n| {
+                if (std.mem.eql(u8, n, name)) return true;
+            }
+        }
+        return false;
+    }
+
     pub fn isRedefined(self: *const IR, name: []const u8) bool {
         // A lexical binding (lambda parameter or enclosing local) shadowing the
         // primitive makes any fold that assumes the built-in's semantics wrong.
-        // The globals map never sees these, so consult the compiler's scope.
+        // The globals map never sees these, so consult the lexical scope.
+        if (self.isLexicallyBound(name)) return true;
         if (self.compiler) |c| {
-            if (c.isLexicallyBound(name)) return true;
             // A truncated `set!` pre-scan means "any name may be reassigned"
             // (kaappi#1775); suppress every fold rather than trust a partial
             // set_targets map. Every caller of isRedefined is an optimization
@@ -361,11 +386,6 @@ pub const IR = struct {
             // quiet about its direct built-in calls. Nothing here decides
             // special-form-vs-call lowering.
             if (c.set_targets_all) return true;
-        }
-        if (self.bound_names) |names| {
-            for (names) |n| {
-                if (std.mem.eql(u8, n, name)) return true;
-            }
         }
         // A `set!` target in the enclosing form suppresses folding even when
         // the global still holds the original primitive at compile time.
@@ -644,8 +664,15 @@ fn lowerFormWithMacros(ir: *IR, expr: Value, macros: ?*std.StringHashMap(Value))
         // Mirrors the `is_shadowed` guard in the legacy compileForm path.
         // A hygienic rename (effective_name != name) is never shadowed: it
         // came from a macro template and must keep its special-form meaning.
+        //
+        // `isLexicallyBound` answers from the Compiler's scope when there is
+        // one and from `bound_names` otherwise, so the LLVM native backend —
+        // which lowers every lambda/let body through a scratch IR with no
+        // Compiler — honours the binding too (#2118). Without that it read
+        // `(define (f if) (if 1 2))` as the special form and printed 2 where
+        // the interpreter printed 99.
         const is_shadowed = std.mem.eql(u8, effective_name, name) and
-            if (ir.compiler) |c| c.isLexicallyBound(name) else false;
+            ir.isLexicallyBound(name);
 
         if (!is_shadowed) {
             // R7RS has no reserved words: an imported macro may shadow a
@@ -731,15 +758,14 @@ pub fn lowerAndOptimize(
     return node;
 }
 
-pub fn lowerSingleExpr(allocator: std.mem.Allocator, gc: ?*memory.GC, expr: Value) CompileError!*Node {
-    return lowerSingleExprTail(allocator, gc, expr, false);
-}
-
-pub fn lowerSingleExprTail(allocator: std.mem.Allocator, gc: ?*memory.GC, expr: Value, is_tail: bool) CompileError!*Node {
-    var scratch = IR.init(allocator);
-    scratch.gc = gc;
-    return lowerAndOptimize(&scratch, expr, null, is_tail);
-}
+// The scope-less `lowerSingleExpr` / `lowerSingleExprTail` that used to live
+// here are gone (kaappi#2117/#2118). Their only callers were the LLVM native
+// backend's re-lowering sites, and a scratch IR built with neither
+// `bound_names` nor `set_targets` answers "is this name bound here?" and "may
+// this name's value change?" as if the program had no lexical scope at all —
+// which is exactly how a shadowed keyword lowered as the special form and a
+// `set!`-clobbered primitive folded to its stale value. `LLVMEmitter.lowerScoped`
+// replaces both and cannot be called without a scope.
 
 fn lowerIf(ir: *IR, args: Value, macros: ?*std.StringHashMap(Value)) CompileError!*Node {
     if (args == types.NIL) return CompileError.InvalidSyntax;

--- a/src/llvm_emit.zig
+++ b/src/llvm_emit.zig
@@ -158,11 +158,22 @@ pub const LLVMEmitter = struct {
     // because those tests never exercise macros inside these forms.
     macros: ?*const std.StringHashMap(Value) = null,
     // GC backing the Values being emitted, threaded into every scratch IR
-    // this emitter lowers (lowerSingleExpr/lowerSingleExprTail, and the
+    // this emitter lowers (lowerScoped, and the
     // per-lambda body_ir in llvm_emit_lambda.zig) so lowerQuote can strip
     // hygiene renames from a macro-produced quoted datum (#1801). Null when
     // driven without a VM (unit tests that never exercise such macros).
     gc: ?*memory.GC = null,
+    // Names that are the target of a `set!` anywhere in the program being
+    // compiled, threaded into every scratch lowering as `IR.set_targets` so
+    // the constant folders never fold a call to a primitive the program
+    // reassigns (#2117 route 1). The interpreter gets this from the
+    // Compiler's own per-form pre-scan; a lambda body re-lowered here has no
+    // Compiler, so native_compiler.zig hands its accumulated map over
+    // instead. Whole-program rather than per-form — every form of a compiled
+    // binary runs in one process, and the emitter runs only after all of
+    // them have been read. Null when the emitter is driven without one (unit
+    // tests), which folds exactly as before.
+    set_targets: ?*const std.StringHashMap(void) = null,
     params: ?std.StringHashMap(u8),
     upvalues: ?std.StringHashMap(u8),
     tmp_counter: u32,
@@ -523,6 +534,63 @@ pub const LLVMEmitter = struct {
         return false;
     }
 
+    // Every name lexically bound at the current emission point, in
+    // isNameShadowed's order, plus `extra` — the parameters of a frame whose
+    // scope is not installed yet, since a lambda body is lowered before
+    // emitLambdaFunction swaps `params` in.
+    //
+    // This is what a scratch lowering gets as `IR.bound_names`, standing in
+    // for the Compiler scope it has no access to. Deriving it from the same
+    // four maps `emitGlobalRef` resolves against is deliberate: a parallel
+    // list maintained alongside them is exactly what drifted before (the
+    // backend passed only the immediate frame's parameters, so a binding one
+    // level out was invisible and `(define (outer +) (lambda () (+ 5 2)))`
+    // folded to 7 — #2117 route 2, #2118's upvalue case).
+    //
+    // Allocated on the emitter arena; valid for the rest of emission.
+    pub fn lexicalNames(self: *LLVMEmitter, extra: []const []const u8) error{OutOfMemory}![]const []const u8 {
+        var out: std.ArrayList([]const u8) = .empty;
+        try out.appendSlice(self.allocator(), extra);
+        if (self.locals) |loc| {
+            var it = loc.keyIterator();
+            while (it.next()) |k| try out.append(self.allocator(), k.*);
+        }
+        if (self.boxes) |bx| {
+            var it = bx.keyIterator();
+            while (it.next()) |k| try out.append(self.allocator(), k.*);
+        }
+        if (self.rest_param_name) |rp| try out.append(self.allocator(), rp);
+        if (self.params) |p| {
+            var it = p.keyIterator();
+            while (it.next()) |k| try out.append(self.allocator(), k.*);
+        }
+        if (self.upvalues) |uv| {
+            var it = uv.keyIterator();
+            while (it.next()) |k| try out.append(self.allocator(), k.*);
+        }
+        return out.items;
+    }
+
+    // Lower one raw sub-expression through a scratch IR carrying this
+    // emitter's lexical scope and `set!` targets. THE way the backend
+    // re-lowers a sub-form — the scope-less `ir.lowerSingleExpr*` this
+    // replaced dropped both and is deleted, since a scratch IR without them
+    // reads every shadowing binding as absent (#2117/#2118). `extra` names a
+    // not-yet-installed frame's parameters (see lexicalNames); pass `&.{}`
+    // from inside an installed scope.
+    pub fn lowerScoped(
+        self: *LLVMEmitter,
+        expr: Value,
+        is_tail: bool,
+        extra: []const []const u8,
+    ) ir.CompileError!*ir.Node {
+        var scratch = ir.IR.init(self.allocator());
+        scratch.gc = self.gc;
+        scratch.bound_names = try self.lexicalNames(extra);
+        scratch.set_targets = self.set_targets;
+        return ir.lowerAndOptimize(&scratch, expr, null, is_tail);
+    }
+
     // Whether `name` resolves to a top-level global rather than a lexical
     // capture: a built-in / special form (ir.isKnownGlobal), or a name reserved
     // for a top-level define emitted later in the program (#1499). The latter is
@@ -855,7 +923,7 @@ pub const LLVMEmitter = struct {
         // calls correctly; the standalone IR lowering below runs without a
         // macro table and would mis-lower a top-level (set! x (some-macro ...)).
         if (!self.inLexicalScope()) return self.emitEvalExpr(value);
-        const node = ir.lowerSingleExpr(self.allocator(), self.gc, value) catch return self.emitEvalExpr(value);
+        const node = self.lowerScoped(value, false, &.{}) catch return self.emitEvalExpr(value);
         return self.emitNode(node);
     }
 

--- a/src/llvm_emit_forms.zig
+++ b/src/llvm_emit_forms.zig
@@ -48,7 +48,7 @@ fn fmt(self: *LLVMEmitter, comptime f: []const u8, a: anytype) EmitError![]const
 // in-scope form to its enclosing form's abandon path (a top-level form has no
 // partial state to unwind at this point — the leaf lowers before any branch).
 fn lower(self: *LLVMEmitter, expr: Value, tail: bool) EmitError!*ir.Node {
-    return ir.lowerSingleExprTail(self.allocator(), self.gc, expr, tail) catch return error.UnsupportedNodeType;
+    return self.lowerScoped(expr, tail, &.{}) catch return error.UnsupportedNodeType;
 }
 
 // ---------------------------------------------------------------------------
@@ -1139,7 +1139,7 @@ pub fn emitApplyForm(self: *LLVMEmitter, expr: Value, is_tail: bool) EmitError![
 // enclosing scope — emitScopedValue's emitEvalExpr fallback would run the
 // operand in the global environment, the exact #1799 failure mode.
 pub fn emitScopedOperand(self: *LLVMEmitter, operand: Value) EmitError![]const u8 {
-    const node = ir.lowerSingleExpr(self.allocator(), self.gc, operand) catch return error.UnsupportedNodeType;
+    const node = self.lowerScoped(operand, false, &.{}) catch return error.UnsupportedNodeType;
     return self.emitNode(node);
 }
 

--- a/src/llvm_emit_lambda.zig
+++ b/src/llvm_emit_lambda.zig
@@ -73,9 +73,11 @@ fn tryCompilePureLambdaAsNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) 
     var body_ir = ir.IR.init(self.allocator());
     body_ir.gc = self.gc;
     defer body_ir.deinit();
-    // Parameters shadow primitives of the same name; don't fold calls to them
-    // using the built-in's semantics (issue #790).
-    body_ir.bound_names = param_names.items;
+    // This frame's parameters plus every binding still visible from the
+    // enclosing frames shadow both primitives (no fold — #790/#2117) and
+    // syntactic keywords (lower as a call, not the special form — #788/#2118).
+    body_ir.bound_names = self.lexicalNames(param_names.items) catch return null;
+    body_ir.set_targets = self.set_targets;
     var body_nodes: std.ArrayList(*ir.Node) = .empty;
     var body_expr = body_list;
     while (body_expr != types.NIL and types.isPair(body_expr)) {
@@ -149,9 +151,11 @@ fn tryCompileNativeClosure(self: *LLVMEmitter, data: ir.LambdaData) ?[]const u8 
     var body_ir = ir.IR.init(self.allocator());
     body_ir.gc = self.gc;
     defer body_ir.deinit();
-    // Parameters shadow primitives of the same name; don't fold calls to them
-    // using the built-in's semantics (issue #790).
-    body_ir.bound_names = param_names.items;
+    // Same scope-wide shadowing set as the sibling tier above (#790/#2117,
+    // #788/#2118). A closure's own body sees the enclosing frame's bindings
+    // as upvalues, so passing only `param_names` here missed every one.
+    body_ir.bound_names = self.lexicalNames(param_names.items) catch return null;
+    body_ir.set_targets = self.set_targets;
     var body_nodes: std.ArrayList(*ir.Node) = .empty;
     var body_expr = body_list;
     while (body_expr != types.NIL and types.isPair(body_expr)) {
@@ -519,16 +523,16 @@ pub fn tryCompileDefineFunction(self: *LLVMEmitter, name: []const u8, formals: V
     var body_ir = ir.IR.init(self.allocator());
     body_ir.gc = self.gc;
     defer body_ir.deinit();
-    // Parameters (including a rest parameter) shadow primitives of the same
-    // name; don't fold calls to them using the built-in's semantics (#790).
-    if (rest_name) |rn| {
-        var bound_names: std.ArrayList([]const u8) = .empty;
-        bound_names.appendSlice(self.allocator(), param_names.items) catch return null;
-        bound_names.append(self.allocator(), rn) catch return null;
-        body_ir.bound_names = bound_names.items;
-    } else {
-        body_ir.bound_names = param_names.items;
+    // Parameters (including a rest parameter) and every binding still visible
+    // from the enclosing frames shadow primitives (no fold — #790/#2117) and
+    // syntactic keywords (lower as a call — #788/#2118).
+    {
+        var own: std.ArrayList([]const u8) = .empty;
+        own.appendSlice(self.allocator(), param_names.items) catch return null;
+        if (rest_name) |rn| own.append(self.allocator(), rn) catch return null;
+        body_ir.bound_names = self.lexicalNames(own.items) catch return null;
     }
+    body_ir.set_targets = self.set_targets;
 
     var body_nodes: std.ArrayList(*ir.Node) = .empty;
     var body_expr = body;

--- a/src/llvm_emit_let.zig
+++ b/src/llvm_emit_let.zig
@@ -209,7 +209,7 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
                 return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
             }
 
-            const node = ir.lowerSingleExpr(self.allocator(), self.gc, init_expr) catch {
+            const node = self.lowerScoped(init_expr, false, &.{}) catch {
                 return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
             };
             const alloca = try self.freshTemp();
@@ -261,7 +261,7 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
                 return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
             }
 
-            const node = ir.lowerSingleExpr(self.allocator(), self.gc, init_expr) catch {
+            const node = self.lowerScoped(init_expr, false, &.{}) catch {
                 return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
             };
             const val = self.emitNode(node) catch {
@@ -358,7 +358,7 @@ pub fn emitLet(self: *LLVMEmitter, args: Value, sequential: bool, is_tail: bool)
     while (body_expr != types.NIL and types.isPair(body_expr)) {
         const rest = types.cdr(body_expr);
         const expr_is_tail = body_tail and (rest == types.NIL or !types.isPair(rest));
-        const node = ir.lowerSingleExprTail(self.allocator(), self.gc, types.car(body_expr), expr_is_tail) catch {
+        const node = self.lowerScoped(types.car(body_expr), expr_is_tail, &.{}) catch {
             return abandonLetForFallback(self, args, sequential, saved_locals, checkpoint);
         };
         // #827: if emitNode fails (e.g. a lambda that cannot be eval'd in

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -183,7 +183,12 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
 
     // Track names that are targets of define or set! in previous top-level
     // forms so constant folding does not inline primitive semantics for a
-    // name that will be rebound at runtime (#822).
+    // name that will be rebound at runtime (#822), plus every `set!` target
+    // nested anywhere inside the form about to be lowered — a `set!` in a
+    // lambda body runs before a call in that same body, so the primitive's
+    // compile-time value is already stale there (#2117 route 1). The
+    // interpreter gets the second half from Compiler.compile's own per-form
+    // pre-scan; this is the same scan, minus macro expansion.
     var redefined_names = std.StringHashMap(void).init(allocator);
     defer redefined_names.deinit();
     ir_instance.set_targets = &redefined_names;
@@ -236,6 +241,11 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
             }
         }
 
+        // `try`, not a swallowed error: the only failure is OOM growing the
+        // map, and continuing with a partial set would silently fold a call
+        // the scan had not finished proving unsafe.
+        try compiler.scanSetTargetsWithoutMacros(expr, &redefined_names);
+
         const root = ir_mod.lowerAndOptimize(&ir_instance, expr, &vm.macros, false) catch |err| {
             const code = diagnostics.compileErrorCode(err);
             var cbuf: [diagnostics.Code.render_width]u8 = undefined;
@@ -266,6 +276,10 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
     // Threaded into every scratch IR the emitter lowers, so lowerQuote can
     // strip hygiene renames from a macro-produced quoted datum (#1801).
     emitter.gc = vm.gc;
+    // Likewise for the `set!` targets: by now the read loop above has seen
+    // every top-level form, so this map covers the whole program — and the
+    // emitter re-lowers lambda/let bodies from here on (#2117).
+    emitter.set_targets = &redefined_names;
     timings.begin(.llvm_emit); // kaappi#1515: IR → LLVM IR text codegen
     emitter.emitProgram(ir_nodes.items) catch |err| {
         timings.end();

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -1753,6 +1753,17 @@ fn fixnumImm(buf: []u8, n: i64) ![]const u8 {
 // for it, which a bare-name search would match unconditionally.
 const call_scheme = "call i64 @kaappi_call_scheme(ptr %vm";
 
+// Every assertion below that a fold did NOT happen is satisfied vacuously if
+// the frame never compiled natively at all — the interpreter would then be
+// doing the work and the emitted module would contain neither the fold nor
+// anything else. Pin the tier first: `name` has a native definition and the
+// module reaches no code eval fallback, so what the rest of the test inspects
+// is genuinely the native lowering's output.
+fn expectNativeTier(ll: []const u8, name: []const u8) !void {
+    try expectNativeDef(ll, name);
+    try std.testing.expectEqual(@as(usize, 0), countEvalFallbacks(ll));
+}
+
 test "LLVM emit: an enclosing frame's parameter suppresses a fold in a nested lambda (#2117)" {
     // The nested lambda's body is re-lowered through a scratch IR that has no
     // Compiler, so IR.bound_names is the only thing that can tell it `+` is
@@ -1764,6 +1775,7 @@ test "LLVM emit: an enclosing frame's parameter suppresses a fold in a nested la
 
     var res = try emitMultiResult("(define (outer +) (lambda () (+ 5 2)))");
     defer res.deinit();
+    try expectNativeTier(res.toSlice(), "outer");
     try expectNotContains(res.toSlice(), folded);
     // The captured upvalue is called instead.
     try expectContains(res.toSlice(), call_scheme);
@@ -1772,6 +1784,7 @@ test "LLVM emit: an enclosing frame's parameter suppresses a fold in a nested la
     // above is about the shadowing and not about folding being off entirely.
     var ctl = try emitMultiResult("(define (outer y) (lambda () (+ 5 2)))");
     defer ctl.deinit();
+    try expectNativeTier(ctl.toSlice(), "outer");
     try expectContains(ctl.toSlice(), folded);
     try expectNotContains(ctl.toSlice(), call_scheme);
 }
@@ -1782,10 +1795,14 @@ test "LLVM emit: a let-bound name suppresses a fold in the let body (#2117)" {
 
     var res = try emitMultiResult("(define (f) (let ((+ -)) (+ 5 2)))");
     defer res.deinit();
+    try expectNativeTier(res.toSlice(), "f");
     try expectNotContains(res.toSlice(), folded);
+    // The let-local is called rather than folded away.
+    try expectContains(res.toSlice(), call_scheme);
 
     var ctl = try emitMultiResult("(define (f) (let ((y -)) (+ 5 2)))");
     defer ctl.deinit();
+    try expectNativeTier(ctl.toSlice(), "f");
     try expectContains(ctl.toSlice(), folded);
 }
 
@@ -1803,6 +1820,7 @@ test "LLVM emit: a set! in the body suppresses every fold in it (#2117)" {
 
     var res = try emitMultiResultWithSetTargets("(define (f) (set! + -) (+ 5 2))", &targets);
     defer res.deinit();
+    try expectNativeTier(res.toSlice(), "f");
     try expectNotContains(res.toSlice(), folded);
 
     // Control: the same body, with no name declared as a set! target, folds.
@@ -1810,6 +1828,7 @@ test "LLVM emit: a set! in the body suppresses every fold in it (#2117)" {
     defer empty.deinit();
     var ctl = try emitMultiResultWithSetTargets("(define (f) (set! + -) (+ 5 2))", &empty);
     defer ctl.deinit();
+    try expectNativeTier(ctl.toSlice(), "f");
     try expectContains(ctl.toSlice(), folded);
 }
 
@@ -1819,6 +1838,7 @@ test "LLVM emit: a parameter shadowing a keyword lowers the form as a call (#211
     // binary printed 2 where the interpreter printed 99.
     var res = try emitMultiResult("(define (f if) (if 1 2))");
     defer res.deinit();
+    try expectNativeTier(res.toSlice(), "f");
     try expectContains(res.toSlice(), call_scheme);
 
     // Control: unshadowed, the same body IS the special form — no call at all,
@@ -1827,6 +1847,7 @@ test "LLVM emit: a parameter shadowing a keyword lowers the form as a call (#211
     const folded = try fixnumImm(&buf, 2);
     var ctl = try emitMultiResult("(define (f x) (if 1 2))");
     defer ctl.deinit();
+    try expectNativeTier(ctl.toSlice(), "f");
     try expectNotContains(ctl.toSlice(), call_scheme);
     try expectContains(ctl.toSlice(), folded);
 }
@@ -1834,10 +1855,15 @@ test "LLVM emit: a parameter shadowing a keyword lowers the form as a call (#211
 test "LLVM emit: an enclosing frame's parameter shadows a keyword too (#2118)" {
     var res = try emitMultiResult("(define (outer quote) (lambda () (quote 5)))");
     defer res.deinit();
+    try expectNativeTier(res.toSlice(), "outer");
     try expectContains(res.toSlice(), call_scheme);
 
     // Control: `(quote 5)` unshadowed is the literal 5, never a call.
     var ctl = try emitMultiResult("(define (outer y) (lambda () (quote 5)))");
     defer ctl.deinit();
+    try expectNativeTier(ctl.toSlice(), "outer");
     try expectNotContains(ctl.toSlice(), call_scheme);
+    // The literal 5 is materialized as an immediate, not built at runtime.
+    var qbuf: [64]u8 = undefined;
+    try expectContains(ctl.toSlice(), try fixnumImm(&qbuf, 5));
 }

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -149,6 +149,47 @@ pub fn emitMultiResultOpts(source: []const u8, optimize: bool) !EmitResult {
     return .{ .gc = gc, .ir_instance = ir_instance, .emitter = emitter };
 }
 
+/// Like emitMultiResult, but wires `set_targets` into the emitter the way
+/// native_compiler.zig does, so a lambda body re-lowered during emission sees
+/// the program's `set!` targets and declines to fold a call to one (#2117).
+/// Every other helper here leaves the field null — its default, and the same
+/// "no name is reassigned" answer those tests want. `set_targets` is
+/// caller-owned and must outlive `res`.
+fn emitMultiResultWithSetTargets(
+    source: []const u8,
+    set_targets: *const std.StringHashMap(void),
+) !EmitResult {
+    var gc = memory.GC.init(emitter_alloc);
+    errdefer gc.deinit();
+
+    // See emitSourceResult: collection is deferred until emission is done.
+    gc.no_collect += 1;
+
+    var reader = reader_mod.Reader.init(&gc, source);
+    defer reader.deinit();
+
+    var ir_instance = ir_mod.IR.init(emitter_alloc);
+    errdefer ir_instance.deinit();
+    ir_instance.set_targets = set_targets;
+
+    var ir_nodes: std.ArrayList(*ir_mod.Node) = .empty;
+    defer ir_nodes.deinit(emitter_alloc);
+
+    while (try reader.hasMore()) {
+        const expr = try reader.readDatum();
+        const root = try ir_mod.lowerAndOptimize(&ir_instance, expr, null, false);
+        try ir_nodes.append(emitter_alloc, root);
+    }
+
+    var emitter = llvm_emit.LLVMEmitter.init(emitter_alloc);
+    errdefer emitter.deinit();
+    emitter.set_targets = set_targets;
+    try emitter.emitProgram(ir_nodes.items);
+
+    gc.no_collect -= 1;
+    return .{ .gc = gc, .ir_instance = ir_instance, .emitter = emitter };
+}
+
 fn expectContains(haystack: []const u8, needle: []const u8) !void {
     if (std.mem.indexOf(u8, haystack, needle) == null) {
         std.debug.print("\n--- Expected to find ---\n{s}\n--- in output (len={d}) ---\n", .{ needle, haystack.len });
@@ -1698,4 +1739,105 @@ test "LLVM emit: an internal shorthand define drops the direct-call binding (#18
     var ctl = try emitMultiResult("(define (g) 1) (let ((a 2)) (display a)) (g)");
     defer ctl.deinit();
     try std.testing.expect(hasDirectNativeCall(mainBody(ctl.toSlice())));
+}
+
+// The immediate an emitted constant fixnum appears as, e.g. `add i64 0, -84…`
+// for 7. A folded `(+ 5 2)` is exactly this; a call to a shadowed `+` is not.
+fn fixnumImm(buf: []u8, n: i64) ![]const u8 {
+    return std.fmt.bufPrint(buf, "add i64 0, {d}", .{@as(i64, @bitCast(types.makeFixnum(n)))});
+}
+
+// A generic call through a Value operator, as emitted for a call whose head is
+// a lexical binding rather than a known primitive. Spelled as the `call`
+// instruction, not the bare symbol: every module also carries a `declare` line
+// for it, which a bare-name search would match unconditionally.
+const call_scheme = "call i64 @kaappi_call_scheme(ptr %vm";
+
+test "LLVM emit: an enclosing frame's parameter suppresses a fold in a nested lambda (#2117)" {
+    // The nested lambda's body is re-lowered through a scratch IR that has no
+    // Compiler, so IR.bound_names is the only thing that can tell it `+` is
+    // bound. It used to get the immediate frame's parameters only — and the
+    // nested lambda has none — so `(+ 5 2)` folded to 7 and the compiled
+    // binary printed 7 where the interpreter printed 3.
+    var buf: [64]u8 = undefined;
+    const folded = try fixnumImm(&buf, 7);
+
+    var res = try emitMultiResult("(define (outer +) (lambda () (+ 5 2)))");
+    defer res.deinit();
+    try expectNotContains(res.toSlice(), folded);
+    // The captured upvalue is called instead.
+    try expectContains(res.toSlice(), call_scheme);
+
+    // Control: rename the parameter and the same body folds, so the assertion
+    // above is about the shadowing and not about folding being off entirely.
+    var ctl = try emitMultiResult("(define (outer y) (lambda () (+ 5 2)))");
+    defer ctl.deinit();
+    try expectContains(ctl.toSlice(), folded);
+    try expectNotContains(ctl.toSlice(), call_scheme);
+}
+
+test "LLVM emit: a let-bound name suppresses a fold in the let body (#2117)" {
+    var buf: [64]u8 = undefined;
+    const folded = try fixnumImm(&buf, 7);
+
+    var res = try emitMultiResult("(define (f) (let ((+ -)) (+ 5 2)))");
+    defer res.deinit();
+    try expectNotContains(res.toSlice(), folded);
+
+    var ctl = try emitMultiResult("(define (f) (let ((y -)) (+ 5 2)))");
+    defer ctl.deinit();
+    try expectContains(ctl.toSlice(), folded);
+}
+
+test "LLVM emit: a set! in the body suppresses every fold in it (#2117)" {
+    // Route 1: the set! runs before the call, so the compile-time value of `+`
+    // is already stale by the time `(+ 5 2)` evaluates. The emitter gets the
+    // program's set! targets from native_compiler; emitMultiResult drives it
+    // without one, so supply the same map here.
+    var targets = std.StringHashMap(void).init(std.testing.allocator);
+    defer targets.deinit();
+    try targets.put("+", {});
+
+    var buf: [64]u8 = undefined;
+    const folded = try fixnumImm(&buf, 7);
+
+    var res = try emitMultiResultWithSetTargets("(define (f) (set! + -) (+ 5 2))", &targets);
+    defer res.deinit();
+    try expectNotContains(res.toSlice(), folded);
+
+    // Control: the same body, with no name declared as a set! target, folds.
+    var empty = std.StringHashMap(void).init(std.testing.allocator);
+    defer empty.deinit();
+    var ctl = try emitMultiResultWithSetTargets("(define (f) (set! + -) (+ 5 2))", &empty);
+    defer ctl.deinit();
+    try expectContains(ctl.toSlice(), folded);
+}
+
+test "LLVM emit: a parameter shadowing a keyword lowers the form as a call (#2118)" {
+    // `(if 1 2)` as the special form constant-folds to 2; as a call to the
+    // parameter `if` it must reach kaappi_call_scheme instead. The native
+    // binary printed 2 where the interpreter printed 99.
+    var res = try emitMultiResult("(define (f if) (if 1 2))");
+    defer res.deinit();
+    try expectContains(res.toSlice(), call_scheme);
+
+    // Control: unshadowed, the same body IS the special form — no call at all,
+    // and the folded 2 in its place.
+    var buf: [64]u8 = undefined;
+    const folded = try fixnumImm(&buf, 2);
+    var ctl = try emitMultiResult("(define (f x) (if 1 2))");
+    defer ctl.deinit();
+    try expectNotContains(ctl.toSlice(), call_scheme);
+    try expectContains(ctl.toSlice(), folded);
+}
+
+test "LLVM emit: an enclosing frame's parameter shadows a keyword too (#2118)" {
+    var res = try emitMultiResult("(define (outer quote) (lambda () (quote 5)))");
+    defer res.deinit();
+    try expectContains(res.toSlice(), call_scheme);
+
+    // Control: `(quote 5)` unshadowed is the literal 5, never a call.
+    var ctl = try emitMultiResult("(define (outer y) (lambda () (quote 5)))");
+    defer ctl.deinit();
+    try expectNotContains(ctl.toSlice(), call_scheme);
 }

--- a/tests/scheme/compile/native-lexical-scope-fold-2117-2118.sh
+++ b/tests/scheme/compile/native-lexical-scope-fold-2117-2118.sh
@@ -55,15 +55,40 @@ n=0
 # --- Part A: the pre-existing .scm suites, on the native tier --------------
 #
 # These are self-checking: each prints a sentinel and exits nonzero on any
-# failed assertion. Their stdout is NOT compared between tiers — they leave
-# bare `#t` results at top level, which the VM echoes and a native binary
-# does not (difference 1 in shell-common.sh). The sentinel plus the exit
-# status is the whole verdict, and it is the same verdict the interpreter
-# already gets from these files in the smoke suite.
+# failed assertion. They are also compared tier-to-tier like everything else,
+# with one normalization: each `check` call is a bare top-level expression
+# returning #t, and the VM echoes that value while a native binary does not
+# (difference 1 in shell-common.sh). Dropping lines that are exactly `#t` from
+# the interpreter's stdout removes precisely that echo — none of the three
+# files ever displays a boolean itself, and a FAIL line carries its name and
+# both values, so nothing else in the transcript is `#t` alone.
+strip_echo() { grep -v '^#t$' || true; }
+
 check_suite() {
     local name="$1" sentinel="$2"
     local src="$REPO_DIR/tests/scheme/smoke/$name.scm"
     local bin="$DIR/$name.bin"
+    n=$((n + 1))
+
+    local interp_raw interp_out interp_status=0
+    interp_raw="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src")" || interp_status=$?
+    interp_out="$(printf '%s\n' "$interp_raw" | strip_echo)"
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $name — interpreter exited $interp_status:" >&2
+        printf '%s\n' "$interp_raw" >&2
+        fail=1
+        return
+    fi
+    # The golden assertion, against the interpreter: these suites announce
+    # their own verdict, so the sentinel is what "no assertion failed" looks
+    # like. Kept alongside the tier comparison because a bug BOTH tiers share
+    # would leave them agreeing on a transcript full of FAIL lines.
+    if [[ "$interp_out" != *"$sentinel"* ]]; then
+        echo "FAIL: $name — interpreter output missing '$sentinel':" >&2
+        printf '%s\n' "$interp_out" >&2
+        fail=1
+        return
+    fi
 
     (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" > /dev/null 2>&1) || {
         echo "FAIL: $name — native compile failed" >&2
@@ -72,17 +97,7 @@ check_suite() {
     }
     local out status=0
     out="$("$bin" 2> /dev/null)" || status=$?
-    if [[ $status -ne 0 ]]; then
-        echo "FAIL: $name — native binary exited $status:" >&2
-        printf '%s\n' "$out" >&2
-        fail=1
-        return
-    fi
-    if [[ "$out" != *"$sentinel"* ]]; then
-        echo "FAIL: $name — native output missing '$sentinel':" >&2
-        printf '%s\n' "$out" >&2
-        fail=1
-    fi
+    assert_tiers_agree "$name" "$interp_out" "$interp_status" "$out" "$status" || fail=1
 }
 
 check_suite lambda-param-shadows-keyword-788 "all passed"
@@ -219,6 +234,20 @@ check_both do-result-shadowed-primitive 3 '(define (outer +) (do ((i 0 (- i 1)))
 check_both apply-operand-shadowed-primitive '(3)' '(define (outer +) (apply list (list (+ 5 2))))
 (display (outer -)) (newline)'
 
+# The binding INITIALIZERS are their own lowering sites (llvm_emit_let.zig:212
+# for a parallel let, :264 for let*), distinct from the body at :361 — a
+# shadowed operator evaluated in an initializer had no coverage until now.
+check_both let-init-shadowed-primitive 3 '(define (outer +) (let ((x (+ 5 2))) x))
+(display (outer -)) (newline)'
+
+# let* is the sharper of the two: the initializer is shadowed by an EARLIER
+# binding of this same let*, not by an enclosing frame.
+check_both letstar-init-sees-earlier-binding -1 '(define (f) (let* ((+ -) (x (+ 1 2))) x))
+(display (f)) (newline)'
+
+check_both letstar-init-shadowed-by-frame 3 '(define (outer +) (let* ((y 1) (x (+ 5 2))) x))
+(display (outer -)) (newline)'
+
 # A let shadowing survives into a nested let, in both nesting directions.
 check_both let-shadow-into-inner-let 3 '(define (f) (let ((+ -)) (let ((y 1)) (+ 5 2))))
 (display (f)) (newline)'
@@ -245,4 +274,4 @@ if [[ $fail -ne 0 ]]; then
     exit 1
 fi
 
-echo "PASS ($n tier comparisons + 3 native suites)"
+echo "PASS ($n tier comparisons, 3 of them the pre-existing .scm suites)"

--- a/tests/scheme/compile/native-lexical-scope-fold-2117-2118.sh
+++ b/tests/scheme/compile/native-lexical-scope-fold-2117-2118.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# Regression test for #2117 and #2118 (LLVM native backend): a scratch IR
+# lowering must carry the lexical scope and the `set!` targets of the point it
+# is lowering at, or the native tier silently disagrees with the interpreter.
+#
+# The backend re-lowers every lambda/closure/let body through a fresh IR that
+# has no Compiler, so `IR.bound_names` and `IR.set_targets` stand in for the
+# Compiler scope. Both were under-supplied:
+#
+#   * bound_names held only the IMMEDIATE frame's parameter names, so a
+#     binding one level out (an upvalue) or a let-local was invisible. That
+#     fed two different decisions the wrong answer — the constant folders
+#     (#2117 route 2: `(define (outer +) (lambda () (+ 5 2)))` printed 7) and
+#     the special-form-vs-call dispatch (#2118: `(define (f if) (if 1 2))`
+#     printed 2 where the interpreter printed 99, and `(f quote)` printed a
+#     different value entirely).
+#   * set_targets was never populated at all, so a `set!` in the enclosing
+#     body did not suppress a later fold in that same body (#2117 route 1:
+#     `(define (f) (set! + -) (+ 5 2))` printed 7).
+#
+# Part A compiles the three .scm regression suites that #600/#698, #788/#790
+# already own. Every one of them passed under the interpreter and failed
+# natively — 6, 1 and 9 assertions respectively — because no suite had ever
+# run them through `kaappi compile`. That gap is what this part closes.
+#
+# Part B pins the individual routes as tier comparisons, including the two
+# discriminating controls from the issues (the same shadowing used in the
+# frame that binds it, which was already correct) so a fix that simply stops
+# folding everywhere would not pass.
+#
+# Usage: bash tests/scheme/compile/native-lexical-scope-fold-2117-2118.sh [path-to-kaappi]
+
+set -euo pipefail
+
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+ensure_runtime_lib "$REPO_DIR"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+fail=0
+n=0
+
+# --- Part A: the pre-existing .scm suites, on the native tier --------------
+#
+# These are self-checking: each prints a sentinel and exits nonzero on any
+# failed assertion. Their stdout is NOT compared between tiers — they leave
+# bare `#t` results at top level, which the VM echoes and a native binary
+# does not (difference 1 in shell-common.sh). The sentinel plus the exit
+# status is the whole verdict, and it is the same verdict the interpreter
+# already gets from these files in the smoke suite.
+check_suite() {
+    local name="$1" sentinel="$2"
+    local src="$REPO_DIR/tests/scheme/smoke/$name.scm"
+    local bin="$DIR/$name.bin"
+
+    (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" > /dev/null 2>&1) || {
+        echo "FAIL: $name — native compile failed" >&2
+        fail=1
+        return
+    }
+    local out status=0
+    out="$("$bin" 2> /dev/null)" || status=$?
+    if [[ $status -ne 0 ]]; then
+        echo "FAIL: $name — native binary exited $status:" >&2
+        printf '%s\n' "$out" >&2
+        fail=1
+        return
+    fi
+    if [[ "$out" != *"$sentinel"* ]]; then
+        echo "FAIL: $name — native output missing '$sentinel':" >&2
+        printf '%s\n' "$out" >&2
+        fail=1
+    fi
+}
+
+check_suite lambda-param-shadows-keyword-788 "all passed"
+check_suite lambda-param-shadow-fold-790 "PASS"
+check_suite set-redefine-fold "all passed"
+
+# --- Part B: per-route tier comparisons -----------------------------------
+#
+# The interpreter is the oracle; `expected` documents intent and still catches
+# a bug both tiers share. Every program prints explicitly, so the VM's
+# top-level echo never enters the comparison.
+check_both() {
+    local label="$1" expected="$2" src_text="$3"
+    local src="$DIR/$label.scm" bin="$DIR/$label.bin"
+    n=$((n + 1))
+    printf '%s\n' "$src_text" > "$src"
+
+    local interp_out interp_status=0
+    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src")" || interp_status=$?
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        fail=1
+        return
+    fi
+    if [[ "$interp_out" != "$expected" ]]; then
+        echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        fail=1
+        return
+    fi
+
+    (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" > /dev/null 2>&1) || {
+        echo "FAIL: $label — native compile failed" >&2
+        fail=1
+        return
+    }
+    local out status=0
+    out="$("$bin" 2> /dev/null)" || status=$?
+    assert_tiers_agree "$label" "$interp_out" "$interp_status" "$out" "$status" || fail=1
+}
+
+# #2117 route 1 — a set! in the enclosing body makes the compile-time value of
+# `+` stale for every call in that body, folded or not.
+check_both set-in-lambda-body 3 '(define orig+ +)
+(define (f) (set! + -) (+ 5 2))
+(define r (f))
+(set! + orig+)
+(display r) (newline)'
+
+check_both set-in-let-body 3 '(define orig+ +)
+(define (f) (let ((x 1)) (set! + -) (+ 5 2)))
+(define r (f))
+(set! + orig+)
+(display r) (newline)'
+
+# The set! sits in the outer body; the fold lives in a nested lambda.
+check_both set-suppresses-nested-lambda 3 '(define orig+ +)
+(define k (lambda () (set! + -) (lambda () (+ 5 2))))
+(define inner (k))
+(define r (inner))
+(set! + orig+)
+(display r) (newline)'
+
+# Route 1 control: the same set!, with non-constant operands. Already correct
+# natively (nothing to fold — the inline-primitive path re-reads the global),
+# so it must stay correct.
+check_both set-in-body-no-fold 3 '(define orig+ +)
+(define (f a b) (set! + -) (+ a b))
+(define r (f 5 2))
+(set! + orig+)
+(display r) (newline)'
+
+# A set! reachable only through quoted data must NOT suppress the fold — the
+# scan stops at `quote`, and a fix that just gave up on folding would still
+# print 7 here, so this is the discriminating control for the whole route.
+check_both quoted-set-still-folds 7 '(define (p) (quote (set! + -)) (+ 5 2))
+(display (p)) (newline)'
+
+# #2117 route 2 — a shadowing parameter reached through an enclosing frame.
+check_both upvalue-shadowed-primitive 3 '(define (outer +) (lambda () (+ 5 2)))
+(display ((outer -))) (newline)'
+
+check_both let-local-shadowed-primitive -1 '(define (f) (let ((+ -)) (+ 1 2)))
+(display (f)) (newline)'
+
+check_both toplevel-let-shadowed-primitive -1 '(display (let ((+ -)) (+ 1 2))) (newline)'
+
+# Route 2 control: the same shadowing parameter used in the frame that binds
+# it — what #790 fixed, and what already worked.
+check_both own-param-shadowed-primitive 3 '(define (outer +) (+ 5 2))
+(display (outer -)) (newline)'
+
+# #2118 — a parameter shadowing a syntactic keyword hides the keyword for the
+# body. `quote` is the sharp one: the wrong answer is a different value, not a
+# coincidence.
+check_both param-shadows-if 99 '(define (f if) (if 1 2))
+(display (f (lambda (x y) 99))) (newline)'
+
+check_both param-shadows-quote -5 '(define (f quote) (quote 5))
+(display (f -)) (newline)'
+
+check_both upvalue-shadows-if 99 '(define (outer if) (lambda () (if 1 2)))
+(display ((outer (lambda (x y) 99)))) (newline)'
+
+check_both let-local-shadows-if 99 '(define (f) (let ((if (lambda (a b) 99))) (if 1 2)))
+(display (f)) (newline)'
+
+# The shadow also has to reach a form the backend lowers itself (#1496).
+check_both cond-body-shadowed-primitive 3 '(define (outer +) (cond (#t (+ 5 2))))
+(display (outer -)) (newline)'
+
+# #2118 control: the same forms with no shadowing binding still compile as the
+# special form on both tiers.
+check_both unshadowed-if-and-quote '2 5' '(display (if 1 2)) (display " ") (display (quote 5)) (newline)'
+
+# An unshadowed primitive must still fold, so none of the above is achieved by
+# disabling the optimizer.
+check_both unshadowed-fold-survives 3 '(define (f) (+ 1 2))
+(display (f)) (newline)'
+
+if [[ $fail -ne 0 ]]; then
+    exit 1
+fi
+
+echo "PASS ($n tier comparisons + 3 native suites)"

--- a/tests/scheme/compile/native-lexical-scope-fold-2117-2118.sh
+++ b/tests/scheme/compile/native-lexical-scope-fold-2117-2118.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Regression test for #2117 and #2118 (LLVM native backend): a scratch IR
-# lowering must carry the lexical scope and the `set!` targets of the point it
-# is lowering at, or the native tier silently disagrees with the interpreter.
+# Regression test for #2117, #2118 and #2211 (LLVM native backend): a scratch
+# IR lowering must carry the lexical scope and the `set!` targets of the point
+# it is lowering at, or the native tier silently disagrees with the
+# interpreter.
 #
 # The backend re-lowers every lambda/closure/let body through a fresh IR that
 # has no Compiler, so `IR.bound_names` and `IR.set_targets` stand in for the
@@ -23,10 +24,14 @@
 # natively — 6, 1 and 9 assertions respectively — because no suite had ever
 # run them through `kaappi compile`. That gap is what this part closes.
 #
-# Part B pins the individual routes as tier comparisons, including the two
-# discriminating controls from the issues (the same shadowing used in the
-# frame that binds it, which was already correct) so a fix that simply stops
-# folding everywhere would not pass.
+# Part B pins the individual routes as tier comparisons, including the
+# discriminating controls from all three issues (the same shadowing used in
+# the frame that binds it; a `set!` reachable only through quoted data) so a
+# fix that simply stops folding everywhere would not pass.
+#
+# #2211 is the same root cause at four sites neither #2117 nor #2118 names:
+# `let`/`let*` initializers and bodies, cond/case/do sub-forms, and apply
+# operands, which passed NO scope rather than an incomplete one.
 #
 # Usage: bash tests/scheme/compile/native-lexical-scope-fold-2117-2118.sh [path-to-kaappi]
 
@@ -184,9 +189,48 @@ check_both upvalue-shadows-if 99 '(define (outer if) (lambda () (if 1 2)))
 check_both let-local-shadows-if 99 '(define (f) (let ((if (lambda (a b) 99))) (if 1 2)))
 (display (f)) (newline)'
 
-# The shadow also has to reach a form the backend lowers itself (#1496).
+# --- #2211: the four sites that carried no scope at all --------------------
+#
+# `let`/`let*` initializers and bodies, every sub-form of a natively emitted
+# cond/case/do (#1496), and apply operands (#1803) each re-lowered through a
+# scratch IR built from nothing but an allocator and a GC. The three cases
+# just above (let-local-shadowed-primitive, toplevel-let-shadowed-primitive,
+# let-local-shadows-if) are the let half; these are the rest.
+
+check_both letstar-shadowed-primitive -1 '(define (f) (let* ((y 1) (+ -)) (+ 1 2)))
+(display (f)) (newline)'
+
+# A let-bound keyword, where the wrong answer is a different value rather than
+# a coincidence of arithmetic — `quote`s role in #2118, one scope out.
+check_both let-local-shadows-quote -5 '(display (let ((quote -)) (quote 5))) (newline)'
+
+# cond/case/do are NOT saved by the enclosing frame's own bound_names: `outer`s
+# parameter `+` is in it, and each of these forms re-lowers its sub-forms from
+# an empty scratch IR, throwing the shadowing away one level down.
 check_both cond-body-shadowed-primitive 3 '(define (outer +) (cond (#t (+ 5 2))))
 (display (outer -)) (newline)'
+
+check_both case-body-shadowed-primitive 3 '(define (outer +) (case 1 ((1) (+ 5 2)) (else 0)))
+(display (outer -)) (newline)'
+
+check_both do-result-shadowed-primitive 3 '(define (outer +) (do ((i 0 (- i 1))) ((= i -1) (+ 5 2))))
+(display (outer -)) (newline)'
+
+check_both apply-operand-shadowed-primitive '(3)' '(define (outer +) (apply list (list (+ 5 2))))
+(display (outer -)) (newline)'
+
+# A let shadowing survives into a nested let, in both nesting directions.
+check_both let-shadow-into-inner-let 3 '(define (f) (let ((+ -)) (let ((y 1)) (+ 5 2))))
+(display (f)) (newline)'
+
+check_both inner-let-shadows-under-outer-let 3 '(define (f) (let ((x 1)) (let ((+ -)) (+ 5 2))))
+(display (f)) (newline)'
+
+# #2211 control: a lambda capturing an unboxed let-local declines native
+# compilation outright, so the interpreter runs the whole form — correct on
+# both tiers before the fix and after it.
+check_both let-shadow-captured-by-lambda 3 '(define (f) (let ((+ -)) (lambda () (+ 5 2))))
+(display ((f))) (newline)'
 
 # #2118 control: the same forms with no shadowing binding still compile as the
 # special form on both tiers.


### PR DESCRIPTION
Closes #2117
Closes #2118
Closes #2211

#2117 and #2118 are the same missing input reaching two different consumers; #2211 is that same input missing at four further sites neither of them names.

## Root cause

The LLVM backend does not emit from the IR tree it is handed. Every `lambda`, closure and `let` body is still a raw S-expression at that point and is **re-lowered** during emission through a scratch `ir.IR` that has no `Compiler`. Two `IR` fields stand in for the Compiler there, and both were under-supplied:

| Field | Replaces | What it got |
|---|---|---|
| `bound_names` | `Compiler.isLexicallyBound` | the **immediate** frame's parameter names only |
| `set_targets` | `Compiler.compile`'s per-form `set!` pre-scan | nothing |

`bound_names` feeds two *different* decisions — `isRedefined`'s fold gate (#2117) and `lowerFormWithMacros`'s special-form-vs-call dispatch (#2118) — which is why one gap produced two issues.

## Fix

- `LLVMEmitter.lexicalNames` is **derived** from the same `locals`/`boxes`/`rest_param_name`/`params`/`upvalues` maps `emitGlobalRef` already resolves against, in that order, plus an `extra` list for a frame whose scope is not installed yet. A hand-kept parallel list is precisely what drifted.
- `IR.isLexicallyBound` is now the single answer to "does a binding hide this name here?", consulted by both the fold gate and the lowering dispatch, so the two cannot disagree about the same binding again.
- `native_compiler` runs the interpreter's own `set!` pre-scan (`compiler.scanSetTargetsWithoutMacros` — the existing scan minus macro expansion, which needs a `Compiler` and which the backend already declines a body for, #1807) and hands the accumulated map to the emitter.
- `LLVMEmitter.lowerScoped` is now the one way to re-lower a sub-form. The scope-less `ir.lowerSingleExpr`/`lowerSingleExprTail` it replaces are **deleted**, so the omission cannot recur.

That last point is what closes #2211. #2117/#2118 locate the defect at three `body_ir` slots in `llvm_emit_lambda.zig`; four more scratch lowerings passed **no** scope at all — `let`/`let*` binding initializers and bodies, every sub-form of a natively emitted `cond`/`case`/`do`, and `apply` operands. Measured against `798cb607` (the commit before this branch):

```text
                                                              interp   native
(define (f) (let ((+ -)) (+ 1 2)))                               -1        3
(display (let ((+ -)) (+ 1 2)))                                  -1        3
(define (f) (let* ((y 1) (+ -)) (+ 1 2)))                        -1        3
(define (f) (let ((if (lambda (a b) 99))) (if 1 2)))             99        2
(display (let ((quote -)) (quote 5)))                            -5        5
(define (outer +) (cond (#t (+ 5 2))))                            3        7
(define (outer +) (case 1 ((1) (+ 5 2)) (else 0)))                3        7
(define (outer +) (do ((i 0 (- i 1))) ((= i -1) (+ 5 2))))        3        7
(define (outer +) (apply list (list (+ 5 2))))                  (3)      (7)
(define (f) (let ((+ -)) (let ((y 1)) (+ 5 2))))                  3        7
(define (f) (let ((x 1)) (let ((+ -)) (+ 5 2))))                  3        7
```

Note the `cond`/`case`/`do` rows: `outer`'s parameter `+` **was** in the frame's `bound_names`, and those forms still folded — they re-lower each sub-form from an empty scratch IR, so the shadowing was thrown away again one level down. All eleven agree on this branch.

`set_targets` is whole-program on this path rather than per-top-level-form: the emitter runs only after the read loop has seen every form, and every form of a compiled binary runs in one process anyway. Strictly more conservative than the interpreter — costs folding, never correctness.

## Tests

`tests/scheme/compile/native-lexical-scope-fold-2117-2118.sh`:

- **Part A** compiles the three `.scm` suites that already owned these bugs — `lambda-param-shadows-keyword-788`, `lambda-param-shadow-fold-790`, `set-redefine-fold`. All three passed the whole time because **no suite had ever run them through `kaappi compile`**; against the unfixed backend they fail 9, 1 and 6 assertions, exactly the counts the issues measured.
- **Part B** is 16 per-route tier comparisons with the interpreter as oracle, including both issues' own discriminating controls (`(define (f a b) (set! + -) (+ a b))`, `(define (outer +) (+ 5 2))`, `(display (if 1 2))`) and a `quoted-set-still-folds` case — so a "fix" that just stopped folding would not pass.

Five unit tests in `tests_native.zig` pin the emitted IR (folded immediate vs. `call i64 @kaappi_call_scheme`); all five fail against pre-fix behaviour, verified by mutation.

`docs/dev/llvm-backend.md` gains a "Lexical scope in a re-lowered body" section, and its Testing section now says outright that a `.scm` regression test is interpreter-only evidence for this tier.

## Verification

macOS aarch64, ReleaseSafe:

- `zig build test` — 1748/1751 pass (3 skipped)
- `bash tests/scheme/run-all.sh` — 2076 pass, 0 fail (both differential tiers included)
- `bash tests/e2e/run-e2e.sh` — 38/38

🤖 Generated with [Claude Code](https://claude.com/claude-code)
