### PR TITLE
Correct the drift found reviewing docs/dev

### DIFF
--- a/.claude/rules/gc-safety.md
+++ b/.claude/rules/gc-safety.md
@@ -14,8 +14,9 @@ string-set!, record field mutation):
 
 - **Root before allocating**: if you hold a pointer to a heap object and then
   allocate (which may trigger GC), root the value first with
-  `gc.pushRoot(&val)` / `gc.popRoot()`. `pushRoot` is infallible (panics on
-  overflow at 1024 slots) — no `try` or `catch` needed.
+  `gc.pushRoot(&val)` / `gc.popRoot()`. `pushRoot` is infallible — the root
+  buffer grows geometrically and only panics on exceeding
+  `GC.MAX_ROOT_CAPACITY` (65536), so no `try` or `catch` is needed.
 
 - **Allocator Value arguments are auto-rooted**: `allocPair(car, cdr)` and
   other `allocXxx` functions that take Value arguments root them internally

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ single word with zero heap allocation:
 - **0xFFFE | payload**: immediate (nil, true, false, void, eof, char with 21-bit codepoint)
 
 Heap objects share an `Object` header with `ObjectTag` (u6, 64 slots), GC mark
-bit, generation (u1), and survive count (u2) — 36 types.
+bit, generation (u1), and survive count (u2) — 41 types.
 
 ### Strings
 
@@ -207,7 +207,8 @@ resolved relative to the `.sld`), and `(export (rename ...))` in
   library**; several carry hard-won constraints that are invisible from the
   code.
 - **`docs/dev/srfi-exclusions.md`** — the 30 excluded SRFIs, one section each.
-- **`docs/dev/srfi-status-check.md`** — re-deriving the counts.
+- **`docs/dev/srfi-status-check.md`** — the CI guard that fails if a shipped
+  SRFI is `draft` or `withdrawn`, and how it re-derives the set from the binary.
 
 ## Zig 0.16 patterns
 
@@ -467,7 +468,7 @@ Path-scoped rules in `.claude/rules/` load automatically:
 Skills in `.claude/skills/`: `/add-builtin`, `/audit-primitives`,
 `/bytecode-isa`, `/github-release`, `/create-announcement`, `/r7rs-reader`,
 `/linux-test`, `/do-linux-test`, `/do-stress-test`, `/do-gate-benchmark`,
-`/parallel-issues`, `/quiz`. The `infra/` repo additionally hosts the
+`/parallel-issues`, `/quiz`, `/vm-test`. The `infra/` repo additionally hosts the
 `kaappi-dev` plugin (ecosystem-wide skills, a bash guard, an
 `ecosystem-reviewer` agent), loaded from the workspace-level settings.
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -89,7 +89,7 @@ investigations.
 | [ecosystem-library-bar.md](ecosystem-library-bar.md) | Quality bar for `kaappi-*` packages (applies ecosystem-wide, not just this repo) |
 | [github-issues.md](github-issues.md) | Issue tracker: the four label axes, the priority rubric (what separates critical from high), severity-vs-priority, the one-priority-per-open-issue invariant |
 | [srfi-exclusions.md](srfi-exclusions.md) | The 30 SRFIs deliberately not implemented, one section each, with the reason |
-| [srfi-status-check.md](srfi-status-check.md) | How to re-derive the SRFI counts after a release |
+| [srfi-status-check.md](srfi-status-check.md) | The CI guard that fails if a shipped SRFI is `draft` or `withdrawn` in the canonical registry — and how the counts are re-derived from the binary |
 | [understanding-map.md](understanding-map.md) | Where theory must live in a maintainer's head (core tier) vs. where a contract fences deliberate shallowness (fenced tier); the reification ladder; comprehension practices incl. `/quiz` |
 
 ## Adding a new document

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -18,20 +18,21 @@ Source code
 |  lexer)|     |  rules)  |     |      |     |          |     |          |     |          |     |    |
 +--------+     +----------+     +------+     +----------+     +----------+     +----------+     +----+
                                                                                                   |
-                                                                                            +-----+-----+
-                                                                                            | GC (mark  |
-                                                                                            | & sweep)  |
-                                                                                            +-----------+
+                                                                                          +-------+-------+
+                                                                                          | GC (generat-  |
+                                                                                          | ional mark    |
+                                                                                          | & sweep)      |
+                                                                                          +---------------+
 ```
 
 | Stage | File(s) | Role |
 |-------|---------|------|
-| **Reader** | `reader.zig` | Tokenizer + recursive descent parser. Handles full R7RS lexical syntax including Unicode identifiers, `#\lambda` character literals, `#(...)` vectors, `#u8(...)` bytevectors, datum labels. |
-| **Expander** | `expander.zig` | `syntax-rules` pattern matching with ellipsis, literal identifiers, and underscore wildcards. Template instantiation with hygienic renaming (gensym-based). |
+| **Reader** | `reader.zig` + `reader_tokens.zig`, `reader_datum.zig` | Tokenizer + recursive descent parser. Handles full R7RS lexical syntax including Unicode identifiers, `#\lambda` character literals, `#(...)` vectors, `#u8(...)` bytevectors, datum labels. |
+| **Expander** | `expander.zig` + `expander_instantiate.zig` | `syntax-rules` pattern matching with ellipsis, literal identifiers, and underscore wildcards. Template instantiation with hygienic renaming (gensym-based). |
 | **IR** | `ir.zig` | Lowers S-expressions to a tree-structured IR (18 node types, one of which — `sexpr_form` — carries 18 `FormKind`s). Runs 1 analysis pass (tail positions) and 5 optimization passes (constant folding, dead branch elimination, boolean simplification, identity elimination, begin simplification). See [ir.md](ir.md) for details. |
-| **Compiler** | `compiler.zig` + 5 sub-modules | Emits register-based bytecode from IR nodes via `compileFromNode()`. Retains `compileExpr()` for forms delegated via `passthrough`. Dispatches 32 syntax forms across 6 files. |
-| **VM** | `vm.zig` + 7 sub-modules | Executes bytecode with a growable register file, call frame stack, exception handler stack, and dynamic-wind stack (all heap-allocated, double-on-overflow; exceeding a hard cap is an uncatchable KP3008). First-class continuations via stack copying, plus a stepping debugger. |
-| **GC** | `memory.zig` | Mark-and-sweep collector with intrusive linked list. Root tracking via `pushRoot`/`popRoot`. Triggered after N allocations. |
+| **Compiler** | `compiler.zig` + 9 sub-modules | Emits register-based bytecode from IR nodes via `compileFromNode()` (in `compiler_ir.zig`). Retains `compileExpr()` for forms delegated via `passthrough`. See the [Compiler & IR](#compiler--ir-11-files) table for the per-file split. |
+| **VM** | `vm.zig` + 10 sub-modules | Executes bytecode with a growable register file, call frame stack, exception handler stack, and dynamic-wind stack (all heap-allocated, double-on-overflow; exceeding a hard cap is an uncatchable KP3008). First-class continuations via stack copying, plus a stepping debugger. |
+| **GC** | `memory.zig` | Generational (young/old) mark-and-sweep collector over an intrusive linked list, with a write barrier and remembered set for old→young references. Root tracking via `pushRoot`/`popRoot`. Triggered after N allocations. |
 | **Primitives** | 31 `primitives_*.zig` files | 689 built-in procedures organized by domain. |
 
 ---
@@ -42,13 +43,15 @@ Source code
 
 | File | Lines | Responsibility |
 |------|-------|---------------|
-| `types.zig` | ~1200 | Value type, `Object`/`ObjectTag`, opcodes, type predicates, hygiene helpers, re-export hub for the `types_*.zig` heap-type domain files below |
-| `memory.zig` | ~850 | GC struct, lifecycle, write barrier, rooting, quarantine; aliases the allocators below into `GC` |
+| `types.zig` | ~1300 | Value type, `Object`/`ObjectTag`, opcodes, type predicates, hygiene helpers, re-export hub for the `types_*.zig` heap-type domain files below |
+| `memory.zig` | ~900 | GC struct, lifecycle, write barrier, rooting, quarantine; aliases the allocators below into `GC` |
 | `gc_alloc.zig` | ~1400 | All `allocXxx` heap-object constructors (delegated from memory.zig, aliased into `GC` so `gc.allocXxx(...)` is unchanged) |
 | `gc_collect.zig` | ~1000 | GC orchestration, remembered set, marking, SRFI 254 weak-ref processing (delegated from memory.zig) |
 | `gc_sweep.zig` | ~600 | Sweep phase: sweepYoung/sweepOld/sweep, `objectSize`, `freeObject` (delegated from gc_collect.zig) |
-| `gc_deep_copy.zig` | — | Cross-thread deep copy (delegated from memory.zig) |
-| `reader.zig` | ~700 | Tokenizer, S-expression parser, Unicode lexing |
+| `gc_deep_copy.zig` | ~580 | Cross-thread deep copy (delegated from memory.zig) |
+| `reader.zig` | ~1000 | `Reader`/`Token`/`ReadError` definitions and the read entry points |
+| `reader_tokens.zig` | ~975 | Tokenizer: Unicode lexing, string/character escapes, number-literal parsing |
+| `reader_datum.zig` | ~360 | Datum construction: lists, vectors, bytevectors, quote forms, datum labels |
 | `expander.zig` | ~1000 | Macro-use expansion engine: expandMacro/expandProceduralMacro, syntax-rules pattern matching, usertext/hygiene-strip walks |
 | `expander_instantiate.zig` | ~1000 | syntax-rules template instantiation + renameForHygiene/scope-table minting (shares expander.zig's threadlocal expansion context) |
 | `printer.zig` | ~1250 | Value → string: iterative label-aware print engine + hashmap cycle/sharing detection (write/display/write-shared/write-simple; exact at any depth) and the bounded diagnostic `printValue` |
@@ -93,13 +96,15 @@ its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 | `compiler_advanced.zig` | case, case-lambda, guard, quasiquote |
 | `compiler_macro.zig` | Macro-use path: expandAndCompileMacroUse, hygiene injection walks, free-ref collection; re-exports compiler_define_syntax.zig |
 | `compiler_define_syntax.zig` | Macro-defining forms: define-syntax, let-syntax, letrec-syntax, define-property, transformer-spec resolution (SRFI 147), syntax-rules parsing, transformer finalization |
+| `compiler_passthrough.zig` | The `passthrough` path's form compilers: quote, if, call, and the tail-position specializations (`apply`, `call-with-values`, `call/cc`, `eval`) |
 | `compiler_forms.zig` | Re-export hub (thin file, don't edit directly) |
 
-### VM (split into 10 files)
+### VM (split into 11 files)
 
 | File | Responsibility |
 |------|---------------|
 | `vm.zig` | VM struct, init/deinit, error handling, delegation wrappers |
+| `vm_bootstrap.zig` | Scheme-level implementations of the higher-order procedures that must drive their callbacks through the dispatch loop rather than the Zig call stack |
 | `vm_dispatch.zig` | runUntil bytecode dispatch loop, opcode handlers; re-exports vm_dispatch_helpers.zig |
 | `vm_dispatch_helpers.zig` | Dispatch support: bytecode/operand readers, register-window validation, the shared global-resolution helper (lookupGlobalLocked, #1831/#1860), noinline error raisers, buildRestList |
 | `vm_calls.zig` | execute, run, callValue, callClosure, callNative, profile helpers |
@@ -165,7 +170,7 @@ its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 | `native_compiler.zig` | LLVM IR emission, native binary compilation, C compiler discovery, linker invocation |
 | `thottam.zig` | Package manager binary (thottam): install, remove, list, update, verify |
 | `llvm_emit.zig` | LLVM IR text emitter core: LLVMEmitter struct/state, program orchestration, call emission, constants/interning (special-form/cond/case/do emitters live in `llvm_emit_forms.zig`; let/lambda/tailcall/inline/freevars satellites likewise) |
-| `runtime_exports.zig` | C-ABI bridge for LLVM native backend (21 exported functions) |
+| `runtime_exports.zig` | C-ABI bridge for LLVM native backend (28 exported functions) |
 | `fmt.zig` | `kaappi fmt`: comment-preserving CST reader (lexer + parser), CLI entry, real-reader `equal?` round-trip safety net |
 | `fmt_print.zig` | `kaappi fmt` layout engine: fits-or-breaks pretty-printer, special-form indentation rules |
 | `testing_helpers.zig` | Shared `makeTestVM` helper for unit tests |
@@ -213,12 +218,20 @@ Every heap object starts with an `Object` header:
 ```zig
 pub const Object = struct {
     tag: ObjectTag,      // u6 -- which type (64 slots)
-    marked: bool = false, // GC mark bit
+    flags: Flags,        // packed u8: marked, generation:u1, survive_count:u2, immutable
+    owner: u32,          // id of the GC that tracks this object (fits in padding)
     next: ?*Object,      // intrusive linked list for GC
+    _align: Align,       // forces 8-byte alignment for the pointer tag check
 };
 ```
 
-### ObjectTag enum (35 types)
+`owner` is what lets an SRFI-18 child thread's heap hold references into the
+parent's without either collector writing mark bits on the other's objects
+(#958); in Debug and gc-stress builds, freeing stamps it with
+`memory.FREED_OWNER` so a later mark of the dead header panics deterministically
+(#1687).
+
+### ObjectTag enum (41 types)
 
 | Tag | Value | Type |
 |-----|-------|------|
@@ -257,20 +270,37 @@ pub const Object = struct {
 | `mutex` | 32 | SRFI-18 mutex |
 | `condition_variable` | 33 | SRFI-18 condition variable |
 | `srfi18_time` | 34 | SRFI-18 time object |
+| `native_closure` | 35 | Zig closure over captured Values (a native procedure with state) |
+| `scheme_environment` | 36 | First-class environment (`eval`'s second argument) |
+| `ephemeron` | 37 | SRFI-254 ephemeron (key/datum pair the GC treats weakly) |
+| `guardian` | 38 | SRFI-254 guardian |
+| `transport_cell` | 39 | SRFI-254 transport cell (an ordinary strong pair on a non-moving GC) |
+| `numeric_vector` | 40 | SRFI-160 homogeneous numeric vector (u8 stays a plain bytevector) |
 
 ---
 
 ## Garbage Collector
 
-The GC is a **mark-and-sweep** collector using an **intrusive linked list**.
+The GC is a **generational mark-and-sweep** collector using an **intrusive
+linked list**.
 
 ### Design
 
 - All heap objects are linked via their `Object.next` pointer.
+- Every object carries a generation bit (young/old) and a survive count in its
+  header; surviving a few collections promotes a young object to old.
 - The GC maintains a count of allocations since the last collection.
 - When the count exceeds a threshold, a collection cycle runs:
   1. **Mark**: Traverse all roots, mark reachable objects.
   2. **Sweep**: Walk the linked list, free unmarked objects.
+- A **minor** collection only marks and sweeps the young generation. Old→young
+  references are found through the **remembered set**, which `gc.writeBarrier`
+  populates whenever a Value is stored into an old object's field — omitting
+  that barrier is the classic way to corrupt a minor collection. A **full**
+  collection covers both generations.
+
+Orchestration and marking live in `gc_collect.zig`, the sweep phase in
+`gc_sweep.zig`; `memory.zig` holds the `GC` struct and aliases both in.
 
 ### Root tracking
 
@@ -283,8 +313,11 @@ gc.pushRoot(&val);    // protect
 gc.popRoot();         // unprotect (must be LIFO)
 ```
 
-Roots are stored in a fixed-size root stack. `pushRoot`/`popRoot` calls must
-be balanced and follow LIFO order.
+The root stack grows geometrically and is hard-capped at
+`GC.MAX_ROOT_CAPACITY` (65536); exceeding it panics. `pushRoot`/`popRoot` calls
+must be balanced and follow LIFO order — see
+[gc-safety-and-error-handling.md](gc-safety-and-error-handling.md) for why a
+`defer popRoot()` is not always the safe spelling.
 
 ---
 

--- a/docs/dev/claude-code-harness.md
+++ b/docs/dev/claude-code-harness.md
@@ -137,7 +137,7 @@ These exact patterns are in the `allow` array:
 | `Bash(sudo *)` | No privilege escalation |
 | `Bash(git push*--force*)` | Remote history protection |
 | `Read(.env*)` | Secrets protection |
-| `Write(.git/**)` | Repository integrity |
+| `Edit(.git/**)` | Repository integrity |
 
 ### Ask (empty)
 
@@ -158,8 +158,8 @@ matter inside each rule file (not in `settings.json`).
 
 Loaded when editing GC-sensitive code (the primitives files, the GC core and
 its gc_alloc/gc_collect/gc_sweep/gc_deep_copy satellites, the VM files, and
-the compiler/expander files, which do GC-sensitive rooting directly).
-Enforces three rules:
+the compiler/expander files, which do GC-sensitive rooting directly). The
+headline rules:
 
 1. **Write barrier required** — call `gc.writeBarrier(container, new_val)`
    after storing a Value into a heap object field. Missing barriers corrupt the
@@ -174,27 +174,49 @@ Enforces three rules:
 3. **Root Function\* before vm.execute()** — `execute()` allocates a closure
    wrapper internally, so unrooted Function pointers can be collected.
 
-Includes a dangerous/safe code example and a stress-test tip
-(`-Dgc-threshold=1` forces GC on every allocation).
+4. **`popRoot()` is LIFO, not per-variable** — a `defer gc.popRoot()` is only
+   safe when nothing else can push to the same stack before it fires. The rule
+   carries a worked instance where a deferred pop removed the wrong root and
+   surfaced much later as a baffling "invalid syntax" error.
+
+5. **Tag a `gc_instance`/`vm_instance` guard by what the function was going to
+   return anyway** — `OutOfMemory` for an allocator, the helper's own tag for
+   an error-message helper, `InvalidBytecode` for everything else.
+
+It also covers what the allocators root for you, the error-path root-stack
+reset at the pipeline boundaries (#1855), injecting an OOM with
+`gc.oom_countdown`, dangerous/safe code examples, and the stress-test lever
+(`-Dgc-stress=true` forces a collection on every allocation).
+[gc-safety-and-error-handling.md](gc-safety-and-error-handling.md) is the full
+rationale the rule condenses.
 
 ### `compiler-forms.md`
 
 **Globs:** `src/compiler*.zig`, `src/ir.zig`, `src/tests_ir.zig`
 
-Loaded when editing compiler or IR code (main compiler, 4 sub-modules,
-re-export hub, IR module, IR tests). Provides a 6-step checklist for adding a
-new compiler form:
+Loaded when editing compiler or IR code (the main compiler, its nine
+sub-modules, the IR module, and the IR tests). It splits the checklist by which
+kind of form you are adding, because the two cost wildly different amounts:
 
-1. Add IR node type in `ir.zig` — variant in `NodeTag`, `Data` union variant,
-   lowering in `lowerFormWithMacros()`/`lowerForm()`, handle in all 3 analysis
-   pass switch arms and all 5 optimization pass switch arms.
-2. Add dispatch in `compileFromNode()` in `compiler.zig`.
-3. Implement in the appropriate `compiler_*.zig` file.
-4. Re-export through `compiler_forms.zig`.
-5. Add IR tests in `tests_ir.zig` — bytecode parity with the legacy
-   `compileExpr()` path.
-6. Handle tail position — pass `tail=true` to sub-expressions that should
-   receive tail call optimization.
+**A delegating form** — the common case, ~4 edits. The form keeps its tail as a
+raw S-expression and rides the single `sexpr_form` node: add a `FormKind`
+variant with its `keyword()`, add the `sexpr_form_map` entry, add a dispatch
+arm in `compileFromNode()` (`compiler_ir.zig`), implement it in the right
+`compiler_*.zig` and re-export through `compiler_forms.zig`, then add IR
+behavioral tests. Nothing in `NodeTag`, `freeNode`, the analysis pass, or the
+five optimization passes needs touching — they all handle `.sexpr_form`
+through `else` arms.
+
+**A structured form** — 7 steps, for forms that lower into IR-level children
+like `if` and `when`: `NodeTag` variant and `Data` union field, lowering in
+`lowerFormWithMacros()` plus a `makeXxx()` constructor, a `freeNode` arm if it
+owns heap slices, a `markTailPositions` arm with the right tail propagation, an
+`llvm_node_table` entry with its capability, dispatch, then implement and test.
+
+Notably absent, and deliberately: there is no bytecode-parity test group any
+more. It compared `ir.zig`'s standalone `Emitter` against the direct compiler
+path, and that emitter was removed in v0.13.0 — `compileFromNode()` is now the
+only IR-to-bytecode path.
 
 ## Skills
 
@@ -203,17 +225,26 @@ Skills are slash-command workflows defined as Markdown files in
 
 ### `/add-builtin`
 
-Guides adding a new built-in Scheme procedure. Steps: write the function in
-the appropriate `primitives_*.zig` file with the standard signature, register
-it in the file's `registerXxx` function with correct arity (`.exact` or
-`.variadic`), add to library exports in `library.zig`.
+Guides adding a new built-in Scheme procedure. Steps: write the function in the
+appropriate `primitives_*.zig` domain file with the standard signature, report
+type errors through `primitives.typeError` rather than a bare
+`PrimitiveError.TypeError`, then add **one** entry to that file's `specs`
+table carrying name, function, arity and exporting libraries.
+
+The single-registration-point part is the bit worth internalizing: there is no
+second list and no manual `reg()` call. `registerAll` walks `all_specs`, and
+`library.zig` derives every export set from the same `libs` tags, so a spec
+entry is the whole registration. A `%`-prefixed internal helper takes
+`primitives.INTERNAL` instead — registered in `vm.globals`, exported by
+nothing, so it does not reserve the name against user libraries (kaappi#1856).
+[adding-features.md](adding-features.md) is the long-form reference.
 
 ### `/audit-primitives`
 
 Audits a primitives file for R7RS correctness. Takes a filename argument
 (e.g., `primitives_arithmetic.zig`). Five-step workflow:
 
-1. Extract all procedures registered with `try reg(vm, ...)`.
+1. List every entry in the file's `specs` table (the single registration point).
 2. Cross-reference against R7RS sections 6.1–6.14 — check correct behavior,
    type errors, boundary conditions, higher-order callbacks, optional args.
 3. Write test file at `tests/scheme/audit/<basename>-audit.scm`.
@@ -299,6 +330,16 @@ architectures:
 | riscv64 | Cross-compile, run in RISC-V container via QEMU | ~5 min |
 
 Uses `kaappi-builder` Docker images from `ci-images/builder/`.
+
+### `/vm-test`
+
+Powers on one of the local UTM virtual machines via `utmctl` and runs the build
+and test battery on it over SSH. These VMs are the reference machines for the
+OS/architecture ports — FreeBSD, OpenBSD, NetBSD, Windows, and the s390x and
+ppc64le Alpine guests — so this is the way to reproduce a CI failure on a real
+guest rather than an emulated cross-compile. Complements `/linux-test`
+(podman) and `/do-linux-test` (DigitalOcean) with the local fleet; the per-OS
+particulars are in [porting.md](porting.md) and the four BSD/Windows docs.
 
 ### `/do-linux-test`
 
@@ -393,10 +434,11 @@ The plugin manifest lives at `infra/.claude-plugin/plugin.json`.
 
 | Skill | Purpose |
 |-------|---------|
-| `/kaappi-dev:test-ecosystem` | Run tests for one or all 16 ecosystem libraries against the local kaappi binary |
-| `/kaappi-dev:repo-status` | Git status dashboard across all 24 repos (branch, dirty files, ahead/behind, CI) |
+| `/kaappi-dev:test-ecosystem` | Run tests for one or all 20 ecosystem libraries against the local kaappi binary |
+| `/kaappi-dev:repo-status` | Git status dashboard across all repos (branch, dirty files, ahead/behind, CI) |
 | `/kaappi-dev:ci-check` | GitHub Actions status across all repos plus nightly workflow |
-| `/kaappi-dev:pull-all` | Fetch and rebase all 24 repos on `origin/main` |
+| `/kaappi-dev:pull-all` | Fetch and rebase every repo on `origin/main` |
+| `/kaappi-dev:new-ecosystem-lib` | Scaffold a new `kaappi-*` library with the standard layout, CI, and tests (`--ffi`, `--depends`) |
 | `/kaappi-dev:release-ecosystem` | Cut a release for an ecosystem library (version bump, changelog, tag, push) |
 | `/kaappi-dev:coverage-report` | Procedure-level `--coverage` across all ecosystem libs, highlights <80% |
 
@@ -425,8 +467,9 @@ Reports issues by severity: error, warning, suggestion.
 
 The `infra/` repo also contains non-plugin resources:
 
-- `repos.json` — inventory of all 24 repos with categories and expected files
-- `labels.json` — 10 standard GitHub labels synced across all repos
+- `repos.json` — inventory of all 27 repos with categories and expected files
+  (20 ecosystem, 3 meta, plus core, tooling, infra and docs)
+- `labels.json` — the standard GitHub labels synced across all repos
 - `scripts/` — Kaappi Scheme scripts for repo auditing and license generation
 - `docs/` — repo conventions, CI architecture, and release process docs
 - `.github/workflows/sync-labels.yml` — syncs labels to all org repos

--- a/docs/dev/ir.md
+++ b/docs/dev/ir.md
@@ -2,10 +2,10 @@
 
 The compiler IR is a tree-structured intermediate representation that sits
 between the macro expander and bytecode emission. It enables shared analysis
-and optimization passes that benefit both the bytecode VM and LLVM backend, and
-provides a clean lowering target for a future native backend.
+and optimization passes that benefit both the bytecode VM and the LLVM native
+backend.
 
-**Source:** `src/ir.zig` (~1,400 lines)
+**Source:** `src/ir.zig` (~1,450 lines)
 **Tests:** `src/tests_ir.zig` (~850 lines)
 
 **See also:** [KEP-0008](https://github.com/kaappi/keps/blob/main/keps/0008-shared-ir-contract.md)
@@ -255,7 +255,7 @@ Structural cleanup:
 
 ## Bytecode Emission
 
-`compileFromNode()` in `compiler.zig` dispatches on the IR node tag:
+`compileFromNode()` in `compiler_ir.zig` dispatches on the IR node tag:
 
 - **Fully-lowered forms** (`constant`, `global_ref`, `call`, `if`, `begin`,
   `and_form`, `or_form`, `when_form`, `unless_form`, `define`, `set_form`,
@@ -298,10 +298,16 @@ There is no longer a bytecode-parity group. It tested `ir.zig`'s standalone
 
 ---
 
-## Future: Native Backend
+## The native backend's second reading of this IR
 
-The IR is designed to serve as input for a future LLVM IR native backend
-(Stage 6, issue #99). The direct-style IR (not CPS) was chosen to serve
-both the bytecode and native backends without conversion. See
+The LLVM native backend consumes the same IR, which is why it is direct-style
+rather than CPS — one representation serves both tiers without conversion. See
 [continuation-strategy.md](decisions/continuation-strategy.md) for the hybrid
 approach to `call/cc` in native code.
+
+The consequence worth knowing before editing either side: because the binding
+tags and `sexpr_form` hold their tails as raw S-expressions, every lambda,
+closure and `let` body reaches the backend unlowered and gets *re-lowered*
+during emission. `LLVMEmitter.lowerScoped` is the only correct way to do that —
+a bare `ir.lowerSingleExpr*` drops `bound_names`/`set_targets` and reopens
+kaappi#2117/#2118. [llvm-backend.md](llvm-backend.md) is the full reference.

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -21,7 +21,8 @@ All must pass before any change is considered complete.
 
 ### Location
 
-Unit tests live in `src/tests_*.zig`, organized by feature:
+Unit tests live in `src/tests_*.zig`, organized by feature. There are ~50 of
+them; the ones below are the entry points you are most likely to want:
 
 | File | Coverage |
 |------|----------|
@@ -37,7 +38,7 @@ Unit tests live in `src/tests_*.zig`, organized by feature:
 | `tests_continuations.zig` | Continuations (call/cc, dynamic-wind) |
 | `tests_advanced.zig` | Advanced R7RS features |
 | `tests_filesystem.zig` | SRFI-170 filesystem operations |
-| `tests_ir.zig` | IR lowering, analysis passes, optimization passes, bytecode parity |
+| `tests_ir.zig` | IR lowering, the analysis pass, optimization passes, behavioral correctness |
 | `tests_robustness.zig` | Edge cases and stress tests |
 
 ### Helper: makeTestVM
@@ -147,27 +148,45 @@ Scheme tests live in `tests/scheme/`, organized by purpose:
 
 ```text
 tests/scheme/
+  CLAUDE.md         Directory layout rules + the verdict-channel inventory
   r7rs/             R7RS test suite (1,395 tests via chibi test)
     r7rs-tests.scm  Canonical suite — imports (chibi test)
-  smoke/            Quick sanity checks
-    basic.scm       Arithmetic, if, define, lambda, pairs
-    tail-calls.scm  Proper tail recursion
-    derived.scm     and/or/when/unless/cond/do/case/let*
-    numeric.scm     Flonums, inf/nan, mixed arithmetic
-    macros.scm      syntax-rules, ellipsis, hygiene
-    libraries.scm   import/only/rename/prefix
+
+  # .scm suites (globbed by run-all.sh, one fresh interpreter per file)
+  smoke/            Quick sanity checks (basic, tail-calls, derived, numeric,
+                    macros, libraries) plus per-issue regressions
   compliance/       Targeted conformance tests by topic
-    strings.scm, vectors.scm, chars.scm, unicode.scm, etc.
+                    (strings.scm, vectors.scm, chars.scm, unicode.scm, …)
   continuations/    Advanced call/cc and call/ec edge cases
   hygiene/          Macro hygiene edge cases
   srfi/             SRFI library tests
-  ffi/              C FFI tests
+  ffi/              C FFI tests (+ fixtures/ built on the fly by run-all.sh)
   audit/            Primitives correctness audits
-  errors/           Error message format regression tests
-  robustness/       Malformed and adversarial input handling
-  sandbox/          Sandbox escape prevention tests
+
+  # shell suites (each directory's *.sh, run in parallel)
+  errors/           Error format, diagnostics JSON, exit codes, crash handler
+  compile/          Native tier — the only suite that runs `kaappi compile`
+  test-runner/      `kaappi test`: discovery, --json, --seed, --jobs
+  pipeline/         `kaappi ast` / `expand` / `ir` dumps
+  doctor/ fmt/ cache/ timings/ completions/ lsp/ thottam/
+                    One per CLI subcommand or tool surface
+  differential/     Execution-tier differential (opt-off, warm cache, WASM)
+
+  # not run by run-all.sh
+  robustness/       Malformed and adversarial input handling (its own .sh)
+  sandbox/          Sandbox escape prevention (its own .sh)
+  bench/ coverage/  Deliberately skipped by run-all.sh
+
   run-all.sh        Run all suites with summary
+  shell-common.sh   Shared helpers for the .sh suites
 ```
+
+Two structural checks run before any suite. **Reachability** fails the run if a
+file containing `test-begin` sits in a suite *subdirectory*, where the
+non-recursive globs cannot see it — that is how `tests/scheme/srfi/slow/` hid
+two full SRFI 257 suites for eleven days (kaappi#1900). **Verdict-channel**
+fails it if a globbed file contains none of `test-begin`, `(exit`, `(error` or
+`(assert`; see "Do not write a test that prints its answer" below.
 
 ### Running
 
@@ -274,14 +293,29 @@ conversions); keep any count here in step with it.
 
 ## Shell-Based Test Suites
 
-Three shell scripts test behaviors that are easier to verify from outside
-the interpreter:
+Roughly sixty shell scripts test behaviors that are easier to verify from
+outside the interpreter — exit codes, stderr text, subcommand output, native
+compilation. Most live in a per-topic directory that `run-all.sh` picks up
+wholesale via `run_shell_suite` (see the tree above); each sources
+`tests/scheme/shell-common.sh` for the shared assertion helpers.
+
+### Compile (`tests/scheme/compile/*.sh`)
+
+The native tier's only test surface. A `.scm` regression test is
+interpreter-only evidence: it never reaches `kaappi compile`, and three of them
+passed for years while the native backend failed them. Any fix touching the
+LLVM backend belongs here.
+
+```bash
+bash tests/scheme/compile/native-lexical-scope-fold-2117-2118.sh
+```
 
 ### Robustness (`tests/scheme/robustness/robustness.sh`)
 
-Tests that malformed, adversarial, or extreme inputs produce clean errors
-rather than panics or crashes. Uses `assert_error` (must produce `error:`)
-and `assert_no_crash` (must not exit by signal) helpers.
+Not wired into `run-all.sh` — CI invokes it directly. Tests that malformed,
+adversarial, or extreme inputs produce clean errors rather than panics or
+crashes. Uses `assert_error` (must produce `error:`) and `assert_no_crash`
+(must not exit by signal) helpers.
 
 ```bash
 bash tests/scheme/robustness/robustness.sh
@@ -289,10 +323,10 @@ bash tests/scheme/robustness/robustness.sh
 
 ### Sandbox escape (`tests/scheme/sandbox/sandbox-escape.sh`)
 
-Verifies that `--sandbox` mode blocks all restricted operations (FFI,
-file I/O, eval, load, environment access) while allowing safe operations
-(arithmetic, string ports, hash tables). Uses `assert_blocked` and
-`assert_works` helpers.
+Also invoked directly by CI rather than through `run-all.sh`. Verifies that
+`--sandbox` mode blocks all restricted operations (FFI, file I/O, eval, load,
+environment access) while allowing safe operations (arithmetic, string ports,
+hash tables). Uses `assert_blocked` and `assert_works` helpers.
 
 ```bash
 bash tests/scheme/sandbox/sandbox-escape.sh
@@ -300,6 +334,7 @@ bash tests/scheme/sandbox/sandbox-escape.sh
 
 ### Error format (`tests/scheme/errors/error-format.sh`)
 
+One of the `errors/` suite's scripts, so `run-all.sh` already covers it.
 Checks that error messages include proper `file:line` location info for
 reader, compile, and runtime errors.
 
@@ -307,7 +342,7 @@ reader, compile, and runtime errors.
 bash tests/scheme/errors/error-format.sh
 ```
 
-All three are run by CI on every push and pull request.
+CI runs all of these on every push and pull request.
 
 ---
 
@@ -324,8 +359,8 @@ Tests live in `tests/acceptance/`:
 
 | File | Purpose |
 |------|---------|
-| `acceptance.sh` | 34 tests: version, arithmetic, data structures, Unicode, library imports, file execution, tail calls, closures, continuations, error handling, sandbox, thottam |
-| `test-wasm.sh` | 14 WASM-specific tests via wasmtime (no FFI) |
+| `acceptance.sh` | ~36 assertions: version, arithmetic, data structures, Unicode, library imports, file execution, tail calls, closures, continuations, error handling, sandbox, thottam |
+| `test-wasm.sh` | ~13 WASM-specific assertions via wasmtime (no FFI) |
 | `hello.scm` | Minimal test program for file execution |
 
 ### Running locally
@@ -341,16 +376,18 @@ KAAPPI_WASM=./zig-out/bin/kaappi.wasm \
 ### CI workflow
 
 The `post-release.yml` workflow triggers automatically on `release: published`
-events. It runs 6 jobs in parallel:
+events. It runs these jobs in parallel, then a `summary` job that fails the run
+if any of them did:
 
 | Job | What it tests |
 |-----|--------------|
 | `test-macos` | macOS ARM release binary |
 | `test-linux-x86` | Linux x86_64 release binary |
 | `test-linux-arm` | Linux ARM release binary |
+| `test-windows-x64` | Windows x86_64 release binary |
 | `test-wasm` | WASM binary via wasmtime |
 | `test-checksums` | SHA256SUMS verification + GPG signature |
-| `test-install-script` | Full install script end-to-end |
+| `test-install-script` | The live install script from the docs repo, end to end |
 
 To trigger manually against an existing release:
 
@@ -519,13 +556,24 @@ matrix covers:
 
 | Job | Platforms | What it runs |
 |-----|-----------|-------------|
-| `format` | Ubuntu | `zig fmt --check`, TypeError regression baseline |
-| `test` | Ubuntu (x86, ARM), macOS | Unit tests, all Scheme suites, robustness, sandbox, error format, thottam integration |
+| `format` | Ubuntu | `zig fmt --check`, markdownlint, bare-`TypeError` ratchet (zero allowed) |
+| `test` | Ubuntu (x86, ARM), macOS | Unit tests, `run-all.sh`, robustness, sandbox, thottam integration, SRFI final-status guard |
+| `gc-stress` | Ubuntu | Unit suite under `-Dgc-stress=true` |
+| `gc-stress-scheme` | Ubuntu | Scheme suites under `-Dgc-stress=true` |
 | `riscv64-test` | Ubuntu (QEMU) | Cross-compiled unit tests + R7RS suite |
+| `s390x-test` | Ubuntu (QEMU) | Big-endian leg — the byte-order canary (kaappi#1654) |
+| `ppc64le-test` | Ubuntu (QEMU) | Cross-compiled unit tests + R7RS suite |
+| `freebsd-test`, `openbsd-test`, `netbsd-test` | Ubuntu (VM action) | Per-BSD build + tests; see the matching `docs/dev/<os>.md` |
+| `windows-cross` | Ubuntu | Cross-compile check for both Windows targets |
+| `windows-arm-test` | Windows 11 ARM | Native build + tests |
+| `windows-x64-test` | Windows x86_64 | Native build + tests |
 | `wasm` | Ubuntu | WASM build + wasmtime smoke test |
 | `coverage` | Ubuntu (push to main only) | kcov unit + Scheme coverage, Codecov upload |
 | `benchmark` | Ubuntu (push to main only) | Performance benchmarks, trend data to `gh-pages` |
-| `benchmark-pr` | Ubuntu (PRs, path-filtered) | PR vs base branch benchmark comparison |
+| `benchmark-pr` | Ubuntu (PRs, path-filtered) | PR vs base branch benchmark comparison (`benchmark-pr.yml`) |
+
+`fuzz.yml` runs the fuzz targets on a schedule — see
+[fuzzing.md](fuzzing.md).
 
 Post-release: `post-release.yml` runs automatically after each release,
 testing the actual published artifacts on all platforms.
@@ -542,24 +590,21 @@ identical output to the interpreter. They live in `tests/e2e/`:
 ```text
 tests/e2e/
   run-e2e.sh              Shell runner (BDD specs + native parity tests)
+  run-e2e.ps1             PowerShell equivalent for the Windows legs
   test-llvm-backend.scm   BDD specs using kaappi-bdd
-  programs/               Scheme programs compiled to native binaries
-    arithmetic.scm         Constant-folded addition
-    string.scm             String display
-    define.scm             Global variable binding
-    if-expr.scm            Conditional branching
-    lambda-basic.scm       Lambda and application
-    lambda-closure.scm     Closures with upvalues
-    nested-calls.scm       Non-foldable nested calls
-    and-or.scm             Short-circuit boolean logic
-    when-unless.scm        Conditional body execution
-    set-bang.scm           Variable mutation
-    let-binding.scm        Local bindings via kaappi_eval
-    import.scm             Library imports
-    symbol-eq.scm          Symbol identity in closures
-    quoted-list.scm        Quoted list constants
-    macro.scm              User-defined macros
+  test-argv.scm           Command-line argument handling in a native binary
+  programs/               ~37 Scheme programs compiled to native binaries,
+                          covering the language surface the backend emits
+                          directly (arithmetic, closures, captures, variadic
+                          and mutual tail calls, cond/case/do, guard, call/cc)
+                          plus the cache and fallback paths
 ```
+
+Each program is run through the interpreter and through a compiled binary; any
+output difference is a failure. Adding one is the cheapest way to pin a native
+codegen fix — but note that a bug reproducible only through `kaappi compile`
+with a *specific* flag or import belongs in `tests/scheme/compile/*.sh`
+instead, where the invocation itself is part of the test.
 
 ### Running
 
@@ -590,4 +635,6 @@ When making changes, verify:
 4. `bash tests/scheme/run-all.sh` passes all suites
 5. New features have both Zig unit tests and Scheme integration tests
 6. Bug fixes include a regression test that fails without the fix
-7. No regressions in related areas
+7. Anything touching the native tier has a `tests/scheme/compile/*.sh` test —
+   a `.scm` file never reaches `kaappi compile` and so proves nothing about it
+8. No regressions in related areas


### PR DESCRIPTION
A read-through of every document under `docs/dev/`, with each claim checked
mechanically against the source: referenced paths, `.zig` filenames, function
names, CLI flags, `zig build` steps, enum counts, SRFI counts, CI job lists.

Most of the corpus verified clean. `bytecode.md`, `fibers-and-reactor.md`,
`adding-features.md`, `srfi-status-check.md`, `repl.md` and `ir.md`'s node and
`FormKind` tables are all exact, and the comptime doc-sync gates in `ir.zig`
and `types.zig` have held their numbers. The drift had collected in the four
documents those gates do not cover.

## architecture.md

The consequential one. The GC section described a plain **mark-and-sweep**
collector — no generations, no write barrier, no remembered set. A reader
working only from that page would not know why `gc.writeBarrier` exists, which
is the first rule `.claude/rules/gc-safety.md` states. Also:

- `ObjectTag` documented as 35 types; it is **41**. Six tags were missing
  entirely (`native_closure`, `scheme_environment`, the three SRFI-254
  weak-ref tags, `numeric_vector`).
- The `Object` header snippet omitted `flags` (generation, survive count) and
  `owner` — the field that makes cross-heap thread references safe.
- Root stack called "fixed-size"; it grows to `MAX_ROOT_CAPACITY` (65536).
- `compiler_passthrough.zig` and `vm_bootstrap.zig` absent from tables whose
  headers claim to be exhaustive; sub-module counts stale (`+5`, `+7`,
  "32 syntax forms across 6 files"); reader shown as one file when it is
  three; `runtime_exports.zig` 21 → 28 functions.

## claude-code-harness.md

Described the **pre-`specs`-table** registration flow for both `/add-builtin`
and `/audit-primitives`: `registerXxx`, `try reg(vm, ...)`, "add to library
exports in `library.zig`". That is exactly the manual second list the `specs`
table removed, so the harness doc was teaching the mistake the skills were
rewritten to prevent.

Its `compiler-forms.md` summary cited a `lowerForm()` that does not exist,
"3 analysis passes" where there is one, and bytecode-parity tests deleted in
v0.13.0. Its gc-safety summary gave `-Dgc-threshold=1` as the stress lever
instead of `-Dgc-stress=true`. `/vm-test` was missing; the deny rule was
`Write(.git/**)` vs the actual `Edit(.git/**)`; infra counts were 24 repos /
16 libs / 6 skills vs 27 / 20 / 7.

## testing.md

"Three shell scripts" describes a world with roughly sixty across thirteen
directories. The `tests/scheme/` tree omitted `compile/` — the only surface
that reaches `kaappi compile`, and therefore the only place a native-tier
regression test can live — plus `cache/`, `differential/`, `test-runner/`,
`pipeline/`, `lsp/` and six more. The CI table listed 7 of 16 jobs: no
gc-stress, no BSD legs, no Windows, no s390x/ppc64le. The e2e section listed
15 of 37 programs. `tests_ir.zig` was still credited with a bytecode-parity
group.

## ir.md

Closed with a "Future: Native Backend" section pointing at issue #99 for a
backend that shipped. Replaced with the re-lowering constraint that actually
matters when editing either tier (`LLVMEmitter.lowerScoped`, kaappi#2117/#2118).
`compileFromNode()` was attributed to `compiler.zig`; it lives in
`compiler_ir.zig`.

## Outside docs/dev

Same facts, kept in step because the docs require it:

- `CLAUDE.md` — heap types 36 → 41, added `/vm-test`, fixed the
  `srfi-status-check.md` one-liner (it documents a final-status CI guard, not
  count re-derivation — `docs/dev/README.md` had the same wrong description).
- `.claude/rules/gc-safety.md` — "panics on overflow at 1024 slots" → the
  buffer grows geometrically to 65536.

## Deliberately not changed

`README.md`, `CLAUDE.md` and `llvm-backend.md` all say **689 built-in
procedures**; counting unique `.name` entries across the `specs` tables gives
**688**. Without knowing how the original figure was derived, changing it
would trade a possibly-right number for a confidently-wrong one. Worth a look
from someone who knows.

## Verification

Docs-only — no `.zig` changed. `markdownlint-cli2` clean across all 88 files
(the CI `format` job's check). Every intra-doc link and anchor resolves; every
referenced repo path, `.zig` file, function name, CLI flag and `zig build`
step was checked to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)