### PR TITLE
Stop two shell drivers tripping over the .exe suffix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -948,6 +948,16 @@ jobs:
         # hold on Windows — the compile/ suite needs a native Zig toolchain
         # (#1613) — reports itself instead of failing. KAAPPI_HOME is
         # isolated like run-all.sh does, so suites never touch a real cache.
+        #
+        # The directory list mirrors run-all.sh's, plus sandbox and
+        # robustness (which run-all.sh leaves to CI). completions, lsp,
+        # thottam and differential were outside it until #2220 — which is
+        # how completions/completions.sh came to fail on Windows unobserved
+        # for as long as it did. Expect two of the four to report SKIP here:
+        # thottam-lifecycle.sh builds git fixtures at POSIX paths, and
+        # run-wasm-differential.sh wants wasmtime. run-differential.sh is
+        # the expensive one at ~9 min on the reference VM, roughly tripling
+        # this step; the job sits ~6 min against its timeout, so it fits.
         shell: bash
         run: |
           # Some drivers validate JSON with python3; the arm image ships
@@ -963,7 +973,8 @@ jobs:
           export KAAPPI=bin/kaappi.exe
           export KAAPPI_HOME="$RUNNER_TEMP/kaappi-test-home"
           fail=0
-          for dir in smoke errors compile test-runner pipeline doctor fmt cache timings sandbox robustness; do
+          for dir in smoke errors compile test-runner pipeline doctor fmt cache timings \
+                     completions lsp thottam differential sandbox robustness; do
             for s in tests/scheme/$dir/*.sh; do
               [ -e "$s" ] || continue
               # `|| status=$?`: the runner's `shell: bash` implies -e, which
@@ -1098,6 +1109,16 @@ jobs:
         # hold on Windows — the compile/ suite hard-skips on the OS — reports
         # itself instead of failing. KAAPPI_HOME is isolated like run-all.sh
         # does, so suites never touch a real cache.
+        #
+        # The directory list mirrors run-all.sh's, plus sandbox and
+        # robustness (which run-all.sh leaves to CI). completions, lsp,
+        # thottam and differential were outside it until #2220 — which is
+        # how completions/completions.sh came to fail on Windows unobserved
+        # for as long as it did. Expect two of the four to report SKIP here:
+        # thottam-lifecycle.sh builds git fixtures at POSIX paths, and
+        # run-wasm-differential.sh wants wasmtime. run-differential.sh is
+        # the expensive one at ~9 min on the reference VM, roughly tripling
+        # this step; the job sits ~6 min against its timeout, so it fits.
         shell: bash
         run: |
           # Some drivers validate JSON with python3; shim python3 when the
@@ -1112,7 +1133,8 @@ jobs:
           export KAAPPI=bin/kaappi.exe
           export KAAPPI_HOME="$RUNNER_TEMP/kaappi-test-home"
           fail=0
-          for dir in smoke errors compile test-runner pipeline doctor fmt cache timings sandbox robustness; do
+          for dir in smoke errors compile test-runner pipeline doctor fmt cache timings \
+                     completions lsp thottam differential sandbox robustness; do
             for s in tests/scheme/$dir/*.sh; do
               [ -e "$s" ] || continue
               # `|| status=$?`: the runner's `shell: bash` implies -e, which

--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -393,7 +393,7 @@ Read this before every session. The phase sections say *what*; this says *how*.
 ### Footguns
 
 - **`timeout` does not exist on stock macOS.** Use the `run_timeout` helper in
-  `tests/scheme/audit-baseline.sh` (tries `timeout`, then `gtimeout`, then
+  `tools/audit-baseline.sh` (tries `timeout`, then `gtimeout`, then
   `perl -e 'alarm shift; exec @ARGV' 30 <cmd>`). A hang is a finding.
 - **Run expanded/reformatted files in the original's directory.** A
   round-trip harness that runs the output from a different cwd breaks relative
@@ -572,7 +572,7 @@ F1–F13 (reproducing the two `[A]` rows first).
 zig build test
 kaappi test tests
 bash tests/scheme/run-all.sh
-bash tests/scheme/audit-baseline.sh /tmp/audit-v2-baseline
+bash tools/audit-baseline.sh /tmp/audit-v2-baseline
 ```
 
 The 2026-07-31 baseline (`261fde5f`, macOS aarch64, ReleaseSafe) was **624/624

--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -297,8 +297,18 @@ gates lift work at the 0.17.0 toolchain bump) and
 which Windows filenames cannot contain). shell-common.sh also carries
 the portability helpers the drivers need on Windows: `native_path` (the
 C:/-style spelling the binary itself prints, via `cygpath -m` — MSYS
-`/tmp/...` paths never appear in kaappi's own output) and `rt_lib_name`
-(`kaappi_rt.lib` vs `libkaappi_rt.a`).
+`/tmp/...` paths never appear in kaappi's own output), `rt_lib_name`
+(`kaappi_rt.lib` vs `libkaappi_rt.a`), and `sibling_tool` (the path to
+`thottam` or `kaappi-lsp` beside the binary under test, carrying the
+`.exe` suffix). The suffix is the recurring trap: runners spell the
+binary both ways — `bin/kaappi.exe` in CI, plain `zig-out/bin/kaappi`
+from a Git Bash checkout, which works because MSYS appends `.exe` when
+*executing*. A script that merely runs the result never notices; one
+that names the file, `-x`-tests it, or derives an output filename from
+its basename does. `completions/completions.sh` wrote its generated
+scripts to `$TMP/$(basename "$bin").$shell` and then sourced a
+hardcoded `$TMP/kaappi.bash`, so 19 of its 39 checks failed on Windows
+until the generated names were keyed to the tool rather than the file.
 
 What CI still can't run — interactive surfaces like the console REPL —
 is verified against a real Windows 11 ARM64 machine (e.g. a UTM VM with

--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -283,18 +283,34 @@ that `windows-cross` cross-compiles into each artifact
 (`zig cc -target <arch>-windows-gnu -shared`).
 
 The shell-based drivers (errors, test-runner, pipeline, doctor, fmt,
-cache, timings, the smoke `.sh` scripts, sandbox, robustness) run under
-the runner's Git Bash, whose MSYS userland supplies bash, coreutils,
-git, and — via a CI shim when the image only exposes `python` — python3.
+cache, timings, completions, lsp, thottam, differential, the smoke
+`.sh` scripts, sandbox, robustness) run under the runner's Git Bash,
+whose MSYS userland supplies bash, coreutils, git, and — via a CI shim
+when the image only exposes `python` — python3.
+
+**Keep that list in step with `run-all.sh`.** It is a hand-maintained
+enumeration in two places in ci.yml, not a directory glob, so a suite
+added to `run-all.sh` is covered everywhere *except* Windows until
+someone edits both loops. The first four names above were missing for
+exactly that reason, and `completions/completions.sh` failed on Windows
+unobserved the whole time — it wrote `$TMP/kaappi.exe.bash` and sourced
+`$TMP/kaappi.bash`, 19 of 39 checks, fixed in #2220 along with the
+coverage gap that hid it. `differential/run-differential.sh` is the
+expensive addition, ~9 min on the reference VM against a job that
+otherwise runs in ~6.
+
 A driver whose premise cannot hold on Windows sources
 `tests/scheme/shell-common.sh` and calls `skip_on_windows <reason>`,
 exiting 77 (the shell analogue of the `cond-expand (windows ...)` gate
 the `.scm` tests use); run-all.sh and the CI loop report those as SKIP.
 Today that is the `compile/` suite (each script rebuilds the runtime
 archive or interpreter with a native `zig` on the box — #1613, so the
-gates lift work at the 0.17.0 toolchain bump) and
+gates lift work at the 0.17.0 toolchain bump),
 `profile-json-escaping.sh` (it plants `"`/`\` in a real directory name,
-which Windows filenames cannot contain). shell-common.sh also carries
+which Windows filenames cannot contain), `thottam-lifecycle.sh` (its
+fixture builds local git repos at POSIX paths) and
+`run-wasm-differential.sh` (no wasmtime on the runners).
+shell-common.sh also carries
 the portability helpers the drivers need on Windows: `native_path` (the
 C:/-style spelling the binary itself prints, via `cygpath -m` — MSYS
 `/tmp/...` paths never appear in kaappi's own output), `rt_lib_name`
@@ -328,12 +344,24 @@ Two environment notes for the suite:
   `/tmp/...`, which Windows resolves to `\tmp` on the current drive.
 * Run from a writable directory; a few tests create files in the CWD.
 
-Verified on Windows 11 ARM64 (build 26100): full unit suite, the
-complete R7RS suite, every `tests/scheme/{smoke,compliance,
-continuations,hygiene,srfi,ffi,audit}` file, and the shell-based
-suites under Git Bash (34 pass, 15 skip: the 14 `compile/` gates plus
-`profile-json-escaping.sh`) — the same set the `windows-arm-test` CI
-job now runs on every PR.
+Verified on Windows 11 ARM64, most recently build 26200: full unit
+suite (1667 pass, 16 skip), thottam suite (68 pass, 3 skip), the
+complete R7RS suite (1395/0), 612 files across
+`tests/scheme/{smoke,compliance,continuations,hygiene,srfi,ffi,audit,
+errors}`, and the shell-based suites under Git Bash — **46 pass, 0
+fail, 28 skip**, running the exact directory list the CI loop
+iterates. The 28 are the 25 `compile/` gates plus
+`profile-json-escaping.sh`, `thottam-lifecycle.sh`, and
+`run-wasm-differential.sh`. The earlier record for build 26100 read
+34 pass / 15 skip against a smaller CI list and a `compile/` suite
+that had fewer scripts; both numbers grew, neither is a regression.
+
+The interactive REPL is the one surface no CI job can reach. Drive it
+from a pty over ssh — the OpenSSH server hands the session a ConPTY,
+so isocline's Windows console backend gets real key events and VT
+sequences sent as input arrive as arrow keys. Run the binary through a
+`.cmd` launcher rather than an inline command: the box's default shell
+is PowerShell, which rejects `&&` and eats the quoting.
 
 The **x86_64** build was verified on the same reference machine via
 Windows 11's built-in x64 emulation layer (x64 binaries run
@@ -341,7 +369,8 @@ transparently on ARM64 Windows), which is also how to re-test it
 there: cross-compile with `-Dtarget=x86_64-windows`, ship, run. The
 full set passed under emulation — unit suite (1166/0, 15 skips),
 thottam suite, R7RS, all 436 `.scm` suite files, the shell suites
-(same 34/15/0 profile as aarch64), the post-release acceptance script
+(the 34/15/0 profile aarch64 also had at that time), the post-release
+acceptance script
 (34/34), and the native-backend e2e (see above). A stripped x86_64
 kaappi.exe starts and runs correctly — the #1607 strip crash does not
 exist on this arch. Emulation is a fidelity compromise (it validates

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -195,6 +195,8 @@ Conventions:
   above. `shell-common.sh` also provides `is_windows`, `native_path`
   (the C:/-style path spelling kaappi itself prints, for output
   assertions), `rt_lib_name` (`libkaappi_rt.a` / `kaappi_rt.lib`),
+  `sibling_tool` (the path to `thottam`/`kaappi-lsp` next to the binary
+  under test, carrying the `.exe` suffix the caller used),
   `skip_without_zig` (skip when the script itself must rebuild with a
   Zig toolchain — boxes running cross-compiled binaries have none, see
   `docs/dev/freebsd.md`), `ensure_runtime_lib` (freshen

--- a/tests/scheme/completions/completions.sh
+++ b/tests/scheme/completions/completions.sh
@@ -29,7 +29,7 @@ KAAPPI="${1:-${KAAPPI:-zig-out/bin/kaappi}}"
 # *write* a file named after its argument, and a probe that does that in the
 # repo checkout leaves droppings in the working tree.
 KAAPPI="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
-THOTTAM="$(dirname "$KAAPPI")/thottam"
+THOTTAM="$(sibling_tool "$KAAPPI" thottam)"
 PASS=0
 FAIL=0
 TMP="$(mktemp -d)"
@@ -43,11 +43,26 @@ pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "FAIL: $1 — $2"; FAIL=$((FAIL + 1)); }
 
 # ── 1. Every shell emits a script, and unknown shells are a usage error ─────
+#
+# The generated scripts are named after the *tool* (kaappi, thottam), never
+# after the binary file: on Windows that file is kaappi.exe, and every reader
+# below — `bash -n`, the sourced completion function, the grep assertions —
+# wants one stable spelling. Deriving the name from `basename "$bin"` wrote
+# kaappi.exe.bash while §3 and §4 went on sourcing kaappi.bash, which is 19
+# of this suite's 39 checks failing on Windows for no reason of their own.
+
+bin_for() { # <tool> -> the binary path for that tool
+    case "$1" in
+        kaappi) printf '%s\n' "$KAAPPI" ;;
+        thottam) printf '%s\n' "$THOTTAM" ;;
+    esac
+}
 
 for shell in bash zsh fish; do
-    for bin in "$KAAPPI" "$THOTTAM"; do
-        name="$(basename "$bin") --completions $shell"
-        out="$TMP/$(basename "$bin").$shell"
+    for tool in kaappi thottam; do
+        bin="$(bin_for "$tool")"
+        name="$tool --completions $shell"
+        out="$TMP/$tool.$shell"
         status=0
         "$bin" --completions "$shell" > "$out" 2> "$TMP/err" || status=$?
         if [[ "$status" -ne 0 ]]; then
@@ -62,20 +77,20 @@ done
 
 # ── 2. The scripts parse as the shell they claim to be ──────────────────────
 
-for bin in kaappi thottam; do
-    if bash -n "$TMP/$bin.bash" 2> "$TMP/err"; then
-        pass "$bin bash script parses (bash -n)"
+for tool in kaappi thottam; do
+    if bash -n "$TMP/$tool.bash" 2> "$TMP/err"; then
+        pass "$tool bash script parses (bash -n)"
     else
-        fail "$bin bash script parses (bash -n)" "$(cat "$TMP/err")"
+        fail "$tool bash script parses (bash -n)" "$(cat "$TMP/err")"
     fi
 done
 
 if command -v zsh > /dev/null 2>&1; then
-    for bin in kaappi thottam; do
-        if zsh -n "$TMP/$bin.zsh" 2> "$TMP/err"; then
-            pass "$bin zsh script parses (zsh -n)"
+    for tool in kaappi thottam; do
+        if zsh -n "$TMP/$tool.zsh" 2> "$TMP/err"; then
+            pass "$tool zsh script parses (zsh -n)"
         else
-            fail "$bin zsh script parses (zsh -n)" "$(cat "$TMP/err")"
+            fail "$tool zsh script parses (zsh -n)" "$(cat "$TMP/err")"
         fi
     done
 else
@@ -83,11 +98,11 @@ else
 fi
 
 if command -v fish > /dev/null 2>&1; then
-    for bin in kaappi thottam; do
-        if fish --no-execute "$TMP/$bin.fish" 2> "$TMP/err"; then
-            pass "$bin fish script parses (fish --no-execute)"
+    for tool in kaappi thottam; do
+        if fish --no-execute "$TMP/$tool.fish" 2> "$TMP/err"; then
+            pass "$tool fish script parses (fish --no-execute)"
         else
-            fail "$bin fish script parses (fish --no-execute)" "$(cat "$TMP/err")"
+            fail "$tool fish script parses (fish --no-execute)" "$(cat "$TMP/err")"
         fi
     done
 else

--- a/tests/scheme/differential/run-differential.sh
+++ b/tests/scheme/differential/run-differential.sh
@@ -228,7 +228,7 @@ VERBOSE="${KAAPPI_DIFF_VERBOSE:-0}"
 
 # Portable timeout: GNU coreutils `timeout` is absent on stock macOS, and the
 # perl fallback is the only thing guaranteed present on the BSD reference
-# boxes.  Same ladder as tests/scheme/audit-baseline.sh.
+# boxes.  Same ladder as tools/audit-baseline.sh.
 if command -v timeout > /dev/null 2>&1; then
     run_timeout() { timeout "$@"; }
 elif command -v gtimeout > /dev/null 2>&1; then

--- a/tests/scheme/differential/run-wasm-differential.sh
+++ b/tests/scheme/differential/run-wasm-differential.sh
@@ -148,7 +148,7 @@ VERBOSE="${KAAPPI_WASM_DIFF_VERBOSE:-0}"
 
 # Portable timeout: stock macOS has no GNU `timeout`; the perl fallback is the
 # only thing guaranteed on the BSD reference boxes.  Same ladder as
-# tests/scheme/audit-baseline.sh and the sibling script.
+# tools/audit-baseline.sh and the sibling script.
 if command -v timeout > /dev/null 2>&1; then
     run_timeout() { timeout "$@"; }
 elif command -v gtimeout > /dev/null 2>&1; then

--- a/tests/scheme/shell-common.sh
+++ b/tests/scheme/shell-common.sh
@@ -41,6 +41,28 @@ rt_lib_name() {
     if is_windows; then echo "kaappi_rt.lib"; else echo "libkaappi_rt.a"; fi
 }
 
+# sibling_tool <kaappi-binary> <tool>: the path to another shipped binary
+# (thottam, kaappi-lsp) next to the one under test, with the platform's
+# executable suffix.
+#
+# The suffix is taken from the given path rather than from is_windows,
+# because runners spell it both ways: `bin/kaappi.exe` in the Windows CI
+# jobs, plain `zig-out/bin/kaappi` from a Git Bash checkout (MSYS appends
+# .exe when *executing*, which is why the bare spelling works there at
+# all). Mirroring what the caller passed keeps the two in step, and a
+# script that only ever executes the result would not notice — but one
+# that names the file, tests it with -x, or derives an output filename
+# from its basename would.
+sibling_tool() {
+    local ref="$1" tool="$2" dir suffix
+    dir="$(dirname "$ref")"
+    case "$(basename "$ref")" in
+        *.exe) suffix=".exe" ;;
+        *) suffix="" ;;
+    esac
+    printf '%s\n' "$dir/$tool$suffix"
+}
+
 # skip_without_zig <reason>: exit 77 (SKIP) when no Zig toolchain is on
 # PATH. For scripts whose test itself rebuilds with zig (e.g. the
 # -Dbundle standalone-binary tests). Boxes that run cross-compiled

--- a/tools/audit-baseline.sh
+++ b/tools/audit-baseline.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
-# audit-baseline.sh — structured failure report
+# audit-baseline.sh — structured failure report (docs/audit-strategy.md).
+#
+# A developer report generator, not a test: it drives `zig build` and writes a
+# directory of logs, so it needs a Zig toolchain and takes an *output
+# directory* as $1 — the opposite of every driver under tests/scheme/, which
+# takes the kaappi binary there and reports pass/fail through its exit status.
+#
+# It lives in tools/ for exactly that reason. While it sat at the top level of
+# tests/scheme/ nothing in run-all.sh ran it (run_shell_suite globs a suite
+# *directory*, and no call passed tests/scheme itself) — but any sweep of
+# tests/scheme/**/*.sh picked it up, handed it the binary path, and got
+# `mkdir -p zig-out/bin/kaappi.exe` followed by a summary grep against a
+# path that is not a directory.
 set -uo pipefail
 OUT=${1:-/tmp/audit-baseline}
 mkdir -p "$OUT"


### PR DESCRIPTION
Two shell drivers fail on Windows for reasons of their own, not of the code
they test. Found running the whole of `tests/scheme/**/*.sh` on the Windows 11
ARM64 reference VM while verifying [#2219](https://github.com/kaappi/kaappi/pull/2219),
which touches neither file.

Neither is reached by the Windows CI loop — `windows-arm-test` iterates a fixed
list of eleven suite directories (`smoke errors compile test-runner pipeline
doctor fmt cache timings sandbox robustness`), and `completions/` is not among
them — so both had been failing there unobserved.

## `completions.sh` — 19 of 39 checks failing

It generated its scripts into `$TMP/$(basename "$bin").$shell` and then went on
sourcing a hardcoded `$TMP/kaappi.bash`. On Windows the binary is `kaappi.exe`,
so it wrote `kaappi.exe.bash` and every reader missed:

```text
completions.sh: line 106: /tmp/tmp.p3Rs4LhN57/kaappi.bash: No such file or directory
completions.sh: line 114: _kaappi: command not found
FAIL: kaappi test offers something — COMPREPLY was empty
```

The generated names are now keyed to the **tool** (`kaappi`, `thottam`) — the
one spelling stable across platforms *and* across however the caller spelled
the binary. §2's loop already iterated tool names; its variable is renamed
`bin` → `tool` so it stops reading like a path.

### The `.exe` suffix as a class

Worth naming, because it is invisible from POSIX and half-invisible from
Windows. Runners spell the binary both ways — `bin/kaappi.exe` in the CI jobs,
plain `zig-out/bin/kaappi` from a Git Bash checkout — and the bare spelling
*works*, because MSYS appends `.exe` when **executing**. So a script that only
runs the result is fine; one that names the file, `-x`-tests it, or derives an
output name from its basename is not.

That asymmetry is why `THOTTAM`, built as `"$(dirname "$KAAPPI")/thottam"`,
executed correctly on the box while the kaappi half of the same suite failed —
the thottam checks passed and masked how broad the problem was. New
`shell-common.sh` helper `sibling_tool` takes the suffix from the path the
caller passed rather than from `is_windows`, so the two cannot drift apart.

## `audit-baseline.sh` → `tools/`

It is a developer report generator, not a test: it drives `zig build` and takes
an **output directory** as `$1` — the opposite of every driver under
`tests/scheme/`, which takes the kaappi binary there and reports through its
exit status.

`run-all.sh` never ran it (`run_shell_suite` globs a suite *directory*, and no
call passes `tests/scheme` itself), but any sweep of `tests/scheme/**/*.sh`
picks it up, hands it the binary path, and produces `mkdir -p
zig-out/bin/kaappi.exe` followed by a summary grep against a path that is not a
directory. Beside `run-r7rs-suite.sh` and `run-gc-stress-suite.sh` in `tools/`,
that is unreachable rather than merely unlikely. Its four references are
updated in step.

## Verification

On the win11 reference box, **both** spellings of the binary:

| | before | after |
|---|---|---|
| `completions.sh zig-out/bin/kaappi.exe` | 20 pass, 19 fail | **39 pass, 0 fail**, exit 0 |
| `completions.sh zig-out/bin/kaappi` | (masked) | **39 pass, 0 fail**, exit 0 |

On macOS: `completions.sh` **41 pass, 0 fail** (two more than Windows — zsh and
fish are installed, so their `-n` gates run), and full `run-all.sh` **2075 pass,
0 fail**, exit 0. `bash -n` and shellcheck clean on every changed script;
markdownlint 0 issues across 88 files.

## Closing the gap that hid it

Second commit: `completions`, `lsp`, `thottam` and `differential` join the
Windows CI loop. That list is a hand-maintained enumeration in **two** places
in ci.yml, not a glob — so a suite wired into `run-all.sh` is covered on every
platform except this one until someone edits both loops, and nothing said so
out loud. `windows.md` now states the keep-in-step rule where the list is
described.

Measured on the reference VM before wiring them in, since these run on every
PR. The exact new list: **46 pass, 0 fail, 28 skip** — the 28 being 25
`compile/` gates plus `profile-json-escaping.sh`, and the two newcomers' own
skips (`thottam-lifecycle.sh` builds git fixtures at POSIX paths,
`run-wasm-differential.sh` wants wasmtime).

**Cost.** `differential/run-differential.sh` takes ~9 min, against Windows jobs
that currently finish in ~6 and are capped at 40 (arm) and 45 (x64). It roughly
triples the step and still leaves most of the budget. It earns the slot:
cold-vs-warm `.sbc` cache agreement is precisely what a platform's path
handling breaks. The other three are 42s, 69s and 0s.

The doc's older `34 pass, 15 skip` line is left as the point-in-time record it
was, with its framing corrected so it no longer claims to describe the current
CI set.

## Priority

`priority: low` per `docs/dev/github-issues.md` — the behaviour under test is
correct in both cases and the diagnostics are loud; only the harness was wrong.
