### PR TITLE
Add paredit-style structural editing to the REPL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,11 +392,13 @@ It holds a whole form in one buffer, which is why `repl.zig` no longer joins
 continuation lines: `ic_readline` returns a finished expression, newlines
 included, and every line of it stays editable until submit.
 
-**The copy is patched** — two changes, each marked `KAAPPI PATCH` in the source
-and documented in `vendor/isocline/PATCHES.md`: an input-completeness callback
-(upstream's Enter always submits) and a configurable history size (upstream
-caps at 200). Re-apply both when updating; `grep -rn 'KAAPPI PATCH'
-vendor/isocline/` finds every site.
+**The copy is patched** — three changes, each marked `KAAPPI PATCH` in the
+source and documented in `vendor/isocline/PATCHES.md`: an input-completeness
+callback (upstream's Enter always submits), a configurable history size
+(upstream caps at 200), and structural s-expression editing — slurp, barf,
+raise, rotate, whose transforms live in `src/repl_sexp.zig` (`docs/dev/repl.md`).
+Re-apply all three when updating; `grep -rn 'KAAPPI PATCH' vendor/isocline/`
+finds every site.
 
 ## Package manager (thottam)
 

--- a/docs/dev/repl.md
+++ b/docs/dev/repl.md
@@ -21,6 +21,7 @@ which `main.zig` never reaches.
 |---|---|---|
 | `ic_set_default_is_complete` | `isCompleteCallback` → `inputIncomplete` | Enter submits only when the **reader** says the form is finished. Not upstream isocline — see `vendor/isocline/PATCHES.md`. |
 | `ic_set_default_completer` | `completionCallback` | Comma commands match the whole line; everything else goes through `ic_complete_word` over `vm.globals`. `,load`/`,import` complete filenames. |
+| `ic_set_default_sexp_edit` | `sexpEditCallback` → `repl_sexp.apply` | The four structural-edit keys. Not upstream isocline — patch 3. |
 | `ic_set_default_highlighter` | `highlightCallback` → `scanHighlight` | Emits styled spans; `scanHighlight` is separated so the token rules are testable without a terminal. |
 | `ic_style_def` | `applyTheme` | `repl.color.*` names become isocline styles via `ansiToIcStyle`. `ic-prompt` and `ic-bracematch` are isocline's own names, redefined. |
 | `ic_enable_brace_matching` | — | Limited to `"()"`: the reader gives `[`/`]` no meaning (`0]` is KP1002). |
@@ -34,6 +35,47 @@ Two settings are deliberate rather than default:
 
 History is written on every submit, with embedded newlines escaped, so a crash
 no longer loses the session.
+
+## Structural editing
+
+Four keys move a *paren* rather than a character (kaappi#2216). `|` marks the
+cursor:
+
+| Key | Command | Effect |
+|---|---|---|
+| alt+shift+S | slurp | `(a\| b) c d` → `(a\| b c) d` |
+| alt+shift+B | barf | `(a\| b c)` → `(a\| b) c` |
+| alt+shift+R | raise | `(+ 1 (* 2 \|3))` → `(+ 1 \|3)` |
+| alt+y | rotate | `(if a\| b c)` → `(if b c a\|)` |
+
+They are listed under F1 too, and only when the callback is set. Each is
+`ESC` followed by the character, so a terminal that does not send Option as
+Meta (macOS Terminal.app, unless "Use Option as Meta key" is on) will not
+deliver them.
+
+`src/repl_sexp.zig` holds the transforms — pure functions over
+`(buffer, byte cursor)`, so they unit-test without a terminal. The keys and the
+buffer swap live in the vendored editor (`vendor/isocline/PATCHES.md`, patch
+3); `tests/scheme/smoke/repl-structural-editing-2216.sh` drives that half over
+a real pty, since nothing in Zig can reach it.
+
+Three things are worth knowing before changing them:
+
+- **The scanner derives its rules from `reader.zig`.** `Reader.isDelimiter`
+  decides where an atom ends, and strings, `;` and `#|…|#` comments, `#;`
+  datum comments, `#\(` character literals and `|pipe|` symbols all hide their
+  parens. That is not decoration: bestline's originals, which the issue
+  proposed porting, count parens with none of it.
+- **`[` and `]` are ordinary atom characters**, because the reader gives them
+  no meaning (`0]` is KP1002). `scanHighlight` used to paint them like parens;
+  it no longer does, so the colors, `ic_enable_brace_matching`, the reader and
+  `repl_sexp` now all agree.
+- **An unbalanced form declines.** Every command needs a close paren to move,
+  so a half-typed form is left exactly as it is rather than guessed at.
+
+Rotate keeps the head in place and cycles the arguments. Rotating the head too
+would turn every call form into something unevaluatable (`(+ 1 2)` → `(1 2 +)`);
+as it stands, repeating it n-1 times on n arguments restores the original.
 
 ## Comma commands
 
@@ -88,6 +130,7 @@ Width-aware pretty-printing for long output — tracked in
 | Component | Location |
 |-----------|----------|
 | REPL loop, command dispatch, completeness/completion/highlight callbacks | `src/repl.zig` |
+| Structural editing transforms (slurp, barf, raise, rotate) | `src/repl_sexp.zig` |
 | Entry point / CLI flags | `src/main.zig` |
 | Import handling | `src/vm_library.zig` (`handleImport`) |
 | Stepping debugger | `src/vm_debug.zig` |

--- a/src/isocline.zig
+++ b/src/isocline.zig
@@ -7,9 +7,10 @@
 //! `readline` returns a finished expression — newlines and all — and every line
 //! of it stays editable until the user submits.
 //!
-//! Kaappi's copy carries two patches, both documented in
+//! Kaappi's copy carries three patches, all documented in
 //! `vendor/isocline/PATCHES.md`: an input-completeness callback (upstream's
-//! Enter always submits) and a configurable history size (upstream caps at 200).
+//! Enter always submits), a configurable history size (upstream caps at 200),
+//! and structural s-expression editing (upstream has none).
 //!
 //! Isocline is not thread-safe: `readline` and `print` must be called from one
 //! thread. That holds here — only the REPL loop touches it.
@@ -117,6 +118,38 @@ pub fn styleDef(name: [*:0]const u8, fmt: [*:0]const u8) void {
 /// `vendor/isocline/PATCHES.md`.
 pub fn setIsComplete(cb: ?*const fn ([*c]const u8, ?*anyopaque) callconv(.c) bool, arg: ?*anyopaque) void {
     c.ic_set_default_is_complete(cb, arg);
+}
+
+// --- Structural editing (Kaappi patch 3) -----------------------------------
+
+/// Set the callback the four structural-edit keys (alt+shift+S/B/R, alt+y)
+/// dispatch to. It is handed the whole buffer and the cursor as a byte offset,
+/// and returns a replacement buffer from `alloc` below — isocline takes
+/// ownership and frees it — or null to decline and leave the input untouched.
+/// See `vendor/isocline/PATCHES.md`.
+pub fn setSexpEdit(
+    cb: ?*const fn (c.ic_sexp_command_t, [*c]const u8, [*c]c_long, ?*anyopaque) callconv(.c) [*c]u8,
+    arg: ?*anyopaque,
+) void {
+    comptime {
+        // The command numbering is the contract between `repl_sexp.Command`
+        // and isocline's enum; a silent drift would run the wrong command.
+        // This lives in a function body rather than at container scope
+        // because the latter is analyzed eagerly, and `zig build test` does
+        // not compile the C library at all.
+        const Command = @import("repl_sexp.zig").Command;
+        std.debug.assert(@intFromEnum(Command.slurp) == c.IC_SEXP_SLURP);
+        std.debug.assert(@intFromEnum(Command.barf) == c.IC_SEXP_BARF);
+        std.debug.assert(@intFromEnum(Command.raise) == c.IC_SEXP_RAISE);
+        std.debug.assert(@intFromEnum(Command.rotate) == c.IC_SEXP_ROTATE);
+    }
+    c.ic_set_default_sexp_edit(cb, arg);
+}
+
+/// Allocate `n` bytes from isocline's allocator, for a buffer handed back to
+/// it. Null when isocline is not initialized or the allocation fails.
+pub fn alloc(n: usize) ?[*]u8 {
+    return @ptrCast(c.ic_malloc(n));
 }
 
 // --- Options ---------------------------------------------------------------

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -12,6 +12,7 @@ const reporting = @import("reporting.zig");
 const expander = @import("expander.zig");
 const toplevel_driver = @import("toplevel_driver.zig");
 const crash = @import("crash.zig");
+const repl_sexp = @import("repl_sexp.zig");
 /// isocline is the line editor (`vendor/isocline/`). It holds a whole form in
 /// one buffer, so `ic.readline` returns a finished expression — newlines and
 /// all — instead of one physical line, and every line of it stays editable
@@ -182,9 +183,13 @@ fn isSchemeKeyword(word: []const u8) bool {
     return false;
 }
 
-fn isDelimiter(ch: u8) bool {
-    return ch == ' ' or ch == '\t' or ch == '(' or ch == ')' or ch == '[' or ch == ']' or ch == '"' or ch == ';' or ch == '|' or ch == '\n' or ch == '\r';
-}
+/// Where a token ends, for the highlighter. This is `Reader.isDelimiter` — not
+/// a copy of it — so the colors cannot disagree with the parse. In particular
+/// `[` and `]` are *not* delimiters: the reader gives them no meaning (`0]` is
+/// KP1002), so `[i` and `0]` are one atom each, and painting them like parens
+/// advertised a structure neither the reader nor `repl_sexp` believes in
+/// (kaappi#2216).
+const isDelimiter = reader.Reader.isDelimiter;
 
 fn isNumberLike(word: []const u8) bool {
     if (word.len == 0) return false;
@@ -311,7 +316,7 @@ fn scanHighlight(input: []const u8, ctx: anytype) void {
             continue;
         }
 
-        if (ch == '(' or ch == ')' or ch == '[' or ch == ']') {
+        if (ch == '(' or ch == ')') {
             i += 1;
             ctx.emit(start, i, style_paren);
             continue;
@@ -459,6 +464,45 @@ fn isCompleteCallback(input_c: [*c]const u8, arg: ?*anyopaque) callconv(.c) bool
     return !inputIncomplete(vm.gc, input);
 }
 
+/// isocline's structural-edit handler (Kaappi patch 3,
+/// `vendor/isocline/PATCHES.md`). isocline owns the keys; `repl_sexp` owns the
+/// syntax and does the rewriting, on the whole buffer rather than one physical
+/// line — which is why kaappi#2216 waited for the isocline migration.
+///
+/// Returning null declines: isocline leaves the input exactly as it was, which
+/// is what a command that does not apply here should do.
+fn sexpEditCallback(
+    cmd: ic.c.ic_sexp_command_t,
+    input_c: [*c]const u8,
+    pos: [*c]c_long,
+    arg: ?*anyopaque,
+) callconv(.c) [*c]u8 {
+    _ = arg;
+    const input = if (input_c) |p| std.mem.span(@as([*:0]const u8, @ptrCast(p))) else return null;
+    const cursor: usize = if (pos.* < 0) 0 else @intCast(pos.*);
+    // An unknown command id can only mean isocline and `repl_sexp.Command`
+    // have drifted; decline rather than guess (see `ic.setSexpEdit`).
+    const command: repl_sexp.Command = switch (cmd) {
+        ic.c.IC_SEXP_SLURP => .slurp,
+        ic.c.IC_SEXP_BARF => .barf,
+        ic.c.IC_SEXP_RAISE => .raise,
+        ic.c.IC_SEXP_ROTATE => .rotate,
+        else => return null,
+    };
+
+    const allocator = std.heap.c_allocator;
+    const edit = repl_sexp.apply(allocator, command, input, cursor) orelse return null;
+    defer allocator.free(edit.text);
+
+    // isocline frees what it is handed, so the result has to come from its
+    // allocator, not ours.
+    const buf = ic.alloc(edit.text.len + 1) orelse return null;
+    @memcpy(buf[0..edit.text.len], edit.text);
+    buf[edit.text.len] = 0;
+    pos.* = @intCast(edit.pos);
+    return @ptrCast(buf);
+}
+
 /// Translate one of `config.Theme`'s SGR escapes into an isocline style string.
 ///
 /// The theme stores escapes because linenoise was handed raw bytes; isocline
@@ -557,6 +601,7 @@ pub fn repl(vm: *vm_mod.VM) !void {
         applyTheme(cfg.theme);
 
         ic.setIsComplete(&isCompleteCallback, null);
+        ic.setSexpEdit(&sexpEditCallback, null);
         ic.setCompleter(&completionCallback, null);
         if (highlight_enabled) ic.setHighlighter(&highlightCallback, null);
         // The prompt text carries no escapes: isocline measures it to place the
@@ -880,6 +925,13 @@ pub fn repl(vm: *vm_mod.VM) !void {
                 \\  ,step <expr>      Evaluate with single-stepping
                 \\  ,condition <id> <expr>  Set breakpoint condition
                 \\
+                \\ -- Structural editing (moves a paren, not a character):
+                \\  alt-shift-S       Slurp: pull the next datum into the form
+                \\  alt-shift-B       Barf: push the last datum out of the form
+                \\  alt-shift-R       Raise: replace the form with the datum at point
+                \\  alt-y             Rotate the form's arguments
+                \\  F1                All editor keys
+                \\
                 \\ -- System:
                 \\  ,gc               Show GC statistics
                 \\  ,version          Show Kaappi version
@@ -1149,10 +1201,7 @@ test "inputIncomplete — open form continues" {
 test "inputIncomplete — brackets are not list syntax here" {
     // kaappi's reader gives `[` and `]` no special meaning (KP1002 on `0]`),
     // so a bracket binding is a syntax error, not an unfinished form — it must
-    // submit and be reported, not sit at the continuation prompt. The
-    // highlighter diverges from that, cosmetically: `scanHighlight` styles
-    // brackets with `style_paren` like any other delimiter, though nothing
-    // pairs them — `setMatchingBraces` is given "()" alone.
+    // submit and be reported, not sit at the continuation prompt.
     try expectIncomplete("(let loop ([i 0]) i)", false);
     // The enclosing parens still govern continuation.
     try expectIncomplete("(let loop ((i 0))", true);
@@ -1320,6 +1369,15 @@ test "scanHighlight — |symbol| is not a keyword" {
 test "scanHighlight — char literal parens do not become parens" {
     try expectSpan("#\\(", 0, 3, style_number);
     try expectNoStyle("#\\(", style_paren);
+}
+
+test "scanHighlight — brackets are not parens (kaappi#2216)" {
+    // The reader pairs neither, `setMatchingBraces` is given "()" alone, and
+    // `repl_sexp` treats them as ordinary atom characters. The highlighter
+    // used to paint them anyway.
+    try expectNoStyle("[i 0]", style_paren);
+    try expectSpan("(let loop ([i 0]) i)", 0, 1, style_paren);
+    try expectSpan("(let loop ([i 0]) i)", 10, 11, style_paren);
 }
 
 test "scanHighlight — infinities and nan are numbers" {

--- a/src/repl_sexp.zig
+++ b/src/repl_sexp.zig
@@ -1,0 +1,705 @@
+//! Structural s-expression editing for the REPL: slurp, barf, raise, rotate.
+//! These move a *paren* rather than a character — the edits a Lisp programmer
+//! actually wants, and the ones a character-oriented editor makes tedious.
+//!
+//! Everything here is a pure transform over `(buffer, byte cursor)`, so it is
+//! testable without a terminal. `repl.zig` hands the result to isocline, which
+//! owns the keys (`vendor/isocline/PATCHES.md`, patch 3).
+//!
+//! ## Where this came from
+//!
+//! The commands and their keybindings are bestline's (Justine Tunney's
+//! linenoise fork, BSD-2-Clause) — kaappi#2216 filed them after that library
+//! was evaluated and rejected as a base for the REPL. **The code is not a
+//! port.** Two of the four do not exist there to port: `bestlineEditRaise` is
+//! an empty stub, and `bestlineEditRotate` rotates the *kill ring* (emacs
+//! yank-pop), not the datums of a form. The two that do exist, barf and slurp,
+//! count `(` and `)` runes with a mirror stack and no notion of strings,
+//! comments, or character literals — which is exactly the bug class the issue
+//! asked the port to avoid, so the scanner below derives its rules from
+//! `reader.zig` instead. Attribution is for the design; the implementation is
+//! Kaappi's.
+//!
+//! ## Scope of the scanner
+//!
+//! `[` and `]` are deliberately *not* delimiters or brackets: Kaappi's reader
+//! gives them no meaning (`0]` is KP1002), and `Reader.isDelimiter` is what
+//! decides where an atom ends here, so the two cannot drift apart. A form that
+//! is still unbalanced has no close paren to move, so every command declines
+//! (returns null) rather than guessing.
+
+const std = @import("std");
+const Reader = @import("reader.zig").Reader;
+
+/// A half-open byte range `[start, end)` of the buffer.
+pub const Span = struct { start: usize, end: usize };
+
+/// Discriminant shared with isocline's `ic_sexp_command_t`; the numbering is
+/// the contract between the two (see `isocline.zig`).
+pub const Command = enum(c_uint) {
+    slurp = 0,
+    barf = 1,
+    raise = 2,
+    rotate = 3,
+};
+
+/// A rewritten buffer plus where the cursor lands in it. `text` is owned by
+/// the caller.
+pub const Edit = struct { text: []u8, pos: usize };
+
+/// Bounds nesting recursion. A REPL buffer is pasted as often as typed, so a
+/// pathological `((((…` must decline rather than smash the stack.
+const max_depth: u32 = 256;
+
+// --- Lexical scanning ------------------------------------------------------
+
+/// Whitespace, `;` line comments, `#|…|#` block comments (nesting), and
+/// `#!fold-case` directives — everything the reader skips *except* `#;`, which
+/// needs to scan a datum and so lives in `skipTrivia`.
+fn skipAtomicTrivia(src: []const u8, from: usize) usize {
+    var i = from;
+    while (i < src.len) {
+        const c = src[i];
+        if (c == ' ' or c == '\t' or c == '\n' or c == '\r' or c == 0x0b or c == 0x0c) {
+            i += 1;
+            continue;
+        }
+        if (c == ';') {
+            while (i < src.len and src[i] != '\n') : (i += 1) {}
+            continue;
+        }
+        if (c == '#' and i + 1 < src.len and src[i + 1] == '|') {
+            var depth: usize = 1;
+            var j = i + 2;
+            while (j < src.len and depth > 0) {
+                if (src[j] == '#' and j + 1 < src.len and src[j + 1] == '|') {
+                    depth += 1;
+                    j += 2;
+                } else if (src[j] == '|' and j + 1 < src.len and src[j + 1] == '#') {
+                    depth -= 1;
+                    j += 2;
+                } else {
+                    j += 1;
+                }
+            }
+            // An unterminated block comment swallows the rest of the buffer,
+            // which is what the reader does too.
+            if (depth > 0) return src.len;
+            i = j;
+            continue;
+        }
+        if (c == '#' and i + 1 < src.len and src[i + 1] == '!') {
+            i += 2;
+            while (i < src.len and !Reader.isDelimiter(src[i])) : (i += 1) {}
+            continue;
+        }
+        break;
+    }
+    return i;
+}
+
+/// `skipAtomicTrivia` plus `#;` datum comments, which consume the datum that
+/// follows them. Mutually recursive with `scanDatum` — `#;(a b)` has to scan a
+/// list to know how much to skip.
+fn skipTrivia(src: []const u8, from: usize, depth: u32) usize {
+    var i = from;
+    while (true) {
+        i = skipAtomicTrivia(src, i);
+        if (i + 1 < src.len and src[i] == '#' and src[i + 1] == ';') {
+            if (depth >= max_depth) return i;
+            const inner = skipTrivia(src, i + 2, depth + 1);
+            const d = scanDatum(src, inner, depth + 1) orelse return i;
+            i = d.end;
+            continue;
+        }
+        return i;
+    }
+}
+
+/// How many bytes open a list at `i`, or null if nothing does. `#(` and `#u8(`
+/// are list openers as much as `(` is: their contents are datums that barf and
+/// slurp move across.
+fn listOpenLen(src: []const u8, i: usize) ?usize {
+    if (i >= src.len) return null;
+    if (src[i] == '(') return 1;
+    if (src[i] != '#') return null;
+    if (i + 1 < src.len and src[i + 1] == '(') return 2;
+    if (i + 3 < src.len and (src[i + 1] == 'u' or src[i + 1] == 'U') and
+        src[i + 2] == '8' and src[i + 3] == '(') return 4;
+    return null;
+}
+
+/// How many bytes of datum prefix (`'`, `` ` ``, `,`, `,@`) sit at `i`.
+fn prefixLen(src: []const u8, i: usize) usize {
+    if (i >= src.len) return 0;
+    return switch (src[i]) {
+        '\'', '`' => 1,
+        ',' => if (i + 1 < src.len and src[i + 1] == '@') @as(usize, 2) else 1,
+        else => 0,
+    };
+}
+
+/// The span of the single datum beginning at `start`, which must already be
+/// past any trivia. Null when the datum is unterminated (an open list, an
+/// unclosed string) or when `start` is not a datum start at all.
+fn scanDatum(src: []const u8, start: usize, depth: u32) ?Span {
+    if (depth >= max_depth) return null;
+    if (start >= src.len) return null;
+
+    const pl = prefixLen(src, start);
+    if (pl > 0) {
+        const inner_start = skipTrivia(src, start + pl, depth + 1);
+        const inner = scanDatum(src, inner_start, depth + 1) orelse return null;
+        return .{ .start = start, .end = inner.end };
+    }
+
+    if (listOpenLen(src, start)) |ol| return scanList(src, start, ol, depth);
+
+    const c = src[start];
+    switch (c) {
+        ')' => return null,
+        '"' => return scanQuoted(src, start, '"'),
+        '|' => return scanQuoted(src, start, '|'),
+        '#' => {
+            // `#|` and `#;` are trivia, never the start of a datum.
+            if (start + 1 < src.len and (src[start + 1] == '|' or src[start + 1] == ';')) return null;
+            if (start + 1 < src.len and src[start + 1] == '\\') return scanCharLiteral(src, start);
+            return scanAtom(src, start);
+        },
+        else => return scanAtom(src, start),
+    }
+}
+
+fn scanList(src: []const u8, start: usize, open_len: usize, depth: u32) ?Span {
+    var i = start + open_len;
+    while (true) {
+        i = skipTrivia(src, i, depth + 1);
+        if (i >= src.len) return null;
+        if (src[i] == ')') return .{ .start = start, .end = i + 1 };
+        const d = scanDatum(src, i, depth + 1) orelse return null;
+        i = d.end;
+    }
+}
+
+/// A `"string"` or a `|pipe symbol|` — same shape, different terminator, both
+/// with `\` escapes.
+fn scanQuoted(src: []const u8, start: usize, term: u8) ?Span {
+    var i = start + 1;
+    while (i < src.len) {
+        if (src[i] == '\\') {
+            i += 2;
+            continue;
+        }
+        if (src[i] == term) return .{ .start = start, .end = i + 1 };
+        i += 1;
+    }
+    return null;
+}
+
+/// `#\a`, `#\space`, `#\x41`, `#\(`, `#\λ`. The first codepoint is always part
+/// of the literal however delimiting it looks — which is the whole reason
+/// `#\(` must not be counted as an open paren.
+fn scanCharLiteral(src: []const u8, start: usize) ?Span {
+    var i = start + 2;
+    if (i >= src.len) return null;
+    const first = src[i];
+    const seq = std.unicode.utf8ByteSequenceLength(first) catch 1;
+    i = @min(i + seq, src.len);
+    // Only an alphanumeric first character can begin a *named* character
+    // (`space`, `x41`); anything else is the literal, whole.
+    if (std.ascii.isAlphanumeric(first)) {
+        while (i < src.len and !Reader.isDelimiter(src[i])) : (i += 1) {}
+    }
+    return .{ .start = start, .end = i };
+}
+
+fn scanAtom(src: []const u8, start: usize) ?Span {
+    var i = start;
+    while (i < src.len and !Reader.isDelimiter(src[i])) : (i += 1) {}
+    if (i == start) return null;
+    return .{ .start = start, .end = i };
+}
+
+// --- Locating the form under the cursor ------------------------------------
+
+/// The innermost *closed* list containing the cursor.
+pub const Form = struct {
+    /// Byte offset of `(` (or of the `#` in `#(` / `#u8(`).
+    open: usize,
+    /// First byte after the opener, where the children begin.
+    body: usize,
+    /// Byte offset of the matching `)`.
+    close: usize,
+};
+
+/// Walk the whole buffer keeping a stack of open lists, and return the
+/// innermost one whose interior spans `pos`.
+///
+/// "Interior" is `open < pos <= close`: the cursor just after `(` is inside,
+/// just after `)` is outside. Only a list that actually closed can be
+/// returned — an unbalanced buffer has no paren to move, so every command
+/// declines.
+///
+/// Strings, comments, character literals and pipe symbols are skipped whole,
+/// so a paren inside one never reaches the stack. Datum *prefixes* are
+/// stepped over one token at a time rather than scanned as a unit, or the
+/// cursor inside `'(a b)` would find no enclosing form.
+pub fn enclosingList(src: []const u8, pos: usize) ?Form {
+    var stack: [max_depth]struct { open: usize, body: usize } = undefined;
+    var sp: usize = 0;
+    var best: ?Form = null;
+    var i: usize = 0;
+
+    while (true) {
+        i = skipTrivia(src, i, 0);
+        if (i >= src.len) break;
+
+        if (src[i] == ')') {
+            if (sp > 0) {
+                sp -= 1;
+                const top = stack[sp];
+                if (top.open < pos and pos <= i) {
+                    if (best == null or top.open > best.?.open) {
+                        best = .{ .open = top.open, .body = top.body, .close = i };
+                    }
+                }
+            }
+            i += 1;
+            continue;
+        }
+
+        if (listOpenLen(src, i)) |ol| {
+            if (sp >= stack.len) return best;
+            stack[sp] = .{ .open = i, .body = i + ol };
+            sp += 1;
+            i += ol;
+            continue;
+        }
+
+        const pl = prefixLen(src, i);
+        if (pl > 0) {
+            i += pl;
+            continue;
+        }
+
+        // An unterminated string or pipe symbol means the rest of the buffer
+        // is literal text: stop rather than walking into it and counting its
+        // parens.
+        const d = scanDatum(src, i, 0) orelse break;
+        i = d.end;
+    }
+    return best;
+}
+
+/// The datum spans directly inside `form`, in order.
+fn collectChildren(
+    allocator: std.mem.Allocator,
+    src: []const u8,
+    form: Form,
+    out: *std.ArrayList(Span),
+) !void {
+    var i = form.body;
+    while (true) {
+        i = skipTrivia(src, i, 0);
+        if (i >= form.close) break;
+        const d = scanDatum(src, i, 0) orelse break;
+        if (d.end > form.close) break;
+        try out.append(allocator, d);
+        i = d.end;
+    }
+}
+
+// --- The commands ----------------------------------------------------------
+
+/// Apply `cmd` at byte offset `pos`. Returns null when the command does not
+/// apply — an unbalanced form, nothing to slurp, a form too short to rotate —
+/// in which case the caller leaves the buffer untouched. On success the
+/// returned `text` is owned by the caller.
+pub fn apply(
+    allocator: std.mem.Allocator,
+    cmd: Command,
+    src: []const u8,
+    pos: usize,
+) ?Edit {
+    const p = @min(pos, src.len);
+    const form = enclosingList(src, p) orelse return null;
+    return switch (cmd) {
+        .slurp => slurp(allocator, src, form, p),
+        .barf => barf(allocator, src, form, p),
+        .raise => raise(allocator, src, form, p),
+        .rotate => rotate(allocator, src, form, p),
+    } catch null;
+}
+
+/// Pull the next datum in past the closing paren:
+///
+///     (a| b) c d   ->   (a| b c) d
+///
+/// Only the close paren moves, and it moves right, so nothing before the
+/// cursor changes and the cursor stays put.
+fn slurp(allocator: std.mem.Allocator, src: []const u8, form: Form, pos: usize) !?Edit {
+    const after = skipTrivia(src, form.close + 1, 0);
+    const next = scanDatum(src, after, 0) orelse return null;
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    try out.appendSlice(allocator, src[0..form.close]);
+    try out.appendSlice(allocator, src[form.close + 1 .. next.end]);
+    try out.append(allocator, ')');
+    try out.appendSlice(allocator, src[next.end..]);
+    return Edit{ .text = try out.toOwnedSlice(allocator), .pos = pos };
+}
+
+/// Push the last datum out past the closing paren:
+///
+///     (a| b c)   ->   (a| b) c
+///
+/// The paren moves left, so a cursor to its right shifts along with the text.
+/// A one-element list barfs to `() a`, matching paredit.
+fn barf(allocator: std.mem.Allocator, src: []const u8, form: Form, pos: usize) !?Edit {
+    var kids: std.ArrayList(Span) = .empty;
+    defer kids.deinit(allocator);
+    try collectChildren(allocator, src, form, &kids);
+    if (kids.items.len == 0) return null;
+
+    // The paren lands right after the second-to-last datum, so the whitespace
+    // that separated the barfed datum stays outside with it.
+    const n = kids.items.len;
+    const at = if (n >= 2) kids.items[n - 2].end else form.body;
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    try out.appendSlice(allocator, src[0..at]);
+    try out.append(allocator, ')');
+    try out.appendSlice(allocator, src[at..form.close]);
+    try out.appendSlice(allocator, src[form.close + 1 ..]);
+    return Edit{
+        .text = try out.toOwnedSlice(allocator),
+        .pos = if (pos > at) pos + 1 else pos,
+    };
+}
+
+/// Replace the enclosing form with the datum at point:
+///
+///     (+ 1 (* 2 |3))   ->   (+ 1 |3)
+///
+/// The datum at point is the child containing the cursor, or the first one
+/// after it when the cursor sits in whitespace.
+fn raise(allocator: std.mem.Allocator, src: []const u8, form: Form, pos: usize) !?Edit {
+    var kids: std.ArrayList(Span) = .empty;
+    defer kids.deinit(allocator);
+    try collectChildren(allocator, src, form, &kids);
+    if (kids.items.len == 0) return null;
+
+    var chosen: ?Span = null;
+    for (kids.items) |k| {
+        if (pos >= k.start and pos <= k.end) {
+            chosen = k;
+            break;
+        }
+        if (k.start > pos) {
+            chosen = k;
+            break;
+        }
+    }
+    const kid = chosen orelse kids.items[kids.items.len - 1];
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    try out.appendSlice(allocator, src[0..form.open]);
+    try out.appendSlice(allocator, src[kid.start..kid.end]);
+    try out.appendSlice(allocator, src[form.close + 1 ..]);
+
+    const offset = if (pos >= kid.start and pos <= kid.end) pos - kid.start else 0;
+    return Edit{ .text = try out.toOwnedSlice(allocator), .pos = form.open + offset };
+}
+
+/// Rotate the arguments of the enclosing form left, leaving the head alone:
+///
+///     (if a| b c)   ->   (if b c a|)
+///
+/// The head stays because rotating it too would turn every call form into
+/// something that cannot be evaluated (`(+ 1 2)` -> `(1 2 +)`), and the point
+/// of a cycle is that you can keep pressing it: repeating this n-1 times on n
+/// arguments restores the original. The whitespace between arguments stays
+/// where it is; only the datums move, and the cursor follows the one it was
+/// on.
+///
+/// Needs a head and at least two arguments; anything shorter declines.
+fn rotate(allocator: std.mem.Allocator, src: []const u8, form: Form, pos: usize) !?Edit {
+    var kids: std.ArrayList(Span) = .empty;
+    defer kids.deinit(allocator);
+    try collectChildren(allocator, src, form, &kids);
+    if (kids.items.len < 3) return null;
+    const args = kids.items[1..];
+
+    var slots: std.ArrayList(usize) = .empty;
+    defer slots.deinit(allocator);
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    try out.appendSlice(allocator, src[0..args[0].start]);
+    for (args, 0..) |_, j| {
+        try slots.append(allocator, out.items.len);
+        const from = args[(j + 1) % args.len];
+        try out.appendSlice(allocator, src[from.start..from.end]);
+        if (j + 1 < args.len) {
+            try out.appendSlice(allocator, src[args[j].end..args[j + 1].start]);
+        }
+    }
+    try out.appendSlice(allocator, src[args[args.len - 1].end..]);
+
+    // The datum in slot k moved to slot k-1; carry the cursor with it.
+    var new_pos = @min(pos, out.items.len);
+    for (args, 0..) |a, k| {
+        if (pos >= a.start and pos <= a.end) {
+            const dest = (k + args.len - 1) % args.len;
+            new_pos = slots.items[dest] + (pos - a.start);
+            break;
+        }
+    }
+    return Edit{ .text = try out.toOwnedSlice(allocator), .pos = new_pos };
+}
+
+// --- Tests -----------------------------------------------------------------
+
+/// Drive a command with the cursor written as `|`, and compare against an
+/// expected buffer written the same way — the two lines a user would see.
+fn expectEdit(cmd: Command, before: []const u8, after: []const u8) !void {
+    const a = std.testing.allocator;
+    const cursor = std.mem.indexOfScalar(u8, before, '|') orelse return error.NoCursorMarker;
+    const src = try std.mem.concat(a, u8, &.{ before[0..cursor], before[cursor + 1 ..] });
+    defer a.free(src);
+
+    const edit = apply(a, cmd, src, cursor) orelse {
+        std.debug.print("command declined on \"{s}\"\n", .{before});
+        return error.TestUnexpectedResult;
+    };
+    defer a.free(edit.text);
+
+    var got: std.ArrayList(u8) = .empty;
+    defer got.deinit(a);
+    try got.appendSlice(a, edit.text[0..edit.pos]);
+    try got.append(a, '|');
+    try got.appendSlice(a, edit.text[edit.pos..]);
+    try std.testing.expectEqualStrings(after, got.items);
+}
+
+/// Assert the command declines and leaves the buffer alone.
+fn expectDeclined(cmd: Command, before: []const u8) !void {
+    const a = std.testing.allocator;
+    const cursor = std.mem.indexOfScalar(u8, before, '|') orelse return error.NoCursorMarker;
+    const src = try std.mem.concat(a, u8, &.{ before[0..cursor], before[cursor + 1 ..] });
+    defer a.free(src);
+    if (apply(a, cmd, src, cursor)) |edit| {
+        defer a.free(edit.text);
+        std.debug.print("expected no edit on \"{s}\", got \"{s}\"\n", .{ before, edit.text });
+        return error.TestUnexpectedResult;
+    }
+}
+
+test "slurp — pulls the next datum in" {
+    try expectEdit(.slurp, "(a| b) c d", "(a| b c) d");
+    try expectEdit(.slurp, "(+ 1 2|) 3", "(+ 1 2 3|)");
+    try expectEdit(.slurp, "(a|) (b c) d", "(a| (b c)) d");
+}
+
+test "slurp — keeps the separating whitespace outside" {
+    try expectEdit(.slurp, "(a|)   c", "(a|   c)");
+}
+
+test "slurp — nothing to the right declines" {
+    try expectDeclined(.slurp, "(a| b)");
+    try expectDeclined(.slurp, "(a| b)   ");
+    try expectDeclined(.slurp, "(a| b) ; trailing comment");
+}
+
+test "barf — pushes the last datum out" {
+    try expectEdit(.barf, "(a| b c)", "(a| b) c");
+    try expectEdit(.barf, "(a b c|)", "(a b) c|");
+    // A cursor to the right of the moved paren travels with the text.
+    try expectEdit(.barf, "(a b |c)", "(a b) |c");
+}
+
+test "barf — a one-element list barfs to an empty one" {
+    try expectEdit(.barf, "(|a)", "(|) a");
+}
+
+test "barf — an empty list declines" {
+    try expectDeclined(.barf, "(|)");
+}
+
+test "barf then slurp is a round trip" {
+    const a = std.testing.allocator;
+    const src = "(+ 1 2 3)";
+    const barfed = apply(a, .barf, src, 3).?;
+    defer a.free(barfed.text);
+    try std.testing.expectEqualStrings("(+ 1 2) 3", barfed.text);
+    const slurped = apply(a, .slurp, barfed.text, barfed.pos).?;
+    defer a.free(slurped.text);
+    try std.testing.expectEqualStrings(src, slurped.text);
+}
+
+test "raise — replaces the enclosing form with the datum at point" {
+    try expectEdit(.raise, "(+ 1 (* 2 |3))", "(+ 1 |3)");
+    try expectEdit(.raise, "(+ 1 (|* 2 3))", "(+ 1 |*)");
+    try expectEdit(.raise, "(foo (bar |(baz 1)))", "(foo |(baz 1))");
+}
+
+test "raise — a cursor in whitespace takes the datum after it" {
+    try expectEdit(.raise, "(+ 1 (* | 2 3))", "(+ 1 |2)");
+}
+
+test "raise — an empty form declines" {
+    try expectDeclined(.raise, "(|)");
+}
+
+test "rotate — cycles the arguments and leaves the head" {
+    try expectEdit(.rotate, "(if a| b c)", "(if b c a|)");
+    try expectEdit(.rotate, "(list 1| 2 3)", "(list 2 3 1|)");
+}
+
+test "rotate — repeating it restores the original" {
+    const a = std.testing.allocator;
+    const src = "(list 1 2 3)";
+    var cur = try a.dupe(u8, src);
+    defer a.free(cur);
+    var pos: usize = 6;
+    var round: usize = 0;
+    while (round < 3) : (round += 1) {
+        const e = apply(a, .rotate, cur, pos).?;
+        a.free(cur);
+        cur = e.text;
+        pos = e.pos;
+    }
+    try std.testing.expectEqualStrings(src, cur);
+}
+
+test "rotate — too few datums to rotate" {
+    try expectDeclined(.rotate, "(f| x)");
+    try expectDeclined(.rotate, "(|x)");
+    try expectDeclined(.rotate, "(|)");
+}
+
+test "rotate — preserves the gaps, moves only the datums" {
+    try expectEdit(.rotate, "(f a|   bb  ccc)", "(f bb|   ccc  a)");
+}
+
+test "the cursor must be inside a form" {
+    // Before the open paren and after the close paren are both outside.
+    try expectDeclined(.barf, "|(a b c)");
+    try expectDeclined(.barf, "(a b c)|");
+    try expectDeclined(.barf, "|");
+    try expectDeclined(.raise, "a| b c");
+}
+
+test "an unbalanced form has no paren to move" {
+    try expectDeclined(.slurp, "(+ 1 2| 3");
+    try expectDeclined(.barf, "(+ 1 2| 3");
+    try expectDeclined(.raise, "(+ 1 2| 3");
+    try expectDeclined(.rotate, "(+ 1 2| 3");
+}
+
+test "the innermost enclosing form wins" {
+    try expectEdit(.barf, "(a (b |c d) e)", "(a (b |c) d e)");
+    // Slurping from an inner form eats the outer form's next datum.
+    try expectEdit(.slurp, "((a| b) c)", "((a| b c))");
+    try expectEdit(.raise, "(a (b |c) d)", "(a |c d)");
+}
+
+test "a stray close paren before the form does not confuse the walk" {
+    try expectEdit(.barf, ") (a b| c)", ") (a b|) c");
+}
+
+test "the cursor on the close paren is inside; past it is not" {
+    try expectEdit(.barf, "(a b c|)", "(a b) c|");
+    try expectDeclined(.barf, "(a b c)|");
+}
+
+test "a paren inside a string is not a paren" {
+    try expectEdit(.barf, "(display \"a(b\" |x)", "(display \"a(b\") |x");
+    try expectEdit(.slurp, "(a|) \"b)c\" d", "(a| \"b)c\") d");
+    try expectDeclined(.barf, "(display \"unterminated| (");
+}
+
+test "a paren inside a comment is not a paren" {
+    try expectEdit(.barf, "(a b| ; )))\n c)", "(a b|) ; )))\n c");
+    try expectEdit(.barf, "(a b| #| ) |# c)", "(a b|) #| ) |# c");
+}
+
+test "a character literal paren is not a paren (kaappi#358)" {
+    try expectEdit(.barf, "(char=? #\\(| x)", "(char=? #\\(|) x");
+    try expectEdit(.raise, "(f (char=? #\\)| ))", "(f |#\\))");
+    try expectEdit(.barf, "(list #\\space| #\\a)", "(list #\\space|) #\\a");
+}
+
+test "a pipe symbol hides its parens too (kaappi#358)" {
+    try expectEdit(.barf, "(list '|foo(bar|| x)", "(list '|foo(bar|) x");
+}
+
+test "a datum comment is skipped, not treated as a datum" {
+    // `#;(b c)` is trivia: the last real datum is `d`, and the comment goes
+    // out with it rather than being barfed on its own.
+    try expectEdit(.barf, "(a| #;(b c) d)", "(a|) #;(b c) d");
+    try expectEdit(.raise, "(+ #;(x) |1)", "|1");
+}
+
+test "vector and bytevector literals are forms too" {
+    try expectEdit(.barf, "#(1 2| 3)", "#(1 2|) 3");
+    try expectEdit(.slurp, "#u8(1 2|) 3", "#u8(1 2 3|)");
+    try expectEdit(.rotate, "#(a| b c)", "#(b c a|)");
+}
+
+test "a quoted form is still a form (its prefix is not a datum boundary)" {
+    try expectEdit(.barf, "'(a b| c)", "'(a b|) c");
+    try expectEdit(.slurp, "(a|) '(b c)", "(a| '(b c))");
+    try expectEdit(.barf, "`(a ,b| ,@c)", "`(a ,b|) ,@c");
+}
+
+test "brackets are ordinary characters, not parens" {
+    // The reader gives `[`/`]` no meaning, so they neither open a form nor
+    // delimit a datum: `[i` and `0]` are one atom each.
+    try expectEdit(.barf, "(let loop| ([i 0]) i)", "(let loop|) ([i 0]) i");
+    try expectDeclined(.barf, "(let loop ([i| 0]) i)");
+}
+
+test "a multi-line form edits across the newline" {
+    try expectEdit(
+        .barf,
+        "(define (f x)\n  (+ x 1)|\n  2)",
+        "(define (f x)\n  (+ x 1)|)\n  2",
+    );
+}
+
+test "utf-8 stays intact" {
+    try expectEdit(.barf, "(list \"λ\" |π)", "(list \"λ\") |π");
+    try expectEdit(.rotate, "(f λ| π ω)", "(f π| ω λ)");
+}
+
+test "deeply nested input declines rather than smashing the stack" {
+    const a = std.testing.allocator;
+    const depth = max_depth + 64;
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(a);
+    try src.appendNTimes(a, '(', depth);
+    try src.appendSlice(a, "x");
+    try src.appendNTimes(a, ')', depth);
+    // No crash, no hang; whatever it decides, it decides in bounded stack.
+    if (apply(a, .barf, src.items, depth + 1)) |e| a.free(e.text);
+    if (apply(a, .raise, src.items, depth + 1)) |e| a.free(e.text);
+}
+
+test "enclosingList — finds the innermost closed list" {
+    const src = "(+ 1 (* 2 3))";
+    const f = enclosingList(src, 10).?;
+    try std.testing.expectEqual(@as(usize, 5), f.open);
+    try std.testing.expectEqual(@as(usize, 6), f.body);
+    try std.testing.expectEqual(@as(usize, 11), f.close);
+
+    // Just inside the outer open paren, just before the outer close paren.
+    try std.testing.expectEqual(@as(usize, 0), enclosingList(src, 1).?.open);
+    try std.testing.expectEqual(@as(usize, 0), enclosingList(src, 12).?.open);
+    // Outside on either end.
+    try std.testing.expect(enclosingList(src, 0) == null);
+    try std.testing.expect(enclosingList(src, 13) == null);
+}

--- a/tests/scheme/smoke/repl-structural-editing-2216.sh
+++ b/tests/scheme/smoke/repl-structural-editing-2216.sh
@@ -24,6 +24,20 @@ command -v python3 >/dev/null 2>&1 || {
     exit 77
 }
 
+# Resolve to an absolute path for the driver, which execs it directly. A value
+# with no slash is a PATH lookup; anything else is a path as given. A binary
+# that cannot be executed is a *failure*, not a skip — the skip below exists
+# for platforms with no usable terminal, and letting a missing build take that
+# exit would make this test silently green.
+case "$KAAPPI" in
+    */*) kaappi_abs="$(cd "$(dirname "$KAAPPI")" 2>/dev/null && pwd)/$(basename "$KAAPPI")" ;;
+    *)   kaappi_abs="$(command -v "$KAAPPI" || true)" ;;
+esac
+if [ ! -x "$kaappi_abs" ]; then
+    echo "FAIL: $KAAPPI is not an executable file (build first: zig build)"
+    exit 1
+fi
+
 # Isolate history and config: the REPL reads ~/.kaappi, and a developer's own
 # `repl.prompt` would move the sentinel this script waits for.
 work="$(mktemp -d)"
@@ -47,36 +61,51 @@ CASES = [
 
 pid, fd = pty.fork()
 if pid == 0:
-    os.environ['TERM'] = 'xterm'
-    os.environ['NO_COLOR'] = '1'
-    os.execv(kaappi, [kaappi])
+    # The child must exec or die: `pty.fork` gives it the parent's code, so a
+    # raising execv would otherwise let a traceback land in the pty slave and
+    # muddy the buffer the parent is matching against.
+    try:
+        os.environ['TERM'] = 'xterm'
+        os.environ['NO_COLOR'] = '1'
+        os.execv(kaappi, [kaappi])
+    except BaseException:
+        pass
+    os._exit(127)
 
 # A pty starts out 0x0, which gives the editor no room to render in.
 fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack('HHHH', 40, 200, 0, 0))
 
 buf = b''
+eof = False
 deadline = time.time() + 90
 
 def pump(timeout):
-    global buf
+    global buf, eof
     try:
         r, _, _ = select.select([fd], [], [], timeout)
     except OSError:
+        eof = True
         return False
     if not r:
         return False
     try:
         chunk = os.read(fd, 65536)
     except OSError:
+        eof = True
         return False
     if not chunk:
+        eof = True
         return False
     buf += chunk
     return True
 
 def seen(mark=0):
-    """Everything the child has written since byte `mark`, escapes stripped."""
-    return ansi.sub(b'', buf)[mark:]
+    """Everything the child has written since *raw* byte `mark`, escapes
+    stripped. The mark indexes `buf`, not the stripped text, because stripped
+    indices are not stable: a read that ends mid-escape-sequence leaves bytes
+    the regex cannot match yet, and they disappear once the rest arrives —
+    shifting every index taken before that."""
+    return ansi.sub(b'', buf[mark:])
 
 def wait_for(needle, mark=0, timeout=20):
     """Wait for `needle` in output written *after* `mark`. The mark matters:
@@ -86,6 +115,8 @@ def wait_for(needle, mark=0, timeout=20):
     while time.time() < end:
         if needle in seen(mark):
             return True
+        if eof:
+            break          # the child is gone; no more output is coming
         pump(0.2)
     return needle in seen(mark)
 
@@ -102,15 +133,22 @@ def send(data):
     os.write(fd, data)
     time.sleep(0.05)
 
-# No prompt at all means this platform gave us no usable terminal; that is a
-# skip, not a failure — the alternative is a flake on every emulated CI leg.
 if not wait_for(b'kaappi> ', 0, 25):
+    # Two very different things look alike here, and conflating them is how a
+    # test goes quietly green: a REPL that wrote *nothing at all* did not run,
+    # which is a failure; a REPL that wrote something but never prompted has no
+    # usable terminal, which is a skip (the alternative is a flake on every
+    # emulated CI leg).
+    if not buf:
+        sys.stdout.write('the REPL produced no output at all; it did not start\n')
+        sys.exit(1)
+    sys.stdout.write('no prompt in:\n%r\n' % seen())
     sys.exit(77)
 idle()
 
 failures = []
 for typed, lefts, key, expect, reject in CASES:
-    mark = len(seen())
+    mark = len(buf)
     send(typed)
     # The echoed text is proof the editor has the buffer — a plain sleep is not,
     # and typing on while the REPL is still evaluating puts the bytes in the
@@ -148,8 +186,6 @@ for key, expect, produced in failures:
     sys.stdout.write('FAIL %r: expected %r in\n%r\n\n' % (key, expect, produced))
 sys.exit(1 if failures else 0)
 PY
-
-kaappi_abs="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
 
 set +e
 KAAPPI_HOME="$work/home" python3 "$driver" "$kaappi_abs"

--- a/tests/scheme/smoke/repl-structural-editing-2216.sh
+++ b/tests/scheme/smoke/repl-structural-editing-2216.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# kaappi#2216: structural s-expression editing at the REPL.
+#
+# The transforms themselves are unit-tested in `src/repl_sexp.zig`. What this
+# covers is the half that lives in C and cannot be reached from Zig: isocline's
+# key dispatch, the buffer replacement, and the cursor clamp — KAAPPI PATCH 3
+# in `vendor/isocline/PATCHES.md`. Driving it needs a real terminal, so the
+# whole thing runs under a pty.
+#
+# Each case types a form, moves the cursor inside it, presses one structural
+# key, submits, and asserts on what the *evaluator* printed. That keeps the
+# check independent of how the editor redraws the line: the only way to print
+# `(1 2)` from `(list 1 2 3)` is for barf to have moved the paren.
+
+set -eu
+
+KAAPPI="${KAAPPI:-${1:-zig-out/bin/kaappi}}"
+
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "no pty; isocline drives the Windows console API directly"
+
+command -v python3 >/dev/null 2>&1 || {
+    echo "SKIP: python3 is needed to allocate a pty"
+    exit 77
+}
+
+# Isolate history and config: the REPL reads ~/.kaappi, and a developer's own
+# `repl.prompt` would move the sentinel this script waits for.
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+driver="$work/drive.py"
+cat > "$driver" <<'PY'
+import fcntl, os, pty, re, select, struct, sys, termios, time
+
+kaappi = sys.argv[1]
+ansi = re.compile(rb'\x1b\[[0-9;?]*[a-zA-Z]|\x1b[()][B0]|\x1b[=>]|\r')
+
+# typed form, ctrl-b presses to get the cursor inside, key, what the evaluator
+# must print, and what it must NOT print (the unedited form's own answer).
+CASES = [
+    (b'(list 1 2 3)',       1, b'\x1bB', b'(1 2)',   b'(1 2 3)'),   # barf
+    (b'(list 1 2) 3',       3, b'\x1bS', b'(1 2 3)', None),         # slurp
+    (b'(list 1 (list 2 3))', 2, b'\x1bR', b'(1 3)',  b'(1 (2 3))'), # raise
+    (b'(list 1 2 3)',       1, b'\x1by', b'(2 3 1)', b'(1 2 3)'),   # rotate
+]
+
+pid, fd = pty.fork()
+if pid == 0:
+    os.environ['TERM'] = 'xterm'
+    os.environ['NO_COLOR'] = '1'
+    os.execv(kaappi, [kaappi])
+
+# A pty starts out 0x0, which gives the editor no room to render in.
+fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack('HHHH', 40, 200, 0, 0))
+
+buf = b''
+deadline = time.time() + 90
+
+def pump(timeout):
+    global buf
+    try:
+        r, _, _ = select.select([fd], [], [], timeout)
+    except OSError:
+        return False
+    if not r:
+        return False
+    try:
+        chunk = os.read(fd, 65536)
+    except OSError:
+        return False
+    if not chunk:
+        return False
+    buf += chunk
+    return True
+
+def seen(mark=0):
+    """Everything the child has written since byte `mark`, escapes stripped."""
+    return ansi.sub(b'', buf)[mark:]
+
+def wait_for(needle, mark=0, timeout=20):
+    """Wait for `needle` in output written *after* `mark`. The mark matters:
+    every prompt looks alike, so searching the whole buffer would match the
+    previous one and return before this step had produced anything."""
+    end = min(time.time() + timeout, deadline)
+    while time.time() < end:
+        if needle in seen(mark):
+            return True
+        pump(0.2)
+    return needle in seen(mark)
+
+def idle(quiet=0.5, limit=5.0):
+    """Drain until the child has been silent for `quiet` seconds. Typing into
+    a REPL that has not finished evaluating lands in the tty's canonical
+    buffer instead of the editor, so every step waits for quiet first."""
+    end = time.time() + limit
+    while time.time() < end:
+        if not pump(quiet):
+            return
+
+def send(data):
+    os.write(fd, data)
+    time.sleep(0.05)
+
+# No prompt at all means this platform gave us no usable terminal; that is a
+# skip, not a failure — the alternative is a flake on every emulated CI leg.
+if not wait_for(b'kaappi> ', 0, 25):
+    sys.exit(77)
+idle()
+
+failures = []
+for typed, lefts, key, expect, reject in CASES:
+    mark = len(seen())
+    send(typed)
+    # The echoed text is proof the editor has the buffer — a plain sleep is not,
+    # and typing on while the REPL is still evaluating puts the bytes in the
+    # tty's canonical buffer, where ctrl-b arrives as a literal ^B.
+    if not wait_for(typed, mark, 20):
+        failures.append((key, typed, seen(mark)))
+        idle()
+        continue
+    for _ in range(lefts):
+        send(b'\x02')          # ctrl-b: one character left
+    idle(0.3)
+    send(key)
+    idle(0.3)
+    send(b'\r')
+    # The result line, not the prompt: the prompt string appears in every
+    # redraw of the line being typed, so it says nothing about evaluation.
+    ok = wait_for(b'\n' + expect + b'\n', mark, 20)
+    idle()
+    # Only what this case produced, so an earlier case cannot satisfy a later
+    # assertion.
+    produced = seen(mark)
+    if not ok or (reject is not None and reject in produced):
+        failures.append((key, expect, produced))
+
+send(b',quit\r')
+while pump(1.0):
+    pass
+try:
+    os.close(fd)
+    os.waitpid(pid, 0)
+except OSError:
+    pass
+
+for key, expect, produced in failures:
+    sys.stdout.write('FAIL %r: expected %r in\n%r\n\n' % (key, expect, produced))
+sys.exit(1 if failures else 0)
+PY
+
+kaappi_abs="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+set +e
+KAAPPI_HOME="$work/home" python3 "$driver" "$kaappi_abs"
+status=$?
+set -e
+
+case $status in
+    0)  echo "PASS: barf, slurp, raise and rotate all edit the buffer"; exit 0 ;;
+    77) echo "SKIP: no usable pty for the REPL here"; exit 77 ;;
+    *)  echo "FAIL: structural editing did not take effect"; exit 1 ;;
+esac

--- a/vendor/isocline/PATCHES.md
+++ b/vendor/isocline/PATCHES.md
@@ -4,7 +4,7 @@ Vendored from <https://github.com/daanx/isocline> at commit
 `8d6dc1ef95b1b46711e66eb23d39d4467a0fcdac` (2026-04-23, v1.1.0), MIT licensed —
 see `LICENSE`.
 
-**This is a patched copy.** Two changes diverge from upstream. Both are marked
+**This is a patched copy.** Three changes diverge from upstream. Each is marked
 in the source with a `KAAPPI PATCH <n>` comment pointing here. When updating
 isocline, re-apply them; `grep -rn 'KAAPPI PATCH' vendor/isocline/` finds every
 site.
@@ -46,6 +46,52 @@ configurable (`src/config.zig`), so an explicit request has to be honored.
 `IC_MAX_HISTORY` is now a sanity bound (1000000) and `IC_DEFAULT_HISTORY` (200,
 upstream's value) applies when the caller passes a negative count. A caller
 asking for 1000 gets 1000.
+
+## Patch 3 — structural s-expression editing
+
+**Files:** `include/isocline.h`, `src/env.h`, `src/isocline.c`,
+`src/editline.c`, `src/editline_help.c`
+
+Upstream has no structural editing — no way to move a paren rather than a
+character. The patch adds four keys and one callback:
+
+```c
+typedef enum ic_sexp_command_e {
+  IC_SEXP_SLURP = 0, IC_SEXP_BARF = 1, IC_SEXP_RAISE = 2, IC_SEXP_ROTATE = 3
+} ic_sexp_command_t;
+
+typedef char* (ic_sexp_fun_t)(ic_sexp_command_t cmd, const char* input, long* pos, void* arg);
+void ic_set_default_sexp_edit(ic_sexp_fun_t* sexp_edit, void* arg);
+```
+
+| Key | Command |
+|---|---|
+| alt+shift+S | slurp |
+| alt+shift+B | barf |
+| alt+shift+R | raise |
+| alt+y | rotate |
+
+isocline owns the keys and the buffer; the host language owns the syntax and
+does the rewriting. The callback is handed the whole input and the cursor as a
+byte offset, and returns either a replacement buffer allocated with
+`ic_malloc()` (isocline frees it) or NULL to decline — an unbalanced form,
+nothing to slurp — in which case the input is left exactly as it was. One
+`editor_start_modify` wraps the replacement, so ctrl-Z undoes a structural
+edit as a single step.
+
+With no callback set the four keys are unbound and `F1`'s help omits the
+section, so behavior is exactly upstream's.
+
+Kaappi implements the callback in `src/repl_sexp.zig`, whose scanner derives
+its rules from `src/reader.zig` — strings, `;` and `#|…|#` comments, `#;`
+datum comments, `#\(` character literals and `|pipe|` symbols all hide their
+parens, and `[`/`]` are ordinary atom characters because the reader gives them
+no meaning.
+
+The commands and keybindings come from [bestline](https://github.com/jart/bestline)
+(BSD-2-Clause) by way of kaappi#2216. The code does not: bestline's `raise` is
+an empty stub, its `rotate` rotates the kill ring rather than a form, and its
+barf and slurp count parens with no awareness of strings or comments.
 
 ## Deliberately not patched
 

--- a/vendor/isocline/include/isocline.h
+++ b/vendor/isocline/include/isocline.h
@@ -322,6 +322,40 @@ void ic_set_default_is_complete(ic_is_complete_fun_t* is_complete, void* arg);
 /// \}
 
 //--------------------------------------------------------------
+// Structural editing (KAAPPI PATCH 3)
+//--------------------------------------------------------------
+
+/// \defgroup sexp_edit Structural editing
+/// Paren-moving edits, carried out by the host language.
+/// \{
+
+/// A structural edit command. isocline owns the keys; the host language owns
+/// the syntax, so it does the rewriting.
+typedef enum ic_sexp_command_e {
+  IC_SEXP_SLURP  = 0,   ///< alt+shift+S: pull the next datum in past the closing paren
+  IC_SEXP_BARF   = 1,   ///< alt+shift+B: push the last datum out past the closing paren
+  IC_SEXP_RAISE  = 2,   ///< alt+shift+R: replace the enclosing form with the datum at point
+  IC_SEXP_ROTATE = 3    ///< alt+y: rotate the datums of the enclosing form
+} ic_sexp_command_t;
+
+/// Rewrite `input` for `cmd`. `*pos` is the cursor as a byte offset into
+/// `input`, read on the way in and written on the way out. Return a new
+/// NUL-terminated buffer allocated with `ic_malloc()` — isocline takes
+/// ownership and frees it — or NULL to leave the input exactly as it was,
+/// which is how a command declines (an unbalanced form, nothing to slurp).
+///
+/// Upstream isocline has no such hook; there is no structural editing there at
+/// all. The commands are bestline's, the implementation is not — see
+/// `vendor/isocline/PATCHES.md`.
+typedef char* (ic_sexp_fun_t)(ic_sexp_command_t cmd, const char* input, long* pos, void* arg);
+
+/// Set the structural-edit callback. There can only be one; setting it again
+/// replaces the previous one. Pass NULL to leave the four keys unbound.
+void ic_set_default_sexp_edit(ic_sexp_fun_t* sexp_edit, void* arg);
+
+/// \}
+
+//--------------------------------------------------------------
 // Readline with a specific completer and highlighter
 //--------------------------------------------------------------
 

--- a/vendor/isocline/src/editline.c
+++ b/vendor/isocline/src/editline.c
@@ -612,6 +612,22 @@ static void edit_cursor_row_down(ic_env_t* env, editor_t* eb) {
 }
 
 
+// KAAPPI PATCH 3: structural editing. isocline owns the key, the host language
+// owns the syntax — it is handed the buffer and the cursor and returns a
+// rewritten buffer, or NULL to decline. See vendor/isocline/PATCHES.md.
+static void edit_sexp(ic_env_t* env, editor_t* eb, ic_sexp_command_t cmd) {
+  if (env->sexp_edit == NULL) return;
+  long pos = (long)eb->pos;
+  char* res = (*env->sexp_edit)(cmd, sbuf_string(eb->input), &pos, env->sexp_edit_arg);
+  if (res == NULL) return;   // the command does not apply here: leave the input alone
+  editor_start_modify(eb);   // so ^z undoes the whole structural edit as one step
+  sbuf_replace(eb->input, res);
+  mem_free(env->mem, res);
+  const ssize_t len = sbuf_len(eb->input);
+  eb->pos = (pos < 0 ? 0 : (pos > (long)len ? len : (ssize_t)pos));
+  edit_refresh(env, eb);
+}
+
 static void edit_cursor_match_brace(ic_env_t* env, editor_t* eb) {
   ssize_t match = find_matching_brace( sbuf_string(eb->input), eb->pos, ic_env_get_match_braces(env), NULL );
   if (match < 0) return;
@@ -1054,6 +1070,20 @@ static char* edit_line( ic_env_t* env, const char* prompt_text )
         break;
       case WITH_ALT('m'):
         edit_cursor_match_brace(env,&eb);
+        break;
+
+      // structural editing (KAAPPI PATCH 3)
+      case WITH_ALT('S'):
+        edit_sexp(env,&eb,IC_SEXP_SLURP);
+        break;
+      case WITH_ALT('B'):
+        edit_sexp(env,&eb,IC_SEXP_BARF);
+        break;
+      case WITH_ALT('R'):
+        edit_sexp(env,&eb,IC_SEXP_RAISE);
+        break;
+      case WITH_ALT('y'):
+        edit_sexp(env,&eb,IC_SEXP_ROTATE);
         break;
 
       // deletion

--- a/vendor/isocline/src/editline_help.c
+++ b/vendor/isocline/src/editline_help.c
@@ -93,6 +93,18 @@ static const char* help[] = {
   NULL, NULL
 };
 
+// KAAPPI PATCH 3: shown only when a structural-edit callback is set, since the
+// four keys do nothing without one. See vendor/isocline/PATCHES.md.
+static const char* help_sexp[] = {
+  "", "Structural editing:",
+  "alt-shift-S", "slurp: pull the next datum in past the closing paren",
+  "alt-shift-B", "barf: push the last datum out past the closing paren",
+  "alt-shift-R", "raise: replace the enclosing form with the datum at point",
+  "alt-y",       "rotate the form's arguments, leaving the head in place",
+  " ","",
+  NULL, NULL
+};
+
 static const char* help_initial = 
   "[ic-info]"
   "Isocline v1.1, copyright (c) 2021-2026 Daan Leijen.\n"
@@ -122,17 +134,23 @@ static const char* help_initial =
   "       ctrl-u                          ctrl-k\n"
   "[/ansi-lightgray][/ic-info]\n";
 
+static void edit_show_help_entries(ic_env_t* env, const char** entries) {
+  for (ssize_t i = 0; entries[i] != NULL && entries[i+1] != NULL; i += 2) {
+    if (entries[i][0] == 0) {
+      bbcode_printf(env->bbcode, "[ic-info]%s[/]\n", entries[i+1]);
+    }
+    else {
+      bbcode_printf(env->bbcode, "  [ic-emphasis]%-13s[/][ansi-lightgray]%s%s[/]\n", entries[i], (entries[i+1][0] == 0 ? "" : ": "), entries[i+1]);
+    }
+  }
+}
+
 static void edit_show_help(ic_env_t* env, editor_t* eb) {
   edit_clear(env, eb);
   bbcode_println(env->bbcode, help_initial);
-  for (ssize_t i = 0; help[i] != NULL && help[i+1] != NULL; i += 2) {
-    if (help[i][0] == 0) {  
-      bbcode_printf(env->bbcode, "[ic-info]%s[/]\n", help[i+1]);
-    }
-    else {
-      bbcode_printf(env->bbcode, "  [ic-emphasis]%-13s[/][ansi-lightgray]%s%s[/]\n", help[i], (help[i+1][0] == 0 ? "" : ": "), help[i+1]);
-    }
-  }
+  edit_show_help_entries(env, help);
+  // KAAPPI PATCH 3: see vendor/isocline/PATCHES.md
+  if (env->sexp_edit != NULL) { edit_show_help_entries(env, help_sexp); }
 
   eb->cur_rows = 0;
   eb->cur_row = 0;

--- a/vendor/isocline/src/env.h
+++ b/vendor/isocline/src/env.h
@@ -36,6 +36,9 @@ struct ic_env_s {
   // KAAPPI PATCH 1: see vendor/isocline/PATCHES.md
   ic_is_complete_fun_t* is_complete; // "is this input a finished form?" callback
   void*           is_complete_arg;  // user state for is_complete.
+  // KAAPPI PATCH 3: see vendor/isocline/PATCHES.md
+  ic_sexp_fun_t*  sexp_edit;        // structural (paren-moving) edit callback
+  void*           sexp_edit_arg;    // user state for sexp_edit.
   const char*     match_braces;     // matching braces, e.g "()[]{}"
   const char*     auto_braces;      // auto insertion braces, e.g "()[]{}\"\"''"
   char            multiline_eol;    // character used for multiline input ("\") (set to 0 to disable)

--- a/vendor/isocline/src/isocline.c
+++ b/vendor/isocline/src/isocline.c
@@ -337,6 +337,13 @@ ic_public void ic_set_default_is_complete(ic_is_complete_fun_t* is_complete, voi
   env->is_complete_arg = arg;
 }
 
+// KAAPPI PATCH 3: see vendor/isocline/PATCHES.md
+ic_public void ic_set_default_sexp_edit(ic_sexp_fun_t* sexp_edit, void* arg) {
+  ic_env_t* env = ic_get_env(); if (env==NULL) return;
+  env->sexp_edit = sexp_edit;
+  env->sexp_edit_arg = arg;
+}
+
 
 ic_public void ic_free( void* p ) {
   ic_env_t* env = ic_get_env(); if (env==NULL) return;


### PR DESCRIPTION
Closes #2216.

Four keys now move a paren rather than a character. `|` marks the cursor:

| Key | Command | Effect |
|---|---|---|
| alt+shift+S | slurp | `(a\| b) c d` → `(a\| b c) d` |
| alt+shift+B | barf | `(a\| b c)` → `(a\| b) c` |
| alt+shift+R | raise | `(+ 1 (* 2 \|3))` → `(+ 1 \|3)` |
| alt+y | rotate | `(if a\| b c)` → `(if b c a\|)` |

They are listed under `,help` and under isocline's own F1 help, the latter only
when the callback is set.

This had to wait for the isocline migration (#2219): with one editable physical
line per `linenoise()` call there was no whole form to restructure.

## Two corrections to the issue

The issue proposed porting the four commands from bestline, citing four line
numbers. **Two of them are not there to port:**

- `bestlineEditRaise` (line 3335, the line cited) is `(void)l;` — an empty stub.
- `bestlineEditRotate` (line 3040) rotates the **kill ring** and re-yanks —
  emacs `M-y` yank-pop — not the datums of a form.

Barf and slurp do exist, but they walk runes with a mirror stack and no notion
of strings, comments or character literals — precisely the bug class the issue
asked the port to avoid. So this is a reimplementation, not a port, and the
attribution in `PATCHES.md` and the module header says so: the design and the
keybindings are bestline's, the code is not.

## One judgment call worth a look

**Rotate keeps the head and cycles only the arguments.** The issue's table says
"rotate the datums of the enclosing form", which read literally turns
`(+ 1 2)` into `(1 2 +)` — never valid Scheme, so the command would be useless
in practice. Head-preserving rotation is still a pure cycle: repeating it n-1
times on n arguments restores the original. Easy to flip if the literal reading
was meant.

## What is where

**`src/repl_sexp.zig`** (new, 706 lines with tests) — the transforms as pure
functions over `(buffer, byte cursor)`, so they test without a terminal. The
scanner takes `Reader.isDelimiter` from `reader.zig` **directly rather than
copying it**, and skips strings, `;` and `#|…|#` comments, `#;` datum comments,
`#\(` character literals and `|pipe|` symbols. 31 unit tests, including the
cases the ported originals would have got wrong.

An unbalanced form has no paren to move, so every command declines and leaves
the buffer exactly as it was rather than guessing.

**KAAPPI PATCH 3** (`vendor/isocline/`) — `ic_set_default_sexp_edit`, the four
key bindings, and an F1 help section. isocline owns the keys and the buffer;
the host language owns the syntax and does the rewriting. One
`editor_start_modify` wraps the replacement so ctrl-Z undoes a structural edit
as a single step. With no callback set, behavior is exactly upstream's.

**Also closed: the bracket divergence the issue noted in passing.**
`findMatchingOpen` is gone (isocline does brace matching now, already limited
to `"()"`), but `scanHighlight` still painted `[`/`]` like parens while the
reader gives them no meaning (`0]` is KP1002). `repl.isDelimiter` is now an
alias of `Reader.isDelimiter`, so the colors, the brace matcher, the reader and
`repl_sexp` all agree.

## Tests

`tests/scheme/smoke/repl-structural-editing-2216.sh` drives all four keys over
a real pty — the C half is unreachable from Zig. Each case types a form, moves
the cursor inside it, presses one key, submits, and asserts on what the
*evaluator* printed, so the check does not depend on how the editor redraws.

**Mutation-tested:** with `edit_sexp` stubbed to return immediately, all four
cases fail. Two things that make it robust rather than timing-guessy are worth
knowing if it ever needs editing: it sets `TIOCSWINSZ` (a fresh pty is 0x0,
which leaves the editor no room to render), and it never uses the prompt string
as a post-submit sentinel — isocline redraws the prompt on every keystroke, so
waiting on it returns instantly and the next case then types into the tty's
canonical buffer. It waits for the printed result instead. No usable pty exits
77 (skip) rather than failing.

- `zig build test` — 1755/1758 pass (3 pre-existing skips)
- `bash tests/scheme/run-all.sh` — 2077 pass, 0 fail; the new pty test also
  passes under the suite's shell concurrency, and 6/6 standalone runs
- Cross-compiles clean for `x86_64-windows` and `wasm32-wasi`

## Not done

`src/repl.zig` is now 1571 lines, past the 1500-line policy. It was already at
1514 before this change; the natural fix is splitting the highlighter into its
own file, which would move ~340 lines and bury this diff. Worth a separate
pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)