### PR TITLE
Close the last two racing margins in srfi120.scm (#1870)

### DIFF
--- a/tests/scheme/srfi/srfi120-slow-setup.scm
+++ b/tests/scheme/srfi/srfi120-slow-setup.scm
@@ -18,8 +18,16 @@
 ;;   task-remove       300 ms       400 ms      800 ms
 ;;   reschedule       1000 ms       400 ms     1000 ms   (unchanged; pinned)
 ;;   period-0           40 ms       200 ms     2000 ms
-;;   timer-cancel!      30 ms       200 ms      600 ms
-;;   no-handler         30 ms       200 ms      none (nothing follows)
+;;   timer-cancel!     570 ms       800 ms     1200 ms
+;;   no-handler        570 ms       800 ms     1200 ms
+;;
+;; The last two rows were fixed TWICE. The first pass (2026-08-01) reordered
+;; each block so the erroring/`late` task was no longer raced by a following
+;; call, and pinned each at 200 ms -- but both still carried a deadline the
+;; reorder did not touch, at 570 ms, and a 200 ms pin cannot see a 570 ms
+;; margin. Each margin below is now the bisected value at which the block
+;; actually breaks, and each injection is larger than the margin the
+;; previous shape had, so every row fails against the shape it replaced.
 ;;
 ;; The injected delays are what make this file deterministic, so do not
 ;; remove them to "speed it up" -- without them the file asserts nothing the
@@ -81,17 +89,26 @@
   (timer-cancel! t))
 
 ;;; --- timer-cancel! --------------------------------------------------------
-;; OLD: one periodic 30/30 task, so ticks queued between the first receive
-;; and the cancel. This is the shape that produced netbsd-test's
-;; "timer-cancel!: no further firings after cancellation".
+;; OLD (1st shape): one periodic 30/30 task, so ticks queued between the
+;; first receive and the cancel. This is the shape that produced
+;; netbsd-test's "timer-cancel!: no further firings after cancellation".
+;; OLD (2nd shape): two one-shots, but `late` was scheduled FIRST, so its
+;; 600 ms had to cover the `early` receive AND the cancel -- 570 ms in
+;; practice. `late` is now scheduled after the receive, so the only work
+;; inside its 1200 ms is timer-cancel! itself.
+;;
+;; The sleep sits immediately before the cancel, which pins both shapes at
+;; once: here it is the surviving schedule-to-cancel window (1200 ms, so
+;; 800 ms passes), while in either old shape the same statement fell inside
+;; the 570 ms receive-to-cancel window and 800 ms breaks it.
 
 (let* ((sig (make-channel))
        (t (make-timer)))
-  (timer-schedule! t (lambda () (channel-send sig 'late)) 600)
   (timer-schedule! t (lambda () (channel-send sig 'early)) 30)
   (test-equal "slow setup: a task fires before cancellation"
               'early (channel-receive sig 3.0 'timeout))
-  (thread-sleep! 0.2)
+  (timer-schedule! t (lambda () (channel-send sig 'late)) 1200)
+  (thread-sleep! 0.8)
   (timer-cancel! t)
   (test-equal "slow setup: still no further firings after a delayed cancellation"
               'timeout (channel-receive sig 0.4 'timeout)))
@@ -101,20 +118,25 @@
 ;; had to get its second timer-schedule! in before the timer stopped. This
 ;; is the shape that produced netbsd-test's
 ;; "srfi120.scm:153 error[KP3000]: timer-schedule!: timer is not responding".
-;; The fix is ordering, not headroom: nothing calls into the timer after the
-;; erroring task is queued, so the delay below cannot break it however long
-;; it is.
+;; Ordering fixed THAT failure mode -- nothing calls into the timer after
+;; the erroring task is queued, so no delay can make the schedule below
+;; raise -- but it left `should-not-fire`'s own deadline untouched, and at
+;; 600 ms that was 570 ms of margin for the erroring schedule that has to
+;; stop the timer first. So the two assertions below fail for two different
+;; reasons, and only the first is about ordering: at 800 ms the schedule
+;; still never raises, while `should-not-fire` really did arrive until its
+;; delay was widened to 1200 ms.
 
 (let* ((sig (make-channel))
        (t (make-timer)))
-  (timer-schedule! t (lambda () (channel-send sig 'should-not-fire)) 600)
-  (thread-sleep! 0.2)
+  (timer-schedule! t (lambda () (channel-send sig 'should-not-fire)) 1200)
+  (thread-sleep! 0.8)
   (test-assert "slow setup: scheduling the erroring task last never raises"
     (guard (c (#t #f))
       (timer-schedule! t (lambda () (error "srfi-120 test: unhandled")) 30)
       #t))
   (test-equal "slow setup: the timer still stops, so the later task never fires"
-              'timeout (channel-receive sig 1.0 'timeout))
+              'timeout (channel-receive sig 1.5 'timeout))
   (test-assert "slow setup: timer-cancel! still re-raises the preserved error"
     (guard (c (#t (and (error-object? c)
                        (string=? (error-object-message c) "srfi-120 test: unhandled"))))

--- a/tests/scheme/srfi/srfi120.scm
+++ b/tests/scheme/srfi/srfi120.scm
@@ -22,8 +22,19 @@
 ;;       its delay so much larger than the intervening work that no
 ;;       plausible slowdown can close the gap. The intervening work is
 ;;       synchronous request/reply over a channel -- ~0.1 ms healthy -- so
-;;       the delays below (600-1000 ms) leave a margin of several thousand
+;;       the delays below (800-2000 ms) leave a margin of several thousand
 ;;       times, not the ~300x a 30 ms delay left.
+;;
+;;       "Schedule it LAST" removes the following *calls*, never the
+;;       deadlines already set. A block whose last statement schedules
+;;       nothing can still be racing an earlier task's delay -- which is
+;;       what the timer-cancel! and no-error-handler blocks below were
+;;       still doing at 570 ms each, the two smallest margins in the file
+;;       and the two assertions netbsd-test actually went red on, long
+;;       after the ordering fix. Both were found by injecting a delay at
+;;       each block's racy point and bisecting for the value that breaks
+;;       it; the margins are measured, not assumed, and every one is
+;;       pinned in srfi120-slow-setup.scm.
 ;;
 ;;   R2. Never observe a PERIODIC task through a channel and then assert
 ;;       "nothing more arrives". `make-channel` with no capacity argument is
@@ -184,20 +195,25 @@
 ;; exactly what went red on netbsd-test (kaappi#1870). Two one-shots give
 ;; the same two guarantees with nothing to queue: `early` proves the timer
 ;; was genuinely running, `late` proves cancellation stopped it.
-;; R1: `late`'s 600 ms delay has to outlast `early` firing (30 ms) plus the
-;; receive and the cancel; only the last two scale with machine speed, and
-;; they are ~0.2 ms healthy.
-;; R3: the negative wait (1.0 s) outlasts `late`'s 600 ms delay, so a
+;; R1: `late` is scheduled LAST, once `early` has already been received. It
+;; used to be scheduled first, which put the `early` receive inside its
+;; margin alongside the cancel and left 570 ms for both -- the smallest
+;; margin in the file, guarding the very assertion netbsd-test went red on.
+;; Scheduling it here empties that window of deadlines altogether: injecting
+;; a 1.4 s stall between the receive and this schedule now changes nothing,
+;; where 0.6 s used to fail. The only work left inside `late`'s 1200 ms is
+;; timer-cancel! itself.
+;; R3: the negative wait (1.5 s) outlasts `late`'s 1200 ms delay, so a
 ;; cancellation that failed to stop the timer would be caught.
 (let* ((sig (make-channel))
        (t (make-timer)))
-  (timer-schedule! t (lambda () (channel-send sig 'late)) 600)
   (timer-schedule! t (lambda () (channel-send sig 'early)) 30)
   (test-equal "timer-cancel!: at least one firing happens before cancellation"
               'early (channel-receive sig 3.0 'timeout))
+  (timer-schedule! t (lambda () (channel-send sig 'late)) 1200)
   (timer-cancel! t)
   (test-equal "timer-cancel!: no further firings after cancellation"
-              'timeout (channel-receive sig 1.0 'timeout)))
+              'timeout (channel-receive sig 1.5 'timeout)))
 
 ;;; --- error-handler ---------------------------------------------------------
 
@@ -222,16 +238,25 @@
 ;; "timer is not responding" -- which is precisely what went red on
 ;; netbsd-test (kaappi#1870, srfi120.scm:153 on PR #2076): the old order
 ;; scheduled the erroring task first, at 30 ms, and then needed its own next
-;; line to beat that 30 ms deadline. Nothing follows the erroring schedule
-;; now, so there is no deadline left to lose.
-;; R3: the should-not-fire task's 600 ms delay is still well inside the
-;; 1.0 s negative wait, so a timer that failed to stop would be caught.
+;; line to beat that 30 ms deadline.
+;;
+;; That ordering removed the "not responding" failure mode but NOT every
+;; deadline, and this comment used to claim it had ("nothing follows the
+;; erroring schedule now, so there is no deadline left to lose"). It is the
+;; general R1 trap: `should-not-fire` still has to outlast the erroring
+;; timer-schedule! that is meant to stop the timer first. At 600 ms that
+;; left 570 ms, and injecting 0.6 s here failed the block for real -- with
+;; `should-not-fire` arriving, not with "not responding", so the ordering
+;; fix was genuinely intact and simply did not cover this. 1200 ms brings
+;; the margin into line with the rest of the file.
+;; R3: the should-not-fire task's 1200 ms delay is still inside the 1.5 s
+;; negative wait, so a timer that failed to stop would be caught.
 (let* ((sig (make-channel))
        (t (make-timer)))
-  (timer-schedule! t (lambda () (channel-send sig 'should-not-fire)) 600)
+  (timer-schedule! t (lambda () (channel-send sig 'should-not-fire)) 1200)
   (timer-schedule! t (lambda () (error "srfi-120 test: unhandled")) 30)
   (test-equal "no error-handler: the timer stops, so later tasks never fire"
-              'timeout (channel-receive sig 1.0 'timeout))
+              'timeout (channel-receive sig 1.5 'timeout))
   ;; SRFI 120: "the procedure raises the preserved error if there is" --
   ;; timer-cancel! on an already-stopped-by-error timer must re-raise it.
   (test-assert "timer-cancel!: raises the preserved error from an unhandled task failure"


### PR DESCRIPTION
`#2120` de-flaked five blocks in `tests/scheme/srfi/srfi120.scm` and pinned each in `srfi120-slow-setup.scm`. **Two of them were still racing a deadline afterwards, at 570 ms each** — the two smallest margins in the file, and the two assertions `netbsd-test` actually went red on.

## Why they survived the previous pass

"Schedule the deadline-bearing task LAST" was read as removing every deadline. It only removes the following *calls*.

- **no-error-handler** (`:229`) said so outright — *"nothing follows the erroring schedule now, so there is no deadline left to lose"* — while `should-not-fire`'s own 600 ms still had to outlast the erroring `timer-schedule!` that is meant to stop the timer first.
- **timer-cancel!** (`:192`) scheduled `late` first, so its 600 ms covered the `early` receive *as well as* the cancel.

The 200 ms pins `#2120` left cannot see a 570 ms margin, which is why both looked covered.

## Measured, not assumed

Each block's racy point was injected with a `thread-sleep!` and bisected for the value that breaks it:

| block | was | now |
|---|--:|--:|
| task-remove (`:125`) | 800 ms | 800 ms *(unchanged)* |
| reschedule (`:144`) | 1000 ms | 1000 ms *(unchanged)* |
| period-0 (`:167`) | 2000 ms | 2000 ms *(unchanged)* |
| **timer-cancel! (`:192`)** | **570 ms** | **1200 ms** |
| **no-handler (`:229`)** | **570 ms** | **1200 ms** |

The three unchanged rows are reported because the probe covered them; claiming them as fixes would be false.

## The fixes

**`timer-cancel!` is fixed structurally, not by headroom.** `late` is scheduled *after* the `early` receive, which empties that window of deadlines altogether — a **1.4 s** stall between the receive and the schedule now changes nothing, where **0.6 s** used to fail. Only the cancel itself remains inside `late`'s 1200 ms.

**`no-handler` has no such reordering available** (the erroring task must stay last, or the "not responding" failure `#2120` fixed comes back), so its delay is widened to match the rest of the file. Confirmed the ordering fix is intact and simply did not cover this: at 0.6 s the block failed with `should-not-fire` arriving, *not* with "not responding".

**Detection is not traded away.** Both negative waits still outlast the delay of the task they disprove (rule R3): 1.5 s against 1200 ms.

## Evidence

Both `srfi120-slow-setup.scm` pins raised 200 ms → 800 ms, which exceeds the margin the shape they replaced had, so each fails against that shape. Mutation-tested — the new pins applied to the old blocks fail **3 of 5** assertions, including both `netbsd-test` failures by name:

```
FAIL old shape: still no further firings after a delayed cancellation
FAIL old shape: the timer still stops, so the later task never fires
FAIL old shape: timer-cancel! still re-raises the preserved error
```

The third is a **cascade, not a third race**: the negative wait returns early on the leaked value, so `timer-cancel!` beats the erroring task and finds nothing to re-raise. Same shape as this issue's original `:177`/`:179` pair.

Also verified `error-handler` (`:204`), the re-raising-handler / `raise #f` / sentinel-lookalike cancels (`:248`, `:272`, `:285`) and the normal cancel (`:262`) are genuinely immune — they pass with a **6 s** stall injected, because the control channel is unbounded and `%wait-for-cancel` blocks without a deadline.

## Cost

Assertion counts unchanged (41 and 12). `srfi120.scm` 5.02 s → 5.37 s; `srfi120-slow-setup.scm` 3.80 s → 5.49 s. Both files 25× under concurrent `run-all.sh` load: **50/50**. Full suite green (`2074 pass`) apart from three `tests/scheme/compile/*.sh` failures that reproduce without this change and are a stale local Zig bundle cache (`invalid embedded bytecode`) — CI does not show them.

The rules header in `srfi120.scm` now records the trap under R1, so the next edit does not repeat it.

Closes #1870

🤖 Generated with [Claude Code](https://claude.com/claude-code)