### PR TITLE
Stop discarding pasted input when the REPL drops out of raw mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,13 +392,15 @@ It holds a whole form in one buffer, which is why `repl.zig` no longer joins
 continuation lines: `ic_readline` returns a finished expression, newlines
 included, and every line of it stays editable until submit.
 
-**The copy is patched** — three changes, each marked `KAAPPI PATCH` in the
+**The copy is patched** — four changes, each marked `KAAPPI PATCH` in the
 source and documented in `vendor/isocline/PATCHES.md`: an input-completeness
 callback (upstream's Enter always submits), a configurable history size
-(upstream caps at 200), and structural s-expression editing — slurp, barf,
-raise, rotate, whose transforms live in `src/repl_sexp.zig` (`docs/dev/repl.md`).
-Re-apply all three when updating; `grep -rn 'KAAPPI PATCH' vendor/isocline/`
-finds every site.
+(upstream caps at 200), structural s-expression editing — slurp, barf,
+raise, rotate, whose transforms live in `src/repl_sexp.zig` (`docs/dev/repl.md`)
+— and `TCSADRAIN` instead of `TCSAFLUSH` around raw-mode transitions, so a
+multi-line paste that submits partway through doesn't get its still-unread
+tail silently discarded (kaappi#2226). Re-apply all four when updating;
+`grep -rn 'KAAPPI PATCH' vendor/isocline/` finds every site.
 
 ## Package manager (thottam)
 

--- a/tests/scheme/smoke/repl-paste-multiple-forms-2226.sh
+++ b/tests/scheme/smoke/repl-paste-multiple-forms-2226.sh
@@ -101,6 +101,11 @@ def idle(quiet=0.5, limit=5.0):
             return
 
 if not wait_for(b'kaappi> ', 0, 25):
+    # Two very different things look alike here, and conflating them is how a
+    # test goes quietly green: a REPL that wrote *nothing at all* did not run,
+    # which is a failure; a REPL that wrote something but never prompted has no
+    # usable terminal, which is a skip (the alternative is a flake on every
+    # emulated CI leg).
     if not buf:
         sys.stdout.write('the REPL produced no output at all; it did not start\n')
         sys.exit(1)
@@ -167,6 +172,8 @@ else:
 
 if exit_status is not None and os.WIFEXITED(exit_status) and os.WEXITSTATUS(exit_status) != 0:
     failures.append(('shutdown: REPL exited with status %d' % os.WEXITSTATUS(exit_status), b''))
+elif exit_status is not None and os.WIFSIGNALED(exit_status):
+    failures.append(('shutdown: REPL was killed by signal %d' % os.WTERMSIG(exit_status), b''))
 
 try:
     os.close(fd)

--- a/tests/scheme/smoke/repl-paste-multiple-forms-2226.sh
+++ b/tests/scheme/smoke/repl-paste-multiple-forms-2226.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+# kaappi#2226: pasting a block with more than one top-level form into the
+# REPL dropped everything after the first form.
+#
+# Many terminal emulators deliver a pasted newline as a literal CR ('\r') —
+# the same byte a real Enter keypress sends. `ic_editline` (isocline) wraps
+# every `ic_readline` call in `tty_start_raw()`/`tty_end_raw()`
+# (vendor/isocline/src/tty.c), and both used `tcsetattr(..., TCSAFLUSH, ...)`.
+# TCSAFLUSH discards any input the kernel has already received but the
+# process has not yet read(2) — so the moment the first pasted form's CR
+# submits it (that line alone is already complete) and `ic_editline` returns,
+# `tty_end_raw()`'s flush throws away the rest of the still-unread paste
+# before the REPL ever asks for it. This needs a real terminal (isocline's
+# raw-mode reads, not a piped stdin), so it runs under a pty like
+# `repl-structural-editing-2216.sh`.
+
+set -eu
+
+KAAPPI="${KAAPPI:-${1:-zig-out/bin/kaappi}}"
+
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "no pty; isocline drives the Windows console API directly"
+
+command -v python3 >/dev/null 2>&1 || {
+    echo "SKIP: python3 is needed to allocate a pty"
+    exit 77
+}
+
+case "$KAAPPI" in
+    */*) kaappi_abs="$(cd "$(dirname "$KAAPPI")" 2>/dev/null && pwd)/$(basename "$KAAPPI")" ;;
+    *)   kaappi_abs="$(command -v "$KAAPPI" || true)" ;;
+esac
+if [ ! -x "$kaappi_abs" ]; then
+    echo "FAIL: $KAAPPI is not an executable file (build first: zig build)"
+    exit 1
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+driver="$work/drive.py"
+cat > "$driver" <<'PY'
+import fcntl, os, pty, re, select, struct, sys, termios, time
+
+kaappi = sys.argv[1]
+ansi = re.compile(rb'\x1b\[[0-9;?]*[a-zA-Z]|\x1b[()][B0]|\x1b[=>]|\r')
+
+pid, fd = pty.fork()
+if pid == 0:
+    try:
+        os.environ['TERM'] = 'xterm'
+        os.environ['NO_COLOR'] = '1'
+        os.execv(kaappi, [kaappi])
+    except BaseException:
+        pass
+    os._exit(127)
+
+fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack('HHHH', 40, 200, 0, 0))
+
+buf = b''
+eof = False
+deadline = time.time() + 60
+
+def pump(timeout):
+    global buf, eof
+    try:
+        r, _, _ = select.select([fd], [], [], timeout)
+    except OSError:
+        eof = True
+        return False
+    if not r:
+        return False
+    try:
+        chunk = os.read(fd, 65536)
+    except OSError:
+        eof = True
+        return False
+    if not chunk:
+        eof = True
+        return False
+    buf += chunk
+    return True
+
+def seen(mark=0):
+    return ansi.sub(b'', buf[mark:])
+
+def wait_for(needle, mark=0, timeout=20):
+    end = min(time.time() + timeout, deadline)
+    while time.time() < end:
+        if needle in seen(mark):
+            return True
+        if eof:
+            break
+        pump(0.2)
+    return needle in seen(mark)
+
+def idle(quiet=0.5, limit=5.0):
+    end = time.time() + limit
+    while time.time() < end:
+        if not pump(quiet):
+            return
+
+if not wait_for(b'kaappi> ', 0, 25):
+    if not buf:
+        sys.stdout.write('the REPL produced no output at all; it did not start\n')
+        sys.exit(1)
+    sys.stdout.write('no prompt in:\n%r\n' % seen())
+    sys.exit(77)
+idle()
+
+failures = []
+
+# Paste three separate, individually-complete top-level forms as ONE write(2)
+# — the way a terminal delivers a clipboard paste, not one line at a time.
+# Newlines arrive as CR ('\r'), matching how terminals commonly translate a
+# pasted newline into the same byte a real Enter keypress sends: the buggy
+# version submitted the first form on its CR and then discarded the rest of
+# the still-unread paste when isocline dropped back out of raw mode.
+mark = len(buf)
+paste = b'(define x 1)\r(define y 2)\r(display (+ x y))\r'
+os.write(fd, paste)
+if not wait_for(b'kaappi> ', mark, 20):
+    failures.append(('paste: no prompt returned after pasted block', seen(mark)))
+idle(0.3)
+
+produced = seen(mark)
+if b'3' not in produced:
+    failures.append(('paste: (display (+ x y)) did not print 3 — later forms were lost', produced))
+
+# Confirm `y` actually landed as a binding (not just that "3" appeared
+# somewhere incidentally) by asking for it directly.
+mark = len(buf)
+send = lambda data: (os.write(fd, data), time.sleep(0.05))
+send(b'y\r')
+wait_for(b'kaappi> ', mark, 10)
+idle(0.3)
+produced = seen(mark)
+if b'undefined variable' in produced:
+    failures.append(("paste: 'y' was never defined — the second form was dropped", produced))
+elif b'2' not in produced:
+    failures.append(("paste: 'y' did not evaluate to 2", produced))
+
+send(b',quit\r')
+while pump(1.0):
+    pass
+
+# Bounded reap: a hung `,quit` must fail the test, not hang the process (and
+# the CI worker after it, since the outer shell timeout only kills this
+# script's own pid, not a grandchild it never waited for).
+shutdown_deadline = time.time() + 10
+exit_status = None
+while time.time() < shutdown_deadline:
+    try:
+        reaped, exit_status = os.waitpid(pid, os.WNOHANG)
+    except OSError:
+        reaped = pid  # already reaped
+    if reaped == pid:
+        break
+    time.sleep(0.1)
+else:
+    failures.append(('shutdown: REPL did not exit after ,quit', seen()))
+    try:
+        os.kill(pid, 9)
+        os.waitpid(pid, 0)
+    except OSError:
+        pass
+
+if exit_status is not None and os.WIFEXITED(exit_status) and os.WEXITSTATUS(exit_status) != 0:
+    failures.append(('shutdown: REPL exited with status %d' % os.WEXITSTATUS(exit_status), b''))
+
+try:
+    os.close(fd)
+except OSError:
+    pass
+
+for label, produced in failures:
+    sys.stdout.write('FAIL %s:\n%r\n\n' % (label, produced))
+sys.exit(1 if failures else 0)
+PY
+
+set +e
+KAAPPI_HOME="$work/home" python3 "$driver" "$kaappi_abs"
+status=$?
+set -e
+
+case $status in
+    0)  echo "PASS: pasting multiple top-level forms evaluates all of them"; exit 0 ;;
+    77) echo "SKIP: no usable pty for the REPL here"; exit 77 ;;
+    *)  echo "FAIL: pasting multiple top-level forms lost input after the first"; exit 1 ;;
+esac

--- a/vendor/isocline/PATCHES.md
+++ b/vendor/isocline/PATCHES.md
@@ -4,7 +4,7 @@ Vendored from <https://github.com/daanx/isocline> at commit
 `8d6dc1ef95b1b46711e66eb23d39d4467a0fcdac` (2026-04-23, v1.1.0), MIT licensed —
 see `LICENSE`.
 
-**This is a patched copy.** Three changes diverge from upstream. Each is marked
+**This is a patched copy.** Four changes diverge from upstream. Each is marked
 in the source with a `KAAPPI PATCH <n>` comment pointing here. When updating
 isocline, re-apply them; `grep -rn 'KAAPPI PATCH' vendor/isocline/` finds every
 site.
@@ -92,6 +92,37 @@ The commands and keybindings come from [bestline](https://github.com/jart/bestli
 (BSD-2-Clause) by way of kaappi#2216. The code does not: bestline's `raise` is
 an empty stub, its `rotate` rotates the kill ring rather than a form, and its
 barf and slurp count parens with no awareness of strings or comments.
+
+## Patch 4 — don't discard buffered input when leaving/entering raw mode
+
+**File:** `src/tty.c`
+
+Upstream's `tty_start_raw`/`tty_end_raw` — called at the start and end of
+*every* `ic_readline` call — used `tcsetattr(..., TCSAFLUSH, ...)`.
+`TCSAFLUSH` discards any input the kernel has already received but the
+process hasn't `read(2)`ed yet.
+
+That is fine for a shell reading one physical line at a time, and wrong for a
+Lisp prompt reading a whole form: pasting a block with more than one
+top-level form delivers it to the pty as a single burst, often with each
+pasted newline arriving as a literal CR (terminals commonly translate a
+pasted newline into the same byte a real Enter keypress sends). If the first
+form alone is already complete, `isCompleteCallback` (Patch 1) submits right
+there and `ic_editline` returns — before the rest of the still-unread paste
+has been read at all. The `TCSAFLUSH` in `tty_end_raw` then throws it away
+before the REPL's next `ic_readline` call ever gets a chance to read it
+(kaappi#2226).
+
+The fix is `TCSADRAIN` in both `tty_start_raw` and `tty_end_raw`: it still
+waits for pending output (the prompt, the echoed line) to finish writing, but
+leaves unread input alone. Both call sites need the change, not just
+`tty_end_raw` — otherwise the next `tty_start_raw` discards on the way back
+in what the previous `tty_end_raw` spared.
+
+The `TCSAFLUSH` in the termination-signal handler (`sig_handler`, for
+SIGINT/SIGTSTP/etc.) is untouched: the process is dying or suspending there,
+not reading the next form, so discarding stray input is the right call and
+out of scope for this bug.
 
 ## Deliberately not patched
 

--- a/vendor/isocline/src/tty.c
+++ b/vendor/isocline/src/tty.c
@@ -653,7 +653,10 @@ static void signals_restore(void) {
 ic_private bool tty_start_raw(tty_t* tty) {
   if (tty == NULL) return false;
   if (tty->raw_enabled) return true;
-  if (tcsetattr(tty->fd_in,TCSAFLUSH,&tty->raw_ios) < 0) return false;
+  // KAAPPI PATCH 4: TCSADRAIN, not TCSAFLUSH — see tty_end_raw below, whose
+  // matching TCSAFLUSH is the actual bug; this one is symmetric so a byte
+  // that survives one transition isn't discarded by the next.
+  if (tcsetattr(tty->fd_in,TCSADRAIN,&tty->raw_ios) < 0) return false;
   tty->raw_enabled = true;
   return true;
 }
@@ -662,7 +665,15 @@ ic_private void tty_end_raw(tty_t* tty) {
   if (tty == NULL) return;
   if (!tty->raw_enabled) return;
   tty->cpush_count = 0;
-  if (tcsetattr(tty->fd_in,TCSAFLUSH,&tty->orig_ios) < 0) return;
+  // KAAPPI PATCH 4: TCSADRAIN, not TCSAFLUSH. Every ic_readline() call ends
+  // here, and TCSAFLUSH discards any input the kernel has already received
+  // but this call hasn't read(2) yet — exactly the tail of a multi-line
+  // paste whose first line alone was already a complete form (kaappi#2226):
+  // isCompleteCallback submits after that line's CR, edit_line() returns
+  // without draining the rest of the paste, and this flush then throws it
+  // away before the next ic_readline() gets a chance to read it. TCSADRAIN
+  // waits for pending output but leaves unread input alone.
+  if (tcsetattr(tty->fd_in,TCSADRAIN,&tty->orig_ios) < 0) return;
   tty->raw_enabled = false;
 }
 


### PR DESCRIPTION
## Summary

- Pasting a block of Scheme source with more than one top-level form into the REPL only evaluated the first form — everything after it silently vanished, with no error or indication anything was lost.
- Root cause: many terminals deliver a pasted newline as a literal CR (the same byte a real Enter keypress sends). isocline's `ic_editline` wraps every `ic_readline` call in `tty_start_raw()`/`tty_end_raw()`, both of which called `tcsetattr(..., TCSAFLUSH, ...)`. If the first pasted form is already complete on its own, `isCompleteCallback` submits right there and `ic_editline` returns *before* the rest of the still-unread paste has been read from the pty — and `tty_end_raw`'s `TCSAFLUSH` then discards it before the next `ic_readline` call gets a chance.
- Fix: switch both `tty_start_raw` and `tty_end_raw` (`vendor/isocline/src/tty.c`) from `TCSAFLUSH` to `TCSADRAIN`, which still waits for pending output but leaves unread input alone. Documented as Patch 4 in `vendor/isocline/PATCHES.md` and the root `CLAUDE.md`'s isocline section, per the existing convention for this vendored/patched copy.
- Left the `TCSAFLUSH` in the termination-signal handler (`sig_handler`) untouched — that path runs when the process is dying/suspending, where discarding stray input is correct and unrelated to this bug.

Fixes #2226

## Test plan

- [x] New pty-driven regression test `tests/scheme/smoke/repl-paste-multiple-forms-2226.sh`: pastes `(define x 1)\r(define y 2)\r(display (+ x y))\r` as a single `write(2)` (mirroring how a terminal delivers a clipboard paste) and asserts all three forms take effect.
- [x] Verified the new test **fails** against the pre-fix `tty.c` (`y` ends up undefined, `display` never prints `3`) and **passes** with the fix.
- [x] `zig build test` passes.
- [x] Existing REPL pty suites (`repl-structural-editing-2216.sh`, `repl-comma-command-completion-2224.sh`) still pass — no regression in raw-mode handling for typed (non-pasted) input.