### PR TITLE
Root what the collector cannot see: SRFI-1 accumulators and the uid registry (#2160, #2161)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,13 +404,10 @@ jobs:
           #     gate is green for everything else, exactly as the campaign
           #     comments out a failing assertion behind a `;; FAIL: #N` marker
           #     rather than leaving the suite red. Each fix PR deletes its
-          #     names from this list:
-          #       #2160  primitives_srfi1 buildList reads freed values from its
-          #              unrooted `items` slice -- all three abort with
-          #              "GC: marking freed object (use-after-free)"
-          #       #2161  record_uid_registry keys are borrowed slices into
-          #              GC-owned strings, so a nongenerative uid stops
-          #              resolving once its string is collected (19 assertions)
+          #     names from this list -- #2160 (primitives_srfi1-audit.scm,
+          #     srfi1-ext.scm, srfi1-gc-stress.scm) and #2161
+          #     (primitives_srfi237-audit.scm, srfi237.scm, srfi240-audit.scm)
+          #     are gone from it for that reason, leaving:
           #       #2027  srfi18-deepcopy-matrix-audit.scm's section E binds a
           #              child-created ffi_function returned through
           #              thread-join!, which is aliased rather than copied --
@@ -439,8 +436,6 @@ jobs:
           KAAPPI_GC_STRESS_SKIP: >-
             trampoline-polish-1375.scm srfi14.scm srfi264.scm
             reader-port-refill-gaps.scm srfi178-segment-stack-2084.scm
-            primitives_srfi1-audit.scm srfi1-ext.scm srfi1-gc-stress.scm
-            primitives_srfi237-audit.scm srfi237.scm srfi240-audit.scm
             srfi18-deepcopy-matrix-audit.scm
 
   riscv64-test:

--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -75,6 +75,18 @@ keeps it alive.
    and allocate during the rooted build phase, or use `gc.extra_roots`
    (see `readVector` in `reader_datum.zig` for the pattern).
 
+   What makes this one easy to get half-right: an element the primitive's
+   own `args` still reaches — a `car` of an input list — is rooted by the
+   VM's registers whatever the buffer does, so a whole file of
+   accumulate-then-`buildList` primitives can be correct while the few that
+   accumulate *freshly allocated* values (a callback's result, a `cons` the
+   primitive just made) are not. `primitives_srfi1.zig` was exactly that:
+   kaappi#1027 rooted four callback-result accumulators, and
+   `list-tabulate`, `zip` and `alist-copy` stayed broken until kaappi#2160.
+   Rooting inside the *consumer* does not help — the element is already
+   freed by the time the list gets built — so the root has to go on at the
+   append (`appendRooted` there).
+
 5. **Symbols are safe.** Interned symbols live in `gc.symbols` and are
    always reachable — no rooting needed.
 

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -237,6 +237,20 @@ rather than constructing a wrong record. That combination is what makes
 the SRFI's own worked Examples section run — a procedural type inheriting
 from a syntactic one whose construction a protocol governs.
 
+`VM.record_uid_registry` — the map that makes `nongenerative` mean
+anything — is a `StringHashMap` that **does not own its keys**, so every
+insert must supply a key that outlives the entry. There are three inserts
+and they must all key off the *rtd's own* `RecordType.uid`, an owned copy:
+`gc_deep_copy.zig` always did, `vm_records.zig`'s syntactic path gets away
+with an interned symbol's name (interned symbols are permanently rooted),
+and the procedural `%make-record-type-descriptor` keyed off the uid
+argument's `SchemeString` bytes until kaappi#2161. That string is transient
+— `lib/srfi/237/base.sld` makes it fresh with `symbol->string` on every
+call — so ordinary allocation between two same-uid definitions collected it,
+the key dangled, the lookup missed, and the second definition quietly built
+a second, non-interoperable type for one uid. Silent, and only on the
+procedural path.
+
 ### SRFI 137 — Minimal Unique Types
 
 SRFI 137 (Minimal Unique

--- a/src/primitives_srfi1.zig
+++ b/src/primitives_srfi1.zig
@@ -97,6 +97,25 @@ fn isTruthyResult(v: Value) bool {
     return types.isTruthy(v);
 }
 
+/// Append `val` to a to-be-`buildList`ed accumulator *and* to the GC's extra
+/// roots, so it stays alive until the buffer is consumed.
+///
+/// `ArrayList(Value)` storage is caller-owned Zig memory the collector cannot
+/// see, so a value that is reachable from *nothing else* dies at the next
+/// allocation — the callback's own next call, or `buildList`'s first
+/// `allocPair`. That is only safe for values the primitive's `args` still
+/// reach (an element of an input list); anything freshly allocated — a
+/// callback result, a `cons` this primitive just made — must go through here.
+/// The caller owns a `gc.rootedScope()` spanning the whole accumulation
+/// (kaappi#1027, kaappi#2160).
+fn appendRooted(gc: *memory.GC, list: *std.ArrayList(Value), val: Value) PrimitiveError!void {
+    list.append(gc.allocator, val) catch return PrimitiveError.OutOfMemory;
+    gc.extra_roots.append(gc.allocator, val) catch return PrimitiveError.OutOfMemory;
+}
+
+/// Cons `items` onto `tail`, right to left. Rooting `items` here would not
+/// help: every element must already be reachable when this is called, since
+/// the very first `allocPair` can collect. See `appendRooted`.
 fn buildList(gc: *memory.GC, items: []const Value, tail: Value) PrimitiveError!Value {
     var result = tail;
     gc.pushRoot(&result);
@@ -507,6 +526,8 @@ fn zipFn(args: []const Value) PrimitiveError!Value {
     var iter = MultiListIter.init(args, false);
     var results: std.ArrayList(Value) = .empty;
     defer results.deinit(gc.allocator);
+    const scope = gc.rootedScope();
+    defer scope.release();
 
     while (try iter.next("zip")) |call_args| {
         var row: Value = types.NIL;
@@ -515,7 +536,8 @@ fn zipFn(args: []const Value) PrimitiveError!Value {
             j -= 1;
             row = gc.allocPair(call_args[j], row) catch return PrimitiveError.OutOfMemory;
         }
-        results.append(gc.allocator, row) catch return PrimitiveError.OutOfMemory;
+        // `row` is fresh, and the next row's allocPair can collect it.
+        try appendRooted(gc, &results, row);
         iter.advance();
     }
 
@@ -655,10 +677,7 @@ fn filterMapFn(args: []const Value) PrimitiveError!Value {
     var iter = MultiListIter.init(args[1..], false);
     while (try iter.next("filter-map")) |call_args| {
         const result = try callVM(proc, call_args);
-        if (isTruthyResult(result)) {
-            results.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
-            gc.extra_roots.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
-        }
+        if (isTruthyResult(result)) try appendRooted(gc, &results, result);
         iter.advance();
     }
 
@@ -683,8 +702,7 @@ fn appendMapFn(args: []const Value) PrimitiveError!Value {
         while (sub != types.NIL) {
             if (!types.isPair(sub)) return primitives.typeError("append-map", "pair", sub);
             const elem = types.car(sub);
-            all_elems.append(gc.allocator, elem) catch return PrimitiveError.OutOfMemory;
-            gc.extra_roots.append(gc.allocator, elem) catch return PrimitiveError.OutOfMemory;
+            try appendRooted(gc, &all_elems, elem);
             sub = types.cdr(sub);
         }
         iter.advance();
@@ -952,11 +970,15 @@ fn listTabulateFn(args: []const Value) PrimitiveError!Value {
 
     var elems: std.ArrayList(Value) = .empty;
     defer elems.deinit(gc.allocator);
+    const scope = gc.rootedScope();
+    defer scope.release();
     var i: i64 = 0;
     while (i < n) : (i += 1) {
         const call_args = [1]Value{types.makeFixnum(i)};
         const val = try callVM(proc, &call_args);
-        elems.append(gc.allocator, val) catch return PrimitiveError.OutOfMemory;
+        // `val` is whatever the callback allocated, reachable from nothing
+        // once the callback's frame is gone.
+        try appendRooted(gc, &elems, val);
     }
 
     return buildList(gc, elems.items, types.NIL);
@@ -1348,13 +1370,17 @@ fn alistCopyFn(args: []const Value) PrimitiveError!Value {
 
     var elems: std.ArrayList(Value) = .empty;
     defer elems.deinit(gc.allocator);
+    const scope = gc.rootedScope();
+    defer scope.release();
 
     while (current != types.NIL) {
         if (!types.isPair(current)) return primitives.typeError("alist-copy", "pair", current);
         const entry = types.car(current);
         if (!types.isPair(entry)) return primitives.typeError("alist-copy", "pair", entry);
         const new_entry = gc.allocPair(types.car(entry), types.cdr(entry)) catch return PrimitiveError.OutOfMemory;
-        elems.append(gc.allocator, new_entry) catch return PrimitiveError.OutOfMemory;
+        // `new_entry` is a fresh copy — the input alist reaches the original,
+        // not this one.
+        try appendRooted(gc, &elems, new_entry);
         current = types.cdr(current);
     }
 
@@ -1511,8 +1537,7 @@ fn unfoldFn(args: []const Value) PrimitiveError!Value {
 
         const map_args = [1]Value{seed};
         const val = try callVM(f, &map_args);
-        elems.append(gc.allocator, val) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, val) catch return PrimitiveError.OutOfMemory;
+        try appendRooted(gc, &elems, val);
 
         const succ_args = [1]Value{seed};
         seed = try callVM(g, &succ_args);
@@ -1736,8 +1761,7 @@ fn mapInOrderFn(args: []const Value) PrimitiveError!Value {
     var iter = MultiListIter.init(args[1..], false);
     while (try iter.next("map-in-order")) |call_args| {
         const result = try callVM(proc, call_args);
-        results.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, result) catch return PrimitiveError.OutOfMemory;
+        try appendRooted(gc, &results, result);
         iter.advance();
     }
 

--- a/src/primitives_srfi237.zig
+++ b/src/primitives_srfi237.zig
@@ -293,13 +293,21 @@ fn makeRecordTypeDescriptorFn(args: []const Value) PrimitiveError!Value {
         else => PrimitiveError.OutOfMemory,
     };
 
-    if (uid) |u| {
+    if (uid != null) {
         const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
+        // Key by the NEW rtd's own uid, never by `uid` itself: that is a slice
+        // into args[2]'s SchemeString bytes, which the registry outlives.
+        // Collect that string and the key dangles, so the uid stops resolving
+        // and a `nongenerative` type silently stops being nongenerative
+        // (kaappi#2161). `RecordType.uid` is an owned copy, kept alive by this
+        // very entry -- registry values are GC roots -- which is the same
+        // reasoning gc_deep_copy.zig documents at its own insert into this map.
+        const owned_uid = asRecordType(new_val).uid.?;
         // Root across put(): a Value reachable only from this local isn't
         // yet visible to markVMRoots' registry scan until the insert lands.
         gc.pushRoot(&new_val);
         defer gc.popRoot();
-        vm.record_uid_registry.put(u, new_val) catch return PrimitiveError.OutOfMemory;
+        vm.record_uid_registry.put(owned_uid, new_val) catch return PrimitiveError.OutOfMemory;
     }
 
     return new_val;

--- a/src/tests_gc_runtime_stress.zig
+++ b/src/tests_gc_runtime_stress.zig
@@ -1,0 +1,162 @@
+// Values a primitive holds where the collector cannot see them (#2160, #2161).
+//
+// Two shapes, one failure mode. A primitive parks a heap `Value` outside the
+// GC's view — in an `ArrayList(Value)`'s caller-owned storage, or as a
+// borrowed key slice in a `StringHashMap` — and then keeps allocating. The
+// next collection sees no reference and reclaims it, so the primitive later
+// reads freed memory: a use-after-free abort under a stressed build, and
+// silent wrong data (recycled bytes) under a plain one.
+//
+// `gc.stress` is a *runtime* field, not only what `-Dgc-stress=true` sets at
+// comptime, so flipping it here forces a collection at every allocation on
+// every build — which is what makes the #2160 cases deterministic at n = 3
+// instead of needing the n = 2000 allocation storm the issue used to trip a
+// default build's threshold.
+//
+// What the flag cannot supply is *detection*: freed-object poisoning and the
+// marking-freed-object panic are both comptime (`memory.uaf_detection`, Debug
+// or gc-stress). On a plain ReleaseSafe build a freed pair at these sizes is
+// usually read back intact, so the #2160 cases are a live gate on the Debug
+// and `-Dgc-stress=true` unit legs and only a smoke test on the plain one.
+// Measured pre-fix, not assumed: the three abort with "GC: marking freed
+// object" under both `-Doptimize=Debug` and `-Dgc-stress=true` — at the exact
+// frame, `markRoots` marking `allocPair`'s own `arg_roots` entry, which is
+// `items[i]` — and pass under plain ReleaseSafe.
+//
+// Bootstrapping runs unstressed: registering ~700 primitives with a
+// collection per allocation costs seconds and proves nothing.
+
+const std = @import("std");
+const th = @import("testing_helpers.zig");
+const types = @import("types.zig");
+
+/// Evaluate `source` with a collection forced at every allocation, and expect
+/// `#t`.
+fn expectStressedTrue(source: []const u8) !void {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    ctx.gc.stress = true;
+    const result = try ctx.vm.eval(source);
+    try std.testing.expectEqual(types.TRUE, result);
+}
+
+// --------------------------------------------------------------------------
+// #2160 — primitives_srfi1 accumulators
+//
+// `buildList` conses an `ArrayList(Value)` into a list. Elements taken from
+// the *input* list are fine: `args` still reaches them. Elements the
+// primitive or a callback freshly allocated are reachable from nothing, and
+// the next allocation — the callback's own, or buildList's first allocPair —
+// frees them. Only `appendRooted` makes the buffer's contents visible.
+//
+// `list-tabulate` was the one #1027 missed; `zip` and `alist-copy` allocate
+// their elements directly and were never covered by it at all.
+// --------------------------------------------------------------------------
+
+test "#2160: list-tabulate keeps an allocating callback's results" {
+    try expectStressedTrue(
+        \\(import (scheme base) (srfi 1))
+        \\(equal? (list-tabulate 3 (lambda (i) (list i i)))
+        \\        '((0 0) (1 1) (2 2)))
+    );
+}
+
+test "#2160: list-tabulate with a non-allocating callback (control)" {
+    // The discriminating control: fixnums are immediates, never heap values,
+    // so this half was correct even pre-fix. If it ever fails, the bug is in
+    // list-tabulate itself and not in what the accumulator can see.
+    try expectStressedTrue(
+        \\(import (scheme base) (srfi 1))
+        \\(equal? (list-tabulate 3 values) '(0 1 2))
+    );
+}
+
+test "#2160: zip keeps the rows it just allocated" {
+    try expectStressedTrue(
+        \\(import (scheme base) (srfi 1))
+        \\(equal? (zip '(1 2 3) '(4 5 6)) '((1 4) (2 5) (3 6)))
+    );
+}
+
+test "#2160: alist-copy keeps the entries it just allocated" {
+    try expectStressedTrue(
+        \\(import (scheme base) (srfi 1))
+        \\(equal? (alist-copy '((1 . 2) (3 . 4) (5 . 6)))
+        \\        '((1 . 2) (3 . 4) (5 . 6)))
+    );
+}
+
+test "#2160: the accumulators #1027 already fixed stay fixed" {
+    try expectStressedTrue(
+        \\(import (scheme base) (srfi 1))
+        \\(and (equal? (filter-map (lambda (x) (cons x x)) '(1 2 3))
+        \\             '((1 . 1) (2 . 2) (3 . 3)))
+        \\     (equal? (append-map (lambda (x) (list (cons x x))) '(1 2 3))
+        \\             '((1 . 1) (2 . 2) (3 . 3)))
+        \\     (equal? (map-in-order (lambda (x) (cons x x)) '(1 2 3))
+        \\             '((1 . 1) (2 . 2) (3 . 3)))
+        \\     (equal? (unfold (lambda (i) (= i 3)) (lambda (i) (cons i i))
+        \\                     (lambda (i) (+ i 1)) 0)
+        \\             '((0 . 0) (1 . 1) (2 . 2))))
+    );
+}
+
+// --------------------------------------------------------------------------
+// #2161 — the nongenerative-uid registry
+//
+// `%make-record-type-descriptor` keyed `record_uid_registry` by the uid
+// argument's own `SchemeString` bytes. The registry outlives that transient
+// string, so once it is collected the key dangles and the uid stops
+// resolving: a later definition with the same uid allocates a fresh,
+// non-interoperable rtd instead of reusing the registered one — silently,
+// which is exactly the R6RS guarantee `nongenerative` exists to provide.
+//
+// Asserted here as *pointer identity*, not as an observed miss. Reproducing
+// the miss needs the source string to actually be collected AND its bytes
+// reused, which in-process is not something a unit test controls: a string
+// literal is pinned by the compiled form's constant pool, and freed string
+// data is deliberately not poisoned (`freeSliceNoFill`), so a freed key
+// usually still compares equal. The `-Dgc-stress=true` run of
+// tests/scheme/srfi/srfi237.scm is what observes the behaviour end to end.
+// What *is* deterministic, and is the whole fix, is where the key points:
+// the rtd's own owned `uid` copy, whose lifetime is the entry's, rather than
+// a borrowed slice into a Value the registry does not keep alive. Same
+// reasoning gc_deep_copy.zig documents at its own insert into this map.
+// --------------------------------------------------------------------------
+
+test "#2161: the registry key is the rtd's own uid, not the argument's bytes" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const rtd_val = try ctx.vm.eval(
+        \\(import (scheme base) (srfi 237 primitives))
+        \\(%make-record-type-descriptor
+        \\  "thing" #f (string-copy "my-uid") #f #f (list (cons "v" #f)))
+    );
+    const owned = types.toObject(rtd_val).as(types.RecordType).uid.?;
+    try std.testing.expectEqualStrings("my-uid", owned);
+
+    const key = ctx.vm.record_uid_registry.getKey("my-uid") orelse
+        return error.UidNotRegistered;
+    // Pre-fix this is the argument SchemeString's `data` slice: same bytes,
+    // different memory, and freed the moment that string is collected.
+    try std.testing.expectEqual(owned.ptr, key.ptr);
+    try std.testing.expectEqual(owned.len, key.len);
+}
+
+test "#2161: the same uid reuses the same rtd" {
+    try expectStressedTrue(
+        \\(import (scheme base) (srfi 237 primitives))
+        \\(define (rtd uid)
+        \\  (%make-record-type-descriptor
+        \\    "thing" #f (and uid (string-copy uid)) #f #f (list (cons "v" #f))))
+        \\(and (eq? (rtd "my-uid") (rtd "my-uid"))
+        \\     (eq? (rtd "my-uid") (%record-uid->rtd (string-copy "my-uid")))
+        \\     ;; controls: a different uid is a different type, and a
+        \\     ;; generative type is registered under nothing at all.
+        \\     (not (eq? (rtd "my-uid") (rtd "other-uid")))
+        \\     (not (eq? (rtd #f) (rtd #f))))
+    );
+}

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -21,6 +21,7 @@ test {
     _ = @import("tests_robustness.zig");
     _ = @import("tests_gc_root_boundary.zig");
     _ = @import("tests_gc_tracing.zig");
+    _ = @import("tests_gc_runtime_stress.zig");
     _ = @import("tests_fuzz.zig");
     _ = @import("tests_deepcopy.zig");
     _ = @import("tests_shared_channel.zig");

--- a/tests/scheme/srfi/srfi1-gc-stress.scm
+++ b/tests/scheme/srfi/srfi1-gc-stress.scm
@@ -99,6 +99,46 @@
   (check "unfold-alloc first" (car result) '(0 . 0))
   (check "unfold-alloc last" (list-ref result 499) '(499 . 249001)))
 
+;; list-tabulate with an allocating callback — regression #2160
+;;
+;; The sibling #1027 missed. Every element is a fresh list reachable from
+;; nothing but the primitive's own ArrayList, which the collector cannot see,
+;; so the next callback's allocation frees it. Unlike the three above, this
+;; one is visible on a *default* build as well, which is why it is the one
+;; case here sized past the 8192-object GC threshold rather than to the 200-500
+;; the rest of this file uses: at 2000 three-pair elements a plain build
+;; returns (1 1 1)-shaped garbage for element 0.
+;; Compared as booleans, not values: a lost element comes back spliced into
+;; the recycled tail, so printing the "got" side of element 0 dumps hundreds
+;; of pairs into the log.
+(let ((result (list-tabulate 2000 (lambda (i) (list i i i)))))
+  (check "list-tabulate-alloc first" (equal? (car result) '(0 0 0)) #t)
+  (check "list-tabulate-alloc middle" (equal? (list-ref result 1000) '(1000 1000 1000)) #t)
+  (check "list-tabulate-alloc last" (equal? (list-ref result 1999) '(1999 1999 1999)) #t))
+
+;; The control: an immediate needs no rooting, so this half was always
+;; correct. If it ever fails, list-tabulate itself is broken, not its buffer.
+(let ((result (list-tabulate 500 values)))
+  (check "list-tabulate-immediate first" (car result) 0)
+  (check "list-tabulate-immediate last" (list-ref result 499) 499))
+
+;; zip and alist-copy — regression #2160
+;;
+;; Neither takes a callback, so #1027 never looked at them, but both allocate
+;; their elements directly and park them in the same unrooted buffer: zip's
+;; rows and alist-copy's copied entries. Both abort at three elements under
+;; -Dgc-stress=true.
+(let ((result (zip (list-tabulate 200 values) (list-tabulate 200 values))))
+  (check "zip first row" (car result) '(0 0))
+  (check "zip last row" (list-ref result 199) '(199 199)))
+
+(let* ((original (map (lambda (i) (cons i i)) (list-tabulate 200 values)))
+       (result (alist-copy original)))
+  (check "alist-copy first entry" (car result) '(0 . 0))
+  (check "alist-copy last entry" (list-ref result 199) '(199 . 199))
+  (check "alist-copy is a copy, not the original spine"
+    (eq? (car result) (car original)) #f))
+
 (display pass) (display " passed, ") (display fail) (display " failed")
 (newline)
 (if (> fail 0) (error "SRFI-1 GC stress tests failed" fail))

--- a/tests/scheme/srfi/srfi237.scm
+++ b/tests/scheme/srfi/srfi237.scm
@@ -214,6 +214,34 @@
 (test-eq "record-uid->rtd resolves a registered uid" proc-uid-rtd1 (record-uid->rtd 'proc-uid-example))
 (test-assert "record-uid->rtd returns #f for an unregistered uid" (not (record-uid->rtd 'never-registered-uid)))
 
+;; regression #2161 — the two assertions above pass only because nothing
+;; allocates between the two definitions. The registry used to key off the
+;; uid argument's own SchemeString bytes (`symbol->string` of the uid, made
+;; fresh by the portable layer on every call), so once that string was
+;; collected the key dangled, the lookup missed, and the second definition
+;; built a fresh, non-interoperable rtd — silently, which is the one thing
+;; `nongenerative` is for.
+;;
+;; The gate for this is the -Dgc-stress=true leg, where these three failed
+;; pre-fix and the 200-iteration loop below is not even needed. A *default*
+;; build reaches the same corruption with ordinary allocation, but only once
+;; it crosses the GC threshold — the issue's own repro needs 300,000
+;; iterations, which stressed would be quadratic and take the whole job's
+;; budget. So the loop is sized for the stressed leg, not the plain one.
+(define uid-rtd-before (make-record-type-descriptor 'churned #f 'churn-uid #f #f #((immutable v))))
+(let loop ((i 0)) (when (< i 200) (list i i i) (loop (+ i 1))))
+(test-eq "nongenerative uid survives allocation between definitions"
+  uid-rtd-before
+  (make-record-type-descriptor 'churned #f 'churn-uid #f #f #((immutable v))))
+(test-eq "nongenerative uid still resolves after allocation"
+  uid-rtd-before
+  (record-uid->rtd 'churn-uid))
+;; The control: a dangling key can collide as easily as it can miss, so
+;; "found" alone is not the property being pinned.
+(test-assert "a different uid is still a different rtd after the churn"
+  (not (eq? uid-rtd-before
+            (make-record-type-descriptor 'churned #f 'other-churn-uid #f #f #((immutable v))))))
+
 ;;; --- error paths --------------------------------------------------------
 
 (test-assert "record-accessor on an unknown field name raises"


### PR DESCRIPTION
Two GC bugs the `-Dgc-stress=true` Scheme gate found on its first run, both the
same shape: a heap `Value` parked where the collector cannot reach it, followed
by more allocation. Fixing them lets six files come off `KAAPPI_GC_STRESS_SKIP`.

## #2160 — `primitives_srfi1` accumulators

`buildList`'s caller-owned `ArrayList(Value)` is invisible to the collector.
That is harmless for elements the primitive's own `args` still reach (a `car`
of an input list) — which is most of them — but not for freshly allocated ones.

Two corrections to the issue as filed, both measured:

- **Rooting inside `buildList` cannot fix it.** The issue's original suggestion
  roots the wrong thing at the wrong time: the element is already freed by the
  time the list gets built. The root has to go on at the *append*.
- **The scope is three primitives, not one** (the follow-up comment said only
  `list-tabulate`; the body said ~20 call sites). A sweep of 39 SRFI-1 list
  producers against a pre-fix `-Dgc-stress` binary aborts on exactly
  `list-tabulate`, `zip` and `alist-copy`, and on nothing else post-fix.
  kaappi#1027 rooted four callback-result accumulators; `zip` and `alist-copy`
  take no callback, so it never looked at them, but both cons their elements
  directly into the same unrooted buffer.

All seven sites now share one `appendRooted` helper, and `buildList` documents
why it is not the place for the fix.

`list-tabulate` is also wrong on a **default** build once the list crosses the
GC threshold — silent garbage, exit 0 — so it is not stress-only.

## #2161 — `record_uid_registry`

The map does not own its keys, and `%make-record-type-descriptor` keyed off the
uid argument's `SchemeString` bytes — a string `lib/srfi/237/base.sld` makes
fresh with `symbol->string` on every call. Collect it and the key dangles, so a
second definition with the same uid stops finding the first and quietly builds a
second, non-interoperable type for one uid: the R6RS guarantee `nongenerative`
exists to provide, lost silently.

Fixed as the issue's own comment recommends — key by the new rtd's owned `uid`
copy, whose lifetime is the entry's — which is what `gc_deep_copy.zig` already
does at its own insert into this map and needs no `VM.deinit` change.
`vm_records.zig`'s syntactic path keys off an interned symbol name; interned
symbols are permanently rooted (`gc_collect.zig` marks the whole table), so it
was already safe and is unchanged.

## Tests

`src/tests_gc_runtime_stress.zig` flips the GC's **runtime** `stress` field, so
the #2160 cases are deterministic at n = 3 rather than needing the issue's
n = 2000 storm. Pre-fix they abort with `GC: marking freed object` under both
`-Doptimize=Debug` and `-Dgc-stress=true`, at the exact frame — `markRoots`
marking `allocPair`'s own `arg_roots` entry, i.e. `items[i]` — and pass under
plain ReleaseSafe, where a freed pair at that size is still read back intact.

#2161 is pinned as **pointer identity** of the registry key rather than as an
observed miss: reproducing the miss in-process needs the freed bytes to be
reused, which a unit test cannot arrange (a string literal is pinned by the
constant pool, and freed string data is deliberately not poisoned). The
end-to-end behaviour is what the stressed `srfi237.scm` run observes.

Corpus assertions that fail pre-fix:

| file | pre-fix, plain build | pre-fix, `-Dgc-stress=true` |
|---|---|---|
| `srfi1-gc-stress.scm` | 2 assertions fail | aborts (SIGABRT) |
| `srfi237.scm` | passes (needs the issue's 300k-iteration churn) | 4 assertions fail |

## Verification

| Check | Result |
|---|---|
| Both issue repros, plain build | fixed |
| `zig build test` | 1691 pass, 7 skip |
| `zig build test -Dgc-stress=true` | 1698 pass |
| `bash tests/scheme/run-all.sh` | 2076 pass, 0 fail |
| gc-stress Scheme corpus, six files restored | 606 files pass, 0 fail; R7RS 1395 pass |

macOS aarch64, ReleaseSafe.

Closes #2160
Closes #2161

🤖 Generated with [Claude Code](https://claude.com/claude-code)