### PR TITLE
Give records and FFI handles an identity that survives a heap copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **A record returned from a thread keeps its type** (#1932). `(thread-join!
+  t)` on a thunk returning a `define-record-type` instance handed back a value
+  that *printed* as a well-formed `#<<pt> 1 2>` while its predicate answered
+  `#f` and every accessor raised `expected <pt>, got #<record_instance>` — so
+  a `cond` dispatching on the predicate silently took the wrong branch. Record
+  type identity was the `RecordType` address, and every thread boundary deep-
+  copies into a separate heap, which necessarily changes it; a lexically
+  captured predicate failed the same way on the way *in*, and the uncaught-
+  exception path a third time. Identity is now a process-global counter
+  carried across the copy, so all four boundaries (thunk capture, join result,
+  raised object, channel message) preserve it. Generativity is untouched: two
+  evaluations of a `define-record-type` form still make two distinct types.
+  A `nongenerative` (SRFI 237 uid) type was the one working case before, and
+  still works.
+
+- **An FFI handle created on a child thread is no longer freed under the
+  receiver** (#2027). `gc_deep_copy.zig` aliased `ffi-library` and
+  `ffi-function` across heaps instead of copying them, on the reasoning that a
+  dlopen handle cannot be duplicated per-heap — true of the handle, but the
+  *wrapper* is an ordinary object owned by one GC, and marking skips
+  foreign-owner objects. The receiver therefore held a reference neither
+  collector could see: the sender's own collector reclaimed it, whether or not
+  the sender had exited, and the recycled slot read back as `(0.0 . 0.0)` — an
+  ordinary pair that passes `write` and every non-FFI type check, so a stored
+  handle failed later with `KP3005: not a procedure`, at an arbitrary distance
+  from the thread that produced it. The wrapper is now copied and the
+  process-global handle and symbol address shared by value, at all three copy
+  boundaries. A handle created on the *parent* and captured by a child kept
+  working throughout and still does — which is why refusing FFI handles
+  outright was not the fix. `ffi-callback` remains refused: it wraps a live
+  Scheme closure, not a process-global address. One consequence: `ffi-close`
+  now nulls the handle in one wrapper only, so a copy on another heap does not
+  see the library as closed — closing a library another thread is calling was
+  already undefined behaviour, and this moves where it is diagnosed.
+
 - **SRFI 42's generic `:` qualifier works, along with `:real-range`,
   `:char-range`, `:dispatched`, and the full dispatch machinery** (#2177).
   `(list-ec (: i 5) i)` — the first form in every SRFI 42 tutorial — was

--- a/docs/dev/thread-value-sharing.md
+++ b/docs/dev/thread-value-sharing.md
@@ -66,6 +66,27 @@ its unpromoted twin failed, so a thread that read one out of a shared
 global could still hand it down to a child, and that child got a working
 stub for a channel nobody gave it.
 
+FFI handles are not on that list either — `ffi-library` and `ffi-function`
+are **copied**, and only the callback is refused. The dlopen handle and the
+symbol address are process-global and are shared by value; it is the
+wrapper object that gets duplicated into the receiving heap, exactly as
+`native-fn` duplicates the object around a static function pointer. Until
+kaappi#2027 the arm aliased them instead, which handed the receiver a
+pointer neither collector accounts for — a child-created handle was freed
+by the child's own collector, running or not, and read back in the parent
+as `(0.0 . 0.0)`. One consequence to know: `ffi-close` nulls the handle in
+one wrapper only, so a copy on another heap no longer reports the library
+as closed. (Closing a library another thread is calling was already
+undefined; this moves where it is diagnosed, not whether it is safe.)
+
+Record types are copied, and the copy is **the same type**. Type identity
+is `RecordType.identity`, a process-global counter carried across every
+copy boundary, not the RecordType address — which each copy necessarily
+changes. Until kaappi#1932 it was the address, so a record returned by
+`thread-join!` printed as a well-formed `#<<pt> 1 2>` while `pt?` answered
+`#f` and every accessor raised. Generativity is unaffected: two evaluations
+of a `define-record-type` form still mint two identities.
+
 A refusal surfaces as `error.UncopyableType`, which the boundary turns
 into a catchable error naming neither the type nor the offending value:
 
@@ -126,6 +147,8 @@ with a top-level `define` and named by the thunk.
 | `scheme-environment` | refused | works (`eval` in it succeeds) | unchecked |
 | `file-info` / `user-info` / `group-info` | refused | works | unchecked |
 | directory object | refused | works | unchecked |
+| ffi-library / ffi-function | **copied** | works | **coherent** since kaappi#2027 — the wrapper crosses, the process-global handle is shared by value |
+| record type / instance | **copied, same type** | works | **coherent** since kaappi#1932 — identity is a counter carried by the copy, not the address |
 | guardian | refused | refused (kaappi#2008) | **coherent** — the raw-container mutation made a check mandatory |
 | ephemeron | refused | works | unchecked — bound to one GC's collection cycle, but nothing mutates a raw container through it |
 | transport cell | refused | — | unreachable from Scheme: on this non-moving collector a transport-cell guardian always yields `#f` |
@@ -257,3 +280,12 @@ duplicating: `src/tests_deepcopy.zig` asserts the port and continuation
 refusals at the `GC.deepCopy` level directly, and
 `src/tests_shared_channel.zig` asserts that a channel *message* carrying a
 port is refused the same way.
+
+The two copied rows added above have their own regression suites, each
+covering all four boundaries (into the child, out of it, the raise path, a
+channel message): `tests/scheme/srfi/srfi18-record-identity-1932.scm` and
+`tests/scheme/ffi/thread-boundary-2027.scm`. Both carry the control that
+constrains the fix — a second look-alike record type that must stay
+disjoint, and the parent-owned FFI handle a blanket refusal would have
+broken. `tests/scheme/audit/srfi18-deepcopy-matrix-audit.scm` remains the
+per-tag enumeration.

--- a/docs/dev/thread-value-sharing.md
+++ b/docs/dev/thread-value-sharing.md
@@ -131,7 +131,10 @@ usable from a child thread through a global.
 
 ## The actual matrix
 
-Verified at `e24e594e`, ReleaseSafe, isolated `KAAPPI_HOME`. "capture"
+Verified at `e24e594e`, ReleaseSafe, isolated `KAAPPI_HOME` — except the
+two **copied** rows, which describe behaviour that commit predates and
+which were verified on kaappi#1932 / kaappi#2027's own branch. Their
+regression suites are named under "Keeping it honest" below. "capture"
 means bound in a `let` and closed over by the thunk; "global" means bound
 with a top-level `define` and named by the thunk.
 

--- a/src/gc_alloc.zig
+++ b/src/gc_alloc.zig
@@ -361,6 +361,7 @@ pub fn allocRecordType(self: *GC, name: []const u8, num_fields: u8) !Value {
         .header = .{ .tag = .record_type },
         .name = owned_name,
         .num_fields = num_fields,
+        .identity = types.nextRecordTypeIdentity(),
     };
     self.finishAlloc(&rt.header, @sizeOf(RecordType) + name.len);
     return types.makePointer(&rt.header);
@@ -435,6 +436,7 @@ pub fn allocRecordTypeExtended(
         .uid = owned_uid,
         .sealed = sealed,
         .is_opaque = is_opaque,
+        .identity = types.nextRecordTypeIdentity(),
     };
 
     var extra_bytes: usize = owned_field_names.len * @sizeOf([]const u8);

--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -25,6 +25,17 @@ pub fn deepCopy(gc: *GC, src: Value) DeepCopyError!Value {
     return deepCopyValue(gc, src, &visited);
 }
 
+/// Record-type identity is the `identity` counter, not the RecordType
+/// address -- so a copy is the SAME type as its source, and a record built
+/// on a child thread still satisfies the parent's predicate and accessors
+/// after thread-join! (kaappi#1932). The allocators mint a fresh identity
+/// for every RecordType they build; a copy must overwrite that with the
+/// source's, which is the one thing that distinguishes copying a type from
+/// defining a new one.
+fn carryIdentity(src_rt: *const types.RecordType, new_val: Value) void {
+    types.toObject(new_val).as(types.RecordType).identity = src_rt.identity;
+}
+
 fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) DeepCopyError!Value {
     if (!types.isPointer(src)) return src;
 
@@ -316,6 +327,7 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
                 // a type with no SRFI 237 metadata at all, so a type that has
                 // any must take the slow path below.
                 const new_val = try gc.allocRecordType(rt.name, rt.num_fields);
+                carryIdentity(rt, new_val);
                 try visited.put(src_ptr, new_val);
                 return new_val;
             }
@@ -365,6 +377,7 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
             // construction on the defining path too (vm_records.zig), since
             // only the desugarer's generated code knows a protocol was given.
             types.toObject(new_val).as(types.RecordType).has_protocol = rt.has_protocol;
+            carryIdentity(rt, new_val);
             try visited.put(src_ptr, new_val);
             if (rt.uid != null) {
                 if (vm_mod.vm_instance) |dest_vm| {
@@ -462,11 +475,49 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
             }
             return new_val;
         },
-        // FFI objects wrap process-global dlopen handles that cannot be
-        // duplicated per-heap, so they are aliased. Known limitation: an FFI
-        // handle created inside a child thread and returned through
-        // thread-join! dangles once the child heap is freed.
-        .ffi_library, .ffi_function => src,
+        // The dlopen handle and the symbol address are process-global, but the
+        // OBJECTS that wrap them are ordinary heap objects owned by one GC.
+        // Aliasing them (the behaviour until kaappi#2027) handed the receiving
+        // heap a raw pointer neither collector accounts for: the receiver never
+        // marks a foreign-owner object and the sender never finds a root for
+        // it, so a child-created handle returned through thread-join! or sent
+        // down a channel was freed under the parent and read back as whatever
+        // landed in the recycled slot -- typically `(0.0 . 0.0)`, an ordinary
+        // pair that passes every non-FFI type check.
+        //
+        // So copy the wrapper, exactly like `.native_fn` above copies the
+        // object around a static function pointer. The handle and symbol are
+        // shared by value, which is what makes the copy usable: no second
+        // dlopen, no per-heap duplication of anything process-global.
+        //
+        // Consequence to know: `ffi-close` nulls the handle in ONE wrapper, so
+        // a copy on another heap no longer sees the library as closed. Closing
+        // a library another thread is still calling was already undefined
+        // (dlclose unmaps the code out from under it); this only moves where
+        // it is diagnosed. `ffi_callback` stays refused -- it wraps a live
+        // Scheme closure, not a process-global address.
+        .ffi_library => {
+            const lib = obj.as(types.FfiLibrary);
+            const new_val = try gc.allocFfiLibrary(lib.handle, lib.name);
+            try visited.put(src_ptr, new_val);
+            return new_val;
+        },
+        .ffi_function => {
+            const f = obj.as(types.FfiFunction);
+            // `library` is an FfiLibrary Value, or #f for a synthesised
+            // function with no owning library. deepCopyValue passes the
+            // latter straight through.
+            const new_lib = try deepCopyValue(gc, f.library, visited);
+            const new_val = try gc.allocFfiFunction(
+                f.symbol,
+                new_lib,
+                f.name,
+                f.param_types,
+                f.return_type,
+            );
+            try visited.put(src_ptr, new_val);
+            return new_val;
+        },
         .srfi18_time => {
             const t = obj.as(types.Srfi18Time);
             return try gc.allocSrfi18Time(t.seconds, t.nanoseconds, t.time_type);

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -1051,7 +1051,7 @@ fn recordCheckFn(args: []const Value) PrimitiveError!Value {
     const rt = types.toObject(args[1]).as(types.RecordType);
     if (!types.isRecordInstance(args[0])) return types.FALSE;
     const ri = types.toObject(args[0]).as(types.RecordInstance);
-    return if (ri.record_type == rt) types.TRUE else types.FALSE;
+    return if (types.sameRecordType(ri.record_type, rt)) types.TRUE else types.FALSE;
 }
 
 fn recordRefFn(args: []const Value) PrimitiveError!Value {
@@ -1060,7 +1060,7 @@ fn recordRefFn(args: []const Value) PrimitiveError!Value {
     const rt = types.toObject(args[2]).as(types.RecordType);
     if (!types.isRecordInstance(args[0])) return typeError("%record-ref", rt.name, args[0]);
     const ri = types.toObject(args[0]).as(types.RecordInstance);
-    if (ri.record_type != rt) return typeError("%record-ref", rt.name, args[0]);
+    if (!types.sameRecordType(ri.record_type, rt)) return typeError("%record-ref", rt.name, args[0]);
     if (!types.isFixnum(args[1])) return typeError("%record-ref", "exact integer", args[1]);
     const raw_idx = types.toFixnum(args[1]);
     if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
@@ -1075,7 +1075,7 @@ fn recordSetFn(args: []const Value) PrimitiveError!Value {
     const rt = types.toObject(args[3]).as(types.RecordType);
     if (!types.isRecordInstance(args[0])) return typeError("%record-set!", rt.name, args[0]);
     const ri = types.toObject(args[0]).as(types.RecordInstance);
-    if (ri.record_type != rt) return typeError("%record-set!", rt.name, args[0]);
+    if (!types.sameRecordType(ri.record_type, rt)) return typeError("%record-set!", rt.name, args[0]);
     if (!types.isFixnum(args[1])) return typeError("%record-set!", "exact integer", args[1]);
     const raw_idx = types.toFixnum(args[1]);
     if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive

--- a/src/primitives_srfi237.zig
+++ b/src/primitives_srfi237.zig
@@ -107,11 +107,11 @@ fn asRecordType(v: Value) *RecordType {
 }
 
 /// Walks from `start` up through `.parent` looking for `target` -- the
-/// inheritance-aware analogue of R7RS's `ri.record_type == rt` exact check.
+/// inheritance-aware analogue of R7RS's exact `types.sameRecordType` check.
 fn isOrDescendsFrom(start: *RecordType, target: *RecordType) bool {
     var rt: ?*RecordType = start;
     while (rt) |r| {
-        if (r == target) return true;
+        if (types.sameRecordType(r, target)) return true;
         rt = r.parent;
     }
     return false;

--- a/src/tests_deepcopy.zig
+++ b/src/tests_deepcopy.zig
@@ -493,6 +493,106 @@ test "deepCopy native procedures survive freeing the source heap" {
     try std.testing.expectEqual(types.makeFixnum(5), nc.upvalues[0]);
 }
 
+// kaappi#1932. Record type identity used to BE the RecordType pointer, which
+// a copy necessarily changes -- so a record returned through thread-join!
+// printed as `#<<pt> 1 2>` while `pt?` answered #f and every accessor raised.
+// `identity` is the part of the type that survives the copy.
+test "deepCopy preserves record type identity across heaps (#1932)" {
+    var gc1 = memory.GC.init(std.testing.allocator);
+    defer gc1.deinit();
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+
+    const rt_val = try gc1.allocRecordType("point", 2);
+    const rt = types.toObject(rt_val).as(types.RecordType);
+    const ri = try gc1.allocRecordInstance(rt, &.{ types.makeFixnum(10), types.makeFixnum(20) });
+
+    const cri = types.toObject(try gc2.deepCopy(ri)).as(types.RecordInstance);
+    // A distinct object in the receiving heap, but the SAME type -- which is
+    // exactly what `%record?`/`%record-ref` ask via types.sameRecordType.
+    try std.testing.expect(@intFromPtr(rt) != @intFromPtr(cri.record_type));
+    try std.testing.expect(types.sameRecordType(cri.record_type, rt));
+
+    // The SRFI 237 path (parent/uid/sealed/opaque metadata) is a separate arm
+    // and carries the identity the same way.
+    const ext_val = try gc1.allocRecordTypeExtended("ext", null, &.{"a"}, &.{true}, null, false, true);
+    const ext = types.toObject(ext_val).as(types.RecordType);
+    const cext = types.toObject(try gc2.deepCopy(ext_val)).as(types.RecordType);
+    try std.testing.expect(@intFromPtr(ext) != @intFromPtr(cext));
+    try std.testing.expect(types.sameRecordType(cext, ext));
+
+    // The control the fix must not break: two separately DEFINED types stay
+    // distinct however alike they look, so `define-record-type` keeps its
+    // generative semantics.
+    const other = types.toObject(try gc1.allocRecordType("point", 2)).as(types.RecordType);
+    try std.testing.expect(!types.sameRecordType(other, rt));
+    try std.testing.expect(!types.sameRecordType(other, cri.record_type));
+}
+
+// kaappi#2027. The dlopen handle and symbol address are process-global, but
+// the wrapper objects belong to one heap. Aliasing them handed the receiver a
+// pointer neither collector tracks; the sender's own collector then freed it.
+const fake_handle: *anyopaque = @ptrFromInt(0x1000);
+const fake_symbol: *anyopaque = @ptrFromInt(0x2000);
+
+test "deepCopy FFI wrappers are copied, not aliased (#2027)" {
+    var gc1 = memory.GC.init(std.testing.allocator);
+    defer gc1.deinit();
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+
+    var lib_val = try gc1.allocFfiLibrary(fake_handle, "libprobe");
+    gc1.pushRoot(&lib_val);
+    defer gc1.popRoot();
+    const params = [_]types.FfiType{ .int, .double };
+    const fn_val = try gc1.allocFfiFunction(fake_symbol, lib_val, "probe", &params, .int64);
+
+    const copied = try gc2.deepCopy(fn_val);
+    try std.testing.expect(fn_val != copied);
+    const cf = types.toObject(copied).as(types.FfiFunction);
+    try std.testing.expectEqual(fake_symbol, cf.symbol);
+    try std.testing.expectEqualStrings("probe", cf.name);
+    try std.testing.expectEqualSlices(types.FfiType, &params, cf.param_types);
+    try std.testing.expectEqual(types.FfiType.int64, cf.return_type);
+    try std.testing.expectEqual(@as(u8, 2), cf.param_count);
+
+    // The library rides along as a copy too -- an aliased one would be the
+    // same dangling reference one level down.
+    try std.testing.expect(cf.library != lib_val);
+    const cl = types.toObject(cf.library).as(types.FfiLibrary);
+    try std.testing.expectEqual(fake_handle, cl.handle);
+    try std.testing.expectEqualStrings("libprobe", cl.name);
+}
+
+// The thread-join! shape of #2027, mirroring the #958 test above: the child GC
+// is deinited right after the result is copied out. Before the fix the parent
+// held the child's freed slot, which read back as an ordinary pair.
+test "deepCopy FFI wrappers survive freeing the source heap (#2027)" {
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+
+    var copied: types.Value = undefined;
+    {
+        var gc1 = memory.GC.init(std.testing.allocator);
+        defer gc1.deinit();
+        var lib_val = try gc1.allocFfiLibrary(fake_handle, "libgone");
+        gc1.pushRoot(&lib_val);
+        defer gc1.popRoot();
+        const params = [_]types.FfiType{.int};
+        const fn_val = try gc1.allocFfiFunction(fake_symbol, lib_val, "gone", &params, .int);
+        copied = try gc2.deepCopy(fn_val);
+    }
+
+    const cf = types.toObject(copied).as(types.FfiFunction);
+    try std.testing.expectEqual(types.ObjectTag.ffi_function, types.toObject(copied).tag);
+    try std.testing.expectEqual(fake_symbol, cf.symbol);
+    try std.testing.expectEqualStrings("gone", cf.name);
+    const cl = types.toObject(cf.library).as(types.FfiLibrary);
+    try std.testing.expectEqual(types.ObjectTag.ffi_library, types.toObject(cf.library).tag);
+    try std.testing.expectEqual(fake_handle, cl.handle);
+    try std.testing.expectEqualStrings("libgone", cl.name);
+}
+
 test "deepCopy rejects port" {
     var gc1 = memory.GC.init(std.testing.allocator);
     defer gc1.deinit();

--- a/src/tests_deepcopy.zig
+++ b/src/tests_deepcopy.zig
@@ -503,7 +503,16 @@ test "deepCopy preserves record type identity across heaps (#1932)" {
     var gc2 = memory.GC.init(std.testing.allocator);
     defer gc2.deinit();
 
-    const rt_val = try gc1.allocRecordType("point", 2);
+    // `rt` is dereferenced (for `identity`) after two more gc1 allocations, so
+    // it has to be rooted for the whole test: under -Dgc-stress=true each of
+    // them collects gc1, this bare GC has no root marker, and
+    // allocRecordTypeExtended roots only its `parent` argument. Unrooted, the
+    // last assertions read a freed header — verified: the tag comes back an
+    // invalid enum value, and the test passed only because the garbage
+    // identity happened not to collide.
+    var rt_val = try gc1.allocRecordType("point", 2);
+    gc1.pushRoot(&rt_val);
+    defer gc1.popRoot();
     const rt = types.toObject(rt_val).as(types.RecordType);
     const ri = try gc1.allocRecordInstance(rt, &.{ types.makeFixnum(10), types.makeFixnum(20) });
 
@@ -515,7 +524,13 @@ test "deepCopy preserves record type identity across heaps (#1932)" {
 
     // The SRFI 237 path (parent/uid/sealed/opaque metadata) is a separate arm
     // and carries the identity the same way.
-    const ext_val = try gc1.allocRecordTypeExtended("ext", null, &.{"a"}, &.{true}, null, false, true);
+    // Rooted for the same reason. Nothing allocates in gc1 between here and
+    // its last read today, but the root also keeps that true for the next
+    // assertion someone appends. Strictly nested inside rt_val's: this defer
+    // fires first.
+    var ext_val = try gc1.allocRecordTypeExtended("ext", null, &.{"a"}, &.{true}, null, false, true);
+    gc1.pushRoot(&ext_val);
+    defer gc1.popRoot();
     const ext = types.toObject(ext_val).as(types.RecordType);
     const cext = types.toObject(try gc2.deepCopy(ext_val)).as(types.RecordType);
     try std.testing.expect(@intFromPtr(ext) != @intFromPtr(cext));

--- a/src/tests_gc_tracing.zig
+++ b/src/tests_gc_tracing.zig
@@ -1329,12 +1329,13 @@ test "gc tracing: heap-struct field inventory is unchanged" {
         "write_buf",      "write_buf_start", "write_buf_len",  "fd_state",
         "custom_backend", "transcode",
     });
-    // `has_protocol` (kaappi#1974) is a plain bool, not Value-bearing, so it
-    // adds no marking or sweeping obligation -- only this re-pin.
+    // `has_protocol` (kaappi#1974) is a plain bool and `identity`
+    // (kaappi#1932) a plain u64 -- neither is Value-bearing, so they add no
+    // marking or sweeping obligation, only this re-pin.
     expectFields(types.RecordType, &.{
         "header", "name",            "num_fields",        "own_field_count",
         "parent", "own_field_names", "own_field_mutable", "uid",
-        "sealed", "is_opaque",       "has_protocol",
+        "sealed", "is_opaque",       "has_protocol",      "identity",
     });
     expectFields(types.Function, &.{
         "header",          "code",                 "constants",           "arity",

--- a/src/types.zig
+++ b/src/types.zig
@@ -467,6 +467,8 @@ pub const ErrorObject = types_error.ErrorObject;
 const types_record = @import("types_record.zig");
 pub const RecordType = types_record.RecordType;
 pub const RecordInstance = types_record.RecordInstance;
+pub const nextRecordTypeIdentity = types_record.nextRecordTypeIdentity;
+pub const sameRecordType = types_record.sameRecordType;
 
 pub const Vector = struct {
     header: Object,

--- a/src/types_record.zig
+++ b/src/types_record.zig
@@ -1,6 +1,33 @@
+const std = @import("std");
 const types = @import("types.zig");
 const Value = types.Value;
 const Object = types.Object;
+
+/// Source of `RecordType.identity`. Process-global and atomic because
+/// SRFI-18 threads allocate record types concurrently on independent heaps
+/// (each with its own GC), and the whole point of the counter is that no
+/// two *distinct* types ever collide, whichever heap minted them. Starts at
+/// 1 so a zero-initialised RecordType never accidentally matches a real one.
+var next_identity: std.atomic.Value(u64) = .init(1);
+
+/// Mints the identity for a freshly *defined* record type. A record type
+/// COPIED across a thread boundary must not call this -- gc_deep_copy
+/// carries the source's identity over instead (see `identity` below).
+pub fn nextRecordTypeIdentity() u64 {
+    return next_identity.fetchAdd(1, .monotonic);
+}
+
+/// The type-identity predicate behind `pt?`, `%record-ref`'s type check,
+/// and SRFI 237's inheritance walk. Not pointer equality: a record type
+/// that crosses a thread boundary is deep-copied into the receiving heap,
+/// so the same type is represented by two distinct RecordType objects
+/// (kaappi#1932). `identity` is what survives that copy.
+pub fn sameRecordType(a: *const RecordType, b: *const RecordType) bool {
+    if (a == b) return true;
+    // 0 means "never went through the allocators", so it identifies nothing
+    // -- two such types must not become interchangeable by both being 0.
+    return a.identity != 0 and a.identity == b.identity;
+}
 
 pub const RecordType = struct {
     header: Object,
@@ -45,6 +72,17 @@ pub const RecordType = struct {
     /// definitions that disagree about having a protocol stays conservative,
     /// because refusing is recoverable and a wrong field value is not.
     has_protocol: bool = false,
+    /// Process-globally unique, assigned once by `nextRecordTypeIdentity` at
+    /// definition and PRESERVED verbatim by gc_deep_copy. This is what makes
+    /// a record type still be the same type after crossing an SRFI-18 thread
+    /// boundary: the copy lands in another heap and therefore has another
+    /// address, so the RecordType *pointer* cannot be the identity
+    /// (kaappi#1932). Compare with `sameRecordType`, never with `==`.
+    ///
+    /// Only 0 for a RecordType built outside the GC allocators (none in
+    /// shipped code); `sameRecordType` treats 0 as identifying nothing, so
+    /// such a type matches only itself, by address.
+    identity: u64 = 0,
 };
 
 pub const RecordInstance = struct {

--- a/src/types_record.zig
+++ b/src/types_record.zig
@@ -1,20 +1,36 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const types = @import("types.zig");
 const Value = types.Value;
 const Object = types.Object;
 
-/// Source of `RecordType.identity`. Process-global and atomic because
-/// SRFI-18 threads allocate record types concurrently on independent heaps
-/// (each with its own GC), and the whole point of the counter is that no
-/// two *distinct* types ever collide, whichever heap minted them. Starts at
-/// 1 so a zero-initialised RecordType never accidentally matches a real one.
-var next_identity: std.atomic.Value(u64) = .init(1);
+/// Source of `RecordType.identity`. Process-global because SRFI-18 threads
+/// allocate record types concurrently on independent heaps (each with its
+/// own GC), and the whole point of the counter is that no two *distinct*
+/// types ever collide, whichever heap minted them. Starts at 1 so a
+/// zero-initialised RecordType never accidentally matches a real one.
+///
+/// It stays 64-bit rather than joining the u32 counters elsewhere
+/// (`next_gc_id`, the expander's scope ids) because those tolerate
+/// wrapping and this one must not: two types sharing an identity are
+/// silently interchangeable, which is the very bug #1932 was.
+var next_identity: u64 = 1;
 
 /// Mints the identity for a freshly *defined* record type. A record type
 /// COPIED across a thread boundary must not call this -- gc_deep_copy
 /// carries the source's identity over instead (see `identity` below).
 pub fn nextRecordTypeIdentity() u64 {
-    return next_identity.fetchAdd(1, .monotonic);
+    // wasm32 has no 64-bit atomic RMW, and `zig build wasm` is
+    // -fsingle-threaded, so there is no concurrent minter to race with
+    // there. A future 32-bit target built WITH threads would fail to
+    // compile on the branch below rather than race silently -- which is
+    // the right way for it to surface (docs/dev/porting.md).
+    if (comptime builtin.single_threaded) {
+        const id = next_identity;
+        next_identity += 1;
+        return id;
+    }
+    return @atomicRmw(u64, &next_identity, .Add, 1, .monotonic);
 }
 
 /// The type-identity predicate behind `pt?`, `%record-ref`'s type check,

--- a/tests/scheme/audit/cross-thread-boundary-audit.scm
+++ b/tests/scheme/audit/cross-thread-boundary-audit.scm
@@ -620,10 +620,14 @@
 ;; The same root cause reached from the other side: a record
 ;; predicate/accessor LEXICALLY CAPTURED by a thunk is copied together with
 ;; its record type, so it used to reject a genuine parent-heap instance.
+;; Compared against #t rather than used as a truth value: on-thread answers
+;; (raised . msg) when the child raises, which is itself truthy and would let
+;; this row pass on a boundary failure. The neighbouring row escapes that only
+;; because pt? happens to reject the pair.
 (test-assert "a captured record predicate still recognises a parent instance"
   (let ((b (make-abox 5)))
     (set! probe-container b)
-    (on-thread (let ((p abox?)) (lambda () (p probe-container))))))
+    (eq? #t (on-thread (let ((p abox?)) (lambda () (p probe-container)))))))
 
 ;; FAIL: #1936 (a continuation reached through a global is invoked by a child
 ;; with no check: the parent's continuation is NOT resumed, and

--- a/tests/scheme/audit/cross-thread-boundary-audit.scm
+++ b/tests/scheme/audit/cross-thread-boundary-audit.scm
@@ -590,11 +590,13 @@
 ;; ---------------------------------------------------------------------
 ;; 10. Record type identity across the copy
 ;;
-;; gc_deep_copy.zig's `.record_type` arm MANUFACTURES A NEW RecordType for
-;; a plain R7RS record type: same name, same field count, different
-;; identity. The one identity-preserving path is SRFI 237's
-;; `nongenerative` uid, which the arm looks up in the destination VM's
-;; `record_uid_registry` and reuses.
+;; gc_deep_copy.zig's `.record_type` arm builds a NEW RecordType object in
+;; the receiving heap -- it must, the source belongs to another GC -- but
+;; that object is the SAME TYPE: `RecordType.identity` is a process-global
+;; counter carried across the copy, and `types.sameRecordType` compares it
+;; rather than the address (#1932). Before that, identity WAS the address,
+;; and the only path that survived was SRFI 237's `nongenerative` uid, which
+;; the arm looks up in the destination VM's `record_uid_registry` and reuses.
 ;; ---------------------------------------------------------------------
 
 ;; Control: an instance built in this thread is of course recognised.
@@ -607,27 +609,21 @@
   (let ((r (on-thread (lambda () (make-upt 1)))))
     (and (upt? r) (= 1 (upt-x r)))))
 
-;; FAIL: #1932 (a PLAIN R7RS record constructed by a child and returned
-;; through thread-join! arrives as an instance of a DIFFERENT record type:
-;; `pt?` answers #f and every accessor raises "type error in '%record-ref':
-;; expected <pt>, got #<record_instance>", even though it prints as
-;; #<<pt> 1 2>. Verified 3/3. No shared global and no mutation is involved
-;; -- this is the plain, supported worker-thread path, and it is a
-;; wrong-but-stable answer rather than a memory-safety problem. The
-;; nongenerative case above is the discriminating control.)
-;; (test-assert "a plain record returned by a child is usable in the parent"
-;;   (let ((r (on-thread (lambda () (make-pt 1 2)))))
-;;     (and (pt? r) (= 1 (pt-x r)) (= 2 (pt-y r)))))
+;; The plain, supported worker-thread path: no shared global, no mutation.
+;; It used to hand back an instance of a DIFFERENT type -- `pt?` answered #f
+;; and every accessor raised "expected <pt>, got #<record_instance>", even
+;; though it printed as #<<pt> 1 2> (#1932).
+(test-assert "a plain record returned by a child is usable in the parent"
+  (let ((r (on-thread (lambda () (make-pt 1 2)))))
+    (and (pt? r) (= 1 (pt-x r)) (= 2 (pt-y r)))))
 
-;; FAIL: #1932 (same root cause, reached from the other side: a record
-;; accessor/mutator/predicate LEXICALLY CAPTURED by a thunk is copied
-;; together with a fresh copy of its record type, so applying it to a
-;; parent-heap instance fails -- the predicate answers #f for a genuine
-;; instance, and the accessor raises.)
-;; (test-assert "a captured record predicate still recognises a parent instance"
-;;   (let ((b (make-abox 5)))
-;;     (set! probe-container b)
-;;     (on-thread (let ((p abox?)) (lambda () (p probe-container))))))
+;; The same root cause reached from the other side: a record
+;; predicate/accessor LEXICALLY CAPTURED by a thunk is copied together with
+;; its record type, so it used to reject a genuine parent-heap instance.
+(test-assert "a captured record predicate still recognises a parent instance"
+  (let ((b (make-abox 5)))
+    (set! probe-container b)
+    (on-thread (let ((p abox?)) (lambda () (p probe-container))))))
 
 ;; FAIL: #1936 (a continuation reached through a global is invoked by a child
 ;; with no check: the parent's continuation is NOT resumed, and

--- a/tests/scheme/audit/primitives_srfi181-audit.scm
+++ b/tests/scheme/audit/primitives_srfi181-audit.scm
@@ -1192,9 +1192,9 @@
 (test-assert "D6: a codec symbol survives thread-join! with eqv? identity intact"
   (eqv? (utf-8-codec) (thread-join! (thread-start! (make-thread (lambda () (utf-8-codec)))))))
 
-;; FAIL: #1932 (a record returned through thread-join! loses its type)
-;; (test-assert "D6: a transcoder record survives thread-join! and stays a transcoder?"
-;;   (transcoder? (thread-join! (thread-start! (make-thread (lambda () (native-transcoder)))))))
+;; Enabled by #1932: a record's type now survives the copy at the join.
+(test-assert "D6: a transcoder record survives thread-join! and stays a transcoder?"
+  (transcoder? (thread-join! (thread-start! (make-thread (lambda () (native-transcoder)))))))
 
 ;;; ==================================================================
 ;;; 11. Port lifecycle

--- a/tests/scheme/audit/primitives_srfi237-audit.scm
+++ b/tests/scheme/audit/primitives_srfi237-audit.scm
@@ -810,8 +810,10 @@
             (record-type-uid (record-rtd xt-joined)))
 (test-assert "cross-thread: the joined record is still a record" (record? xt-joined))
 
-;; A GENERATIVE type has no registry entry, so the child heap's copy gets a
-;; fresh rtd and the parent's predicate no longer recognizes it (#1932).
+;; A GENERATIVE type has no registry entry, so the copy in the receiving heap
+;; is a different rtd OBJECT. It is still the same TYPE: rtd identity is
+;; RecordType.identity, carried across the copy, not the rtd's address
+;; (#1932). Before that fix the parent's predicate answered #f here.
 (define GT (make-record-type-descriptor 'GT #f #f #f #f #((immutable v))))
 (define gt-ctor (root-ctor GT))
 (define gt-joined
@@ -819,18 +821,18 @@
     (thread-start! t)
     (thread-join! t)))
 
-;; Enabled: the current, broken behaviour, pinned so #1932's fix flips it.
-(test-assert "cross-thread: a generative record loses its type across thread-join! (#1932)"
-             (not ((record-predicate GT) gt-joined)))
-(test-assert "cross-thread control: it is still *a* record, just not of the original type"
+(test-assert "cross-thread: a generative record keeps its type across thread-join! (#1932)"
+             ((record-predicate GT) gt-joined))
+(test-equal "cross-thread: a generative record's field reads after join" 42
+            ((record-accessor GT 'v) gt-joined))
+(test-assert "cross-thread control: it is still *a* record"
              (record? gt-joined))
 
-;; FAIL: #1932 (a generative record type is not preserved across thread-join!)
-;; (test-assert "cross-thread: a generative record keeps its type across thread-join!"
-;;              ((record-predicate GT) gt-joined))
-;; FAIL: #1932 (a generative record type is not preserved across thread-join!)
-;; (test-equal "cross-thread: a generative record's field reads after join" 42
-;;             ((record-accessor GT 'v) gt-joined))
+;; The control that constrains the fix: identity is per DEFINITION, so a
+;; second, identically shaped generative type stays disjoint after the copy.
+(define GT2 (make-record-type-descriptor 'GT #f #f #f #f #((immutable v))))
+(test-assert "cross-thread: a look-alike generative type stays disjoint (#1932)"
+             (not ((record-predicate GT2) gt-joined)))
 
 
 ;;; ===================================================================

--- a/tests/scheme/audit/srfi18-deepcopy-matrix-audit.scm
+++ b/tests/scheme/audit/srfi18-deepcopy-matrix-audit.scm
@@ -374,8 +374,13 @@
 ;; disjoint after the copy, which is what a name- or shape-keyed fix would
 ;; have broken while passing everything above.
 (define-record-type mrec2 (fields a b))
+;; `(mrec? r)` is not redundant with the row above: join-thunk answers a
+;; (RAISED ...) list when the boundary refuses, mrec2? says #f to a list, and
+;; the bare `not` would then pass this control on a join that never delivered
+;; a record at all.
 (test-assert "OUT record_instance: a look-alike type stays disjoint (#1932)"
-             (not (mrec2? (join-thunk (lambda () (make-mrec 30 40))))))
+             (let ((r (join-thunk (lambda () (make-mrec 30 40)))))
+               (and (mrec? r) (not (mrec2? r)))))
 
 ;; The control: with a uid, both directions were correct even before #1932.
 (test-assert "IN record_instance: nongenerative type keeps identity into the child"
@@ -578,15 +583,20 @@
   (test-assert "OUT group_info: refused at the join (direct)" (refuses-out? mk-group-info)))
 
 ;; ---------------------------------------------------------------------
-;; Section E — the ALIASED tags, and the hole in the matrix
+;; Section E — the FFI wrapper tags
 ;;
-;; gc_deep_copy.zig:465 is `.ffi_library, .ffi_function => src` — the
-;; source Value is returned unchanged, so the receiving heap gets a pointer
-;; into the sending heap. That is sound only while the sending heap
-;; outlives the receiving one. It does for the globals route and for a
-;; parent-owned handle aliased back to the parent (controls below). It does
-;; NOT for a handle the CHILD allocates and returns: thread-join! frees the
-;; child heap, and the parent is left holding a freed object.
+;; gc_deep_copy.zig copies the ffi_library / ffi_function WRAPPER into the
+;; receiving heap and shares the process-global dlopen handle and symbol
+;; address by value (kaappi#2027). It used to return the source Value
+;; unchanged, which was sound only while the sending heap outlived the
+;; receiving one — true for the globals route and for a parent-owned handle
+;; aliased back to the parent, false for a handle the CHILD allocates and
+;; returns, where the sending heap's own collector reclaimed it and the
+;; receiver was left reading a recycled slot.
+;;
+;; Which heap OWNS the wrapper is still the discriminating axis, so all four
+;; cells stay below: they are what shows the fix did not simply refuse the
+;; tag, which would have broken the two parent-owned controls.
 ;;
 ;; FFI needs a loadable system library, so this whole section is probed.
 ;; ---------------------------------------------------------------------

--- a/tests/scheme/audit/srfi18-deepcopy-matrix-audit.scm
+++ b/tests/scheme/audit/srfi18-deepcopy-matrix-audit.scm
@@ -13,10 +13,10 @@
 ;; which documents the two routes and is the table this file keeps honest.
 ;;
 ;; THE MATRIX. src/types.zig's ObjectTag has 41 members, and gc_deep_copy's
-;; switch puts each in exactly one of three classes — 24 + 3 + 14 = 41.
+;; switch puts each in exactly one of three classes — 26 + 1 + 14 = 41.
 ;; This file covers every REACHABLE cell:
 ;;
-;;   copied   24 arms — 22 reachable from interpreted Scheme and
+;;   copied   26 arms — 24 reachable from interpreted Scheme and
 ;;                      round-tripped below for type AND content fidelity.
 ;;                      The 2 unreachable ones are `flonum` (vestigial:
 ;;                      allocFlonum returns a NaN-boxed immediate, so no
@@ -27,9 +27,12 @@
 ;;                      *inside* another value — a Function rides along in
 ;;                      every closure test; MultipleValues never survives
 ;;                      to a boundary at all.
-;;   aliased   3 tags — ffi_library and ffi_function (UNSAFE — section E,
-;;                      kaappi#2027) plus channel (safe, KEP-0002, and
-;;                      Phase 2.6's subject rather than this file's).
+;;                      ffi_library and ffi_function joined this class when
+;;                      kaappi#2027 was fixed: the WRAPPER is copied and the
+;;                      process-global dlopen handle / symbol address are
+;;                      shared by value (section E).
+;;   aliased   1 tag  — channel (safe, KEP-0002, and Phase 2.6's subject
+;;                      rather than this file's).
 ;;   refused  14 tags — 13 reachable, each asserted at BOTH copy
 ;;                      boundaries in section D. `transport_cell` is
 ;;                      unreachable: a transport-cell guardian on this
@@ -349,26 +352,32 @@
              (crossed? (lambda () (symbol->string (record-type-name mrec)))
                        (lambda (r) (string=? r "mrec"))))
 
-;; FAIL: #1932 (a generative record type is re-manufactured by the copy, so
-;; the instance is of a disjoint type — the accessor raises)
-;; (test-assert "IN record_instance: fields readable in the child"
-;;              (let ((v (make-mrec 10 20)))
-;;                (crossed? (lambda () (list (mrec-a v) (mrec-b v)))
-;;                          (lambda (r) (equal? r '(10 20))))))
-;;
-;; FAIL: #1932 (same root cause, out of the child)
-;; (test-assert "OUT record_instance: a child-built record arrives with its fields"
-;;              (let ((r (join-thunk (lambda () (make-mrec 30 40)))))
-;;                (and (mrec? r) (= (mrec-a r) 30) (= (mrec-b r) 40))))
+;; Enabled by the #1932 fix: RecordType.identity is carried across the copy,
+;; so a generative type is still the same type in the receiving heap.
+(test-assert "IN record_instance: fields readable in the child"
+             (let ((v (make-mrec 10 20)))
+               (crossed? (lambda () (list (mrec-a v) (mrec-b v)))
+                         (lambda (r) (equal? r '(10 20))))))
 
-;; Pinned enabled so #1932's fix flips them rather than leaving a silent gap.
-(test-assert "IN record_instance: generative type's predicate wrongly answers #f (#1932)"
-             (eq? #f (join-thunk (let ((v (make-mrec 10 20))) (lambda () (mrec? v))))))
+(test-assert "OUT record_instance: a child-built record arrives with its fields"
+             (let ((r (join-thunk (lambda () (make-mrec 30 40)))))
+               (and (mrec? r) (= (mrec-a r) 30) (= (mrec-b r) 40))))
 
-(test-assert "OUT record_instance: generative type's predicate wrongly answers #f (#1932)"
-             (not (mrec? (join-thunk (lambda () (make-mrec 30 40))))))
+;; The predicate rows the bug used to pin, now flipped to the correct answer.
+(test-assert "IN record_instance: generative type's predicate answers #t (#1932)"
+             (eq? #t (join-thunk (let ((v (make-mrec 10 20))) (lambda () (mrec? v))))))
 
-;; The control: with a uid, both directions are correct today.
+(test-assert "OUT record_instance: generative type's predicate answers #t (#1932)"
+             (mrec? (join-thunk (lambda () (make-mrec 30 40)))))
+
+;; Generativity is not weakened: a SECOND type with the same shape is still
+;; disjoint after the copy, which is what a name- or shape-keyed fix would
+;; have broken while passing everything above.
+(define-record-type mrec2 (fields a b))
+(test-assert "OUT record_instance: a look-alike type stays disjoint (#1932)"
+             (not (mrec2? (join-thunk (lambda () (make-mrec 30 40))))))
+
+;; The control: with a uid, both directions were correct even before #1932.
 (test-assert "IN record_instance: nongenerative type keeps identity into the child"
              (let ((v (make-nrec 10 20)))
                (crossed? (lambda () (list (nrec? v) (nrec-a v)))
@@ -420,15 +429,11 @@
 (test-assert "EXC vector: the raised vector is the reason"
              (equal? (raised-reason (lambda () (raise (vector 1 2)))) #(1 2)))
 
-;; FAIL: #1932 (the raise path shares the record-copy arm, so a generative
-;; type loses its identity here too — a third direction the issue's own
-;; repro did not cover)
-;; (test-assert "EXC record_instance: a raised record keeps its type and fields"
-;;              (let ((r (raised-reason (lambda () (raise (make-mrec 1 2))))))
-;;                (and (mrec? r) (= (mrec-b r) 2))))
-
-(test-assert "EXC record_instance: generative type's predicate wrongly answers #f (#1932)"
-             (not (mrec? (raised-reason (lambda () (raise (make-mrec 1 2)))))))
+;; The raise path shares the record-copy arm, so the #1932 fix reaches it too
+;; — a third direction the issue's own repro did not cover.
+(test-assert "EXC record_instance: a raised record keeps its type and fields"
+             (let ((r (raised-reason (lambda () (raise (make-mrec 1 2))))))
+               (and (mrec? r) (= (mrec-b r) 2))))
 
 (test-assert "EXC record_instance: nongenerative type keeps identity on the raise path"
              (let ((r (raised-reason (lambda () (raise (make-nrec 1 2))))))
@@ -605,72 +610,54 @@
                (= (pfn -5) 5))
 
   ;; CONTROL 1 — parent-owned handle, used by the child through lexical
-  ;; capture. The alias points into the parent heap, which outlives the
-  ;; child, so this is the sound direction.
+  ;; capture. Sound before #2027 too (the alias pointed into the parent
+  ;; heap, which outlives the child); kept because a fix that REFUSED FFI
+  ;; handles would have broken it.
   (test-assert "IN ffi_function: parent-owned handle is callable in the child"
                (crossed? (lambda () (pfn -5)) (lambda (r) (eqv? r 5))))
 
   (test-assert "IN ffi_function: parent's handle still works after the join"
                (= (pfn -6) 6))
 
-  ;; CONTROL 2 — parent-owned handle captured AND returned. Aliased back
-  ;; into the heap that already owns it: still sound.
+  ;; CONTROL 2 — parent-owned handle captured AND returned.
   (test-assert "OUT ffi_function: a parent-owned handle returned by the child survives"
                (let ((r (join-thunk (lambda () pfn))))
                  (and (procedure? r) (= (r -8) 8))))
 
-  ;; THE FAILING CELL — child-allocated handle returned through the join.
-  ;; Same code path as the two controls; the only difference is which heap
-  ;; owns the object. Left disabled: the value that comes back has been
-  ;; observed reading as the pair (0.0 . 0.0), so asserting anything about
-  ;; its contents dereferences freed memory.
-  ;;
-  ;; FAIL: #2027 (child-created ffi_function/ffi_library is aliased across
-  ;; thread-join!, so the parent receives a freed object: procedure? is #f
-  ;; and the slot reads back as (0.0 . 0.0))
-  ;; (test-assert "OUT ffi_function: a child-created handle arrives callable"
-  ;;              (let ((r (join-thunk (lambda ()
-  ;;                                     (ffi-fn (ffi-open ffi-name) "abs"
-  ;;                                             '(int) 'int)))))
-  ;;                (and (procedure? r) (= (r -9) 9))))
-  ;;
-  ;; FAIL: #2027 (same root cause, ffi_library rather than ffi_function)
-  ;; (test-assert "OUT ffi_library: a child-created library handle arrives usable"
-  ;;              (let ((r (join-thunk (lambda () (ffi-open ffi-name)))))
-  ;;                (procedure? (ffi-fn r "abs" '(int) 'int))))
+  ;; THE CELL #2027 FIXED — child-allocated handle returned through the
+  ;; join. Same code path as the two controls; the only difference is which
+  ;; heap owns the object, and that is what used to decide whether the
+  ;; receiver got a live object or a freed slot reading as (0.0 . 0.0).
+  ;; The wrapper is now copied into the receiving heap, so its contents are
+  ;; safe to touch.
+  (test-assert "OUT ffi_function: a child-created handle arrives callable"
+               (let ((r (join-thunk (lambda ()
+                                      (ffi-fn (ffi-open ffi-name) "abs"
+                                              '(int) 'int)))))
+                 (and (procedure? r) (= (r -9) 9))))
 
-  ;; What IS safe to assert: the returned object is not a usable handle.
-  ;; This pins the bug without touching its contents, so it flips when the
-  ;; aliasing is fixed.
+  (test-assert "OUT ffi_library: a child-created library handle arrives usable"
+               (let ((r (join-thunk (lambda () (ffi-open ffi-name)))))
+                 (procedure? (ffi-fn r "abs" '(int) 'int))))
+
+  ;; The classification row, kept from when it was all this cell could
+  ;; safely assert. The child re-opens the library BY NAME rather than
+  ;; capturing `ffi-name`, and `crossed?`-style shape checking is what makes
+  ;; it meaningful: `procedure?` must not answer #f merely because an error
+  ;; list came back, which is how it would read on a platform where FFI does
+  ;; not work at all.
   ;;
-  ;; The child re-opens the library BY NAME rather than capturing `ffi-name`
-  ;; from the parent, and the two-part assertion below is what makes the
-  ;; result meaningful: `crossed?` must be #t (the boundary itself did not
-  ;; refuse — otherwise `procedure?` would answer #f merely because an error
-  ;; list came back, and the assertion would pass on a platform where FFI
-  ;; does not work at all).
+  ;; Its historical other half — `(not (procedure? r))`, pinning the bug as
+  ;; still present — is deliberately gone rather than inverted-and-kept:
+  ;; whether an ALIASED handle stayed usable after the far heap freed it was
+  ;; an accident of the allocator (it held on macOS, failed on freebsd-test),
+  ;; not a property of the code. Same class as the #2023 pin that held on
+  ;; ReleaseSafe and failed on the Debug leg.
   (let ((r (join-thunk (lambda () (ffi-fn (ffi-open ffi-name) "abs" '(int) 'int)))))
     (test-assert "OUT ffi_function: the join itself does not refuse the handle"
                  (not (and (pair? r) (eq? (car r) 'RAISED))))
-    ;; FAIL: #2027 — DO NOT re-enable as a bug-presence pin.
-    ;;
-    ;;   (test-assert "OUT ffi_function: child-created handle does NOT arrive
-    ;;                 callable (bug pinned, #2027)"
-    ;;                (not (procedure? r)))
-    ;;
-    ;; This asserted that the bug is still THERE, and whether an aliased
-    ;; handle is still usable after the far heap frees it is an accident of
-    ;; the allocator, not a property of the code.  It held on macOS and
-    ;; failed on freebsd-test, where the handle arrives callable.  Same class
-    ;; as the #2023 pin that held on ReleaseSafe and failed on the Debug leg.
-    ;;
-    ;; The assertion above it is the stable half and is the one the matrix
-    ;; actually needs: `ffi_function` is in the ALIASED class, not the
-    ;; REFUSED class, and "the join does not refuse it" is exactly that
-    ;; classification.  When #2027 is fixed, that assertion flips — a fixed
-    ;; implementation must refuse or copy, not alias — so the row still has
-    ;; a tripwire without depending on how a freed pointer happens to behave.
-    (if #f #f))
+    (test-assert "OUT ffi_function: the copy is a real, callable handle"
+                 (and (procedure? r) (= (r -12) 12))))
 
   ;; ffi_callback is the one refused FFI tag, and docs/dev/thread-value-sharing.md
   ;; records it as "not probed". Only some signatures are supported, so this

--- a/tests/scheme/ffi/thread-boundary-2027.scm
+++ b/tests/scheme/ffi/thread-boundary-2027.scm
@@ -27,74 +27,96 @@
       (begin (set! fail (+ fail 1))
              (display "FAIL: ") (display name) (newline))))
 
-;; Same library basic.scm uses: libm on POSIX, the CRT on Windows.
+;; Same library and symbol basic.scm uses: libm on POSIX, the CRT on Windows,
+;; and `sqrt` rather than a name the platform might inline away (OpenBSD's
+;; libm exports no `fabs`).
 (define libm-name (cond-expand (windows "ucrtbase") (else "libm")))
-(define parent-fn (ffi-fn (ffi-open libm-name) "fabs" '(double) 'double))
+
+(define (open-sqrt) (ffi-fn (ffi-open libm-name) "sqrt" '(double) 'double))
+
+;; Probe once, the way tests/scheme/audit/srfi18-deepcopy-matrix-audit.scm
+;; does: a platform with no loadable libm has nothing to say about deep copy,
+;; and must not fail this file. basic.scm is the unconditional canary that FFI
+;; works at all on each leg, so this skip cannot hide a broken FFI.
+(define parent-fn (guard (e (#t #f)) (open-sqrt)))
 
 (define (join-thunk thunk)
   (let ((t (make-thread thunk)))
     (thread-start! t)
     (thread-join! t)))
 
-(check "control: the parent's own handle works before any thread"
-       (= (parent-fn -5.0) 5.0))
+(if (not parent-fn)
+    (begin
+      (display "SKIP: no loadable ")
+      (display libm-name)
+      (display " with a `sqrt` symbol on this platform")
+      (newline))
+    (begin
 
-;; A — parent-owned handle, called by the child through lexical capture.
-(check "A: parent-owned handle is callable in the child"
-       (= (join-thunk (lambda () (parent-fn -5.0))) 5.0))
+      (check "control: the parent's own handle works before any thread"
+             (= (parent-fn 9.0) 3.0))
 
-;; A' — and the parent's own handle is undisturbed by the copy.
-(check "A': parent's handle still works after the join"
-       (= (parent-fn -6.0) 6.0))
+      ;; A — parent-owned handle, called by the child through lexical capture.
+      (check "A: parent-owned handle is callable in the child"
+             (= (join-thunk (lambda () (parent-fn 16.0))) 4.0))
 
-;; B — parent-owned handle captured AND returned. Must keep working: this is
-;; the cell a blanket refusal would have broken.
-(let ((r (join-thunk (lambda () parent-fn))))
-  (check "B: a parent-owned handle returned by the child is a procedure"
-         (procedure? r))
-  (check "B: ...and is callable" (= (r -8.0) 8.0)))
+      ;; A' — and the parent's own handle is undisturbed by the copy.
+      (check "A': parent's handle still works after the join"
+             (= (parent-fn 25.0) 5.0))
 
-;; C — THE BUG. Child-allocated handle returned through thread-join!.
-(let ((r (join-thunk (lambda ()
-                       (ffi-fn (ffi-open libm-name) "fabs" '(double) 'double)))))
-  (check "C: a child-created ffi-fn arrives as a procedure" (procedure? r))
-  (check "C: ...and is callable" (= (r -9.0) 9.0)))
+      ;; B — parent-owned handle captured AND returned. Must keep working:
+      ;; this is the cell a blanket refusal would have broken.
+      (let ((r (join-thunk (lambda () parent-fn))))
+        (check "B: a parent-owned handle returned by the child is a procedure"
+               (procedure? r))
+        (check "B: ...and is callable" (and (procedure? r) (= (r 36.0) 6.0))))
 
-;; C, one level down: the ffi-library wrapper itself must cross too, since the
-;; ffi-function's `library` field is what `callFfi` reads the handle from.
-(let ((lib (join-thunk (lambda () (ffi-open libm-name)))))
-  (check "C: a child-created ffi-library yields a working ffi-fn"
-         (= ((ffi-fn lib "fabs" '(double) 'double) -11.0) 11.0)))
+      ;; C — THE BUG. Child-allocated handle returned through thread-join!.
+      (let ((r (join-thunk (lambda () (open-sqrt)))))
+        (check "C: a child-created ffi-fn arrives as a procedure" (procedure? r))
+        (check "C: ...and is callable" (and (procedure? r) (= (r 49.0) 7.0))))
 
-;; The channel boundary, where the child is still RUNNING when the parent
-;; receives — so this cannot be explained away as "the child heap was freed at
-;; join".
-(let ((ch (make-channel)))
-  (let ((t (make-thread (lambda ()
-                          (channel-send ch (ffi-fn (ffi-open libm-name)
-                                                   "fabs" '(double) 'double))
-                          (thread-sleep! 0.05)
-                          'sent))))
-    (thread-start! t)
-    (let ((got (channel-receive ch)))
-      (check "channel: a child-created handle arrives as a procedure"
-             (procedure? got))
-      (check "channel: ...and is callable while the child still runs"
-             (= (got -13.0) 13.0))
-      (thread-join! t)
-      (if #f #f))))
+      ;; C, one level down: the ffi-library wrapper itself must cross too,
+      ;; since the ffi-function's `library` field is what `callFfi` reads the
+      ;; handle from.
+      (let ((lib (join-thunk (lambda () (ffi-open libm-name)))))
+        (check "C: a child-created ffi-library yields a working ffi-fn"
+               (guard (e (#t #f))
+                 (= ((ffi-fn lib "sqrt" '(double) 'double) 64.0) 8.0))))
 
-;; ffi-callback stays REFUSED: it wraps a live Scheme closure, not a
-;; process-global address, so there is nothing safe to copy.
-(let ((cb (guard (e (#t #f))
-            (ffi-callback (lambda (a b) 0) '(pointer pointer) 'int))))
-  (when cb
-    (check "ffi-callback is still refused at the join"
-           (guard (e (#t #t))
-             (join-thunk (lambda ()
-                           (ffi-callback (lambda (a b) 0)
-                                         '(pointer pointer) 'int)))
-             #f))))
+      ;; The channel boundary, where the child is still RUNNING when the parent
+      ;; receives — so this cannot be explained away as "the child heap was
+      ;; freed at join".
+      ;;
+      ;; The child's send is unconditional: a `guard` turns any failure into a
+      ;; sentinel it still sends, so a broken cell fails an assertion here
+      ;; instead of leaving the parent blocked in channel-receive forever.
+      (let ((ch (make-channel)))
+        (let ((t (make-thread (lambda ()
+                                (channel-send ch (guard (e (#t 'child-raised))
+                                                   (open-sqrt)))
+                                (thread-sleep! 0.05)
+                                'sent))))
+          (thread-start! t)
+          (let ((got (channel-receive ch)))
+            (check "channel: a child-created handle arrives as a procedure"
+                   (procedure? got))
+            (check "channel: ...and is callable while the child still runs"
+                   (and (procedure? got) (= (got 81.0) 9.0)))
+            (thread-join! t)
+            (if #f #f))))
+
+      ;; ffi-callback stays REFUSED: it wraps a live Scheme closure, not a
+      ;; process-global address, so there is nothing safe to copy.
+      (let ((cb (guard (e (#t #f))
+                  (ffi-callback (lambda (a b) 0) '(pointer pointer) 'int))))
+        (when cb
+          (check "ffi-callback is still refused at the join"
+                 (guard (e (#t #t))
+                   (join-thunk (lambda ()
+                                 (ffi-callback (lambda (a b) 0)
+                                               '(pointer pointer) 'int)))
+                   #f))))))
 
 (display pass) (display " passed, ") (display fail) (display " failed")
 (newline)

--- a/tests/scheme/ffi/thread-boundary-2027.scm
+++ b/tests/scheme/ffi/thread-boundary-2027.scm
@@ -1,0 +1,102 @@
+;; Regression test for kaappi#2027 — an FFI handle that crosses an SRFI-18
+;; thread boundary is COPIED into the receiving heap, not aliased into the
+;; sender's.
+;;
+;; gc_deep_copy.zig used to return the source Value unchanged for
+;; .ffi_library/.ffi_function, on the reasoning that a dlopen handle cannot be
+;; duplicated per-heap. True of the handle, but the WRAPPER is an ordinary heap
+;; object owned by one GC — and gc_collect skips foreign-owner objects while
+;; marking, so the alias was a cross-heap reference neither collector could
+;; see. The sender's own collector reclaimed it (no need for the child to have
+;; exited), and the parent read the recycled slot back as `(0.0 . 0.0)`: an
+;; ordinary pair that passes `write` and every non-FFI type check.
+;;
+;; The discriminating axis is which heap OWNS the handle, so all four cells of
+;; the issue's matrix are below. A/A'/B aliased a parent-heap object and worked
+;; by accident of lifetime; only C — child-allocated, returned — was the bug,
+;; and a fix that simply refused FFI handles would have broken B.
+
+(import (scheme base) (scheme write) (srfi 18) (srfi 120))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name ok?)
+  (if ok?
+      (set! pass (+ pass 1))
+      (begin (set! fail (+ fail 1))
+             (display "FAIL: ") (display name) (newline))))
+
+;; Same library basic.scm uses: libm on POSIX, the CRT on Windows.
+(define libm-name (cond-expand (windows "ucrtbase") (else "libm")))
+(define parent-fn (ffi-fn (ffi-open libm-name) "fabs" '(double) 'double))
+
+(define (join-thunk thunk)
+  (let ((t (make-thread thunk)))
+    (thread-start! t)
+    (thread-join! t)))
+
+(check "control: the parent's own handle works before any thread"
+       (= (parent-fn -5.0) 5.0))
+
+;; A — parent-owned handle, called by the child through lexical capture.
+(check "A: parent-owned handle is callable in the child"
+       (= (join-thunk (lambda () (parent-fn -5.0))) 5.0))
+
+;; A' — and the parent's own handle is undisturbed by the copy.
+(check "A': parent's handle still works after the join"
+       (= (parent-fn -6.0) 6.0))
+
+;; B — parent-owned handle captured AND returned. Must keep working: this is
+;; the cell a blanket refusal would have broken.
+(let ((r (join-thunk (lambda () parent-fn))))
+  (check "B: a parent-owned handle returned by the child is a procedure"
+         (procedure? r))
+  (check "B: ...and is callable" (= (r -8.0) 8.0)))
+
+;; C — THE BUG. Child-allocated handle returned through thread-join!.
+(let ((r (join-thunk (lambda ()
+                       (ffi-fn (ffi-open libm-name) "fabs" '(double) 'double)))))
+  (check "C: a child-created ffi-fn arrives as a procedure" (procedure? r))
+  (check "C: ...and is callable" (= (r -9.0) 9.0)))
+
+;; C, one level down: the ffi-library wrapper itself must cross too, since the
+;; ffi-function's `library` field is what `callFfi` reads the handle from.
+(let ((lib (join-thunk (lambda () (ffi-open libm-name)))))
+  (check "C: a child-created ffi-library yields a working ffi-fn"
+         (= ((ffi-fn lib "fabs" '(double) 'double) -11.0) 11.0)))
+
+;; The channel boundary, where the child is still RUNNING when the parent
+;; receives — so this cannot be explained away as "the child heap was freed at
+;; join".
+(let ((ch (make-channel)))
+  (let ((t (make-thread (lambda ()
+                          (channel-send ch (ffi-fn (ffi-open libm-name)
+                                                   "fabs" '(double) 'double))
+                          (thread-sleep! 0.05)
+                          'sent))))
+    (thread-start! t)
+    (let ((got (channel-receive ch)))
+      (check "channel: a child-created handle arrives as a procedure"
+             (procedure? got))
+      (check "channel: ...and is callable while the child still runs"
+             (= (got -13.0) 13.0))
+      (thread-join! t)
+      (if #f #f))))
+
+;; ffi-callback stays REFUSED: it wraps a live Scheme closure, not a
+;; process-global address, so there is nothing safe to copy.
+(let ((cb (guard (e (#t #f))
+            (ffi-callback (lambda (a b) 0) '(pointer pointer) 'int))))
+  (when cb
+    (check "ffi-callback is still refused at the join"
+           (guard (e (#t #t))
+             (join-thunk (lambda ()
+                           (ffi-callback (lambda (a b) 0)
+                                         '(pointer pointer) 'int)))
+             #f))))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(when (> fail 0)
+  (error "kaappi#2027 FFI thread-boundary tests failed"))

--- a/tests/scheme/ffi/thread-boundary-2027.scm
+++ b/tests/scheme/ffi/thread-boundary-2027.scm
@@ -85,24 +85,33 @@
                  (= ((ffi-fn lib "sqrt" '(double) 'double) 64.0) 8.0))))
 
       ;; The channel boundary, where the child is still RUNNING when the parent
-      ;; receives — so this cannot be explained away as "the child heap was
-      ;; freed at join".
+      ;; receives and calls the handle — so this cannot be explained away as
+      ;; "the child heap was freed at join".
       ;;
-      ;; The child's send is unconditional: a `guard` turns any failure into a
-      ;; sentinel it still sends, so a broken cell fails an assertion here
-      ;; instead of leaving the parent blocked in channel-receive forever.
-      (let ((ch (make-channel)))
+      ;; A second channel enforces that rather than a `thread-sleep!`, which
+      ;; guarantees nothing: on a loaded runner the child could exit first and
+      ;; the cell would silently degrade into cell C above.
+      ;;
+      ;; Neither side can deadlock. The child's send is unconditional — a
+      ;; `guard` turns any failure into a sentinel it still sends — and the
+      ;; parent's `go` is sent after a total `guard`, so no assertion can
+      ;; escape before it and leave the child parked on `done`.
+      (let ((ch (make-channel))
+            (done (make-channel)))
         (let ((t (make-thread (lambda ()
                                 (channel-send ch (guard (e (#t 'child-raised))
                                                    (open-sqrt)))
-                                (thread-sleep! 0.05)
+                                (channel-receive done)
                                 'sent))))
           (thread-start! t)
-          (let ((got (channel-receive ch)))
+          (let* ((got (channel-receive ch))
+                 (callable (guard (e (#t #f))
+                             (and (procedure? got) (= (got 81.0) 9.0)))))
+            (channel-send done 'go)
             (check "channel: a child-created handle arrives as a procedure"
                    (procedure? got))
             (check "channel: ...and is callable while the child still runs"
-                   (and (procedure? got) (= (got 81.0) 9.0)))
+                   callable)
             (thread-join! t)
             (if #f #f))))
 

--- a/tests/scheme/srfi/srfi-notest-batch.scm
+++ b/tests/scheme/srfi/srfi-notest-batch.scm
@@ -19,9 +19,7 @@
 (import (scheme base) (scheme write) (scheme case-lambda) (srfi 64)
         (srfi 8) (srfi 11) (srfi 16) (srfi 28) (srfi 31) (srfi 34)
         (srfi 111) (srfi 145) (srfi 229)
-        ;; (srfi 18) is imported only for the disabled #1932 assertion far below,
-        ;; so that uncommenting it is a one-line change. Every other test file
-        ;; in this directory that needs threads imports it the same way.
+        ;; (srfi 18) is for the thread-join! box assertion far below (#1932).
         (srfi 18))
 
 (test-begin "srfi-notest-batch")
@@ -341,15 +339,13 @@
 (test-assert "111: box with no argument raises" (guard (e (#t #t)) (box) #f))
 (test-assert "111: box with two arguments raises" (guard (e (#t #t)) (box 1 2) #f))
 
-;; FAIL: #1932 (a record returned through thread-join! loses its type; an SRFI
-;; 111 box is a record, so a box built on a worker thread comes back with
-;; box? => #f and unbox raising). The Phase 5C suite pins #1932 for a
-;; user-defined record; this is the same defect reaching a *spec-mandated*
-;; type, which is why it is worth a second pin.
-;; (test-equal "111: a box survives thread-join!" '(#t 42)
-;;             (let ((t (make-thread (lambda () (box 42)))))
-;;               (thread-start! t)
-;;               (let ((r (thread-join! t))) (list (box? r) (unbox r)))))
+;; An SRFI 111 box is a record, so this was #1932 reaching a *spec-mandated*
+;; type: a box built on a worker thread came back with box? => #f and unbox
+;; raising. Enabled now that record identity survives the copy.
+(test-equal "111: a box survives thread-join!" '(#t 42)
+            (let ((t (make-thread (lambda () (box 42)))))
+              (thread-start! t)
+              (let ((r (thread-join! t))) (list (box? r) (unbox r)))))
 
 ;;; ====================================================================
 ;;; SRFI 145 -- assume

--- a/tests/scheme/srfi/srfi18-record-identity-1932.scm
+++ b/tests/scheme/srfi/srfi18-record-identity-1932.scm
@@ -1,0 +1,91 @@
+;; Regression test for kaappi#1932 — a record that crosses an SRFI-18 thread
+;; boundary keeps its TYPE, not just its printed shape.
+;;
+;; Record type identity used to be the RecordType pointer, and every copy
+;; boundary in gc_deep_copy.zig necessarily allocates a new RecordType in the
+;; receiving heap. So `(thread-join! t)` handed back a value that printed as
+;; `#<<pt> 1 2>` while `pt?` answered #f and every accessor raised
+;; "expected <pt>, got #<record_instance>" — a `cond` dispatching on the
+;; predicate silently took the wrong branch. RecordType.identity is the part
+;; that now survives the copy (types_record.sameRecordType).
+;;
+;; All four boundaries are covered: into the child (thunk capture), out of it
+;; (join result), the uncaught-exception path, and a channel message. The last
+;; one matters because the child is still RUNNING when the parent receives.
+
+(import (scheme base) (scheme write) (srfi 18) (srfi 120))
+
+(define pass-count 0)
+(define fail-count 0)
+
+(define (check desc ok?)
+  (if ok?
+      (set! pass-count (+ pass-count 1))
+      (begin (set! fail-count (+ fail-count 1))
+             (display "  FAIL: ") (display desc) (newline))))
+
+(define-record-type <pt> (make-pt x y) pt? (x pt-x) (y pt-y))
+
+(define (join-thunk thunk)
+  (let ((t (make-thread thunk)))
+    (thread-start! t)
+    (thread-join! t)))
+
+;; --- OUT: the issue's own reproduction ---------------------------------
+(let ((r (join-thunk (lambda () (make-pt 1 2)))))
+  (check "OUT: predicate recognises a child-built record" (pt? r))
+  (check "OUT: accessors read the fields" (equal? (list (pt-x r) (pt-y r)) '(1 2))))
+
+;; --- IN: the same failure from the other side --------------------------
+;; The thunk captures both the instance and (through pt?) the record type, so
+;; the child receives copies of each; they must still agree about the type.
+(let ((v (make-pt 7 8)))
+  (check "IN: captured predicate recognises a parent-built record"
+         (equal? (join-thunk (lambda () (list (pt? v) (pt-x v)))) '(#t 7))))
+
+;; --- EXC: the raise path shares the same copy arm ----------------------
+(let* ((t (make-thread (lambda () (raise (make-pt 3 4)))))
+       (r (guard (e (#t (and (uncaught-exception? e) (uncaught-exception-reason e))))
+            (thread-start! t)
+            (thread-join! t)
+            #f)))
+  (check "EXC: a raised record keeps its type" (pt? r))
+  (check "EXC: a raised record keeps its fields" (= (pt-y r) 4)))
+
+;; --- CHANNEL: the child is still alive when the parent receives --------
+(let ((ch (make-channel)))
+  (let ((t (make-thread (lambda () (channel-send ch (make-pt 5 6)) 'sent))))
+    (thread-start! t)
+    (let ((r (channel-receive ch)))
+      (thread-join! t)
+      (check "CHANNEL: a messaged record keeps its type" (pt? r))
+      (check "CHANNEL: a messaged record keeps its fields"
+             (equal? (list (pt-x r) (pt-y r)) '(5 6))))))
+
+;; --- CONTROL: generative semantics are not weakened --------------------
+;; `define-record-type` is generative: two evaluations of the SAME form make
+;; two distinct types. A fix that made every same-named type interchangeable
+;; would pass everything above and break this.
+(define (fresh-type)
+  (define-record-type <g> (make-g v) g? (v g-v))
+  (list (make-g 1) g?))
+
+(let ((a (fresh-type)) (b (fresh-type)))
+  (check "CONTROL: a type recognises its own instance" ((cadr a) (car a)))
+  (check "CONTROL: a separately defined type does not" (not ((cadr b) (car a))))
+  ;; And the distinctness survives the copy, rather than collapsing on the
+  ;; far side.
+  (check "CONTROL: distinctness survives thread-join!"
+         (let ((crossed (join-thunk (lambda () (car a)))))
+           (and ((cadr a) crossed) (not ((cadr b) crossed))))))
+
+;; --- CONTROL: a foreign value is still rejected by the predicate -------
+(check "CONTROL: predicate rejects a non-record" (not (pt? '(1 2))))
+(check "CONTROL: accessor raises on a foreign record"
+       (let ((other (car (fresh-type))))
+         (guard (e (#t #t)) (pt-x other) #f)))
+
+(display pass-count) (display " pass, ")
+(display fail-count) (display " fail") (newline)
+(when (> fail-count 0)
+  (error "kaappi#1932 record identity tests failed"))


### PR DESCRIPTION
Closes #1932
Closes #2027

Both issues are the same mistake in `src/gc_deep_copy.zig`, reached from opposite directions: a value's identity was its **address**, and every thread boundary copies into a heap where the address is necessarily different.

## #1932 — a record loses its type through `thread-join!`

Record type identity *was* the `RecordType` pointer. The copy is a new object, so it was a disjoint type: the value printed as a well-formed `#<<pt> 1 2>` while `pt?` answered `#f` and every accessor raised `expected <pt>, got #<record_instance>`. A `cond` dispatching on the predicate silently took the wrong branch.

`RecordType` gains an `identity: u64` from a process-global atomic counter — minted at definition by the two allocators, carried verbatim by both `.record_type` copy paths. `types.sameRecordType` replaces the four pointer comparisons behind `%record?`, `%record-ref`, `%record-set!` and SRFI 237's `isOrDescendsFrom`.

Generativity is untouched: two evaluations of a `define-record-type` form still mint two identities. That is the control the tests pin, in both the local and the post-copy direction — a fix keyed on name or shape would pass every positive assertion and fail it.

All four boundaries are fixed, not just the one in the repro: thunk capture (a captured predicate rejecting a genuine parent-heap instance), the join result, the uncaught-exception path, and a channel message.

## #2027 — a child-created FFI handle is freed under the receiver

The `.ffi_library, .ffi_function => src` arm aliased, on the reasoning that a dlopen handle cannot be duplicated per-heap. True of the handle — but the *wrapper* is an ordinary object owned by one GC, and `gc_collect` skips foreign-owner objects while marking. The receiver held a reference neither collector could see; the sender's own collector reclaimed it, **whether or not the sender had exited** (so `channel-send` was affected too, with the child still running), and the recycled slot read back as `(0.0 . 0.0)` — an ordinary pair that passes `write` and every non-FFI type check, so a stored handle failed later with `KP3005: not a procedure` at an arbitrary distance from the thread that produced it.

The wrapper is now copied, exactly as `.native_fn` copies the object around a static function pointer; the process-global handle and symbol address are shared by value. No second `dlopen`, nothing process-global duplicated.

The issue's other option — refusing the tag, joining the 14-tag list — is why controls A/A'/B are in the test file: a parent-owned handle captured (and returned) by a child works today and a refusal would have broken it. `ffi_callback` stays refused; it wraps a live Scheme closure, not a process-global address.

**One behaviour change worth flagging:** `ffi-close` nulls the handle in one wrapper only, so a copy on another heap no longer reports the library as closed. `dlclose` while another thread is calling into the library was already undefined, so this moves where it is diagnosed rather than whether it is safe. Documented in the arm's comment, in `docs/dev/thread-value-sharing.md`, and in the changelog.

## Tests

New:
- `tests/scheme/srfi/srfi18-record-identity-1932.scm` — 12 assertions over all four boundaries plus the generativity controls.
- `tests/scheme/ffi/thread-boundary-2027.scm` — 11 assertions: the issue's full A/A'/B/C matrix, the channel boundary with the child still alive, and the `ffi-callback` refusal.
- 5 Zig unit tests in `src/tests_deepcopy.zig`, including the "source heap is freed right after the copy" shape the `#958` `native_fn` test already uses.

Both new `.scm` files were A/B'd against a binary built from the parent commit: `srfi18-record-identity-1932.scm` goes 12 pass → 4 pass / 4 fail with hard errors, `thread-boundary-2027.scm` 11 pass → 8 pass / 1 fail (it aborts at cell C).

Re-enabled, in four files:
- `audit/srfi18-deepcopy-matrix-audit.scm` — three `#1932` rows and two `#2027` rows; the class table at the top moves `ffi_library`/`ffi_function` from **aliased** to **copied** (26 + 1 + 14 = 41).
- `audit/cross-thread-boundary-audit.scm` — the plain-record join and the captured-predicate rows.
- `audit/primitives_srfi237-audit.scm`, `audit/primitives_srfi181-audit.scm`, `srfi/srfi-notest-batch.scm` — a generative rtd, a transcoder, and an SRFI 111 box (a spec-mandated record type reached by the same defect).

Two bug-presence pins are **replaced, not inverted**, per `docs/audit-strategy.md`'s "never assert that a bug is still present" — #2027's own pin (`the aliased handle arrives unusable`, green on macOS, red on FreeBSD after merge) is the cautionary case that rule was written from.

## Verification

- `zig build test` — 1701 pass, 7 skip
- `zig build test -Dgc-stress=true` — 1701 pass, 0 fail
- `bash tests/scheme/run-all.sh` — 2080 pass, 0 fail (685 Scheme files + the 1395-test R7RS suite)
- `zig fmt --check src/`, markdownlint — clean

macOS aarch64. The FFI arm is platform-independent; the new `.scm` test uses `libm`/`ucrtbase` the way `ffi/basic.scm` does, so it runs on every leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)