### PR TITLE
Fix four SRFI-18 concurrency bugs from the v0.22.2 audit (#2129, #2194, #1982, #2125)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,8 +373,9 @@ library and vendored code are excluded).
   another thread by one of **two routes with separate, unrelated enforcement**:
   the **copy route** (deep copy at thread start, join, and channel messages;
   `gc_deep_copy.zig` refuses 14 tags) and the **globals route**
-  (`VM.initForThread` shares the parent's `globals` map *by pointer*, so
-  naming a top-level binding gets the parent's own uncopied object — that list
+  (`VM.initForThread` shares the root's `globals` map *by pointer* — every
+  thread chains to the same map its ancestors use, kaappi#2129 — so
+  naming a top-level binding gets the root's own uncopied object — that list
   of 14 does not apply, and only four types defend themselves via
   `Object.owner`). Consequence worth memorizing: **mutexes and condition
   variables must be shared through a global; channels must be captured

--- a/docs/dev/thread-value-sharing.md
+++ b/docs/dev/thread-value-sharing.md
@@ -97,9 +97,11 @@ uncaught exception in thread: thread thunk contains an uncopyable type
 
 ## The globals route
 
-`VM.initForThread` shares the parent's `globals` map **by pointer**. A
-child thread reading a top-level binding gets the parent's object itself,
-in the parent's heap, with no copy and no check at the point of access.
+`VM.initForThread` shares the **root** VM's `globals` map **by pointer**,
+resolved through the parent chain: a child uses the same map its parent
+uses, so every thread's pointer is the root's map (kaappi#2129). A
+child thread reading a top-level binding gets the root's object itself,
+in the root's heap, with no copy and no check at the point of access.
 
 Four types defend themselves at the primitive level, by comparing
 `Object.owner` against the running thread's `GC.id`:
@@ -250,9 +252,9 @@ thread gets its own VM and GC with an independent heap.
 | Piece | Where | What it does |
 |-------|-------|--------------|
 | `vm_instance`, `gc_instance` | `src/vm.zig`, `src/memory.zig` | `threadlocal` — the running thread's VM and GC |
-| `GC.initForThread` | `src/memory.zig` | Per-thread GC, sharing the parent's symbol table |
+| `GC.initForThread` | `src/memory.zig` | Per-thread GC, sharing the **root's** symbol table (chained through the parent chain; a joined middle thread's own tables stay empty, kaappi#2129) |
 | `GC.deepCopy` / `deepCopyValue` | `src/memory.zig` (impl in `gc_deep_copy.zig`) | Deep-copies values between GC heaps; owns the 14-tag refusal list |
-| `VM.initForThread` | `src/vm.zig` | Per-thread VM, sharing the parent's globals and libraries **by pointer** |
+| `VM.initForThread` | `src/vm.zig` | Per-thread VM, sharing the **root's** globals and libraries **by pointer** |
 | `VM.owns_globals` | `src/vm.zig` | Stops a child VM freeing the shared maps on deinit |
 | `symbol_mutex` | `src/memory.zig` | Spinlock protecting concurrent symbol interning |
 | `child_resources` | `src/primitives_srfi18.zig` | Global map holding child GC/VM references |

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -1096,6 +1096,7 @@ pub fn abandonFiberMutexes(fiber: *Fiber, sched: ?*FiberScheduler) void {
             // abandonment).
             @atomicStore(bool, &m.abandoned, true, .release);
             m.owner = types.VOID;
+            m.owner_thread = types.VOID;
             @atomicStore(bool, &m.locked, false, .release);
             if (sched) |s| s.wakeMutexWaiters(m_val);
         }

--- a/src/fiber_wait.zig
+++ b/src/fiber_wait.zig
@@ -245,6 +245,20 @@ pub fn parkOnReactor(vm: *VM, sched: *FiberScheduler, cap_ns: ?u64) VMError!bool
     return true;
 }
 
+/// thread-terminate! sets the *handle's* `terminated` flag, which an
+/// OS-thread child's VM reaches through `terminate_flag` (the bytecode
+/// safepoint's own check) and a local fiber reaches directly (`me` IS the
+/// handle). A native wait must consult both: it never executes bytecode, so
+/// without this a thread parked in thread-sleep!/a mutex/a condvar wait
+/// never observes termination, never unwinds, and the joining thread hangs
+/// forever in reapOsThread's thread.join() (#1982).
+fn waitTerminated(vm: *VM, me: *Fiber) bool {
+    if (vm.terminate_flag) |flag| {
+        if (@atomicLoad(bool, flag, .monotonic)) return true;
+    }
+    return @atomicLoad(bool, &me.terminated, .monotonic);
+}
+
 /// Drives the scheduler — dispatching other fibers, saving/restoring their
 /// state exactly as switchTo would — until `ctx.isDone()` becomes true or
 /// `me`'s own timed wait expires (`me.timed_out`), parking on the reactor
@@ -288,26 +302,7 @@ pub fn parkOnReactor(vm: *VM, sched: *FiberScheduler, cap_ns: ?u64) VMError!bool
 /// independent progress while a descendant is active regardless, so
 /// excluding them from selection changes no genuine liveness outcome —
 /// only the parked fiber's own loop, right here, ever consumes its wake).
-/// thread-terminate! sets the *handle's* `terminated` flag, which an
-/// OS-thread child's VM reaches through `terminate_flag` (the bytecode
-/// safepoint's own check) and a local fiber reaches directly (`me` IS the
-/// handle). A native wait must consult both: it never executes bytecode, so
-/// without this a thread parked in thread-sleep!/a mutex/a condvar wait
-/// never observes termination, never unwinds, and the joining thread hangs
-/// forever in reapOsThread's thread.join() (#1982).
-fn waitTerminated(vm: *VM, me: *Fiber) bool {
-    if (vm.terminate_flag) |flag| {
-        if (@atomicLoad(bool, flag, .monotonic)) return true;
-    }
-    return @atomicLoad(bool, &me.terminated, .monotonic);
-}
-
 pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberScheduler, me: *Fiber) VMError!bool {
-    // Checked at the top of every loop iteration: a capped park (pollCapNs,
-    // which the SRFI-18 waits set whenever another OS thread could terminate
-    // this one) re-enters this loop at that cadence, and a local sibling
-    // terminator runs inside this very drive and is observed on the next
-    // iteration.
     // SRFI 181: reaching here from inside a custom port callback means that
     // callback is about to block, which it may not do -- see
     // vm.in_custom_port_callback's doc comment. The guard lives at this
@@ -382,7 +377,15 @@ pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberSche
     defer _ = sched.driving_waits.pop();
 
     while (!ctx.isDone() and !me.timed_out) {
-        if (waitTerminated(vm, me)) return VMError.Terminated;
+        // Checked at the top of every loop iteration: a capped park
+        // (pollCapNs, which the SRFI-18 waits set whenever another OS thread
+        // could terminate this one) re-enters this loop at that cadence, and
+        // a local sibling terminator runs inside this very drive and is
+        // observed on the next iteration.
+        if (waitTerminated(vm, me)) {
+            vm.setErrorDetail("thread terminated", .{});
+            return VMError.Terminated;
+        }
         const next_idx = sched.scheduleForDispatch() orelse {
             // Nothing dispatchable — but scheduleForDispatch's own per-tick
             // runReactorTick may have just resolved *this* wait, after the

--- a/src/fiber_wait.zig
+++ b/src/fiber_wait.zig
@@ -288,7 +288,26 @@ pub fn parkOnReactor(vm: *VM, sched: *FiberScheduler, cap_ns: ?u64) VMError!bool
 /// independent progress while a descendant is active regardless, so
 /// excluding them from selection changes no genuine liveness outcome —
 /// only the parked fiber's own loop, right here, ever consumes its wake).
+/// thread-terminate! sets the *handle's* `terminated` flag, which an
+/// OS-thread child's VM reaches through `terminate_flag` (the bytecode
+/// safepoint's own check) and a local fiber reaches directly (`me` IS the
+/// handle). A native wait must consult both: it never executes bytecode, so
+/// without this a thread parked in thread-sleep!/a mutex/a condvar wait
+/// never observes termination, never unwinds, and the joining thread hangs
+/// forever in reapOsThread's thread.join() (#1982).
+fn waitTerminated(vm: *VM, me: *Fiber) bool {
+    if (vm.terminate_flag) |flag| {
+        if (@atomicLoad(bool, flag, .monotonic)) return true;
+    }
+    return @atomicLoad(bool, &me.terminated, .monotonic);
+}
+
 pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberScheduler, me: *Fiber) VMError!bool {
+    // Checked at the top of every loop iteration: a capped park (pollCapNs,
+    // which the SRFI-18 waits set whenever another OS thread could terminate
+    // this one) re-enters this loop at that cadence, and a local sibling
+    // terminator runs inside this very drive and is observed on the next
+    // iteration.
     // SRFI 181: reaching here from inside a custom port callback means that
     // callback is about to block, which it may not do -- see
     // vm.in_custom_port_callback's doc comment. The guard lives at this
@@ -363,6 +382,7 @@ pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberSche
     defer _ = sched.driving_waits.pop();
 
     while (!ctx.isDone() and !me.timed_out) {
+        if (waitTerminated(vm, me)) return VMError.Terminated;
         const next_idx = sched.scheduleForDispatch() orelse {
             // Nothing dispatchable — but scheduleForDispatch's own per-tick
             // runReactorTick may have just resolved *this* wait, after the

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -252,7 +252,7 @@ fn referencesYoung(gc: *GC, obj: *Object) bool {
         },
         .mutex => {
             const m = obj.as(types.Mutex);
-            if (isYoungPointer(gc, m.name) or isYoungPointer(gc, m.owner) or isYoungPointer(gc, m.specific)) return true;
+            if (isYoungPointer(gc, m.name) or isYoungPointer(gc, m.owner) or isYoungPointer(gc, m.owner_thread) or isYoungPointer(gc, m.specific)) return true;
         },
         .condition_variable => {
             const cv = obj.as(types.ConditionVariable);
@@ -553,6 +553,7 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
             const m = obj.as(types.Mutex);
             markValue(gc, m.name);
             markValue(gc, m.owner);
+            markValue(gc, m.owner_thread);
             markValue(gc, m.specific);
         },
         .condition_variable => {
@@ -908,6 +909,7 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
             const m = obj.as(types.Mutex);
             worklist.append(gc.allocator, m.name) catch @panic("GC mark: worklist OOM");
             worklist.append(gc.allocator, m.owner) catch @panic("GC mark: worklist OOM");
+            worklist.append(gc.allocator, m.owner_thread) catch @panic("GC mark: worklist OOM");
             worklist.append(gc.allocator, m.specific) catch @panic("GC mark: worklist OOM");
         },
         .condition_variable => {

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -807,8 +807,27 @@ fn threadJoinFn(args: []const Value) PrimitiveError!Value {
         return reapOsThread(target, args[0]);
     }
 
-    // Never-started thread: poll until started+finished or timeout
-    if (@atomicLoad(fiber_mod.FiberStatus, &target.status, .acquire) == .created) {
+    // Never-started target, in two kinds discriminated by sched_idx (set only
+    // by addFiber; a make-thread object is never added to any scheduler and
+    // leaves it at 0):
+    //
+    //  * A make-thread handle awaiting thread-start! (sched_idx == 0): poll.
+    //    The status is changed from outside this loop, so polling observes it
+    //    (#878). os_thread alone is NOT a safe discriminator here -- a handle
+    //    about to be started has os_thread == null for the whole window before
+    //    thread-start!'s std.Thread.spawn, and must keep polling, not fall
+    //    through to the cooperative path.
+    //
+    //  * A (kaappi fibers) spawn'd fiber (sched_idx != 0) still in .created:
+    //    only THIS thread's cooperative scheduler can dispatch it, and the
+    //    poll loop below is exactly what starves it -- the status can never
+    //    change from outside, so without a timeout the loop is unbounded and
+    //    thread-join! hangs on a fiber that would have completed instantly
+    //    (#2194). Fall through to the fiber path below, which drives the
+    //    scheduler.
+    if (target.sched_idx == 0 and
+        @atomicLoad(fiber_mod.FiberStatus, &target.status, .acquire) == .created)
+    {
         while (@atomicLoad(fiber_mod.FiberStatus, &target.status, .acquire) != .completed and
             @atomicLoad(fiber_mod.FiberStatus, &target.status, .acquire) != .errored)
         {

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -450,8 +450,15 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
     // it one below the true count with other children alive), letting
     // crossThreadWaitPossible wrongly conclude no other thread exists.
     _ = @atomicRmw(usize, &live_child_threads, .Add, 1, .release);
+    // Pass the ROOT VM, not this thread's own: threadEntryFn's prologue
+    // dereferences it (GC.initForThread's shared symbol tables, and the
+    // shared maps), and a middle thread's VM/GC are freed when *it* is
+    // joined -- a grandchild still starting (or interning symbols) would
+    // then read freed memory (#2129). The root VM lives for the whole
+    // process, so every descendant chains its shared state to it.
+    const root_vm = vm.root_vm orelse vm;
     fiber.os_thread = std.Thread.spawn(.{}, threadEntryFn, .{
-        fiber, gc.allocator, vm, envelope,
+        fiber, gc.allocator, root_vm, envelope,
     }) catch {
         _ = @atomicRmw(usize, &live_child_threads, .Sub, 1, .release);
         envelope.deinit();
@@ -461,7 +468,11 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
     return args[0];
 }
 
-fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_vm: *vm_mod.VM, envelope: *shared_channel.Envelope) void {
+fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, root_vm: *vm_mod.VM, envelope: *shared_channel.Envelope) void {
+    // `root_vm` is the ROOT VM (see threadStartImpl): its struct, GC and
+    // shared maps are never freed, so the whole prologue below -- and this
+    // thread's later symbol interning into GC.initForThread's shared tables
+    // -- cannot race a join of whatever thread spawned this one (#2129).
     // Balances the increment in threadStartFn on every exit path (including
     // the early GC/VM-init failures below), so crossThreadWaitPossible's "is
     // another OS thread still alive" check stays accurate.
@@ -475,7 +486,7 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_v
         @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
         return;
     };
-    child_gc.* = memory.GC.initForThread(allocator, parent_vm.gc);
+    child_gc.* = memory.GC.initForThread(allocator, root_vm.gc);
 
     const child_vm = allocator.create(vm_mod.VM) catch {
         child_gc.deinit();
@@ -484,7 +495,7 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_v
         return;
     };
     @memset(std.mem.asBytes(child_vm), 0);
-    child_vm.* = vm_mod.VM.initForThread(child_gc, parent_vm) catch {
+    child_vm.* = vm_mod.VM.initForThread(child_gc, root_vm) catch {
         allocator.destroy(child_vm);
         child_gc.deinit();
         allocator.destroy(child_gc);
@@ -502,10 +513,18 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_v
     // The thread handle (the parent-heap fiber make-thread returned) this
     // child runs for, so mutex-state on a mutex this thread locks reports
     // the thread the caller holds -- not the child's internal current
-    // fiber, which lives in this child heap (#2125). Foreign to this GC;
-    // the parent roots the handle while the child runs, and isYoungPointer
-    // returns false for it, so no write barrier is needed.
-    child_vm.thread_handle = types.makePointer(&fiber.header);
+    // fiber, which lives in this child heap (#2125). Recorded only when the
+    // handle is ROOT-heap (this thread's creator was the root thread): a
+    // middle thread's handle lives in the middle's heap and is freed when
+    // the middle is joined, while this child -- and any mutex-state query on
+    // a mutex it locked -- can outlive that join, so a recorded middle-heap
+    // handle would dangle (#2129's grandchild shape). Such a child falls
+    // back to its own (never-freed, un-joinable) current fiber, the
+    // pre-#2125 behaviour. Foreign to this GC either way; the owner roots
+    // the handle, and isYoungPointer returns false for it, so no write
+    // barrier is needed.
+    if (fiber.header.owner == root_vm.gc.id)
+        child_vm.thread_handle = types.makePointer(&fiber.header);
 
     child_registry.put(@intFromPtr(fiber), .{ .child_gc = child_gc, .child_vm = child_vm }) catch {
         fiber.result = types.VOID;

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -628,6 +628,15 @@ pub const SleepWait = struct {
     // them (#1982); the runSchedulerStep loop re-checks the termination
     // flag at this cadence. Solo (no other OS thread can exist to
     // terminate this one) it stays a single true reactor block.
+    //
+    // Cost of the cap: crossThreadWaitPossible() is unconditionally true on
+    // a child thread (!vm.owns_globals), so a child's (thread-sleep! 60)
+    // wakes 60,000 times -- measured ~5k involuntary context switches and
+    // ~0.04s CPU for a pair of 2.5s/3.0s sleeps vs 33 switches and 0.00s
+    // without the cap. Small per-sleep, linear in duration and thread
+    // count. A notifier-based interrupt (thread-terminate! notifying the
+    // victim's reactor) would make termination immediate and remove the
+    // wakeups; the cap is the minimal correct fix.
     pub fn pollCapNs(_: SleepWait) ?u64 {
         return if (crossThreadWaitPossible()) CROSS_THREAD_POLL_NS else null;
     }
@@ -1090,7 +1099,7 @@ fn mutexStateFn(args: []const Value) PrimitiveError!Value {
         const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         return gc.allocSymbol("not-abandoned") catch return PrimitiveError.OutOfMemory;
     }
-    if (m.owner != types.VOID) return m.owner_thread;
+    if (m.owner_thread != types.VOID) return m.owner_thread;
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocSymbol("not-owned") catch return PrimitiveError.OutOfMemory;
 }
@@ -1169,12 +1178,17 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
         const ctx = try ensureScheduler();
         if (ctx.vm.current_fiber) |cf| {
             const cf_val = types.makePointer(&cf.header);
-            m.owner = resolveMutexOwner(args, cf_val);
             // The owner's thread handle: the explicit owner arg when given,
             // else this thread's handle -- for an OS-thread child that is
             // the parent-heap handle (vm.thread_handle), NOT cf_val, which
             // belongs to the child heap and would dangle past join (#2125).
-            m.owner_thread = resolveMutexOwner(args, if (ctx.vm.thread_handle) |h| h else cf_val);
+            // Compute both before publishing either, and publish owner_thread
+            // first: mutex-state gates on owner_thread alone, so a concurrent
+            // reader can never observe a partially initialized owner pair.
+            const owner = resolveMutexOwner(args, cf_val);
+            const owner_thread = resolveMutexOwner(args, if (ctx.vm.thread_handle) |h| h else cf_val);
+            m.owner_thread = owner_thread;
+            m.owner = owner;
             if (memory.gc_instance) |gc| {
                 gc.writeBarrier(&m.header, m.owner);
                 gc.writeBarrier(&m.header, m.owner_thread);
@@ -1278,19 +1292,22 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
     if (deadline != null) ctx.reactor.removeTimer(me);
     me.deadline_ns = null;
 
-    m.owner = if (owner_arg) |oa|
-        (if (types.isFiber(oa)) oa else if (oa == types.FALSE) types.VOID else types.makePointer(&me.header))
-    else
-        types.makePointer(&me.header);
+    const owner_fiber = types.makePointer(&me.header);
+    const owner_handle = if (ctx.vm.thread_handle) |h| h else owner_fiber;
     // Same resolution for the reported owner thread (see the fast path):
     // an OS-thread child reports its parent-heap handle, not me.header
-    // (#2125). Kept in sync with `owner` so mutex-state and abandonment
-    // never disagree.
-    const owner_handle = if (ctx.vm.thread_handle) |h| h else types.makePointer(&me.header);
-    m.owner_thread = if (owner_arg) |oa|
+    // (#2125). Computed before publishing either field and owner_thread
+    // stored first, as in the fast path.
+    const owner = if (owner_arg) |oa|
+        (if (types.isFiber(oa)) oa else if (oa == types.FALSE) types.VOID else owner_fiber)
+    else
+        owner_fiber;
+    const owner_thread = if (owner_arg) |oa|
         (if (types.isFiber(oa)) oa else if (oa == types.FALSE) types.VOID else owner_handle)
     else
         owner_handle;
+    m.owner_thread = owner_thread;
+    m.owner = owner;
     if (memory.gc_instance) |gc| {
         gc.writeBarrier(&m.header, m.owner);
         gc.writeBarrier(&m.header, m.owner_thread);

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -499,6 +499,14 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, allocator: std.mem.Allocator, parent_v
     // loop safepoint polls this flag and unwinds with VMError.Terminated.
     child_vm.terminate_flag = &fiber.terminated;
 
+    // The thread handle (the parent-heap fiber make-thread returned) this
+    // child runs for, so mutex-state on a mutex this thread locks reports
+    // the thread the caller holds -- not the child's internal current
+    // fiber, which lives in this child heap (#2125). Foreign to this GC;
+    // the parent roots the handle while the child runs, and isYoungPointer
+    // returns false for it, so no write barrier is needed.
+    child_vm.thread_handle = types.makePointer(&fiber.header);
+
     child_registry.put(@intFromPtr(fiber), .{ .child_gc = child_gc, .child_vm = child_vm }) catch {
         fiber.result = types.VOID;
         @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
@@ -1063,7 +1071,7 @@ fn mutexStateFn(args: []const Value) PrimitiveError!Value {
         const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         return gc.allocSymbol("not-abandoned") catch return PrimitiveError.OutOfMemory;
     }
-    if (m.owner != types.VOID) return m.owner;
+    if (m.owner != types.VOID) return m.owner_thread;
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     return gc.allocSymbol("not-owned") catch return PrimitiveError.OutOfMemory;
 }
@@ -1141,14 +1149,24 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
     if (tryClaimMutex(m)) {
         const ctx = try ensureScheduler();
         if (ctx.vm.current_fiber) |cf| {
-            m.owner = resolveMutexOwner(args, types.makePointer(&cf.header));
-            if (memory.gc_instance) |gc| gc.writeBarrier(&m.header, m.owner);
+            const cf_val = types.makePointer(&cf.header);
+            m.owner = resolveMutexOwner(args, cf_val);
+            // The owner's thread handle: the explicit owner arg when given,
+            // else this thread's handle -- for an OS-thread child that is
+            // the parent-heap handle (vm.thread_handle), NOT cf_val, which
+            // belongs to the child heap and would dangle past join (#2125).
+            m.owner_thread = resolveMutexOwner(args, if (ctx.vm.thread_handle) |h| h else cf_val);
+            if (memory.gc_instance) |gc| {
+                gc.writeBarrier(&m.header, m.owner);
+                gc.writeBarrier(&m.header, m.owner_thread);
+            }
             // Only track when *this* fiber became the owner: an explicit
             // owner arg naming another fiber (possibly on another thread)
             // must not append to this fiber's list.
-            if (m.owner == types.makePointer(&cf.header)) trackOwnedMutex(cf, args[0]);
+            if (m.owner == cf_val) trackOwnedMutex(cf, args[0]);
         } else {
             m.owner = resolveMutexOwner(args, types.VOID);
+            m.owner_thread = m.owner;
             if (memory.gc_instance) |gc| gc.writeBarrier(&m.header, m.owner);
         }
         if (tryClaimAbandoned(m)) return raiseError(.abandoned_mutex, "mutex was abandoned", types.VOID);
@@ -1245,7 +1263,19 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
         (if (types.isFiber(oa)) oa else if (oa == types.FALSE) types.VOID else types.makePointer(&me.header))
     else
         types.makePointer(&me.header);
-    if (memory.gc_instance) |gc| gc.writeBarrier(&m.header, m.owner);
+    // Same resolution for the reported owner thread (see the fast path):
+    // an OS-thread child reports its parent-heap handle, not me.header
+    // (#2125). Kept in sync with `owner` so mutex-state and abandonment
+    // never disagree.
+    const owner_handle = if (ctx.vm.thread_handle) |h| h else types.makePointer(&me.header);
+    m.owner_thread = if (owner_arg) |oa|
+        (if (types.isFiber(oa)) oa else if (oa == types.FALSE) types.VOID else owner_handle)
+    else
+        owner_handle;
+    if (memory.gc_instance) |gc| {
+        gc.writeBarrier(&m.header, m.owner);
+        gc.writeBarrier(&m.header, m.owner_thread);
+    }
     // Track only when `me` itself became the owner (see the fast path).
     if (m.owner == types.makePointer(&me.header)) trackOwnedMutex(me, mutex_val);
 
@@ -1290,6 +1320,7 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
     // acquirer that wins the locked CAS right after the store below could
     // write its own owner, and this line would then stomp it back to VOID.
     m.owner = types.VOID;
+    m.owner_thread = types.VOID;
     @atomicStore(bool, &m.locked, false, .release);
 
     const ctx = try ensureScheduler();

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -594,6 +594,16 @@ pub const SleepWait = struct {
     pub fn isDone(_: SleepWait) bool {
         return false; // a pure sleep only ever ends via me.timed_out
     }
+    // See MutexWait.pollCapNs: thread-terminate! from another OS thread is
+    // observed only by polling -- nothing wakes a sleep park on termination
+    // -- so a sleep in a program with other live OS threads must not block
+    // for its whole duration on the offchance the terminator is one of
+    // them (#1982); the runSchedulerStep loop re-checks the termination
+    // flag at this cadence. Solo (no other OS thread can exist to
+    // terminate this one) it stays a single true reactor block.
+    pub fn pollCapNs(_: SleepWait) ?u64 {
+        return if (crossThreadWaitPossible()) CROSS_THREAD_POLL_NS else null;
+    }
 };
 
 /// A timed park on the reactor's timer heap instead of a whole-thread

--- a/src/tests_gc_tracing.zig
+++ b/src/tests_gc_tracing.zig
@@ -474,12 +474,14 @@ test "gc tracing: mutex traces name, owner and specific" {
     defer gc.deinit();
     const name = try young(&gc, 1);
     const owner = try young(&gc, 2);
+    const owner_thread = try young(&gc, 4);
     const specific = try young(&gc, 3);
     const m_val = try gc.allocMutex(name);
     const m = types.toObject(m_val).as(types.Mutex);
     m.owner = owner;
+    m.owner_thread = owner_thread;
     m.specific = specific;
-    try expectTraced(&gc, m_val, &.{ ref(name, 1), ref(owner, 2), ref(specific, 3) });
+    try expectTraced(&gc, m_val, &.{ ref(name, 1), ref(owner, 2), ref(owner_thread, 4), ref(specific, 3) });
 }
 
 test "gc tracing: condition_variable traces name and specific" {
@@ -1083,13 +1085,16 @@ test "gc tracing (remembered set): mutex" {
     try promoteToOld(&gc, m_val);
     const name = try young(&gc, 1);
     const owner = try young(&gc, 2);
+    const owner_thread = try young(&gc, 4);
     const specific = try young(&gc, 3);
     const m = types.toObject(m_val).as(types.Mutex);
     m.name = name;
     m.owner = owner;
+    m.owner_thread = owner_thread;
     m.specific = specific;
     gc.writeBarrier(&m.header, owner);
-    try expectRememberedTrace(&gc, m_val, &.{ ref(name, 1), ref(owner, 2), ref(specific, 3) });
+    gc.writeBarrier(&m.header, owner_thread);
+    try expectRememberedTrace(&gc, m_val, &.{ ref(name, 1), ref(owner, 2), ref(owner_thread, 4), ref(specific, 3) });
 }
 
 test "gc tracing (remembered set): condition_variable" {
@@ -1402,7 +1407,7 @@ test "gc tracing: heap-struct field inventory is unchanged" {
         "header", "head", "tail", "queue_len", "capacity", "rv_demand", "closed", "shared",
     });
     expectFields(types.Mutex, &.{
-        "header", "name", "owner", "locked", "abandoned", "specific",
+        "header", "name", "owner", "owner_thread", "locked", "abandoned", "specific",
     });
     expectFields(types.ConditionVariable, &.{
         "header", "name", "specific", "signal_generation",

--- a/src/tests_waitforfd.zig
+++ b/src/tests_waitforfd.zig
@@ -373,10 +373,13 @@ test "#1625: every wait context still satisfies runSchedulerStep's duck type" {
         if (!@hasDecl(row.Ctx, "isDone")) return error.MissingIsDone;
         if (@hasDecl(row.Ctx, "pollCapNs")) with_cap += 1;
     }
-    // Only the two SRFI-18 waits that can be resolved by another OS thread
-    // need a poll cap; a third would mean a new cross-thread resolution
-    // path worth reviewing.
-    try std.testing.expectEqual(@as(usize, 2), with_cap);
+    // The two SRFI-18 waits resolvable by another OS thread (mutex unlock,
+    // condvar signal) plus SleepWait, whose cap exists not for resolution
+    // but so a sleeping thread observes thread-terminate! from another OS
+    // thread within a poll cadence (#1982) -- the only way a terminate can
+    // interrupt an otherwise timer-bounded sleep park. A new cap beyond
+    // these three means a new cross-thread path worth reviewing.
+    try std.testing.expectEqual(@as(usize, 3), with_cap);
 }
 
 // --- anyAncestorWaitResolved, directly ------------------------------------

--- a/src/types_threading.zig
+++ b/src/types_threading.zig
@@ -39,7 +39,17 @@ pub const Channel = struct {
 pub const Mutex = struct {
     header: Object,
     name: Value,
+    /// The fiber that owns the mutex, used for abandonment tracking
+    /// (abandonFiberMutexes compares identity on this). For an OS-thread
+    /// child this is the child-heap current fiber -- NOT a value the
+    /// parent's GC owns, so mutex-state must not hand it out.
     owner: Value,
+    /// The owning thread handle as the caller knows it: the fiber value
+    /// make-thread returned for an OS-thread child (parent heap), or the
+    /// owner fiber itself for a local/main thread. What mutex-state
+    /// returns for the owned state (#2125). Kept in sync with `owner` at
+    /// every write site.
+    owner_thread: Value = types.VOID,
     locked: bool,
     abandoned: bool,
     specific: Value,

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -223,6 +223,10 @@ fn markVMRoots(gc: *memory.GC) void {
     if (vm.callback_error_value) |exc| gc.markValue(exc);
     gc.markValue(vm.continuation_value);
     gc.markValue(vm.default_random_source);
+    // Foreign (parent-heap) for a child thread, so markValue skips it; the
+    // parent roots the handle. Marked here for the same reason every other
+    // Value field is: a same-heap value would be kept alive by it (#2125).
+    if (vm.thread_handle) |h| gc.markValue(h);
 
     // Only mark globals/macros when this VM owns them. Child threads
     // share the parent's maps — the parent GC keeps those values alive.
@@ -548,6 +552,14 @@ pub const VM = struct {
     /// thread-terminate! from another thread can stop this VM. Written by the
     /// parent thread, read here — access must be atomic.
     terminate_flag: ?*bool = null,
+    /// For child OS threads (SRFI-18): the thread handle (the fiber value
+    /// make-thread returned, in the parent's heap) this VM was started for,
+    /// so mutex-state can report the owner as the thread the caller holds
+    /// rather than this child's internal current fiber (#2125). Set by
+    /// threadEntryFn. Null for the main VM and for local fibers -- there the
+    /// current fiber IS the thread. The handle is foreign to this GC and is
+    /// rooted by the parent while the child runs, so markValue skips it.
+    thread_handle: ?Value = null,
 
     pub fn init(gc: *memory.GC) !VM {
         const frames = try gc.allocator.alloc(CallFrame, INITIAL_FRAME_CAPACITY);

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -560,6 +560,12 @@ pub const VM = struct {
     /// current fiber IS the thread. The handle is foreign to this GC and is
     /// rooted by the parent while the child runs, so markValue skips it.
     thread_handle: ?Value = null,
+    /// The root VM (the one with owns_globals == true, never freed): what a
+    /// child thread's threadEntryFn prologue must dereference, not the
+    /// immediate parent's VM, whose struct and tables a grandchild's parent
+    /// join can free underneath it (#2129). Resolved at initForThread by
+    /// walking the parent chain; null on the root itself.
+    root_vm: ?*VM = null,
 
     pub fn init(gc: *memory.GC) !VM {
         const frames = try gc.allocator.alloc(CallFrame, INITIAL_FRAME_CAPACITY);
@@ -635,6 +641,11 @@ pub const VM = struct {
             .lib_paths = parent.lib_paths,
             .param_overrides = std.AutoHashMap(usize, Value).init(gc.allocator),
             .owns_globals = false,
+            // Chain to the root VM (never freed), not the immediate parent:
+            // threadEntryFn dereferences this for GC.initForThread's symbol
+            // tables and for the shared maps, and a grandchild's parent join
+            // frees the middle VM/GC underneath it (#2129).
+            .root_vm = parent.root_vm orelse parent,
             // Shared reference, not a copy: SRFI 59/193 want a thread's
             // `program-vicinity`/`script-file` to still answer for the
             // top-level script, not #f. Never freed by the child -- see the

--- a/tests/scheme/audit/primitives_fiber-audit.scm
+++ b/tests/scheme/audit/primitives_fiber-audit.scm
@@ -414,10 +414,13 @@
 ;; thread-join!'s *fiber* path is the one that drives. Its OS-thread path
 ;; does not (reapOsThread joins the pthread, or polls with sleepNs), which
 ;; is why primitives_srfi181-audit.scm's "a read! that joins a short-lived
-;; thread is NOT rejected" control keeps passing. The target must already
-;; have STARTED: thread-join! on a spawn'd fiber still in .created spins in
-;; its own sleepNs poll and never reaches the scheduler at all — unrelated
-;; to this guard, and it hangs, so it is not probed here.
+;; thread is NOT rejected" control keeps passing. Since #2194 a spawn'd
+;; fiber still in .created is routed to the fiber path (sched_idx != 0), so
+;; the custom-port guard fires for it too -- but this probe keeps joining a
+;; *started* fiber parked on a channel: that is the shape that exercises the
+;; guard on a genuinely-parked fiber without depending on the #2194 dispatch
+;; fix, and a never-dispatched probe would wedge the runner (unbounded poll)
+;; if that fix regressed.
 (test-assert "a custom-port read! that blocks in thread-join! on a started fiber is rejected"
     (let ((started (make-channel)) (hold (make-channel)))
       (let ((f (spawn (lambda () (channel-send started 'up) (channel-receive hold) 'done))))

--- a/tests/scheme/srfi/srfi18-cross-heap-abandoned-mutex.scm
+++ b/tests/scheme/srfi/srfi18-cross-heap-abandoned-mutex.scm
@@ -91,27 +91,26 @@
 ;; synchronises on the event rather than on a duration, and the retry budget
 ;; is a loud failure rather than a hang if the child never gets there.
 ;;
-;; "Held" means mutex-state answers with an owner object rather than either
-;; of the two unowned symbols. It is deliberately not compared against the
-;; thread handle: SRFI 18 describes mutex-state as yielding the owning
-;; *thread*, but a mutex locked by a child here answers with that child's
-;; own fiber object, which is not eq? to the thread returned by make-thread
-;; (kaappi#2125). Excluding 'abandoned as well as 'not-abandoned is what
-;; keeps this from mistaking a child that died on the way for one that
-;; acquired the lock.
-(define (mutex-held? m)
-  (let ((s (mutex-state m)))
-    (not (or (eq? s 'not-abandoned) (eq? s 'abandoned)))))
+;; "Held" means mutex-state answers with the owning thread handle -- the
+;; make-thread object the caller holds -- so a caller synchronises on the
+;; child having acquired the lock with `(eq? (mutex-state m) t)`
+;; (kaappi#2125). Before the fix it answered with the child's own internal
+;; fiber object (child heap, not eq? to anything the caller holds), which
+;; is why this used to exclude the two unowned symbols instead -- and the
+;; probe below spun to its retry budget. Now it succeeds on the first
+;; iteration, and a regression fails loudly here rather than hanging.
+(define (mutex-held? m t)
+  (eq? (mutex-state m) t))
 
-(define (wait-until-held! m tries)
-  (cond ((mutex-held? m) #t)
+(define (wait-until-held! m t tries)
+  (cond ((mutex-held? m t) #t)
         ((<= tries 0) #f)
-        (else (thread-sleep! 0.005) (wait-until-held! m (- tries 1)))))
+        (else (thread-sleep! 0.005) (wait-until-held! m t (- tries 1)))))
 
 (let ((t (make-thread hold-mt-forever)))
   (thread-start! t)
   (check-true "the child acquires mt before it is terminated"
-              (wait-until-held! mt 1000))   ; up to 5 s, normally ~1 iteration
+              (wait-until-held! mt t 1000))   ; up to 5 s, normally ~1 iteration
   (thread-terminate! t)
   (guard (e (#t #t)) (thread-join! t))
   (check "parent-heap mutex abandoned after thread-terminate!"

--- a/tests/scheme/srfi/srfi18-join-created-fiber-2194.scm
+++ b/tests/scheme/srfi/srfi18-join-created-fiber-2194.scm
@@ -1,0 +1,56 @@
+;; Regression test for #2194: thread-join! on a (kaappi fibers) fiber that
+;; has been spawn'd but never dispatched hangs forever.
+;;
+;; thread-join!'s "never-started" path polled fiber.status in a sleepNs loop
+;; without ever driving the scheduler. For a make-thread handle awaiting
+;; thread-start! from outside that is exactly right (#878) -- the status
+;; changes from outside. For a spawn'd fiber (sched_idx != 0; only this
+;; thread's cooperative scheduler can dispatch it) the poll loop IS the
+;; starvation: the status can never change, so without a timeout the join
+;; hung forever on a fiber that would have completed instantly -- and with a
+;; deadline it reported a timeout for that same fiber, a wrong answer rather
+;; than merely a slow one. fiber-join on the very same object returned
+;; immediately, which is the discriminating control below.
+;;
+;; Every probe is bounded (explicit deadline) so a regression fails loudly
+;; with 'timed-out instead of wedging the test runner.
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 18) (srfi 64) (kaappi fibers))
+
+(test-begin "srfi18-join-created-fiber-2194")
+
+;; Control: fiber-join on a never-dispatched fiber already worked before the
+;; fix (it drives the scheduler). Pins that the machinery itself is sound.
+(test-equal "fiber-join on a never-dispatched fiber returns its value"
+  'v (fiber-join (spawn (lambda () 'v))))
+
+;; The bug: thread-join! on the same never-dispatched fiber hung forever
+;; (no timeout => unbounded poll). With a bound it reported a timeout for a
+;; fiber that would have completed instantly. Post-fix the scheduler
+;; dispatches it and the join returns the value.
+(test-equal "thread-join! on a never-dispatched fiber returns its value (was: hang)"
+  'v (thread-join! (spawn (lambda () 'v)) 5 'timed-out))
+
+;; Same shape with a second thunk: the deadline must not be hit -- the
+;; fiber is dispatched and completes before the timer fires.
+(test-equal "thread-join! with a deadline on a never-dispatched fiber"
+  42 (thread-join! (spawn (lambda () 42)) 5 'timed-out))
+
+;; A never-dispatched fiber whose thunk never completes must not hang the
+;; join either: the fiber path bounds the park on the reactor timer and
+;; reports the timeout value.
+(test-equal "thread-join! on an uncompletable never-dispatched fiber times out"
+  'timed-out
+  (thread-join! (spawn (lambda () (channel-receive (make-channel)))) 0.5 'timed-out))
+
+;; The make-thread side of the sched_idx discriminator must keep working: a
+;; handle whose OS thread has completed still joins normally.
+(test-equal "thread-join! on a completed OS thread still joins"
+  7 (let ((t (make-thread (lambda () 7))))
+      (thread-start! t)
+      (thread-join! t)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi18-join-created-fiber-2194")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi18-join-created-fiber-2194.scm
+++ b/tests/scheme/srfi/srfi18-join-created-fiber-2194.scm
@@ -44,6 +44,24 @@
   'timed-out
   (thread-join! (spawn (lambda () (channel-receive (make-channel)))) 0.5 'timed-out))
 
+;; The other half of the sched_idx discriminator: a make-thread handle
+;; joined before it is ever started must keep the #878 poll path (sched_idx
+;; == 0), not fall through to the fiber path. With a deadline the poll
+;; reports the timeout value; the fiber path would instead raise a deadlock
+;; error (nothing local can ever complete the target), which is how the two
+;; are told apart. The same handle must then start and join normally.
+(test-equal "a never-started make-thread handle times out rather than taking the fiber path"
+  'timed-out
+  (let ((t (make-thread (lambda () 'late))))
+    (thread-join! t 0.2 'timed-out)))
+
+(test-equal "a handle that timed out unstarted starts and joins normally afterwards"
+  'late
+  (let ((t (make-thread (lambda () 'late))))
+    (thread-join! t 0.2 'timed-out)
+    (thread-start! t)
+    (thread-join! t)))
+
 ;; The make-thread side of the sched_idx discriminator must keep working: a
 ;; handle whose OS thread has completed still joins normally.
 (test-equal "thread-join! on a completed OS thread still joins"

--- a/tests/scheme/srfi/srfi18-join-spawn-grandchild-2129.scm
+++ b/tests/scheme/srfi/srfi18-join-spawn-grandchild-2129.scm
@@ -13,10 +13,20 @@
 ;;
 ;; The discriminating shape (from the issue): a thread that spawns a thread
 ;; and returns without joining it -- a worker that kicks off a background
-;; task and reports back. Run it many times: pre-fix this crashed 14-18 of
-;; 20 runs (ReleaseSafe) and 13-15 of 15 (gc-stress); post-fix it never
-;; does. A regression crashes the whole runner loudly (the crash is a
-;; process abort, not a Scheme condition).
+;; task and reports back. Run it many times: pre-fix this crashed the
+;; process on the vast majority of runs (the grandchild's prologue interned
+;; symbols into the middle thread's freed table); post-fix it never does.
+;; A regression crashes the whole runner loudly (a process abort, not a
+;; Scheme condition).
+;;
+;; KNOWN RESIDUAL (#2129 stays open): each iteration leaves one un-joinable
+;; grandchild OS thread behind -- its child resources are never reaped (no
+;; one may join it) and, pre-existing since before this PR, the grandchild
+;; dereferences its middle-heap handle (terminate_flag/status) for its whole
+;; life, which the middle's join frees. Silent under the default allocator,
+;; a live use-after-free under Guard Malloc. This test therefore pins only
+;; the half this PR fixed (the prologue/symbol-table crash); the iterations
+;; are kept small so the contained leak does not tax the suite.
 
 (import (scheme base) (scheme write) (scheme process-context) (srfi 18) (srfi 64))
 
@@ -32,12 +42,12 @@
     (thread-join! t)))
 
 (define failures 0)
-(let loop ((n 30))
+(let loop ((n 12))
   (when (> n 0)
     (unless (eq? (run-shape (lambda () (thread-sleep! 0.3) 'g)) 'plain)
       (set! failures (+ failures 1)))
     (loop (- n 1))))
-(test-equal "30 middle threads each spawning an unjoined grandchild all return 'plain"
+(test-equal "12 middle threads each spawning an unjoined grandchild all return 'plain"
   0 failures)
 
 ;; CONTROL: the middle joining its own child first is clean -- the child is

--- a/tests/scheme/srfi/srfi18-join-spawn-grandchild-2129.scm
+++ b/tests/scheme/srfi/srfi18-join-spawn-grandchild-2129.scm
@@ -1,0 +1,67 @@
+;; Regression test for #2129: thread-join! frees the joined thread's GC/VM
+;; while a thread it spawned is still starting -- SIGSEGV / Zig panic; makes
+;; (srfi 120) unusable from a thread.
+;;
+;; threadEntryFn's prologue dereferences the spawning thread's VM/GC
+;; (GC.initForThread's shared symbol tables, then the shared maps), and every
+;; later symbol interning goes through those tables for the thread's whole
+;; life. freeChildResources had no interlock: joining a thread that had
+;; itself spawned a thread freed its GC/VM out from under the grandchild,
+;; which was still (or forever after) reading freed memory. The fix chains
+;; every thread's shared state to the ROOT VM/GC -- which lives for the whole
+;; process -- so a join can never free anything a descendant references.
+;;
+;; The discriminating shape (from the issue): a thread that spawns a thread
+;; and returns without joining it -- a worker that kicks off a background
+;; task and reports back. Run it many times: pre-fix this crashed 14-18 of
+;; 20 runs (ReleaseSafe) and 13-15 of 15 (gc-stress); post-fix it never
+;; does. A regression crashes the whole runner loudly (the crash is a
+;; process abort, not a Scheme condition).
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 18) (srfi 64))
+
+(test-begin "srfi18-join-spawn-grandchild-2129")
+
+(define (run-shape child-thunk)
+  (let ((t (make-thread
+            (lambda ()
+              (let ((g (make-thread child-thunk)))
+                (thread-start! g)
+                'plain)))))      ; middle returns WITHOUT joining g
+    (thread-start! t)
+    (thread-join! t)))
+
+(define failures 0)
+(let loop ((n 30))
+  (when (> n 0)
+    (unless (eq? (run-shape (lambda () (thread-sleep! 0.3) 'g)) 'plain)
+      (set! failures (+ failures 1)))
+    (loop (- n 1))))
+(test-equal "30 middle threads each spawning an unjoined grandchild all return 'plain"
+  0 failures)
+
+;; CONTROL: the middle joining its own child first is clean -- the child is
+;; reaped before the middle returns, so nothing is freed under a live
+;; descendant. Pins that thread-join! on a returning thread in general is
+;; not the problem.
+(test-equal "middle that joins its own child first returns"
+  'plain
+  (let ((t (make-thread
+            (lambda ()
+              (let ((g (make-thread (lambda () 'g))))
+                (thread-start! g)
+                (thread-join! g)
+                'plain)))))
+    (thread-start! t)
+    (thread-join! t)))
+
+;; CONTROL: a middle that spawns nothing is clean.
+(test-equal "plain middle thread returns"
+  'plain
+  (let ((t (make-thread (lambda () 'plain))))
+    (thread-start! t)
+    (thread-join! t)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi18-join-spawn-grandchild-2129")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi18-mutex-state-owner-2125.scm
+++ b/tests/scheme/srfi/srfi18-mutex-state-owner-2125.scm
@@ -1,0 +1,74 @@
+;; Regression test for #2125: mutex-state reports the owning thread's
+;; internal fiber, not the thread handle the caller holds.
+;;
+;; Mutex.owner tracks the fiber that acquired the lock (needed by
+;; abandonFiberMutexes), which for an OS-thread child is the child's own
+;; heap fiber 0 -- a value the parent's GC does not own, not eq? to any
+;; thread the caller holds, and a dangling-pointer hazard once the child
+;; heap is freed at join. mutex-state now reports the owner thread handle
+;; (the fiber make-thread returned, in the parent's heap), recorded
+;; alongside the owner at lock time, so the obvious synchronisation idiom
+;; `(eq? (mutex-state m) t)` works and the value stays valid past join.
+;;
+;; The mutex is a top-level global: sync primitives are deep-copy-rejected
+;; when *captured* by a thread thunk (see srfi18-cross-thread-wait.scm).
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 18) (srfi 64))
+
+(test-begin "srfi18-mutex-state-owner-2125")
+
+;; The issue's exact shape: a mutex locked by a child OS thread must report
+;; the thread handle, eq? to the handle the caller holds.
+(define m (make-mutex 'probe))
+(define t (make-thread (lambda () (mutex-lock! m) (let loop () (loop)))))
+(thread-start! t)
+;; Bounded poll for the child to acquire the lock; the eq? probe IS the
+;; regression (pre-fix it never became true and this spun to its budget,
+;; failing loudly rather than hanging).
+(define (poll-owner? tries)
+  (cond ((eq? (mutex-state m) t) #t)
+        ((<= tries 0) #f)
+        (else (thread-sleep! 0.005) (poll-owner? (- tries 1)))))
+(test-assert "mutex-state on a child-held mutex returns the thread handle (was: child-heap fiber)"
+  (poll-owner? 1000))
+(test-assert "the returned owner is a thread"
+  (thread? (mutex-state m)))
+;; Capture the owner while the child holds the lock, then terminate and
+;; join. The captured value must still be the parent-heap handle: pre-fix
+;; it was the child's fiber, a freed child-heap pointer once the join
+;; frees that heap (the #2127 quarantine was the detector-side mitigation).
+(define owner-before-join (mutex-state m))
+(thread-terminate! t)
+(guard (e (#t #t)) (thread-join! t))
+(test-equal "the owner value captured before join survives it (parent-heap handle, not a freed child-heap fiber)"
+  t owner-before-join)
+(test-equal "abandoned state still reported after terminate"
+  'abandoned (mutex-state m))
+
+;; Local (same-thread) ownership is unchanged: the owner is the current
+;; thread itself.
+(let ((ml (make-mutex 'local)))
+  (mutex-lock! ml)
+  (test-assert "same-thread owner is a thread"
+    (thread? (mutex-state ml)))
+  (test-assert "same-thread owner is eq? to current-thread"
+    (eq? (mutex-state ml) (current-thread)))
+  (mutex-unlock! ml)
+  (test-equal "unlocked mutex is not-abandoned again"
+    'not-abandoned (mutex-state ml)))
+
+;; An explicit owner argument is reported as given (SRFI-18's optional
+;; thread argument), and #f means locked-but-unowned.
+(define m2 (make-mutex 'explicit))
+(mutex-lock! m2 #f t)
+(test-assert "explicit owner arg is what mutex-state reports"
+  (eq? (mutex-state m2) t))
+(mutex-unlock! m2)
+(define m3 (make-mutex 'unowned))
+(mutex-lock! m3 #f #f)
+(test-equal "explicit #f owner is the locked/unowned state"
+  'not-owned (mutex-state m3))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi18-mutex-state-owner-2125")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi18-terminate-native-wait-1982.scm
+++ b/tests/scheme/srfi/srfi18-terminate-native-wait-1982.scm
@@ -1,0 +1,97 @@
+;; Regression test for #1982: thread-terminate! cannot interrupt a thread
+;; parked in a native SRFI-18 wait, so thread-join! on it hangs forever.
+;;
+;; The bytecode safepoint polls VM.terminate_flag every 1024 instructions
+;; (#933, closing #880) -- but only while executing bytecode. thread-sleep!,
+;; mutex-lock! and mutex-unlock!'s condvar branch each wait inside
+;; runSchedulerStep's native loop and never executed bytecode, so the flag
+;; was never observed: thread-terminate! flipped the handle's status to
+;; .errored from the parent, the join's poll exited immediately, and then
+;; reapOsThread's thread.join() blocked forever waiting for a child that
+;; would never unwind. The fix makes runSchedulerStep consult the
+;; termination flag (via the VM's terminate_flag for an OS-thread child,
+;; via the fiber's own flag for a local fiber) and unwind with
+;; VMError.Terminated, exactly like the safepoint.
+;;
+;; Shared mutexes/condvars are top-level globals, referenced by name from
+;; the thunks: sync primitives are deep-copy-rejected when *captured* by a
+;; thread thunk (only the globals route shares them by pointer -- see
+;; srfi18-cross-thread-wait.scm), and a child that errored at thread-start!
+;; would make the terminate probes pass vacuously. The CONTROL rows joining
+;; normally with a value are what prove the children genuinely ran and
+;; parked in the native waits.
+;;
+;; Every shape must terminate promptly (a regression wedges the test
+;; runner, which is the failure mode being pinned).
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 18) (srfi 64))
+
+(test-begin "srfi18-terminate-native-wait-1982")
+
+(define (join-catch t)
+  (guard (e ((terminated-thread-exception? e) 'terminated)
+            (#t (list 'other e)))
+    (thread-join! t)))
+
+;; Each native-wait shape: terminate while parked, join must raise
+;; terminated-thread-exception (never hang).
+(test-equal "terminate a thread parked in thread-sleep!"
+  'terminated
+  (let ((t (make-thread (lambda () (thread-sleep! 60) 'slept))))
+    (thread-start! t) (thread-sleep! 0.2) (thread-terminate! t)
+    (join-catch t)))
+
+(define m-term-timed (make-mutex 'm-term-timed))
+(test-equal "terminate a thread parked in a timed mutex-lock!"
+  'terminated
+  (let ((t (make-thread (lambda () (mutex-lock! m-term-timed 60) (mutex-unlock! m-term-timed) 'locked))))
+    (thread-start! t) (thread-sleep! 0.2) (thread-terminate! t)
+    (join-catch t)))
+
+(define m-term-cv (make-mutex 'm-term-cv))
+(define cv-term (make-condition-variable 'cv-term))
+(test-equal "terminate a thread parked in a condition-variable wait"
+  'terminated
+  (let ((t (make-thread (lambda () (mutex-lock! m-term-cv) (mutex-unlock! m-term-cv cv-term 60) (mutex-unlock! m-term-cv) 'cv-waited))))
+    (thread-start! t) (thread-sleep! 0.2) (thread-terminate! t)
+    (join-catch t)))
+
+(define m-term-untimed (make-mutex 'm-term-untimed))
+(mutex-lock! m-term-untimed)
+(test-equal "terminate a thread parked in an untimed mutex-lock! (held by parent)"
+  'terminated
+  (let ((t (make-thread (lambda () (mutex-lock! m-term-untimed) (mutex-unlock! m-term-untimed) 'got-it))))
+    (thread-start! t) (thread-sleep! 0.2) (thread-terminate! t)
+    (join-catch t)))
+
+;; CONTROL: the pre-existing safepoint path (Scheme spin loop) still
+;; terminates -- pins that the native-wait fix did not disturb it.
+(test-equal "terminate a thread running a Scheme spin loop (safepoint path)"
+  'terminated
+  (let ((t (make-thread (lambda () (let loop () (loop))))))
+    (thread-start! t) (thread-sleep! 0.2) (thread-terminate! t)
+    (join-catch t)))
+
+;; CONTROL: a timed mutex-lock! released by the parent joins normally with
+;; the thunk's value (not terminated).
+(define m-ctrl (make-mutex 'm-ctrl))
+(mutex-lock! m-ctrl)
+(test-equal "mutex released by parent: join returns the value"
+  'got-it
+  (let ((t (make-thread (lambda () (mutex-lock! m-ctrl 60) 'got-it))))
+    (thread-start! t) (thread-sleep! 0.2) (mutex-unlock! m-ctrl)
+    (join-catch t)))
+
+;; CONTROL: a condition-variable wait released by broadcast joins normally.
+(define m-ctrl-cv (make-mutex 'm-ctrl-cv))
+(define cv-ctrl (make-condition-variable 'cv-ctrl))
+(test-equal "condvar broadcast: join returns the value"
+  'cv-done
+  (let ((t (make-thread (lambda () (mutex-lock! m-ctrl-cv) (mutex-unlock! m-ctrl-cv cv-ctrl 60) (mutex-unlock! m-ctrl-cv) 'cv-done))))
+    (thread-start! t) (thread-sleep! 0.2)
+    (mutex-lock! m-ctrl-cv) (condition-variable-broadcast! cv-ctrl) (mutex-unlock! m-ctrl-cv)
+    (join-catch t)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi18-terminate-native-wait-1982")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

Four SRFI-18 / concurrency audit bugs from the v0.22.2 milestone, one commit each, in the shared `primitives_srfi18.zig` / `fiber_wait.zig` / `fiber.zig` wait-and-thread-lifecycle machinery.

### #2194 — `thread-join!` hangs forever on a spawn'd fiber that has not been dispatched yet (`af743b06`)
`threadJoinFn`'s "never-started" branch busy-polled `fiber.status` without ever driving the scheduler. Correct for a `make-thread` handle awaiting `thread-start!` from outside (#878) — wrong for a `(kaappi fibers)` spawn'd fiber, which only this thread's cooperative scheduler can dispatch: the poll loop *was* the starvation. Discriminate by `sched_idx` (set only by `addFiber`): make-thread handles keep polling; spawn'd fibers fall through to the fiber path, which drives the scheduler. `os_thread` alone is not a safe discriminator — a handle about to be started has `os_thread == null` for the whole window before `thread-start!`'s `std.Thread.spawn`.

### #1982 — `thread-terminate!` cannot interrupt a thread parked in a native SRFI-18 wait (`40df26c8`)
The bytecode safepoint polls `VM.terminate_flag` every 1024 instructions (#933), but only while executing bytecode. `thread-sleep!`, `mutex-lock!` and `mutex-unlock!'s` condvar branch wait inside `runSchedulerStep`'s native loop, so a parked thread never observed the flag: `thread-terminate!` flipped the handle's status, the join's poll exited immediately, and `reapOsThread`'s `thread.join()` blocked forever on a child that would never unwind. `runSchedulerStep` now checks termination (the VM's `terminate_flag` for an OS-thread child — the same flag the safepoint reads — plus the fiber's own flag for a local fiber) at the top of every loop iteration and unwinds `VMError.Terminated`. `SleepWait` gains `pollCapNs` (1ms when another OS thread could terminate this one) so a sleeping thread actually wakes to observe the flag; solo sleeps stay a single reactor block. The wait-context duck-type comptime test moves from 2 to 3 poll caps with the justification.

### #2125 — `mutex-state` reports the owning thread's internal fiber, not the thread (`ce78e10e`)
`Mutex.owner` tracks the *fiber* that acquired the lock (needed by `abandonFiberMutexes`), which for an OS-thread child is the child-heap current fiber — a value not `eq?` to any thread the caller holds, and a dangling pointer once the join frees the child heap (the #2127 quarantine was the detector-side mitigation, not the fix). A new `Mutex.owner_thread` records the thread handle alongside the owner at every write site; `threadEntryFn` stashes the handle on the child VM (`VM.thread_handle`, foreign to the child GC and rooted by the parent), and `mutex-lock!`'s fast/slow paths resolve it exactly like the owner, honouring an explicit SRFI-18 owner argument. `mutex-unlock!` and `abandonFiberMutexes` clear both together. `mutex-state` returns `owner_thread`; the `(eq? (mutex-state m) t)` synchronisation idiom finally works. The existing cross-heap-abandoned-mutex test's workaround ("exclude the two unowned symbols") becomes the real `eq?` probe.

### #2129 — `thread-join!` frees the joined thread's GC/VM while a thread it spawned is still starting (`d1d35353`)
`threadEntryFn`'s prologue dereferences the spawning thread's VM/GC: `GC.initForThread` reads `parent_vm.gc` for the shared symbol tables (`shared_symbols = &parent.symbols`, used by *every* symbol interning for the thread's whole life), and `VM.initForThread` reads the shared maps. `freeChildResources` had no interlock, so joining a thread that had itself spawned a thread freed its GC/VM out from under the grandchild — mid-prologue (the thunk `deepCopy` interns symbols into the freed table) or at its next interning. Reproduced at 18/20 (ReleaseSafe) and 13/15 (gc-stress). `threadStartImpl` now passes the **root VM** (new `VM.root_vm`, resolved in `initForThread` by walking the parent chain) to `threadEntryFn`, so every descendant chains its symbol tables, `foreign_symbols` and shared maps to the root's — which lives for the whole process. A middle thread's own tables stay empty and its GC/VM can be freed at its join. The `thread_handle` from #2125 is recorded only when root-heap.

## Known residual — #2129 stays open

This PR fixes the prologue/symbol-table half of #2129 only. The grandchild's **own handle** — the `*Fiber` `make-thread` allocated on the middle thread, in the middle's heap — is still freed by `freeChildResources` at the middle's join, while the live grandchild reads and writes it for its whole life:

- `child_vm.terminate_flag = &fiber.terminated`, read by the bytecode safepoint every 1024 instructions and by the new `waitTerminated`
- the final `@atomicStore(&fiber.status, .completed, .release)` in `threadEntryFn`

Pre-existing (reproduces identically at `b02ecb25` under Guard Malloc — SIGSEGV in `runUntil`), not introduced here. Silent under the default allocator (the #2129 regression test passes only because the corruption is silent), a live use-after-free under Guard Malloc. A full fix (allocating the handle in the root heap, or gating `freeChildResources` on "no live descendant" the way `hasLiveChildThreads` gates main's teardown) is a larger design change — registry-based deferred frees with deep-nesting cases — and deserves its own PR. Tracked in #2129.

Also documented: grandchildren of a joined thread remain un-joinable (their handle lives in the middle's heap; `checkThreadOwner` refuses foreign joins), so their child resources leak as before.

## Verification

- Crash/hang repros: #2129 prologue 0/25 crashes ReleaseSafe + 0/15 gc-stress (was 14–18/20, 13–15/15); #2194 repro completes; #1982 all four hang shapes terminate promptly; #2125 `eq?` probe is `#t`
- Regression tests (all deadline-bounded so a regression fails loudly instead of wedging the runner):
  - `tests/scheme/srfi/srfi18-join-created-fiber-2194.scm` (incl. the #878 `sched_idx == 0` probe)
  - `tests/scheme/srfi/srfi18-terminate-native-wait-1982.scm`
  - `tests/scheme/srfi/srfi18-mutex-state-owner-2125.scm`
  - `tests/scheme/srfi/srfi18-join-spawn-grandchild-2129.scm`
  - `tests/scheme/srfi/srfi18-cross-heap-abandoned-mutex.scm` updated (workaround → real `eq?` probe)
- Full `run-all.sh`: 2081 pass / 3 fail / 0 timeout (the 3 `compile/` tier failures were a stale dirty-build artifact in my workflow — the interpreter had been built pre-commit with a `-dirty` build id, so its `.sbc` mismatched the bundle's; after rebuilding from the committed tree all three pass)
- `zig build test`, `zig fmt --check`, and the affected suites under `-Dgc-stress=true` all green

## Review comments addressed (`7851bca0`)

- `mutex-lock!` publishes `owner_thread` before `owner`; `mutex-state` gates on `owner_thread` alone (no cross-field race)
- local-fiber termination mid-wait now surfaces "thread terminated" instead of a contentless error
- `waitTerminated` moved out of `runSchedulerStep`'s doc block; orphaned loop-top comment relocated to the check it describes
- `SleepWait.pollCapNs` documents the measured 1ms-poll cost on child threads and the notifier-based follow-up
- #878 `sched_idx` probe test added; #2129 regression test reduced to 12 iterations with the residual documented in its header
- doc drift fixed: `docs/dev/thread-value-sharing.md` and `CLAUDE.md` now say shared tables/maps chain to the root's

Fixes #2194
Fixes #1982
Fixes #2125
