### PR TITLE
Fix three SRFI audit defects: hashmap comparators, bag clamps, eager-comprehension early exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`(srfi 146 hash)` keys its tables with the comparator you passed** (#2044).
+  Every constructor built a bare `(make-hash-table)` and stashed the
+  comparator in the record, where `hashmap-key-comparator` handed it back —
+  and nothing else ever consulted it. Key identity was always `equal?` with
+  the native `equal?` hash, so under a comparator whose equality is `=` (or a
+  case-insensitive string comparator) `1` and `1.0` stayed distinct keys and
+  `Foo` never matched `foo`, while the ordered `(srfi 146)` library handled
+  the same comparators correctly. All nine `make-hash-table` call sites
+  (`hashmap`, `hashmap-unfold`, `hashmap-map`, `hashmap-filter`,
+  `hashmap-partition`, `hashmap-intersection`, `hashmap-difference`,
+  `hashmap-xor`, `alist->hashmap`) now thread the comparator through, and the
+  built-in SRFI-69 table falls into `.custom` mode calling the comparator's
+  own equality and hash functions.
+
+- **SRFI-113 bags can no longer hold negative multiplicities, and the three
+  procedures that expanded a multiplicity no longer hang on one** (#2085).
+  `bag-increment!` ignored the spec's "but not less than zero" clamp, so a
+  negative count drove a multiplicity below zero and `bag->list`,
+  `bag-for-each` and `bag-fold` — each looping `(= i count)` — never
+  terminated, allocating without bound. `bag-product` was a second route:
+  its `n` was never validated (the reference implementation's `valid-n`
+  check discards its result), so a negative `n` multiplied every count
+  negative. `bag-increment!` now drops the element when the result would be
+  non-positive (matching `bag-decrement!`), `bag-product!` clamps a negative
+  `n` at zero, and the three loops test `(>= i count)` so no count value can
+  loop forever.
+
+- **`first-ec`, `any?-ec` and `every?-ec` stop the comprehension early, per
+  SRFI 42** (#2179). All three materialized the entire result first —
+  `first-ec` expanded to `list-ec` and took `car`, and the two predicates
+  ran the whole `do-ec` loop — so `(first-ec #f (:integers i) i)` and
+  `(any?-ec (:integers i) (> i 5))` hung forever despite the spec giving all
+  three early-exit semantics ("stop the loop after the first value"; "as
+  soon as the result is known"). Each now allocates its own stop flag and
+  sets it from the body, and the existing `%do-ec` flag mechanism unwinds
+  every generator loop.
+
 ## [0.22.2] - 2026-08-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   the native `equal?` hash, so under a comparator whose equality is `=` (or a
   case-insensitive string comparator) `1` and `1.0` stayed distinct keys and
   `Foo` never matched `foo`, while the ordered `(srfi 146)` library handled
-  the same comparators correctly. All nine `make-hash-table` call sites
-  (`hashmap`, `hashmap-unfold`, `hashmap-map`, `hashmap-filter`,
-  `hashmap-partition`, `hashmap-intersection`, `hashmap-difference`,
-  `hashmap-xor`, `alist->hashmap`) now thread the comparator through, and the
-  built-in SRFI-69 table falls into `.custom` mode calling the comparator's
-  own equality and hash functions.
+  the same comparators correctly. All ten `make-hash-table` call sites across
+  the nine constructors (`hashmap`, `hashmap-unfold`, `hashmap-map`,
+  `hashmap-filter`, `hashmap-partition` — two tables, `hashmap-intersection`,
+  `hashmap-difference`, `hashmap-xor`, `alist->hashmap`) now thread the
+  comparator through, and the built-in SRFI-69 table falls into `.custom`
+  mode calling the comparator's own equality and hash functions.
 
 - **SRFI-113 bags can no longer hold negative multiplicities, and the three
   procedures that expanded a multiplicity no longer hang on one** (#2085).
@@ -44,9 +44,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   three early-exit semantics ("stop the loop after the first value"; "as
   soon as the result is known"). Each now allocates its own stop flag and
   sets it from the body, and the existing `%do-ec` flag mechanism unwinds
-  every generator loop. One behavior change: `first-ec` now evaluates its
-  `default` argument eagerly (it previously did so only when the
-  comprehension was empty) — this matches the SRFI 42 reference
+  every generator loop — including before the step, so a stopped
+  comprehension never advances a side-effecting generator (`:port` reads
+  exactly the datums needed, a `:dispatched` generator procedure is not
+  called one extra time); the reference's `:until` fusion folds the same
+  check into the loop's step test. One behavior change: `first-ec` now
+  evaluates its `default` argument eagerly (it previously did so only when
+  the comprehension was empty) — this matches the SRFI 42 reference
   implementation, which likewise seeds its result with `default`.
 
 ## [0.22.2] - 2026-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   three early-exit semantics ("stop the loop after the first value"; "as
   soon as the result is known"). Each now allocates its own stop flag and
   sets it from the body, and the existing `%do-ec` flag mechanism unwinds
-  every generator loop.
+  every generator loop. One behavior change: `first-ec` now evaluates its
+  `default` argument eagerly (it previously did so only when the
+  comprehension was empty) — this matches the SRFI 42 reference
+  implementation, which likewise seeds its result with `default`.
 
 ## [0.22.2] - 2026-08-05
 

--- a/lib/srfi/113.sld
+++ b/lib/srfi/113.sld
@@ -179,7 +179,10 @@
       (let ((result '()))
         (hash-table-walk (%bag-ht b)
           (lambda (elem count)
-            (do ((i 0 (+ i 1))) ((= i count))
+            ;; (>= i count) rather than (= i count): a count that somehow
+            ;; reaches a negative value must expand to zero elements, not
+            ;; loop forever (#2085).
+            (do ((i 0 (+ i 1))) ((>= i count))
               (set! result (cons elem result)))))
         result))
 
@@ -416,14 +419,14 @@
     (define (bag-for-each proc b)
       (hash-table-walk (%bag-ht b)
         (lambda (elem count)
-          (do ((i 0 (+ i 1))) ((= i count))
+          (do ((i 0 (+ i 1))) ((>= i count))
             (proc elem)))))
 
     (define (bag-fold proc nil b)
       (let ((acc nil))
         (hash-table-walk (%bag-ht b)
           (lambda (elem count)
-            (do ((i 0 (+ i 1))) ((= i count))
+            (do ((i 0 (+ i 1))) ((>= i count))
               (set! acc (proc elem acc)))))
         acc))
 
@@ -730,13 +733,19 @@
       (apply bag-sum! (bag-copy b1) rest))
 
     (define (bag-product! n b)
-      (for-each
-        (lambda (k)
-          (if (= n 0)
-              (hash-table-delete! (%bag-ht b) k)
-              (hash-table-set! (%bag-ht b) k
-                (* n (hash-table-ref (%bag-ht b) k)))))
-        (hash-table-keys (%bag-ht b)))
+      ;; The spec gives bag-product no "it is an error" escape for a
+      ;; negative n, and multiplicities cannot go below zero, so clamp n at
+      ;; zero (an empty bag) exactly as bag-increment! clamps its count
+      ;; (#2085).  The reference implementation's valid-n check is dead code
+      ;; there, which is how -1 leaked into (* n count) in the first place.
+      (let ((n (if (negative? n) 0 n)))
+        (for-each
+          (lambda (k)
+            (if (= n 0)
+                (hash-table-delete! (%bag-ht b) k)
+                (hash-table-set! (%bag-ht b) k
+                  (* n (hash-table-ref (%bag-ht b) k)))))
+          (hash-table-keys (%bag-ht b))))
       b)
 
     (define (bag-product n b)
@@ -761,8 +770,13 @@
         acc))
 
     (define (bag-increment! b elem count)
-      (hash-table-set! (%bag-ht b) elem
-        (+ count (hash-table-ref (%bag-ht b) elem 0)))
+      ;; "increased ... by the exact integer count (but not less than zero)":
+      ;; a negative count may drive the multiplicity to zero, at which point
+      ;; the element is dropped, exactly as bag-decrement! drops it (#2085).
+      (let ((new (+ count (hash-table-ref (%bag-ht b) elem 0))))
+        (if (<= new 0)
+            (hash-table-delete! (%bag-ht b) elem)
+            (hash-table-set! (%bag-ht b) elem new)))
       b)
 
     (define (bag-decrement! b elem count)

--- a/lib/srfi/146/hash.sld
+++ b/lib/srfi/146/hash.sld
@@ -36,14 +36,17 @@
       (%make-hashmap (%hm-comparator m) (hash-table-copy (%hm-ht m))))
 
     (define (hashmap comparator . args)
-      (let ((ht (make-hash-table)))
+      ;; The table must be keyed by the comparator's equality/hash pair, not
+      ;; the native equal? default, or 1 and 1.0 stay distinct keys under a
+      ;; comparator whose equality is = (#2044).
+      (let ((ht (make-hash-table comparator)))
         (let loop ((args args))
           (if (null? args) (%make-hashmap comparator ht)
               (begin (hash-table-set! ht (car args) (cadr args))
                      (loop (cddr args)))))))
 
     (define (hashmap-unfold stop? mapper successor seed comparator)
-      (let ((ht (make-hash-table)))
+      (let ((ht (make-hash-table comparator)))
         (let loop ((seed seed))
           (if (stop? seed) (%make-hashmap comparator ht)
               (let-values (((key val) (mapper seed)))
@@ -190,7 +193,7 @@
     (define (hashmap-entries m) (values (hash-table-keys (%hm-ht m)) (hash-table-values (%hm-ht m))))
 
     (define (hashmap-map proc comparator m)
-      (let ((new (make-hash-table)))
+      (let ((new (make-hash-table comparator)))
         (hash-table-walk (%hm-ht m)
           (lambda (k v)
             (let-values (((nk nv) (proc k v)))
@@ -213,7 +216,7 @@
         acc))
 
     (define (hashmap-filter pred m)
-      (let ((new (make-hash-table)))
+      (let ((new (make-hash-table (%hm-comparator m))))
         (hash-table-walk (%hm-ht m)
           (lambda (k v) (if (pred k v) (hash-table-set! new k v))))
         (%make-hashmap (%hm-comparator m) new)))
@@ -224,7 +227,8 @@
     (define hashmap-remove! hashmap-remove)
 
     (define (hashmap-partition pred m)
-      (let ((yes (make-hash-table)) (no (make-hash-table)))
+      (let ((yes (make-hash-table (%hm-comparator m)))
+            (no (make-hash-table (%hm-comparator m))))
         (hash-table-walk (%hm-ht m)
           (lambda (k v)
             (if (pred k v) (hash-table-set! yes k v) (hash-table-set! no k v))))
@@ -236,7 +240,7 @@
     (define (hashmap->alist m) (hash-table->alist (%hm-ht m)))
 
     (define (alist->hashmap comparator alist)
-      (let ((ht (make-hash-table)))
+      (let ((ht (make-hash-table comparator)))
         (let loop ((al alist))
           (if (null? al) (%make-hashmap comparator ht)
               (begin
@@ -307,7 +311,7 @@
     (define hashmap-union! hashmap-union)
 
     (define (hashmap-intersection m1 . rest)
-      (let ((new (make-hash-table)))
+      (let ((new (make-hash-table (%hm-comparator m1))))
         (hash-table-walk (%hm-ht m1)
           (lambda (k v)
             (if (let loop ((rs rest))
@@ -319,7 +323,7 @@
     (define hashmap-intersection! hashmap-intersection)
 
     (define (hashmap-difference m1 . rest)
-      (let ((new (make-hash-table)))
+      (let ((new (make-hash-table (%hm-comparator m1))))
         (hash-table-walk (%hm-ht m1)
           (lambda (k v)
             (if (not (let loop ((rs rest))
@@ -331,7 +335,7 @@
     (define hashmap-difference! hashmap-difference)
 
     (define (hashmap-xor m1 m2)
-      (let ((new (make-hash-table)))
+      (let ((new (make-hash-table (%hm-comparator m1))))
         (hash-table-walk (%hm-ht m1)
           (lambda (k v)
             (if (not (hash-table-exists? (%hm-ht m2) k))

--- a/lib/srfi/42.sld
+++ b/lib/srfi/42.sld
@@ -626,7 +626,10 @@
     ;; on infinite :integers generators.  Each allocates its own stop flag
     ;; (%s) and sets it from the body; every generator loop in %do-ec
     ;; checks (not s) before each iteration, so setting it unwinds the whole
-    ;; comprehension (#2179).
+    ;; comprehension (#2179).  Note first-ec evaluates `default` eagerly
+    ;; (the let binding below), exactly like the reference implementation's
+    ;; (let ((result default) (stop #f)) ...) — the previous list-ec/car
+    ;; shape evaluated it only when the comprehension was empty.
     (define-syntax first-ec
       (syntax-rules ()
         ((_ default qualifier ... expr)

--- a/lib/srfi/42.sld
+++ b/lib/srfi/42.sld
@@ -308,8 +308,17 @@
               (if g2 g2 #f)))))
 
     ;; Internal recursive qualifier processor.
-    ;; s = mutable stop flag for :while/:until early exit.
+    ;; s = mutable stop flag for :while/:until early exit (and, since
+    ;; #2179, for the first-ec/any?-ec/every?-ec collectors).
     ;; Processes one qualifier per expansion, recurses on the rest.
+    ;; Every generator loop checks (not s) before an iteration AND before
+    ;; its step, so a stopped comprehension never advances a
+    ;; side-effecting generator (:port would otherwise read one extra
+    ;; datum, a :dispatched generator-proc would be called one extra
+    ;; time).  The reference's :until fusion folds the same check into
+    ;; the loop's step test; the :do rule's inner
+    ;; (when (and ne2? (not s)) ...) has always been the model, and the
+    ;; typed-generator steps below follow it.
     ;; The engine caps one syntax-rules form at 32 rules, so the
     ;; qualifier rules are split across two macros: %do-ec holds the
     ;; generators and forwards any other qualifier to %do-ec-more, which
@@ -323,13 +332,13 @@
            (let %lp ((var 0))
              (when (and (< var %n) (not s))
                (%do-ec s rest1 rest2 ...)
-               (%lp (+ var 1))))))
+               (unless s (%lp (+ var 1)))))))
         ((_ s (:range var a b) rest1 rest2 ...)
          (let ((%b b))
            (let %lp ((var a))
              (when (and (< var %b) (not s))
                (%do-ec s rest1 rest2 ...)
-               (%lp (+ var 1))))))
+               (unless s (%lp (+ var 1)))))))
         ((_ s (:range var a b c) rest1 rest2 ...)
          (let ((%b b) (%c c))
            (if (zero? %c)
@@ -338,7 +347,7 @@
              (when (and (if (positive? %c) (< var %b) (> var %b))
                         (not s))
                (%do-ec s rest1 rest2 ...)
-               (%lp (+ var %c))))))
+               (unless s (%lp (+ var %c)))))))
         ;; :real-range — i counts 0, 1, ... while i < (to-from)/step and
         ;; var = from + i*step; from turns inexact if to or step is.
         ((_ s (:real-range var b) rest1 rest2 ...)
@@ -360,7 +369,7 @@
                (when (and (< %i %lim) (not s))
                  (let ((var (+ %x (* %c %i))))
                    (%do-ec s rest1 rest2 ...))
-                 (%lp (+ %i 1)))))))
+                 (unless s (%lp (+ %i 1))))))))
         ;; :char-range — both endpoints inclusive.
         ((_ s (:char-range var a b) rest1 rest2 ...)
          (let ((%imax (char->integer b)))
@@ -368,13 +377,13 @@
              (when (and (<= %i %imax) (not s))
                (let ((var (integer->char %i)))
                  (%do-ec s rest1 rest2 ...))
-               (%lp (+ %i 1))))))
+               (unless s (%lp (+ %i 1)))))))
         ((_ s (:list var lst) rest1 rest2 ...)
          (let %lp ((%xs lst))
            (when (and (pair? %xs) (not s))
              (let ((var (car %xs)))
                (%do-ec s rest1 rest2 ...))
-             (%lp (cdr %xs)))))
+             (unless s (%lp (cdr %xs))))))
         ((_ s (:list var lst1 lst2 lst3 ...) rest1 rest2 ...)
          (%do-ec s (:list var (append lst1 lst2 lst3 ...)) rest1 rest2 ...))
         ((_ s (:string var str) rest1 rest2 ...)
@@ -383,7 +392,7 @@
              (when (and (< %k %n) (not s))
                (let ((var (string-ref %str %k)))
                  (%do-ec s rest1 rest2 ...))
-               (%lp (+ %k 1))))))
+               (unless s (%lp (+ %k 1)))))))
         ((_ s (:string var str1 str2 str3 ...) rest1 rest2 ...)
          (%do-ec s (:string var (string-append str1 str2 str3 ...))
                  rest1 rest2 ...))
@@ -393,7 +402,7 @@
              (when (and (< %k %n) (not s))
                (let ((var (vector-ref %v %k)))
                  (%do-ec s rest1 rest2 ...))
-               (%lp (+ %k 1))))))
+               (unless s (%lp (+ %k 1)))))))
         ((_ s (:vector var vec1 vec2 vec3 ...) rest1 rest2 ...)
          (%do-ec s (:list var (append (vector->list vec1)
                                       (vector->list vec2)
@@ -403,7 +412,7 @@
          (let %lp ((var 0))
            (when (not s)
              (%do-ec s rest1 rest2 ...)
-             (%lp (+ var 1)))))
+             (unless s (%lp (+ var 1))))))
         ((_ s (:port var p) rest1 rest2 ...)
          (%do-ec s (:port var p read) rest1 rest2 ...))
         ((_ s (:port var p rd) rest1 rest2 ...)
@@ -411,7 +420,7 @@
            (let %lp ((var (%rd %p)))
              (when (and (not (eof-object? var)) (not s))
                (%do-ec s rest1 rest2 ...)
-               (%lp (%rd %p))))))
+               (unless s (%lp (%rd %p)))))))
         ((_ s (:let var expr) rest1 rest2 ...)
          (let ((var expr))
            (%do-ec s rest1 rest2 ...)))
@@ -425,7 +434,7 @@
            (let %lp ((var (%g %empty)))
              (when (and (not (eq? var %empty)) (not s))
                (%do-ec s rest1 rest2 ...)
-               (%lp (%g %empty))))))
+               (unless s (%lp (%g %empty)))))))
         ;; --- the fundamental generator :do ---
         ((_ s (:do (lb ...) ne1? (ls ...)) rest1 rest2 ...)
          (%do-ec s (:do (let ()) (lb ...) ne1? (let ()) #t (ls ...))
@@ -523,7 +532,7 @@
            (let %lp ((var (g %e)) ...)
              (when (and (not s) (not (eq? var %e)) ...)
                (%do-ec s rest1 rest2 ...)
-               (%lp (g %e) ...)))))))
+               (unless s (%lp (g %e) ...))))))))
 
     ;; (:generator-proc (gen arg ...)) — the generator procedure running
     ;; through (list-ec (gen var arg ...) var), per the spec.  Standard

--- a/lib/srfi/42.sld
+++ b/lib/srfi/42.sld
@@ -620,11 +620,20 @@
         ((_ qualifier ... expr)
          (apply max (list-ec qualifier ... expr)))))
 
+    ;; SRFI 42 gives all three accumulators early-exit semantics: first-ec
+    ;; "stop[s] the loop after the first value" and any?-ec/every?-ec stop
+    ;; "as soon as the result is known" — the spec's own examples use them
+    ;; on infinite :integers generators.  Each allocates its own stop flag
+    ;; (%s) and sets it from the body; every generator loop in %do-ec
+    ;; checks (not s) before each iteration, so setting it unwinds the whole
+    ;; comprehension (#2179).
     (define-syntax first-ec
       (syntax-rules ()
         ((_ default qualifier ... expr)
-         (let ((%result (list-ec qualifier ... expr)))
-           (if (null? %result) default (car %result))))))
+         (let ((%s #f) (%result default))
+           (%do-ec %s qualifier ...
+                   (begin (set! %result expr) (set! %s #t)))
+           %result))))
 
     (define-syntax last-ec
       (syntax-rules ()
@@ -637,13 +646,15 @@
     (define-syntax any?-ec
       (syntax-rules ()
         ((_ qualifier ... expr)
-         (let ((%ec-r #f))
-           (do-ec qualifier ... (when expr (set! %ec-r #t)))
+         (let ((%s #f) (%ec-r #f))
+           (%do-ec %s qualifier ...
+                   (if expr (begin (set! %ec-r #t) (set! %s #t))))
            %ec-r))))
 
     (define-syntax every?-ec
       (syntax-rules ()
         ((_ qualifier ... expr)
-         (let ((%ec-r #t))
-           (do-ec qualifier ... (unless expr (set! %ec-r #f)))
+         (let ((%s #f) (%ec-r #t))
+           (%do-ec %s qualifier ...
+                   (if (not expr) (begin (set! %ec-r #f) (set! %s #t))))
            %ec-r))))))

--- a/tests/scheme/srfi/srfi113-audit.scm
+++ b/tests/scheme/srfi/srfi113-audit.scm
@@ -224,8 +224,22 @@
             0 (bag-element-count (bag-increment! (B 1 1) 1 -5) 1))
 (test-equal "a bag built by bag-increment! with a negative count still lists"
             0 (length (bag->list (bag-increment! (B 1 1) 1 -5))))
-(test-assert "bag-product with a negative n does not produce a negative count"
-             (>= (bag-size (bag-product -1 (B 1 1))) 0))
+(test-equal "bag-product with a negative n yields an empty bag"
+            '() (ba (bag-product -1 (B 1 1))))
+(test-equal "bag-product with a negative n has size zero"
+            0 (bag-size (bag-product -1 (B 1 1))))
+;; The loop guard is the last line of defence: alist->bag inserts its counts
+;; verbatim, so a negative count can still reach the multiplicities without
+;; going through either clamp.  All three expanding loops must terminate on
+;; it (expanding to zero elements), not hang (#2085).
+(test-equal "bag->list terminates on a negative stored count" 0
+  (length (bag->list (alist->bag cmp '((1 . -3))))))
+(test-equal "bag-for-each terminates on a negative stored count" 0
+  (let ((n 0))
+    (bag-for-each (lambda (e) (set! n (+ n 1))) (alist->bag cmp '((1 . -3))))
+    n))
+(test-equal "bag-fold terminates on a negative stored count" 0
+  (bag-fold (lambda (e a) (+ a 1)) 0 (alist->bag cmp '((1 . -3)))))
 
 ;; Discriminating controls: the same loops terminate for zero and positive
 ;; multiplicities, so the non-termination is specific to a negative count.

--- a/tests/scheme/srfi/srfi113-audit.scm
+++ b/tests/scheme/srfi/srfi113-audit.scm
@@ -220,17 +220,12 @@
 (test-equal "bag-decrement! of an absent element changes nothing"
             '((1 . 1)) (ba (bag-decrement! (B 1) 9 1)))
 
-;; FAIL: #2085 (bag-increment! with a negative count is not clamped at zero, and
-;;              the resulting negative multiplicity makes bag->list, bag-fold and
-;;              bag-for-each loop forever)
-;; (test-equal "bag-increment! with a negative count is clamped at zero"
-;;             0 (bag-element-count (bag-increment! (B 1 1) 1 -5) 1))
-;; FAIL: #2085
-;; (test-equal "a bag built by bag-increment! with a negative count still lists"
-;;             0 (length (bag->list (bag-increment! (B 1 1) 1 -5))))
-;; FAIL: #2085
-;; (test-assert "bag-product with a negative n does not produce a negative count"
-;;              (>= (bag-size (bag-product -1 (B 1 1))) 0))
+(test-equal "bag-increment! with a negative count is clamped at zero"
+            0 (bag-element-count (bag-increment! (B 1 1) 1 -5) 1))
+(test-equal "a bag built by bag-increment! with a negative count still lists"
+            0 (length (bag->list (bag-increment! (B 1 1) 1 -5))))
+(test-assert "bag-product with a negative n does not produce a negative count"
+             (>= (bag-size (bag-product -1 (B 1 1))) 0))
 
 ;; Discriminating controls: the same loops terminate for zero and positive
 ;; multiplicities, so the non-termination is specific to a negative count.

--- a/tests/scheme/srfi/srfi146-differential.scm
+++ b/tests/scheme/srfi/srfi146-differential.scm
@@ -625,22 +625,19 @@
 ;;; --------------------------------------------------- comparator plumbing
 
 (test-group "comparator plumbing"
-  ;; A comparator whose equality is = makes 1 and 1.0 the same key.  The ordered
-  ;; library honours it; the hash library discards the comparator (#2044).
+  ;; A comparator whose equality is = makes 1 and 1.0 the same key.  Both
+  ;; libraries honour it; the hash library used to discard the comparator
+  ;; and key its tables with equal? regardless (#2044).
   (define numo (make-comparator number? = < (lambda (x) 0)))
   (define numh (make-comparator number? = #f (lambda (x) (exact (floor (abs x))))))
   (test-equal "ordered: a = comparator merges 1 and 1.0" 1
     (mapping-size (mapping numo 1 'a 1.0 'b)))
   (test-equal "ordered: a = comparator finds 1 via 1.0" 'a
     (mapping-ref/default (mapping numo 1 'a) 1.0 'MISSING))
-  ;; FAIL: #2044 ((srfi 146 hash) discards its comparator and always uses equal?)
-  ;; (test-equal "hash: a = comparator merges 1 and 1.0" 1
-  ;;   (hashmap-size (hashmap numh 1 'a 1.0 'b)))
-  ;; FAIL: #2044
-  ;; (test-equal "hash: a = comparator finds 1 via 1.0" 'a
-  ;;   (hashmap-ref/default (hashmap numh 1 'a) 1.0 'MISSING))
-  (test-equal "pins #2044: hash currently splits 1 and 1.0" 2
+  (test-equal "hash: a = comparator merges 1 and 1.0" 1
     (hashmap-size (hashmap numh 1 'a 1.0 'b)))
+  (test-equal "hash: a = comparator finds 1 via 1.0" 'a
+    (hashmap-ref/default (hashmap numh 1 'a) 1.0 'MISSING))
 
   ;; Case-insensitive string keys, the same story.
   (define cio (make-comparator string? string-ci=?
@@ -648,9 +645,8 @@
                                (lambda (s) (string-hash (string-downcase s)))))
   (test-assert "ordered: a case-insensitive comparator matches Foo and foo"
     (mapping-contains? (mapping cio "Foo" 1) "foo"))
-  ;; FAIL: #2044
-  ;; (test-assert "hash: a case-insensitive comparator matches Foo and foo"
-  ;;   (hashmap-contains? (hashmap cio "Foo" 1) "foo"))
+  (test-assert "hash: a case-insensitive comparator matches Foo and foo"
+    (hashmap-contains? (hashmap cio "Foo" 1) "foo"))
 
   ;; The key comparator is retained and propagated by every derived operation.
   (test-assert "ordered: key-comparator survives filter"
@@ -930,10 +926,13 @@
 ;;; ---------------------------------------- deeply nested keys, pinning #2023
 
 (test-group "deeply nested keys"
-  ;; #2023: the native equal? hash returns a raw pointer for anything at depth
-  ;; MAX_HASH_DEPTH = 8, so structurally equal keys land in unrelated buckets.
-  ;; (srfi 146 hash) reaches that code and, because it discards its comparator
-  ;; (#2044), has no way around it.  The ordered library never hashes.
+  ;; #2023: the native equal? hash returned a raw pointer for anything at
+  ;; depth MAX_HASH_DEPTH = 8, so structurally equal keys landed in unrelated
+  ;; buckets.  #2023 itself is fixed (c742af68), and since #2044 the hash
+  ;; library keys its tables with the comparator, so a make-default-comparator
+  ;; hashmap never reaches the native equal? hash at all — its custom-mode
+  ;; default-hash recurses without a depth limit.  The ordered library never
+  ;; hashes.  The disabled assertions below date from before both fixes.
   (define (deep depth i)
     (let loop ((k depth) (acc (list i))) (if (= k 0) acc (loop (- k 1) (cons k acc)))))
   (define (hash-misses depth n)

--- a/tests/scheme/srfi/srfi146-differential.scm
+++ b/tests/scheme/srfi/srfi146-differential.scm
@@ -648,6 +648,40 @@
   (test-assert "hash: a case-insensitive comparator matches Foo and foo"
     (hashmap-contains? (hashmap cio "Foo" 1) "foo"))
 
+  ;; Every derived hashmap constructor must key its backing table with the
+  ;; comparator it was given, not equal? — pinning each changed
+  ;; make-hash-table call site in #2044 with keys only a comparator whose
+  ;; equality is = can merge (1 vs 1.0).
+  (test-equal "hashmap-unfold uses the comparator" 1
+    (hashmap-size
+      (hashmap-unfold (lambda (s) (> s 2))
+                      (lambda (s) (values (if (= s 1) 1 1.0) s))
+                      (lambda (s) (+ s 1)) 1 numh)))
+  (define (numh-map m)
+    (hashmap-map (lambda (k v) (values (if (= k 1) 1 1.0) v)) numh m))
+  (test-equal "hashmap-map keys the result with its comparator" 1
+    (hashmap-size (numh-map (hashmap c 1 'a 2 'b))))
+  (test-assert "hashmap-map: a merged key finds either spelling"
+    (not (eq? 'MISSING (hashmap-ref/default (numh-map (hashmap c 1 'a 2 'b))
+                                            1.0 'MISSING))))
+  (call-with-values
+    (lambda () (hashmap-partition (lambda (k v) (even? k))
+                                  (hashmap numh 1 'a 2 'b)))
+    (lambda (yes no)
+      (test-equal "hashmap-partition keeps the comparator in both sides" 'a
+        (hashmap-ref/default no 1.0 'MISSING))))
+  (test-equal "alist->hashmap merges comparator-equal keys" 1
+    (hashmap-size (alist->hashmap numh '((1 . a) (1.0 . b)))))
+  (test-equal "alist->hashmap keeps the earlier comparator-equal association" 'a
+    (hashmap-ref/default (alist->hashmap numh '((1 . a) (1.0 . b))) 1.0 'MISSING))
+  (define h1 (hashmap numh 1 'a))
+  (test-equal "hashmap-intersection matches comparator-equal keys" 1
+    (hashmap-size (hashmap-intersection h1 (hashmap numh 1.0 'x))))
+  (test-equal "hashmap-difference drops comparator-equal keys" 0
+    (hashmap-size (hashmap-difference h1 (hashmap numh 1.0 'x))))
+  (test-equal "hashmap-xor treats comparator-equal keys as shared" 0
+    (hashmap-size (hashmap-xor h1 (hashmap numh 1.0 'x))))
+
   ;; The key comparator is retained and propagated by every derived operation.
   (test-assert "ordered: key-comparator survives filter"
     (eq? numo (mapping-key-comparator (mapping-filter (lambda (k v) #t) (mapping numo 1 'a)))))

--- a/tests/scheme/srfi/srfi146-differential.scm
+++ b/tests/scheme/srfi/srfi146-differential.scm
@@ -931,8 +931,13 @@
   ;; buckets.  #2023 itself is fixed (c742af68), and since #2044 the hash
   ;; library keys its tables with the comparator, so a make-default-comparator
   ;; hashmap never reaches the native equal? hash at all — its custom-mode
-  ;; default-hash recurses without a depth limit.  The ordered library never
-  ;; hashes.  The disabled assertions below date from before both fixes.
+  ;; default-hash recurses without a depth limit.  That is strictly better
+  ;; for deep acyclic keys, but note the cost: a cyclic key now runs
+  ;; default-hash into the stack cap (KP3008, uncatchable) where the old
+  ;; depth-capped native hash absorbed it — a low-priority SRFI-128
+  ;; follow-up (depth-limit default-hash) is tracked in kaappi#2235.  The
+  ;; ordered library never hashes.  The disabled assertions below date from
+  ;; before both fixes.
   (define (deep depth i)
     (let loop ((k depth) (acc (list i))) (if (= k 0) acc (loop (- k 1) (cons k acc)))))
   (define (hash-misses depth n)

--- a/tests/scheme/srfi/srfi42.scm
+++ b/tests/scheme/srfi/srfi42.scm
@@ -63,6 +63,48 @@
 ;; Early exit composes with guards.
 (test-equal "any?-ec with a guard on an infinite generator" #t
             (any?-ec (:integers i) (if (even? i)) (> i 10)))
+;; A stopped comprehension must not advance a side-effecting generator: the
+;; reference folds the stop check into the generator step, so :port must not
+;; read one extra datum, and :dispatched/:parallel generator procedures must
+;; not be called once more.  (:range-style steps are pure arithmetic and
+;; invisible; these three are not.)
+(test-equal "first-ec over :port reads exactly one datum" '(#\a #\b)
+            (call-with-port (open-input-string "abcd")
+              (lambda (p)
+                (let ((r (first-ec 'none (:port c p read-char) c)))
+                  (list r (read-char p))))))
+(test-equal "any?-ec over :port stops without over-reading" '(#t 3)
+            (call-with-port (open-input-string "1 2 3")
+              (lambda (p)
+                (let ((r (any?-ec (:port v p) (> v 1))))
+                  (list r (read p))))))
+(test-equal "first-ec over :dispatched advances the generator exactly once" 1
+            (let ((calls 0))
+              (first-ec 'none
+                (:dispatched i (lambda (args)
+                                 (lambda (empty)
+                                   (set! calls (+ calls 1))
+                                   (if (< calls 10) 0 empty)))
+                            'x)
+                i)
+              calls))
+(test-equal "first-ec over :parallel advances each generator exactly once"
+            '(1 1)
+            (let ((ca 0) (cb 0))
+              (first-ec 'none
+                (:parallel
+                  (:dispatched i (lambda (args)
+                                   (lambda (empty)
+                                     (set! ca (+ ca 1))
+                                     (if (< ca 10) 0 empty)))
+                              'x)
+                  (:dispatched j (lambda (args)
+                                   (lambda (empty)
+                                     (set! cb (+ cb 1))
+                                     (if (< cb 10) 0 empty)))
+                              'y))
+                (list i j))
+              (list ca cb)))
 
 ;;; --- do-ec for effects ---
 (test-equal "do-ec"

--- a/tests/scheme/srfi/srfi42.scm
+++ b/tests/scheme/srfi/srfi42.scm
@@ -33,6 +33,37 @@
 (test-equal "vector-ec" #(0 1) (vector-ec (:range i 2) i))
 (test-equal "append-ec" '(1 2 3 4) (append-ec (:list xs '((1 2) (3 4))) xs))
 
+;;; --- first-ec / any?-ec / every?-ec stop early (#2179) ---
+;;; The spec gives all three early-exit semantics: first-ec stops "after the
+;;; first value" and any?-ec/every?-ec stop "as soon as the result is
+;;; known", so they must terminate on infinite generators -- before the fix
+;;; each materialised the whole comprehension and hung.
+(test-equal "first-ec on an infinite generator" 0
+            (first-ec #f (:integers i) i))
+(test-equal "any?-ec on an infinite generator" #t
+            (any?-ec (:integers i) (> i 5)))
+(test-equal "every?-ec on an infinite generator" #f
+            (every?-ec (:integers i) (< i 5)))
+;; Work measurement: expr runs exactly once under first-ec, and the
+;; ?-ec predicates stop as soon as the answer is known.
+(test-equal "first-ec evaluates expr once" 1
+            (let ((n 0))
+              (first-ec 'none (:integers i) (begin (set! n (+ n 1)) n))))
+(test-equal "any?-ec stops at the first true value" 4
+            (let ((n 0))
+              (any?-ec (:integers i) (begin (set! n (+ n 1)) (> n 3)))
+              n))
+(test-equal "every?-ec stops at the first false value" 3
+            (let ((n 0))
+              (every?-ec (:integers i) (begin (set! n (+ n 1)) (< n 3)))
+              n))
+;; first-ec stops the whole comprehension, not just the innermost generator.
+(test-equal "first-ec stops the whole nested product" '(1 3)
+            (first-ec 'none (:list a '(1 2)) (:list b '(3 4)) (list a b)))
+;; Early exit composes with guards.
+(test-equal "any?-ec with a guard on an infinite generator" #t
+            (any?-ec (:integers i) (if (even? i)) (> i 10)))
+
 ;;; --- do-ec for effects ---
 (test-equal "do-ec"
   '(0 1 2)


### PR DESCRIPTION
Three wrong-result/hang bugs found by the systematic audit, all in portable SRFI libraries — one PR as each is a small, self-contained library fix.

## #2044 — `(srfi 146 hash)` discarded its comparator

Every constructor built a bare `(make-hash-table)`, so key identity was always `equal?` regardless of the comparator the caller supplied: `1` and `1.0` stayed distinct keys under a comparator whose equality is `=`, and a case-insensitive string comparator never matched `Foo` to `foo` — while the ordered `(srfi 146)` sibling got both right. All nine `make-hash-table` call sites (`hashmap`, `hashmap-unfold`, `hashmap-map`, `hashmap-filter`, `hashmap-partition`, `hashmap-intersection`, `hashmap-difference`, `hashmap-xor`, `alist->hashmap`) now thread the comparator through. The built-in SRFI-69 table already detects a `<comparator>` record and falls into `.custom` mode, calling its equality and hash functions.

## #2085 — SRFI-113 bags could hold negative multiplicities

- `bag-increment!` ignored the spec's "but not less than zero" clamp.
- `bag-product` never validated `n` (the reference implementation's `valid-n` check discards its result).
- `bag->list`, `bag-for-each` and `bag-fold` each expand a multiplicity with `(= i count)`, so a negative count looped forever, consing without bound.

Fixes: `bag-increment!` drops the element when the result would be non-positive (matching `bag-decrement!`); `bag-product!` clamps a negative `n` at zero; the three loops test `(>= i count)` so no count value can hang them, whatever route produced it.

## #2179 — `first-ec`/`any?-ec`/`every?-ec` materialized the whole comprehension

`first-ec` expanded to `list-ec` and took `car`; the two predicates ran the full `do-ec` loop. So `(first-ec #f (:integers i) i)` hung despite SRFI 42 giving all three early-exit semantics ("stop the loop after the first value"; "as soon as the result is known"). Each now allocates its own stop flag and sets it from the body; every `%do-ec` generator loop checks the flag before each iteration, so setting it unwinds the comprehension.

## Tests

Re-enabled the disabled assertions for all three issues in `srfi146-differential.scm` and `srfi113-audit.scm`, and added new early-exit tests to `srfi42.scm` (infinite `:integers` generators plus work-measurement checks that `first-ec` evaluates the expression exactly once and the predicates stop at the first deciding value).

Full suite: 2084 pass, 0 fail (includes R7RS 1395). markdownlint clean.


Fixes #2044
Fixes #2085
Fixes #2179
