### PR TITLE
Classify a skill's evals.json as an inert docs-only path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,10 @@ jobs:
       # `.md` under either is, because nothing in CI reads one. Every
       # `docs/`-or-`.md` reference in build.zig, tools/, src/tests_*.zig and
       # tests/scheme/**/*.sh is a comment, so no markdown change can fail the
-      # suites this skips.
+      # suites this skips. A skill's `evals/evals.json` is inert for the same
+      # reason: it is consumed by the skill-eval harness, never by a
+      # workflow, so a PR touching only a SKILL.md and its sibling evals
+      # file still skips the matrix.
       - name: Classify changed paths
         id: classify
         env:
@@ -87,7 +90,7 @@ jobs:
             while IFS= read -r f; do
               [ -n "$f" ] || continue
               case "$f" in
-                *.md|docs/*|LICENSE) ;;
+                *.md|docs/*|LICENSE|.claude/skills/*/evals/*.json) ;;
                 *) docs_only=false; reason="$f is not an inert path"; break ;;
               esac
             done <<< "$files"


### PR DESCRIPTION
Closes #2237

## Summary

The `format` job's changed-path classifier skips the ~194 runner-minutes
of build/test matrix for docs-only PRs. Its allowlist covered `*.md`,
`docs/*` and `LICENSE`, but not a skill's `evals/evals.json`, so a PR
touching only a `SKILL.md` and its sibling `evals.json` ran the whole
matrix for content no CI job reads.

## Change

Add one alternative to the existing allowlist arm
(`.github/workflows/ci.yml:90`):

```sh
*.md|docs/*|LICENSE|.claude/skills/*/evals/*.json) ;;
```

Deliberately narrow: it covers eval fixtures under a skill directory and
nothing else. `.claude/settings.json`, hook scripts, and any other
`.json` in the tree keep falling through to the full matrix, preserving
the allowlist-never-denylist property.

## Evidence the path is inert

`grep -rn 'evals\.json' build.zig tools/ .github/workflows/ src/tests_*.zig`
returns nothing — the only hit in the tree is a prose comment in `ci.yml`
itself. The file is consumed by the skill-eval harness, never by a
workflow.

## Testing

The classifier case statement was exercised against the issue's scenarios
plus the tight-glob boundary cases:

| Path | Result |
|---|---|
| `.claude/skills/pr-groups/evals/evals.json` | inert (skips matrix) |
| `.claude/skills/pr-groups/SKILL.md` | inert (already covered) |
| `.claude/settings.json` | full matrix |
| `.claude/hooks/bash-guard-pre.sh` | full matrix |
| `.claude/skills/whatever.json` | full matrix (not under `evals/`) |
| `src/main.zig`, `.github/workflows/ci.yml` | full matrix |

Also updated the classifier's comment to record why `evals/evals.json`
is inert.