### PR TITLE
Bounds-check fixnum indices in u64 before narrowing to usize (#1912)

### DIFF
--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -538,6 +538,22 @@ pub fn argError(proc: []const u8, comptime explanation: []const u8, fmt_args: an
     return PrimitiveError.InvalidArgument;
 }
 
+/// Whether non-negative fixnum `idx` is strictly inside `len` on every
+/// target, by comparing in u64 BEFORE any narrowing to usize.  On wasm32
+/// (usize = u32) a fixnum-range index (up to 2^47) would otherwise truncate
+/// inside a `@as(usize, @intCast(...))` bounds comparison and silently alias
+/// an in-range element -- a wrong read, and for the set! family a wrong
+/// write (kaappi#1912).  `fixnumIndexInBoundsInclusive` is the range-end
+/// variant (start/end pairs), where an index equal to the length is legal.
+pub inline fn fixnumIndexInBounds(idx: i64, len: usize) bool {
+    return idx >= 0 and @as(u64, @intCast(idx)) < @as(u64, len);
+}
+
+/// `fixnumIndexInBounds`, but inclusive: `idx <= len`.
+pub inline fn fixnumIndexInBoundsInclusive(idx: i64, len: usize) bool {
+    return idx >= 0 and @as(u64, @intCast(idx)) <= @as(u64, len);
+}
+
 pub const Range = struct { start: usize, end: usize };
 
 pub fn parseOptionalRange(args: []const Value, arg_offset: usize, max_len: usize, proc_name: []const u8) PrimitiveError!Range {
@@ -546,13 +562,13 @@ pub fn parseOptionalRange(args: []const Value, arg_offset: usize, max_len: usize
     if (args.len > arg_offset) {
         if (!types.isFixnum(args[arg_offset])) return typeError(proc_name, "exact integer", args[arg_offset]);
         const s = types.toFixnum(args[arg_offset]);
-        if (s < 0 or @as(usize, @intCast(s)) > max_len) return typeError(proc_name, "valid index", args[arg_offset]);
+        if (!fixnumIndexInBoundsInclusive(s, max_len)) return typeError(proc_name, "valid index", args[arg_offset]);
         start = @intCast(s);
     }
     if (args.len > arg_offset + 1) {
         if (!types.isFixnum(args[arg_offset + 1])) return typeError(proc_name, "exact integer", args[arg_offset + 1]);
         const e = types.toFixnum(args[arg_offset + 1]);
-        if (e < 0 or @as(usize, @intCast(e)) > max_len) return typeError(proc_name, "valid index", args[arg_offset + 1]);
+        if (!fixnumIndexInBoundsInclusive(e, max_len)) return typeError(proc_name, "valid index", args[arg_offset + 1]);
         end = @intCast(e);
     }
     if (start > end) return typeError(proc_name, "start <= end", args[arg_offset]);
@@ -1064,8 +1080,9 @@ fn recordRefFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[1])) return typeError("%record-ref", "exact integer", args[1]);
     const raw_idx = types.toFixnum(args[1]);
     if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+    // u64 comparison before narrowing (kaappi#1912): see fixnumIndexInBounds.
+    if (!fixnumIndexInBounds(raw_idx, ri.fields.len)) return indexError("%record-ref", raw_idx, ri.fields.len);
     const idx: usize = @intCast(raw_idx);
-    if (idx >= ri.fields.len) return indexError("%record-ref", raw_idx, ri.fields.len);
     return ri.fields[idx];
 }
 
@@ -1079,8 +1096,9 @@ fn recordSetFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[1])) return typeError("%record-set!", "exact integer", args[1]);
     const raw_idx = types.toFixnum(args[1]);
     if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+    // u64 comparison before narrowing (kaappi#1912): see fixnumIndexInBounds.
+    if (!fixnumIndexInBounds(raw_idx, ri.fields.len)) return indexError("%record-set!", raw_idx, ri.fields.len);
     const idx: usize = @intCast(raw_idx);
-    if (idx >= ri.fields.len) return indexError("%record-set!", raw_idx, ri.fields.len);
     if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[2]);
     ri.fields[idx] = args[2];
     return types.VOID;

--- a/src/primitives_bytevector.zig
+++ b/src/primitives_bytevector.zig
@@ -80,7 +80,8 @@ fn bytevectorU8Ref(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[1])) return primitives.typeError("bytevector-u8-ref", "exact integer", args[1]);
     const bv = types.toBytevector(args[0]);
     const idx = types.toFixnum(args[1]);
-    if (idx < 0 or @as(usize, @intCast(idx)) >= bv.data.len) return primitives.typeError("bytevector-u8-ref", "valid index", args[1]);
+    // u64 comparison before narrowing (kaappi#1912): see fixnumIndexInBounds.
+    if (!primitives.fixnumIndexInBounds(idx, bv.data.len)) return primitives.typeError("bytevector-u8-ref", "valid index", args[1]);
     return types.makeFixnum(@intCast(bv.data[@intCast(@as(u64, @bitCast(idx)))]));
 }
 
@@ -92,7 +93,8 @@ fn bytevectorU8Set(args: []const Value) PrimitiveError!Value {
     const bv = types.toBytevector(args[0]);
     const idx = types.toFixnum(args[1]);
     const val = types.toFixnum(args[2]);
-    if (idx < 0 or @as(usize, @intCast(idx)) >= bv.data.len) return primitives.typeError("bytevector-u8-set!", "valid index", args[1]);
+    // u64 comparison before narrowing (kaappi#1912): see fixnumIndexInBounds.
+    if (!primitives.fixnumIndexInBounds(idx, bv.data.len)) return primitives.typeError("bytevector-u8-set!", "valid index", args[1]);
     if (val < 0 or val > 255) return primitives.typeError("bytevector-u8-set!", "exact integer 0-255", args[2]);
     // Lever D copy-on-write (kaappi#1472): if this bytevector borrows a shared
     // immutable buffer, privatize it before writing. No-op otherwise.
@@ -123,6 +125,9 @@ fn bytevectorCopyBang(args: []const Value) PrimitiveError!Value {
     const to = types.toBytevector(args[0]);
     const at_val = types.toFixnum(args[1]);
     if (at_val < 0) return primitives.typeError("bytevector-copy!", "non-negative integer", args[1]);
+    // u64 comparison before narrowing (kaappi#1912): on wasm32 a fixnum-range
+    // at would truncate and pass the at+count check against a short bytevector.
+    if (!primitives.fixnumIndexInBoundsInclusive(at_val, to.data.len)) return primitives.typeError("bytevector-copy!", "valid range", args[0]);
     const at: usize = @intCast(@as(u64, @bitCast(at_val)));
     const from = types.toBytevector(args[2]);
 

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -1782,16 +1782,20 @@ fn writeStringFn(args: []const Value) PrimitiveError!Value {
     const cp_count = string_mod.utf8CodepointCount(data);
     var start_cp: usize = 0;
     var end_cp: usize = cp_count;
+    var start_raw: i64 = 0;
+    var end_raw: i64 = @intCast(cp_count);
     if (args.len > 2) {
         if (!types.isFixnum(args[2])) return primitives.typeError("write-string", "integer", args[2]);
         const s = types.toFixnum(args[2]);
         if (s < 0) return primitives.typeError("write-string", "non-negative integer", args[2]);
+        start_raw = s;
         start_cp = @intCast(s);
     }
     if (args.len > 3) {
         if (!types.isFixnum(args[3])) return primitives.typeError("write-string", "integer", args[3]);
         const e = types.toFixnum(args[3]);
         if (e < 0) return primitives.typeError("write-string", "non-negative integer", args[3]);
+        end_raw = e;
         end_cp = @intCast(e);
     }
     // Report the *index* that is out of range, not the string: `args[0]` is
@@ -1799,9 +1803,14 @@ fn writeStringFn(args: []const Value) PrimitiveError!Value {
     // house precedent for a start/end pair) already names the index. An
     // inverted-but-in-range pair is neither a type nor a range fault, so it
     // is argError rather than indexError.
-    if (end_cp > cp_count) return primitives.indexError("write-string", @intCast(end_cp), cp_count);
-    if (start_cp > cp_count) return primitives.indexError("write-string", @intCast(start_cp), cp_count);
-    if (start_cp > end_cp) return primitives.argError("write-string", "start {d} is greater than end {d}", .{ start_cp, end_cp });
+    //
+    // The range checks compare the raw fixnums in u64 BEFORE the narrowing
+    // casts: on wasm32 (usize = u32) a fixnum-range index would truncate and
+    // slip past `end_cp > cp_count` (kaappi#1912).  Check order and the
+    // reported index are unchanged from the pre-fix code on 64-bit hosts.
+    if (!primitives.fixnumIndexInBoundsInclusive(end_raw, cp_count)) return primitives.indexError("write-string", end_raw, cp_count);
+    if (!primitives.fixnumIndexInBoundsInclusive(start_raw, cp_count)) return primitives.indexError("write-string", start_raw, cp_count);
+    if (start_raw > end_raw) return primitives.argError("write-string", "start {d} is greater than end {d}", .{ start_cp, end_cp });
     const byte_start = string_mod.utf8IndexToByteOffset(data, start_cp) orelse return primitives.indexError("write-string", @intCast(start_cp), cp_count);
     const byte_end = string_mod.utf8IndexToByteOffset(data, end_cp) orelse return primitives.indexError("write-string", @intCast(end_cp), cp_count);
     try portWriteBytes(port, data[byte_start..byte_end]);

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -1789,14 +1789,12 @@ fn writeStringFn(args: []const Value) PrimitiveError!Value {
         const s = types.toFixnum(args[2]);
         if (s < 0) return primitives.typeError("write-string", "non-negative integer", args[2]);
         start_raw = s;
-        start_cp = @intCast(s);
     }
     if (args.len > 3) {
         if (!types.isFixnum(args[3])) return primitives.typeError("write-string", "integer", args[3]);
         const e = types.toFixnum(args[3]);
         if (e < 0) return primitives.typeError("write-string", "non-negative integer", args[3]);
         end_raw = e;
-        end_cp = @intCast(e);
     }
     // Report the *index* that is out of range, not the string: `args[0]` is
     // the one argument here that is never at fault, and `substring` (the
@@ -1804,15 +1802,19 @@ fn writeStringFn(args: []const Value) PrimitiveError!Value {
     // inverted-but-in-range pair is neither a type nor a range fault, so it
     // is argError rather than indexError.
     //
-    // The range checks compare the raw fixnums in u64 BEFORE the narrowing
-    // casts: on wasm32 (usize = u32) a fixnum-range index would truncate and
-    // slip past `end_cp > cp_count` (kaappi#1912).  Check order and the
-    // reported index are unchanged from the pre-fix code on 64-bit hosts.
+    // The range checks compare the raw fixnums in u64 BEFORE any narrowing:
+    // on wasm32 (usize = u32) a fixnum-range index would otherwise truncate
+    // and slip past `end_cp > cp_count`, or panic @intCast on a safety-checked
+    // build (kaappi#1912).  The narrowing casts run only after the checks
+    // pass.  Check order and the reported index are unchanged from the
+    // pre-fix code on 64-bit hosts.
     if (!primitives.fixnumIndexInBoundsInclusive(end_raw, cp_count)) return primitives.indexError("write-string", end_raw, cp_count);
     if (!primitives.fixnumIndexInBoundsInclusive(start_raw, cp_count)) return primitives.indexError("write-string", start_raw, cp_count);
-    if (start_raw > end_raw) return primitives.argError("write-string", "start {d} is greater than end {d}", .{ start_cp, end_cp });
-    const byte_start = string_mod.utf8IndexToByteOffset(data, start_cp) orelse return primitives.indexError("write-string", @intCast(start_cp), cp_count);
-    const byte_end = string_mod.utf8IndexToByteOffset(data, end_cp) orelse return primitives.indexError("write-string", @intCast(end_cp), cp_count);
+    if (start_raw > end_raw) return primitives.argError("write-string", "start {d} is greater than end {d}", .{ start_raw, end_raw });
+    start_cp = @intCast(start_raw);
+    end_cp = @intCast(end_raw);
+    const byte_start = string_mod.utf8IndexToByteOffset(data, start_cp) orelse return primitives.indexError("write-string", start_raw, cp_count);
+    const byte_end = string_mod.utf8IndexToByteOffset(data, end_cp) orelse return primitives.indexError("write-string", end_raw, cp_count);
     try portWriteBytes(port, data[byte_start..byte_end]);
     return types.VOID;
 }

--- a/src/primitives_srfi1.zig
+++ b/src/primitives_srfi1.zig
@@ -590,14 +590,17 @@ fn takeFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[1])) return primitives.typeError("take", "integer", args[1]);
     const k = types.toFixnum(args[1]);
     if (k < 0) return primitives.typeError("take", "non-negative integer", args[1]);
-    const count: usize = @intCast(k);
 
     var elems: std.ArrayList(Value) = .empty;
     defer elems.deinit(gc.allocator);
 
     var current = args[0];
-    var i: usize = 0;
-    while (i < count) : (i += 1) {
+    // Walk in i64, never narrowing the fixnum to usize: on wasm32 (usize =
+    // u32) a fixnum-range k would truncate and silently return a short list
+    // instead of walking to the end and raising (kaappi#1912).  `drop` below
+    // already loops this way.
+    var i: i64 = 0;
+    while (i < k) : (i += 1) {
         if (!types.isPair(current)) return primitives.typeError("take", "pair", current);
         elems.append(gc.allocator, types.car(current)) catch return PrimitiveError.OutOfMemory;
         current = types.cdr(current);
@@ -1187,14 +1190,15 @@ fn splitAtFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[1])) return primitives.typeError("split-at", "integer", args[1]);
     const k = types.toFixnum(args[1]);
     if (k < 0) return primitives.typeError("split-at", "non-negative integer", args[1]);
-    const count: usize = @intCast(k);
 
     var elems: std.ArrayList(Value) = .empty;
     defer elems.deinit(gc.allocator);
 
     var current = args[0];
-    var i: usize = 0;
-    while (i < count) : (i += 1) {
+    // Walk in i64, never narrowing the fixnum to usize (kaappi#1912): see
+    // takeFn's identical loop.
+    var i: i64 = 0;
+    while (i < k) : (i += 1) {
         if (!types.isPair(current)) return primitives.typeError("split-at", "pair", current);
         elems.append(gc.allocator, types.car(current)) catch return PrimitiveError.OutOfMemory;
         current = types.cdr(current);

--- a/src/primitives_srfi160.zig
+++ b/src/primitives_srfi160.zig
@@ -284,7 +284,9 @@ fn numericVectorRefFn(args: []const Value) PrimitiveError!Value {
     const raw_idx = types.toFixnum(args[1]);
     const width = nv.kind.elementWidth();
     const len = nv.data.len / width;
-    if (raw_idx < 0 or @as(usize, @intCast(raw_idx)) >= len) return indexError("%numeric-vector-ref", raw_idx, len);
+    // u64 comparison before narrowing (kaappi#1912): see fixnumIndexInBounds --
+    // the same hazard makeNumericVectorFn guards for the length argument.
+    if (raw_idx < 0 or !primitives.fixnumIndexInBounds(raw_idx, len)) return indexError("%numeric-vector-ref", raw_idx, len);
     const idx: usize = @intCast(raw_idx);
     return decodeElement(gc, nv.kind, nv.data[idx * width ..][0..width]);
 }
@@ -296,7 +298,8 @@ fn numericVectorSetFn(args: []const Value) PrimitiveError!Value {
     const raw_idx = types.toFixnum(args[1]);
     const width = nv.kind.elementWidth();
     const len = nv.data.len / width;
-    if (raw_idx < 0 or @as(usize, @intCast(raw_idx)) >= len) return indexError("%numeric-vector-set!", raw_idx, len);
+    // u64 comparison before narrowing (kaappi#1912): see fixnumIndexInBounds.
+    if (raw_idx < 0 or !primitives.fixnumIndexInBounds(raw_idx, len)) return indexError("%numeric-vector-set!", raw_idx, len);
     const idx: usize = @intCast(raw_idx);
     try encodeElement("%numeric-vector-set!", nv.kind, args[2], nv.data[idx * width ..][0..width]);
     return types.VOID;

--- a/src/primitives_srfi237.zig
+++ b/src/primitives_srfi237.zig
@@ -356,7 +356,6 @@ fn recordSplitArgsFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const suffix_len_raw = try expectFixnum("%record-split-args", args[1]);
     if (suffix_len_raw < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
-    const suffix_len: usize = @intCast(suffix_len_raw);
     var buf: [256]Value = undefined;
     var n: usize = 0;
     var cur = args[0];
@@ -368,8 +367,11 @@ fn recordSplitArgsFn(args: []const Value) PrimitiveError!Value {
         cur = types.cdr(cur);
     }
     // u64 comparison before narrowing (kaappi#1912): on wasm32 a fixnum-range
-    // suffix would truncate and pass the check against a short list.
+    // suffix would truncate and pass the check against a short list, or panic
+    // @intCast on a safety-checked build.  The narrowing runs only after the
+    // check passes.
     if (!primitives.fixnumIndexInBoundsInclusive(suffix_len_raw, n)) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+    const suffix_len: usize = @intCast(suffix_len_raw);
     const split = n - suffix_len;
 
     var prefix = gc.makeList(buf[0..split]) catch return PrimitiveError.OutOfMemory;

--- a/src/primitives_srfi237.zig
+++ b/src/primitives_srfi237.zig
@@ -336,8 +336,9 @@ fn recordRefInheritFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[1])) return typeError("%record-ref/inherit", "exact integer", args[1]);
     const raw_idx = types.toFixnum(args[1]);
     if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+    // u64 comparison before narrowing (kaappi#1912): see primitives.fixnumIndexInBounds.
+    if (!primitives.fixnumIndexInBounds(raw_idx, ri.fields.len)) return indexError("%record-ref/inherit", raw_idx, ri.fields.len);
     const idx: usize = @intCast(raw_idx);
-    if (idx >= ri.fields.len) return indexError("%record-ref/inherit", raw_idx, ri.fields.len);
     return ri.fields[idx];
 }
 
@@ -356,7 +357,6 @@ fn recordSplitArgsFn(args: []const Value) PrimitiveError!Value {
     const suffix_len_raw = try expectFixnum("%record-split-args", args[1]);
     if (suffix_len_raw < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
     const suffix_len: usize = @intCast(suffix_len_raw);
-
     var buf: [256]Value = undefined;
     var n: usize = 0;
     var cur = args[0];
@@ -367,7 +367,9 @@ fn recordSplitArgsFn(args: []const Value) PrimitiveError!Value {
         n += 1;
         cur = types.cdr(cur);
     }
-    if (suffix_len > n) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+    // u64 comparison before narrowing (kaappi#1912): on wasm32 a fixnum-range
+    // suffix would truncate and pass the check against a short list.
+    if (!primitives.fixnumIndexInBoundsInclusive(suffix_len_raw, n)) return PrimitiveError.TypeError; // bare-ok: internal record primitive
     const split = n - suffix_len;
 
     var prefix = gc.makeList(buf[0..split]) catch return PrimitiveError.OutOfMemory;
@@ -387,8 +389,9 @@ fn recordSetInheritFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[1])) return typeError("%record-set!/inherit", "exact integer", args[1]);
     const raw_idx = types.toFixnum(args[1]);
     if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+    // u64 comparison before narrowing (kaappi#1912): see primitives.fixnumIndexInBounds.
+    if (!primitives.fixnumIndexInBounds(raw_idx, ri.fields.len)) return indexError("%record-set!/inherit", raw_idx, ri.fields.len);
     const idx: usize = @intCast(raw_idx);
-    if (idx >= ri.fields.len) return indexError("%record-set!/inherit", raw_idx, ri.fields.len);
     if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[2]);
     ri.fields[idx] = args[2];
     return types.VOID;
@@ -457,8 +460,9 @@ fn recordFieldMutableFn(args: []const Value) PrimitiveError!Value {
     const rt = asRecordType(args[0]);
     const raw_idx = try expectFixnum("%record-field-mutable?", args[1]);
     if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+    // u64 comparison before narrowing (kaappi#1912): see primitives.fixnumIndexInBounds.
+    if (!primitives.fixnumIndexInBounds(raw_idx, rt.own_field_mutable.len)) return indexError("%record-field-mutable?", raw_idx, rt.own_field_mutable.len);
     const idx: usize = @intCast(raw_idx);
-    if (idx >= rt.own_field_mutable.len) return indexError("%record-field-mutable?", raw_idx, rt.own_field_mutable.len);
     return if (rt.own_field_mutable[idx]) types.TRUE else types.FALSE;
 }
 

--- a/src/primitives_string.zig
+++ b/src/primitives_string.zig
@@ -155,7 +155,8 @@ fn stringRefFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[1])) return primitives.typeError("string-ref", "exact integer", args[1]);
     const k = types.toFixnum(args[1]);
     const str_len = utf8CodepointCount(data);
-    if (k < 0 or @as(usize, @intCast(k)) >= str_len) return primitives.indexError("string-ref", k, str_len);
+    // u64 comparison before narrowing (kaappi#1912): see fixnumIndexInBounds.
+    if (!primitives.fixnumIndexInBounds(k, str_len)) return primitives.indexError("string-ref", k, str_len);
     const byte_off = utf8IndexToByteOffset(data, @intCast(k)) orelse return primitives.indexError("string-ref", k, str_len);
     const cp = utf8DecodeAt(data, byte_off) orelse return primitives.typeError("string-ref", "valid UTF-8 string", args[0]);
     return types.makeChar(cp);
@@ -175,7 +176,8 @@ fn stringSetFn(args: []const Value) PrimitiveError!Value {
     const data = str.data[0..str.len];
     const k = types.toFixnum(args[1]);
     const str_len = utf8CodepointCount(data);
-    if (k < 0 or @as(usize, @intCast(k)) >= str_len) return primitives.indexError("string-set!", k, str_len);
+    // u64 comparison before narrowing (kaappi#1912): see fixnumIndexInBounds.
+    if (!primitives.fixnumIndexInBounds(k, str_len)) return primitives.indexError("string-set!", k, str_len);
     const char_idx: usize = @intCast(k);
     const byte_start = utf8IndexToByteOffset(data, char_idx) orelse return primitives.indexError("string-set!", k, str_len);
     const old_cp_len = utf8ByteLenAt(data, byte_start);
@@ -217,9 +219,14 @@ fn substringFn(args: []const Value) PrimitiveError!Value {
     const str_len = utf8CodepointCount(data);
     if (start_i < 0) return primitives.indexError("substring", start_i, str_len);
     if (end_i < 0) return primitives.indexError("substring", end_i, str_len);
+    // u64 comparisons before narrowing (kaappi#1912): on wasm32 a fixnum-range
+    // index would truncate and alias an in-range codepoint.  Order preserved
+    // from the pre-fix code so the reported index is unchanged on 64-bit.
+    if (@as(u64, @intCast(start_i)) > @as(u64, @intCast(end_i))) return primitives.indexError("substring", end_i, str_len);
+    if (!primitives.fixnumIndexInBoundsInclusive(start_i, str_len)) return primitives.indexError("substring", start_i, str_len);
+    if (!primitives.fixnumIndexInBoundsInclusive(end_i, str_len)) return primitives.indexError("substring", end_i, str_len);
     const start_cp: usize = @intCast(start_i);
     const end_cp: usize = @intCast(end_i);
-    if (start_cp > end_cp) return primitives.indexError("substring", end_i, str_len);
     const byte_start = utf8IndexToByteOffset(data, start_cp) orelse return primitives.indexError("substring", start_i, str_len);
     const byte_end = utf8IndexToByteOffset(data, end_cp) orelse return primitives.indexError("substring", end_i, str_len);
     return gc.allocString(data[byte_start..byte_end]) catch return PrimitiveError.OutOfMemory;
@@ -255,6 +262,10 @@ fn stringCopyBangFn(args: []const Value) PrimitiveError!Value {
     const to_cp_count = utf8CodepointCount(to_data);
     const at_val = types.toFixnum(args[1]);
     if (at_val < 0) return primitives.typeError("string-copy!", "non-negative integer", args[1]);
+    // u64 comparison before narrowing (kaappi#1912): on wasm32 a fixnum-range
+    // at would truncate and pass the at_cp+count check, writing to the wrong
+    // codepoint.
+    if (!primitives.fixnumIndexInBoundsInclusive(at_val, to_cp_count)) return primitives.typeError("string-copy!", "valid range", args[1]);
     const at_cp: usize = @intCast(at_val);
     const from_data = try getStringSlice("string-copy!", args[2]);
     const from_cp_count = utf8CodepointCount(from_data);

--- a/src/primitives_string_ext.zig
+++ b/src/primitives_string_ext.zig
@@ -463,6 +463,9 @@ fn stringTakeFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[1])) return primitives.typeError("string-take", "integer", args[1]);
     const nv = types.toFixnum(args[1]);
     if (nv < 0) return primitives.typeError("string-take", "non-negative integer", args[1]);
+    // u64 comparison before narrowing (kaappi#1912): on wasm32 a fixnum-range
+    // count would truncate and silently take fewer chars.
+    if (!primitives.fixnumIndexInBoundsInclusive(nv, utf8CodepointCount(data))) return PrimitiveError.IndexOutOfBounds;
     const n: usize = @intCast(nv);
     const byte_end = pstr.utf8IndexToByteOffset(data, n) orelse return PrimitiveError.IndexOutOfBounds;
     return gc.allocString(data[0..byte_end]) catch return PrimitiveError.OutOfMemory;
@@ -474,6 +477,9 @@ fn stringDropFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[1])) return primitives.typeError("string-drop", "integer", args[1]);
     const nv = types.toFixnum(args[1]);
     if (nv < 0) return primitives.typeError("string-drop", "non-negative integer", args[1]);
+    // u64 comparison before narrowing (kaappi#1912): on wasm32 a fixnum-range
+    // count would truncate and silently drop fewer chars.
+    if (!primitives.fixnumIndexInBoundsInclusive(nv, utf8CodepointCount(data))) return PrimitiveError.IndexOutOfBounds;
     const n: usize = @intCast(nv);
     const byte_start = pstr.utf8IndexToByteOffset(data, n) orelse return PrimitiveError.IndexOutOfBounds;
     return gc.allocString(data[byte_start..]) catch return PrimitiveError.OutOfMemory;
@@ -485,9 +491,11 @@ fn stringTakeRightFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[1])) return primitives.typeError("string-take-right", "integer", args[1]);
     const nv = types.toFixnum(args[1]);
     if (nv < 0) return primitives.typeError("string-take-right", "non-negative integer", args[1]);
-    const n: usize = @intCast(nv);
     const total_cp = utf8CodepointCount(data);
-    if (n > total_cp) return PrimitiveError.IndexOutOfBounds;
+    // u64 comparison before narrowing (kaappi#1912): on wasm32 a fixnum-range
+    // count would truncate and pass the n > total_cp check below.
+    if (!primitives.fixnumIndexInBoundsInclusive(nv, total_cp)) return PrimitiveError.IndexOutOfBounds;
+    const n: usize = @intCast(nv);
     if (n == total_cp) return gc.allocString(data) catch return PrimitiveError.OutOfMemory;
     const byte_start = pstr.utf8IndexToByteOffset(data, total_cp - n) orelse return PrimitiveError.IndexOutOfBounds;
     return gc.allocString(data[byte_start..]) catch return PrimitiveError.OutOfMemory;
@@ -499,9 +507,11 @@ fn stringDropRightFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[1])) return primitives.typeError("string-drop-right", "integer", args[1]);
     const nv = types.toFixnum(args[1]);
     if (nv < 0) return primitives.typeError("string-drop-right", "non-negative integer", args[1]);
-    const n: usize = @intCast(nv);
     const total_cp = utf8CodepointCount(data);
-    if (n > total_cp) return PrimitiveError.IndexOutOfBounds;
+    // u64 comparison before narrowing (kaappi#1912): on wasm32 a fixnum-range
+    // count would truncate and pass the n > total_cp check below.
+    if (!primitives.fixnumIndexInBoundsInclusive(nv, total_cp)) return PrimitiveError.IndexOutOfBounds;
+    const n: usize = @intCast(nv);
     if (n == total_cp) return gc.allocString("") catch return PrimitiveError.OutOfMemory;
     const byte_end = pstr.utf8IndexToByteOffset(data, total_cp - n) orelse return PrimitiveError.IndexOutOfBounds;
     return gc.allocString(data[0..byte_end]) catch return PrimitiveError.OutOfMemory;
@@ -652,9 +662,15 @@ fn stringReplaceFn(args: []const Value) PrimitiveError!Value {
     const ev = types.toFixnum(args[3]);
     if (sv < 0) return primitives.typeError("string-replace", "non-negative integer", args[2]);
     if (ev < 0) return primitives.typeError("string-replace", "non-negative integer", args[3]);
+    // u64 comparisons before narrowing (kaappi#1912): on wasm32 a fixnum-range
+    // index would truncate and alias an in-range codepoint.  Order preserved
+    // from the pre-fix code so the reported fault is unchanged on 64-bit.
+    const cp_count1 = utf8CodepointCount(data1);
+    if (@as(u64, @intCast(sv)) > @as(u64, @intCast(ev))) return primitives.typeError("string-replace", "valid index range (start <= end)", args[2]);
+    if (!primitives.fixnumIndexInBoundsInclusive(sv, cp_count1)) return PrimitiveError.IndexOutOfBounds;
+    if (!primitives.fixnumIndexInBoundsInclusive(ev, cp_count1)) return PrimitiveError.IndexOutOfBounds;
     const start: usize = @intCast(sv);
     const end: usize = @intCast(ev);
-    if (start > end) return primitives.typeError("string-replace", "valid index range (start <= end)", args[2]);
     const byte_start = pstr.utf8IndexToByteOffset(data1, start) orelse return PrimitiveError.IndexOutOfBounds;
     const byte_end = pstr.utf8IndexToByteOffset(data1, end) orelse return PrimitiveError.IndexOutOfBounds;
     const s2_range = try parseStartEnd(full_data2, args, 4);

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -106,7 +106,8 @@ fn vectorRefFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[1])) return primitives.typeError("vector-ref", "exact integer", args[1]);
     const vec = types.toVector(args[0]);
     const k = types.toFixnum(args[1]);
-    if (k < 0 or @as(usize, @intCast(k)) >= vec.data.len) return primitives.indexError("vector-ref", k, vec.data.len);
+    // u64 comparison before narrowing (kaappi#1912): see fixnumIndexInBounds.
+    if (!primitives.fixnumIndexInBounds(k, vec.data.len)) return primitives.indexError("vector-ref", k, vec.data.len);
     return vec.data[@intCast(k)];
 }
 
@@ -120,7 +121,8 @@ fn vectorSetFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[1])) return primitives.typeError("vector-set!", "exact integer", args[1]);
     const vec = types.toVector(args[0]);
     const k = types.toFixnum(args[1]);
-    if (k < 0 or @as(usize, @intCast(k)) >= vec.data.len) return primitives.indexError("vector-set!", k, vec.data.len);
+    // u64 comparison before narrowing (kaappi#1912): see fixnumIndexInBounds.
+    if (!primitives.fixnumIndexInBounds(k, vec.data.len)) return primitives.indexError("vector-set!", k, vec.data.len);
     if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[2]);
     vec.data[@intCast(k)] = args[2];
     return types.VOID;
@@ -227,6 +229,9 @@ fn vectorCopyBangFn(args: []const Value) PrimitiveError!Value {
     const to_vec = types.toVector(args[0]);
     const at_val = types.toFixnum(args[1]);
     if (at_val < 0) return primitives.typeError("vector-copy!", "exact non-negative integer", args[1]);
+    // u64 comparison before narrowing (kaappi#1912): on wasm32 a fixnum-range
+    // at would truncate and pass the at+count check against a short vector.
+    if (!primitives.fixnumIndexInBoundsInclusive(at_val, to_vec.data.len)) return primitives.typeError("vector-copy!", "valid index range", args[1]);
     const at: usize = @intCast(at_val);
     const from_vec = types.toVector(args[2]);
     const from_len = from_vec.data.len;
@@ -573,10 +578,11 @@ fn vectorSwapFn(args: []const Value) PrimitiveError!Value {
     const j_raw = types.toFixnum(args[2]);
     if (i_raw < 0) return primitives.typeError("vector-swap!", "exact non-negative integer", args[1]);
     if (j_raw < 0) return primitives.typeError("vector-swap!", "exact non-negative integer", args[2]);
+    // u64 comparisons before narrowing (kaappi#1912): see fixnumIndexInBounds.
+    if (!primitives.fixnumIndexInBounds(i_raw, vec.data.len)) return primitives.typeError("vector-swap!", "valid index", args[1]);
+    if (!primitives.fixnumIndexInBounds(j_raw, vec.data.len)) return primitives.typeError("vector-swap!", "valid index", args[2]);
     const i: usize = @intCast(i_raw);
     const j: usize = @intCast(j_raw);
-    if (i >= vec.data.len) return primitives.typeError("vector-swap!", "valid index", args[1]);
-    if (j >= vec.data.len) return primitives.typeError("vector-swap!", "valid index", args[2]);
     const tmp = vec.data[i];
     vec.data[i] = vec.data[j];
     vec.data[j] = tmp;
@@ -981,6 +987,9 @@ fn vectorReverseCopyBangFn(args: []const Value) PrimitiveError!Value {
     const to_vec = types.toVector(args[0]);
     const at_val = types.toFixnum(args[1]);
     if (at_val < 0) return primitives.typeError("vector-reverse-copy!", "exact non-negative integer", args[1]);
+    // u64 comparison before narrowing (kaappi#1912): on wasm32 a fixnum-range
+    // at would truncate and pass the at+count check against a short vector.
+    if (!primitives.fixnumIndexInBoundsInclusive(at_val, to_vec.data.len)) return primitives.typeError("vector-reverse-copy!", "valid index range", args[1]);
     const at: usize = @intCast(at_val);
     const from_vec = types.toVector(args[2]);
     const from_len = from_vec.data.len;
@@ -1017,10 +1026,12 @@ fn vectorUnfoldBangFn(args: []const Value) PrimitiveError!Value {
     const end_val = types.toFixnum(args[3]);
     if (start_val < 0) return primitives.typeError("vector-unfold!", "exact non-negative integer", args[2]);
     if (end_val < 0) return primitives.typeError("vector-unfold!", "exact non-negative integer", args[3]);
+    // u64 comparisons before narrowing (kaappi#1912): on wasm32 a fixnum-range
+    // index would truncate and pass the checks against a short vector.
+    if (!primitives.fixnumIndexInBoundsInclusive(start_val, vec.data.len)) return primitives.indexError("vector-unfold!", start_val, vec.data.len);
+    if (!primitives.fixnumIndexInBoundsInclusive(end_val, vec.data.len)) return primitives.indexError("vector-unfold!", end_val, vec.data.len);
     const start: usize = @intCast(start_val);
     const end: usize = @intCast(end_val);
-    if (start > vec.data.len) return primitives.indexError("vector-unfold!", start_val, vec.data.len);
-    if (end > vec.data.len) return primitives.indexError("vector-unfold!", end_val, vec.data.len);
     if (end < start) return primitives.typeError("vector-unfold!", "valid range (end >= start)", args[3]);
 
     var seeds: std.ArrayList(Value) = .empty;
@@ -1081,10 +1092,12 @@ fn vectorUnfoldRightBangFn(args: []const Value) PrimitiveError!Value {
     const end_val = types.toFixnum(args[3]);
     if (start_val < 0) return primitives.typeError("vector-unfold-right!", "exact non-negative integer", args[2]);
     if (end_val < 0) return primitives.typeError("vector-unfold-right!", "exact non-negative integer", args[3]);
+    // u64 comparisons before narrowing (kaappi#1912): on wasm32 a fixnum-range
+    // index would truncate and pass the checks against a short vector.
+    if (!primitives.fixnumIndexInBoundsInclusive(start_val, vec.data.len)) return primitives.indexError("vector-unfold-right!", start_val, vec.data.len);
+    if (!primitives.fixnumIndexInBoundsInclusive(end_val, vec.data.len)) return primitives.indexError("vector-unfold-right!", end_val, vec.data.len);
     const start: usize = @intCast(start_val);
     const end: usize = @intCast(end_val);
-    if (start > vec.data.len) return primitives.indexError("vector-unfold-right!", start_val, vec.data.len);
-    if (end > vec.data.len) return primitives.indexError("vector-unfold-right!", end_val, vec.data.len);
     if (end < start) return primitives.typeError("vector-unfold-right!", "valid range (end >= start)", args[3]);
 
     var seeds: std.ArrayList(Value) = .empty;
@@ -1191,11 +1204,13 @@ fn vectorAppendSubvectorsFn(args: []const Value) PrimitiveError!Value {
         const e = types.toFixnum(args[i + 2]);
         if (s < 0) return primitives.typeError("vector-append-subvectors", "non-negative integer", args[i + 1]);
         if (e < 0) return primitives.typeError("vector-append-subvectors", "non-negative integer", args[i + 2]);
+        const vec_len = types.toVector(args[i]).data.len;
+        // u64 comparisons before narrowing (kaappi#1912): on wasm32 a
+        // fixnum-range index would truncate and pass the checks below.
+        if (!primitives.fixnumIndexInBoundsInclusive(s, vec_len)) return primitives.indexError("vector-append-subvectors", s, vec_len);
+        if (!primitives.fixnumIndexInBoundsInclusive(e, vec_len)) return primitives.indexError("vector-append-subvectors", e, vec_len);
         const start: usize = @intCast(s);
         const end: usize = @intCast(e);
-        const vec_len = types.toVector(args[i]).data.len;
-        if (start > vec_len) return primitives.indexError("vector-append-subvectors", s, vec_len);
-        if (end > vec_len) return primitives.indexError("vector-append-subvectors", e, vec_len);
         if (end < start) return primitives.typeError("vector-append-subvectors", "valid range (end >= start)", args[i + 2]);
         total += end - start;
     }

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -83,7 +83,7 @@ to; the fourth is exempt for an unrelated reason:
 
 | File | Why it cannot use `(srfi 64)` |
 |------|-------------------------------|
-| `smoke/large-index-bounds-1912.scm` | Must stay import-free: `(import (srfi 64))` fails at library load on WASM (kaappi#2108), which `run-wasm-differential.sh` classifies as LIBDIFF — silently retiring its `KNOWN_DIFFS` entry for #1912 |
+| `smoke/large-index-bounds-1912.scm` | Must stay import-free: it is the cross-tier large-index regression probe for #1912 (fixed), and `(import (srfi 64))` fails at library load on WASM (kaappi#2108), which `run-wasm-differential.sh` classifies as LIBDIFF — dropping the file from the comparison it exists for |
 | `smoke/deep-nesting-print.scm` | Same, for its own `KNOWN_DIFFS` entry against #2107 |
 | `smoke/deep-nesting-print-tier-margin.scm` | Same, and it is the cross-tier positive control for #2107 |
 | `continuations/coroutine-repl-echo.scm` | Its top-level forms must stay **bare** so the value-echo path runs; consuming them in `test-equal` is what hid the original bug |

--- a/tests/scheme/audit/internal-primitives-audit.scm
+++ b/tests/scheme/audit/internal-primitives-audit.scm
@@ -393,16 +393,17 @@
 (test-assert "nv: length arg checked" (raises? (%numeric-vector-length 5)))
 (test-assert "nv: kind arg checked"   (raises? (%numeric-vector-kind 5)))
 
-;; A 2^46 index is a perfectly good fixnum here. On a 64-bit host the bounds
-;; check sees it; on wasm32 (usize = u32) the `@intCast(raw_idx)` inside the
-;; check truncates it and the read silently aliases an in-range element.
-;; This assertion PASSES natively and FAILS under wasmtime -- it is the
-;; native half of that cross-tier pair.
-(test-assert "nv: huge index rejected (fails on wasm32)"
+;; A 2^46 index is a perfectly good fixnum here. The bounds check compares in
+;; u64 BEFORE narrowing to usize (see primitives.fixnumIndexInBounds), so the
+;; index is seen on every target -- on wasm32 (usize = u32) the pre-fix
+;; `@intCast(raw_idx)` inside the check truncated it and the read silently
+;; aliased an in-range element (kaappi#1912, fixed). These now pass on BOTH
+;; tiers and are the %-primitive half of the cross-tier probe.
+(test-assert "nv: huge index rejected (kaappi#1912)"
              (raises? (%numeric-vector-ref (%make-numeric-vector 's8 4 7) 70368744177664)))
-(test-assert "nv: 2^32+1 index rejected (fails on wasm32)"
+(test-assert "nv: 2^32+1 index rejected (kaappi#1912)"
              (raises? (%numeric-vector-ref (%make-numeric-vector 's8 4 7) 4294967297)))
-(test-assert "record: 2^32+1 index rejected (fails on wasm32)"
+(test-assert "record: 2^32+1 index rejected (kaappi#1912)"
              (raises? (let ((rt (%make-record-type "R" 3)))
                         (%record-ref (%make-record rt 1 2 3) 4294967297 rt))))
 

--- a/tests/scheme/differential/run-wasm-differential.sh
+++ b/tests/scheme/differential/run-wasm-differential.sh
@@ -79,9 +79,11 @@
 # imports for exactly this reason and carry a hand-rolled `(exit 1)` instead,
 # because LIBDIFF would have destroyed what they exist to measure --
 # `deep-nesting-print.scm` and
-# `large-index-bounds-1912.scm` (both KNOWN_DIFFS entries below, for #2107 and
-# #1912) and `deep-nesting-print-tier-margin.scm` (the positive control that
-# keeps #2107's margin under watch).  Do not "tidy" those three into SRFI-64.
+# `large-index-bounds-1912.scm` (the latter's KNOWN_DIFFS entry for #1912 was
+# deleted when the fix made the tiers agree again -- it remains the cross-tier
+# large-index probe) and `deep-nesting-print-tier-margin.scm` (the positive
+# control that keeps #2107's margin under watch).  Do not "tidy" those three
+# into SRFI-64.
 # They are three of the FOUR hand-rolled-verdict files; the fourth,
 # `continuations/coroutine-repl-echo.scm`, is exempt for an unrelated reason and
 # is not a tier probe.  tests/scheme/CLAUDE.md holds the single inventory table.
@@ -194,15 +196,15 @@ fi
 #   over a file-backed .sld, the same resolver failure as the LIBDIFF bucket,
 #   but reported through cond-expand rather than a KP2001, so it does not
 #   match that bucket's signature.
-# large-index-bounds-1912.scm kaappi#1912 — index arguments are truncated to
-#   u32 inside the bounds check on wasm32, so 2^32+1 aliases element 1: a
-#   silent wrong read, and a silent wrong WRITE. Written as a probe for this
-#   harness; see its header for the control that pins it to truncation.
+# large-index-bounds-1912.scm kaappi#1912 -- FIXED: index arguments are now
+#   bounds-checked in u64 before any narrowing to usize (usize = u32 on
+#   wasm32), so 2^32+1 raises instead of aliasing element 1.  The KNOWN_DIFFS
+#   entry was deleted when the tiers agreed; the file remains in the corpus as
+#   the cross-tier large-index regression probe.
 KNOWN_DIFFS="
 deep-nesting-print.scm
 command-line-o-flag.scm
 condexpand-include-lib-868-879.scm
-large-index-bounds-1912.scm
 "
 
 is_known_diff() {

--- a/tests/scheme/smoke/large-index-bounds-1912.scm
+++ b/tests/scheme/smoke/large-index-bounds-1912.scm
@@ -1,60 +1,95 @@
-;;; Large-index bounds checking, and the cross-tier probe for kaappi#1912.
+;;; Large-index bounds checking across the vector-like accessors, and the
+;;; cross-tier regression probe for kaappi#1912.
 ;;;
 ;;; Natively this is an ordinary regression test: an index far beyond any
-;;; vector's length must raise, whether or not its low 32 bits happen to be in
-;;; range.
+;;; container's length must raise, whether or not its low 32 bits happen to be
+;;; in range.
 ;;;
-;;; On wasm32 it is the probe for kaappi#1912. Index arguments are @intCast to
-;;; usize INSIDE the bounds comparison, and usize is u32 there, so 2^32+1 wraps
-;;; to 1 before the check, passes it, and aliases element 1 — a silent wrong
-;;; read, and for vector-set! a silent wrong WRITE to a valid-but-unintended
-;;; element. Measured (wasmtime 46.0.0, v0.22.1):
+;;; It is also the WASM cross-tier probe. Before #1912 was fixed, index
+;;; arguments were @intCast to usize INSIDE the bounds comparison, and usize
+;;; is u32 on wasm32, so 2^32+1 wrapped to 1 before the check, passed it, and
+;;; aliased element 1 — a silent wrong read, and for vector-set! a silent
+;;; wrong WRITE to a valid-but-unintended element. Measured (wasmtime 46.0.0,
+;;; v0.22.1):
 ;;;
 ;;;     (vector-ref v 4294967297)   native: raised   wasm32: 11
 ;;;     (vector-set! v 4294967297 99) then (vector-ref v 1)
 ;;;                                 native: 11       wasm32: 99
 ;;;
+;;; The fix (primitives.fixnumIndexInBounds) compares in u64 BEFORE narrowing
+;;; to usize, and every case below now raises identically on both tiers — the
+;;; file's KNOWN_DIFFS entry in run-wasm-differential.sh was deleted when the
+;;; tiers agreed again.
+;;;
 ;;; The 2^32+9 line is the discriminating control that makes this attributable
 ;;; to low-32-bit truncation rather than to a missing bounds check: its low 32
-;;; bits are 9, which still exceeds the length 4, so it raises on BOTH tiers.
-;;;
-;;; run-wasm-differential.sh lists this file in KNOWN_DIFFS against #1912, so
-;;; the divergence does not fail the run while the bug is open — and its STALE
-;;; check reports the entry once the tiers agree again, which is the signal to
-;;; delete both the entry and this note.
+;;; bits are 9, which still exceeds the length 4, so it raises on BOTH tiers
+;;; (it raised even before the fix).
 ;;;
 ;;; Deliberately import-free so it runs on every tier — which is why this is
 ;;; the one file in the corpus that signals failure with a bare `(exit 1)`
 ;;; rather than the SRFI-64 epilogue every other file uses (kaappi#2116).
 ;;; `(import (srfi 64))` would make the WASM leg fail at library load
 ;;; (kaappi#2108, no .sld on WASM), and run-wasm-differential.sh classifies
-;;; that as LIBDIFF — which would silently retire this file's KNOWN_DIFFS
-;;; entry as stale and stop it tracking #1912 at all. The printed lines are
-;;; unchanged and remain the cross-tier comparison channel; the exit status is
-;;; the native verdict layered on top.
+;;; that as LIBDIFF — dropping this file from the cross-tier comparison it
+;;; exists for. The printed lines are unchanged and remain the cross-tier
+;;; comparison channel; the exit status is the native verdict layered on top.
 
 (define v (vector 10 11 12 13))
+(define s (make-string 4 #\a))
+(string-set! s 0 #\a) (string-set! s 1 #\b) (string-set! s 2 #\c) (string-set! s 3 #\d)
+(define bv (bytevector 10 11 12 13))
+(define rt (%make-record-type "large-index-probe" 3))
+(define r (%make-record rt 1 2 3))
+(define nv (%make-numeric-vector 's8 4 7))
 
 (define (try thunk) (guard (e (#t 'raised)) (thunk)))
 
-;; 2^32+1 — low 32 bits are 1, which IS in range for a 4-element vector.
-(define ref-big (try (lambda () (vector-ref v 4294967297))))
-(display (list 'ref-2^32+1 ref-big))
-(newline)
+;; Every accessor must raise for 2^32+1 (whose low 32 bits ARE in range for a
+;; 4-element container — the truncation case) and for the 2^32+9 control
+;; (whose low 32 bits are out of range — the missing-bounds-check case).
+(define cases
+  (list
+    (cons "vector-ref"         (lambda (i) (vector-ref v i)))
+    (cons "vector-set!"        (lambda (i) (vector-set! v i 99)))
+    (cons "string-ref"         (lambda (i) (string-ref s i)))
+    (cons "string-set!"        (lambda (i) (string-set! s i #\X)))
+    (cons "bytevector-u8-ref"  (lambda (i) (bytevector-u8-ref bv i)))
+    (cons "bytevector-u8-set!" (lambda (i) (bytevector-u8-set! bv i 99)))
+    (cons "substring"          (lambda (i) (substring s i (+ i 1))))
+    (cons "vector-swap!"       (lambda (i) (vector-swap! v i 0)))
+    (cons "vector-copy!"       (lambda (i) (vector-copy! v i (vector 9 9))))
+    (cons "bytevector-copy!"   (lambda (i) (bytevector-copy! bv i (bytevector 9 9))))
+    (cons "string-copy!"       (lambda (i) (string-copy! s i "xy")))
+    (cons "string-take"        (lambda (i) (string-take s i)))
+    (cons "string-drop"        (lambda (i) (string-drop s i)))
+    (cons "string-replace"     (lambda (i) (string-replace s "X" i (+ i 1))))
+    (cons "take"               (lambda (i) (take '(1 2 3) i)))
+    (cons "split-at"           (lambda (i) (split-at '(1 2 3) i)))
+    (cons "%record-ref"        (lambda (i) (%record-ref r i rt)))
+    (cons "%record-set!"       (lambda (i) (%record-set! r i 9 rt)))
+    (cons "%numeric-vector-ref"    (lambda (i) (%numeric-vector-ref nv i)))
+    (cons "%numeric-vector-set!"   (lambda (i) (%numeric-vector-set! nv i 1)))))
 
-;; Control: 2^32+9 — low 32 bits are 9, still out of range. Raises everywhere.
-(define ref-ctl (try (lambda () (vector-ref v 4294967305))))
-(display (list 'ref-2^32+9 ref-ctl))
-(newline)
+(for-each
+  (lambda (case)
+    (let ((name (car case)) (thunk (cdr case)))
+      (display (list name "2^32+1" (try (lambda () (thunk 4294967297)))))
+      (newline)
+      (display (list name "2^32+9" (try (lambda () (thunk 4294967305)))))
+      (newline)))
+  cases)
 
-;; The write side, which is the more serious half: element 1 must be untouched.
-(define set-big (try (lambda () (vector-set! v 4294967297 99))))
+;; The write side is the serious half: after a rejected set!, every element
+;; must be untouched.  (The cases above all raised, so the containers below
+;; are pristine.)
 (define elt1 (vector-ref v 1))
-(display (list 'set-2^32+1 set-big 'elt1 elt1))
+(display (list 'set-2^32+1 'elt1 elt1))
 (newline)
 
-;; Native verdict. On wasm32 these fail while #1912 is open, and the harness
-;; suppresses that via KNOWN_DIFFS rather than this file pretending to pass.
+;; Native verdict. On wasm32 this file's lines must match byte-for-byte (the
+;; differential harness compares stdout), and the exit status is the native
+;; verdict layered on top.
 (define failures 0)
 (define (check ok name)
   (if (not ok)
@@ -64,9 +99,24 @@
         (display name)
         (newline))))
 
-(check (eq? ref-big 'raised) "(vector-ref v 2^32+1) must raise")
-(check (eq? ref-ctl 'raised) "(vector-ref v 2^32+9) must raise")
-(check (eq? set-big 'raised) "(vector-set! v 2^32+1 99) must raise")
-(check (= elt1 11) "element 1 must be untouched by the rejected set!")
+(for-each
+  (lambda (case)
+    (let ((name (car case)) (thunk (cdr case)))
+      (check (eq? (try (lambda () (thunk 4294967297))) 'raised)
+             (string-append name " 2^32+1 must raise"))
+      (check (eq? (try (lambda () (thunk 4294967305))) 'raised)
+             (string-append name " 2^32+9 must raise"))))
+  cases)
+
+(check (= elt1 11) "vector element 1 must be untouched by the rejected set!")
+(check (eq? (string-ref s 1) #\b) "string element 1 must be untouched")
+(check (= (bytevector-u8-ref bv 1) 11) "bytevector element 1 must be untouched")
+(check (= (%record-ref r 1 rt) 2) "record field 1 must be untouched")
+(check (= (%numeric-vector-ref nv 1) 7) "numeric-vector element 1 must be untouched")
+
+;; In-range sanity: the same accessors still work at a legal index.
+(check (= (vector-ref v 1) 11) "in-range vector-ref still works")
+(check (string=? (substring s 1 3) "bc") "in-range substring still works")
+(check (equal? (take '(1 2 3) 2) '(1 2)) "in-range take still works")
 
 (if (> failures 0) (exit 1))

--- a/tests/scheme/smoke/large-index-bounds-1912.scm
+++ b/tests/scheme/smoke/large-index-bounds-1912.scm
@@ -63,6 +63,8 @@
     (cons "string-copy!"       (lambda (i) (string-copy! s i "xy")))
     (cons "string-take"        (lambda (i) (string-take s i)))
     (cons "string-drop"        (lambda (i) (string-drop s i)))
+    (cons "string-take-right"  (lambda (i) (string-take-right s i)))
+    (cons "string-drop-right"  (lambda (i) (string-drop-right s i)))
     (cons "string-replace"     (lambda (i) (string-replace s "X" i (+ i 1))))
     (cons "take"               (lambda (i) (take '(1 2 3) i)))
     (cons "split-at"           (lambda (i) (split-at '(1 2 3) i)))


### PR DESCRIPTION
Fixes #1912

## Summary

Fixes kaappi#1912: on wasm32 (usize = u32), every vector-like accessor narrowed its fixnum index to `usize` **inside** the bounds comparison, so an index ≥ 2³² wrapped to its low 32 bits before the check and silently aliased an in-range element — a wrong read, and for the set! family a **wrong write** with no diagnostic. Verified before the fix under wasmtime 46.0.0:

| | native aarch64 | wasm32 |
|---|---|---|
| `(vector-ref v 4294967297)` | RAISED | **11** (read element 1) |
| `(vector-set! v 4294967297 99)` → elt 1 | RAISED, stays 11 | **succeeds, elt 1 becomes 99** |

The fix compares in u64 **before** narrowing — the pattern already used by `makeNumericVectorFn` (primitives_srfi160.zig). Two shared helpers (`primitives.fixnumIndexInBounds` / `...Inclusive`) carry the wasm32 rationale once, applied at every affected site:

- `vector-ref`/`set!`, `vector-swap!`, `vector-copy!`/`reverse-copy!`, `vector-unfold!`/`-right!`, `vector-append-subvectors`
- `string-ref`/`set!`, `string-copy!`, `substring`, `string-take`/`drop`/`-right`, `string-replace`
- `bytevector-u8-ref`/`set!`, `bytevector-copy!`
- `parseOptionalRange` (covers `vector->list`, `string->vector`, `fill!`, `reverse!`, `utf8->string`, `write-bytevector`, …)
- `write-string`
- `%record-ref`/`set!` (+ `/inherit`, `%record-field-mutable?`, `%record-split-args`), `%numeric-vector-ref`/`set!`

`take` and `split-at` walked their list in a narrowed `usize` counter; they now loop in `i64` exactly like `drop` already did, so a huge `k` walks to the end and raises instead of silently returning a short list.

Native error messages are byte-unchanged on 64-bit — each site keeps its original error call and check order.

**Deliberately out of scope** (a separate class, no clean native error to preserve): large *count/size* arguments to allocation and read procedures (`make-vector`/`make-string`/`make-bytevector`, `vector-unfold` length, `string-pad`, `read-bytevector`/`read-string`, `iota`) — native behavior there is OOM or a huge overcommit, not a catchable range error.

## Verification

- `zig build test` — pass
- `bash tests/scheme/run-all.sh` — 2086 pass, 0 fail (incl. R7RS 1395)
- `bash tests/scheme/differential/run-wasm-differential.sh` — **0 divergences** across 361 corpus files (wasmtime 46.0.0); the probe's KNOWN_DIFFS entry now reports STALE and is deleted per the harness's own instructions
- `tests/scheme/smoke/large-index-bounds-1912.scm` extended from the vector-only probe to every fixed accessor; stdout byte-identical native vs wasm32
- `tests/scheme/audit/internal-primitives-audit.scm` `(fails on wasm32)` annotations updated to `(kaappi#1912)` — they now pass on both tiers

## Checklist

- [x] `zig build test` passes
- [x] `zig fmt --check src/` passes
- [x] Scheme test suites pass (`bash tests/scheme/run-all.sh`)
- [x] New tests added for new behavior
- [x] Documentation updated (if applicable) — `tests/scheme/CLAUDE.md` inventory, harness KNOWN_DIFFS
