### PR TITLE
Make the register file grow to its documented cap and report the limit as KP3008 (#2035)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **The register file grows to its documented 65536-register cap instead of
+  silently stopping at 4096, and running off its end is an uncatchable KP3008**
+  (#2035). A tail-position call (`tail_call`, `tail_apply`, `tail_call_global`,
+  `tail_call_cc`'s receiver, and tail `eval`) replaced the current frame's code
+  in place without re-ensuring room for the callee's `locals_count`, so the
+  file stopped growing at the replaced frame's smaller window — 819 nested
+  `dynamic-wind` extents aborted an ordinary program at 6% of the documented
+  capacity with a catchable KP9001 "internal error" whose guard-swallowed
+  object carried the bare message `"error"`. Every replacement site now
+  re-ensures the bound `callClosure` guarantees for a fresh frame
+  (`ensureTailWindow`), `registerIndex` reports a register-file overrun as
+  `StackOverflow` rather than `InvalidBytecode`, and past the real cap the
+  failure is the same uncatchable KP3008 stack overflow as every other VM
+  stack. Unbounded re-entrant promise forcing (`(delay (force p))`), which the
+  cliff used to mask as a catchable error, is now correctly reported as
+  runaway recursion; the R7RS-legal terminating form still works.
+
 - **`(srfi 146 hash)` keys its tables with the comparator you passed** (#2044).
   Every constructor built a bare `(make-hash-table)` and stashed the
   comparator in the record, where `hashmap-key-comparator` handed it back —

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -23,6 +23,7 @@ const vm_dispatch_helpers = @import("vm_dispatch_helpers.zig");
 pub const ensureOperands = vm_dispatch_helpers.ensureOperands;
 pub const registerIndex = vm_dispatch_helpers.registerIndex;
 pub const ensureCallWindow = vm_dispatch_helpers.ensureCallWindow;
+pub const ensureTailWindow = vm_dispatch_helpers.ensureTailWindow;
 pub const constantAt = vm_dispatch_helpers.constantAt;
 pub const readU8 = vm_dispatch_helpers.readU8;
 pub const readU16 = vm_dispatch_helpers.readU16;
@@ -458,6 +459,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     // arity is a u8 and 255 is legal, so the variadic +1 for
                     // the rest-list slot must widen first (#2185).
                     const arg_count: usize = if (func.is_variadic) @as(usize, func.arity) + 1 else nargs;
+                    // The callee's code replaces this frame's code in place,
+                    // but the frame's register window stays the old one — the
+                    // new function's locals may need more room, so re-ensure
+                    // the bound callClosure would have guaranteed (#2035).
+                    try ensureTailWindow(self, @as(usize, frame.base), arg_count, func.locals_count);
                     for (0..arg_count) |i| {
                         const dst_idx = @as(usize, frame.base) + i;
                         const src_idx = @as(usize, abs_base) + 1 + i;
@@ -672,6 +678,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     // Same u8 widening as tail_call above (#2185): a variadic
                     // callee with 255 fixed params needs 256 arg slots.
                     const arg_count: usize = if (func.is_variadic) @as(usize, func.arity) + 1 else total_nargs;
+                    // The callee replaces this frame's code in place; its
+                    // locals may exceed the replaced frame's window, so
+                    // re-ensure the bound callClosure would have guaranteed
+                    // (#2035).
+                    try ensureTailWindow(self, @as(usize, frame.base), arg_count, func.locals_count);
                     for (0..arg_count) |i| {
                         const dst_idx = @as(usize, frame.base) + i;
                         if (dst_idx >= self.registers.len) return VMError.InvalidBytecode;
@@ -1078,6 +1089,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     }
                     // Same u8 widening as tail_call above (#2185).
                     const arg_count: usize = if (tfunc.is_variadic) @as(usize, tfunc.arity) + 1 else nargs;
+                    // The callee replaces this frame's code in place; its
+                    // locals may exceed the replaced frame's window, so
+                    // re-ensure the bound callClosure would have guaranteed
+                    // (#2035).
+                    try ensureTailWindow(self, @as(usize, frame.base), arg_count, tfunc.locals_count);
                     for (0..arg_count) |ai| {
                         const dst_idx = @as(usize, frame.base) + ai;
                         const src_idx = @as(usize, abs_base) + 1 + ai;
@@ -1243,14 +1259,19 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         self.setErrorDetail("call/cc receiver: expected at most 1 required argument, got {d}", .{func.arity});
                         return VMError.ArityMismatch;
                     }
+                    const used: usize = if (func.is_variadic) @as(usize, func.arity) + 1 else 1;
+                    // The receiver's code replaces this frame's code in place;
+                    // its locals may exceed the replaced frame's window, so
+                    // re-ensure the bound callClosure would have guaranteed
+                    // before writing the continuation argument (#2035).
+                    try ensureTailWindow(self, @as(usize, frame.base), used, func.locals_count);
                     self.registers[frame.base] = cont_val;
                     if (func.is_variadic and func.arity == 0) {
                         self.registers[frame.base] = try buildRestList(self.gc, self.registers[frame.base .. frame.base + 1]);
                     } else if (func.is_variadic) {
-                        if (@as(usize, frame.base) + 1 >= self.registers.len) try self.ensureRegisterCapacity(@as(usize, frame.base) + 2);
                         self.registers[frame.base + 1] = types.NIL;
                     }
-                    vm_calls.clearFrameLocals(self, frame.base, if (func.is_variadic) @as(usize, func.arity) + 1 else 1, func.locals_count);
+                    vm_calls.clearFrameLocals(self, frame.base, used, func.locals_count);
                     if (self.profile_mode) func.profile_calls += 1;
                     frame.closure = closure;
                     frame.code = func.code.items;
@@ -1347,6 +1368,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const closure = types.toObject(closure_val).as(types.Closure);
                 const func = closure.func;
                 if (self.profile_mode) func.profile_calls += 1;
+                // The eval'd expression's code replaces this frame's code in
+                // place; its locals may exceed the replaced frame's window,
+                // so re-ensure the bound callClosure would have guaranteed
+                // (#2035).
+                try ensureTailWindow(self, @as(usize, frame.base), 0, func.locals_count);
                 vm_calls.clearFrameLocals(self, frame.base, 0, func.locals_count);
                 frame.closure = closure;
                 frame.code = func.code.items;

--- a/src/vm_dispatch_helpers.zig
+++ b/src/vm_dispatch_helpers.zig
@@ -45,15 +45,43 @@ pub fn ensureOperands(vm: *VM, frame: *CallFrame, operand_bytes: usize) VMError!
     if (frame.ip + operand_bytes > frame.code.len) return VMError.InvalidBytecode;
 }
 
+/// Resolve `base + reg` to an absolute register index. Past the end of the
+/// register file this is `StackOverflow`, not `InvalidBytecode`: the file is
+/// the stack resource, and `ensureRegisterCapacity` already reports running
+/// off its end as StackOverflow. Reporting it as KP9001 "internal error"
+/// misdirected a reader and — because InvalidBytecode is not in
+/// `errors.isUncatchable` — let a `guard` swallow the limit as a bare
+/// `#<error "error">` (#2035). A tail-position call's locals can exceed the
+/// replaced frame's window, and the tail-call paths re-ensure it via
+/// `ensureTailWindow`; every fresh frame is ensured at creation. What is left
+/// to trip this check is either the genuine MAX_REGISTER_LIMIT (a runaway
+/// program, which must not be catchable) or bytecode so corrupt that no
+/// meaningful diagnostic survives anyway.
 pub fn registerIndex(vm: *VM, base: u32, reg: u16) VMError!usize {
     const idx = @as(usize, base) + @as(usize, reg);
-    if (idx >= vm.registers.len) return VMError.InvalidBytecode;
+    if (idx >= vm.registers.len) return VMError.StackOverflow;
     return idx;
 }
 
 pub fn ensureCallWindow(vm: *VM, base: usize, nargs: u8) VMError!void {
     const hi = base + @as(usize, nargs) + 1;
     if (hi > vm.registers.len) try vm.ensureRegisterCapacity(hi);
+}
+
+/// A tail-position call (tail_call, tail_apply, tail_call_global) and a
+/// call/cc receiver in tail position replace the current frame's code in
+/// place: the frame's base and register window are unchanged, but the new
+/// function's `locals_count` may exceed the replaced frame's window. Without
+/// a fresh ensure, the register file silently stops growing at the replaced
+/// frame's smaller bound, and a register read a few slots past it aborts an
+/// ordinary program at a fraction of the documented MAX_REGISTER_LIMIT with
+/// a catchable KP9001 (#2035). This re-ensures the same bound callClosure
+/// guarantees when it builds a fresh frame — `base + max(arg_count,
+/// locals_count) + 1`, so a variadic callee's rest slot is covered too — and
+/// past the cap `ensureRegisterCapacity` reports StackOverflow like every
+/// other VM stack.
+pub fn ensureTailWindow(vm: *VM, base: usize, arg_count: usize, locals_count: u16) VMError!void {
+    try vm.ensureRegisterCapacity(base + @max(arg_count, @as(usize, locals_count)) + 1);
 }
 
 pub fn toBase(base_wide: usize) VMError!u32 {

--- a/tests/scheme/audit/primitives_control-audit.scm
+++ b/tests/scheme/audit/primitives_control-audit.scm
@@ -894,16 +894,19 @@
 ;;; Deeply nested dynamic-wind
 ;;; ------------------------------------------------------------------
 
-;; FAIL: #2035 (819 nested dynamic-wind extents abort the form with KP9001
-;; "internal error" — the register file stops growing at 4096 of a documented
-;; 65536 — and the failure is catchable, unlike every other VM limit)
-;; (test-equal "dynamic-wind: 1000 nested extents unwind cleanly"
-;;             'bottom
-;;             (letrec ((nd (lambda (n) (if (= n 0) 'bottom
-;;                                          (dynamic-wind (lambda () 1)
-;;                                                        (lambda () (nd (- n 1)))
-;;                                                        (lambda () 2))))))
-;;               (nd 1000)))
+;; #2035: the register file used to stop growing at 4096 of a documented
+;; 65536, because a tail-position call replaced the frame in place without
+;; re-ensuring room for the callee's locals — so 819 nested extents aborted
+;; the form with a catchable KP9001 "internal error". Past the real cap the
+;; failure is KP3008 and uncatchable; that half lives in
+;; tests/scheme/errors/error-format.sh.
+(test-equal "dynamic-wind: 1000 nested extents unwind cleanly"
+            'bottom
+            (letrec ((nd (lambda (n) (if (= n 0) 'bottom
+                                         (dynamic-wind (lambda () 1)
+                                                       (lambda () (nd (- n 1)))
+                                                       (lambda () 2))))))
+              (nd 1000)))
 
 ;;; ------------------------------------------------------------------
 ;;; Type errors stay catchable

--- a/tests/scheme/audit/primitives_lazy-audit.scm
+++ b/tests/scheme/audit/primitives_lazy-audit.scm
@@ -91,9 +91,13 @@
 (define cyc (delay-force cyc))
 (test-equal 'caught (guard (e (#t 'caught)) (force cyc)))
 
-;; Direct re-entrant force — catchable error:
-(define selfp (delay (force selfp)))
-(test-equal 'caught (guard (e (#t 'caught)) (force selfp)))
+;; A `delay` whose thunk re-forces the same promise with no termination is
+;; unbounded recursion — the re-entrancy check above only sees cycles whose
+;; thunk RETURNS. It runs to the register-file cap and dies as an
+;; uncatchable KP3008 stack overflow, like any other runaway recursion; that
+;; half lives in tests/scheme/errors/error-format.sh (it would abort this
+;; file). The R7RS-legal *terminating* re-entrant form is pinned in
+;; tests/scheme/compliance/lazy.scm.
 
 ;;; --- stream-style self-reference after memoization ---
 (letrec ((ones (delay (cons 1 (delay (force ones))))))

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -251,6 +251,81 @@ assert_output_lacks "stack overflow is not reported as out-of-memory" \
     '(define (deep n) (if (= n 0) 0 (+ 1 (deep (- n 1))))) (deep 50000)' \
     "KP9002"
 
+# --- Register-file cap (#2035) ---
+# Deeply nested dynamic-wind exhausts the *register file* (65536 registers,
+# roughly 5 per nesting level) before the frame stack (32768), so this shape
+# is a register-cap test, not a frame-cap one. The register file used to stop
+# growing at 4096 — a tail-position call replaced the frame in place without
+# re-ensuring room for the callee's locals — so 819 extents already aborted
+# the form with a catchable KP9001 "internal error", and a guard turned the
+# failure into a bare #<error "error">. Past the real cap it must report the
+# same uncatchable KP3008 as every other VM stack.
+assert_output_contains "register-file cap is reported as stack overflow, not internal error" \
+    '(import (scheme base) (scheme write))
+     (define (nd n) (if (= n 0) (quote bottom)
+                        (dynamic-wind (lambda () 1) (lambda () (nd (- n 1))) (lambda () 2))))
+     (nd 15000)' \
+    "error[KP3008]: stack overflow"
+
+assert_output_lacks "register-file cap is not reported as an internal error" \
+    '(import (scheme base) (scheme write))
+     (define (nd n) (if (= n 0) (quote bottom)
+                        (dynamic-wind (lambda () 1) (lambda () (nd (- n 1))) (lambda () 2))))
+     (nd 15000)' \
+    "KP9001"
+
+assert_output_contains "register-file cap is not catchable by guard" \
+    '(import (scheme base) (scheme write))
+     (define (nd n) (if (= n 0) (quote bottom)
+                        (dynamic-wind (lambda () 1) (lambda () (nd (- n 1))) (lambda () 2))))
+     (guard (e (#t (display "SWALLOWED"))) (nd 15000))' \
+    "error[KP3008]: stack overflow"
+
+assert_output_lacks "guard clause does not run on register-file cap" \
+    '(import (scheme base) (scheme write))
+     (define (nd n) (if (= n 0) (quote bottom)
+                        (dynamic-wind (lambda () 1) (lambda () (nd (- n 1))) (lambda () 2))))
+     (guard (e (#t (display "SWALLOWED"))) (nd 15000))' \
+    "SWALLOWED"
+
+assert_output_lacks "register-file cap is not reported as out-of-memory" \
+    '(import (scheme base) (scheme write))
+     (define (nd n) (if (= n 0) (quote bottom)
+                        (dynamic-wind (lambda () 1) (lambda () (nd (- n 1))) (lambda () 2))))
+     (nd 15000)' \
+    "KP9002"
+
+# --- Unbounded re-entrant promise forcing (#2035) ---
+# `(delay (force p))` re-enters force on the same promise with no termination
+# — genuinely runaway recursion, and the register file is what caps it (the
+# SRFI-45 re-entrancy check only sees cycles whose thunk returns). Pre-fix the
+# file stopped growing at 4096 and the recursion died there with a catchable
+# KP9001 "internal error", which a guard turned into a bare #<error "error">;
+# now it must report the same uncatchable KP3008 as any other runaway.
+assert_output_contains "unbounded re-entrant force is a stack overflow, not an internal error" \
+    '(import (scheme base) (scheme write))
+     (define selfp (delay (force selfp)))
+     (force selfp)' \
+    "error[KP3008]: stack overflow"
+
+assert_output_lacks "unbounded re-entrant force is not an internal error" \
+    '(import (scheme base) (scheme write))
+     (define selfp (delay (force selfp)))
+     (force selfp)' \
+    "KP9001"
+
+assert_output_contains "unbounded re-entrant force is not catchable by guard" \
+    '(import (scheme base) (scheme write))
+     (define selfp (delay (force selfp)))
+     (guard (e (#t (display "SWALLOWED"))) (force selfp))' \
+    "error[KP3008]: stack overflow"
+
+assert_output_lacks "guard clause does not run on unbounded re-entrant force" \
+    '(import (scheme base) (scheme write))
+     (define selfp (delay (force selfp)))
+     (guard (e (#t (display "SWALLOWED"))) (force selfp))' \
+    "SWALLOWED"
+
 # The 255 ceiling on a tail-position `apply` is what the tail_apply opcode's
 # nargs byte encodes — a limit on one argument list, not on the stack. It
 # reported KP3008, which both misdirected the reader and (once limits stopped

--- a/tests/scheme/smoke/gc-root-growth.scm
+++ b/tests/scheme/smoke/gc-root-growth.scm
@@ -4,10 +4,17 @@
 
 (test-begin "gc-root-growth")
 
-;; Re-entrant promise forcing raises a catchable error
-(define selfp (delay (force selfp)))
-(test-assert "re-entrant force is catchable"
-  (guard (e (#t #t)) (force selfp) #f))
+;; Re-entrant promise forcing: the R7RS 4.2.5 *terminating* form re-enters
+;; force on the same promise and must return (the register file grows rather
+;; than dying at a fixed cliff — #2035). The unbounded `(delay (force p))`
+;; form is runaway recursion and correctly dies as an uncatchable KP3008
+;; stack overflow; that half lives in tests/scheme/errors/error-format.sh.
+(define selfp
+  (let ((count 0))
+    (delay (begin (set! count (+ count 1))
+                  (if (> count 100) count (force selfp))))))
+(test-assert "terminating re-entrant force returns"
+  (eqv? 101 (force selfp)))
 
 ;; Deeply nested native higher-order calls no longer panic.
 ;; In Release the root buffer grows and the call succeeds; in Debug the

--- a/tests/scheme/smoke/gc-root-growth.scm
+++ b/tests/scheme/smoke/gc-root-growth.scm
@@ -4,18 +4,6 @@
 
 (test-begin "gc-root-growth")
 
-;; Re-entrant promise forcing: the R7RS 4.2.5 *terminating* form re-enters
-;; force on the same promise and must return (the register file grows rather
-;; than dying at a fixed cliff — #2035). The unbounded `(delay (force p))`
-;; form is runaway recursion and correctly dies as an uncatchable KP3008
-;; stack overflow; that half lives in tests/scheme/errors/error-format.sh.
-(define selfp
-  (let ((count 0))
-    (delay (begin (set! count (+ count 1))
-                  (if (> count 100) count (force selfp))))))
-(test-assert "terminating re-entrant force returns"
-  (eqv? 101 (force selfp)))
-
 ;; Deeply nested native higher-order calls no longer panic.
 ;; In Release the root buffer grows and the call succeeds; in Debug the
 ;; native re-entrancy cap (200) fires first with a catchable error.

--- a/tests/scheme/smoke/register-growth-2035.scm
+++ b/tests/scheme/smoke/register-growth-2035.scm
@@ -1,0 +1,40 @@
+;; Regression test for #2035: the VM register file used to stop growing at
+;; 4096 of its documented 65536 — a tail-position call replaced the frame in
+;; place without re-ensuring room for the callee's locals, so 819 nested
+;; dynamic-wind extents (or a pure-Scheme stand-in of the same shape)
+;; aborted an ordinary program with a catchable KP9001 "internal error".
+;; The file now grows to the cap (deep nesting returns normally); past it the
+;; failure is the same uncatchable KP3008 as every other VM stack, and that
+;; reporting half lives in tests/scheme/errors/error-format.sh.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "register-growth-2035")
+
+;; Deep dynamic-wind nesting: each level consumes registers for the
+;; dynamic-wind lambda, the before-thunk and the thunk frames, so this is
+;; the shape that used to die at the 4096 cliff (depth 819). 10000 is
+;; comfortably past the old cliff and still well inside the cap.
+(test-equal "deep dynamic-wind nesting returns"
+            'bottom
+            (letrec ((nd (lambda (n) (if (= n 0) 'bottom
+                                         (dynamic-wind (lambda () 1)
+                                                       (lambda () (nd (- n 1)))
+                                                       (lambda () 2))))))
+              (nd 10000)))
+
+;; Re-entrant promise forcing: the R7RS 4.2.5 *terminating* form re-enters
+;; force on the same promise and must return — with the register file
+;; growing, the recursion no longer dies early at a fixed cliff. The
+;; unbounded `(delay (force p))` form is genuinely runaway recursion and is
+;; reported as an uncatchable KP3008 stack overflow; that half lives in
+;; tests/scheme/errors/error-format.sh.
+(define selfp
+  (let ((count 0))
+    (delay (begin (set! count (+ count 1))
+                  (if (> count 100) count (force selfp))))))
+(test-assert "terminating re-entrant force returns"
+  (eqv? 101 (force selfp)))
+
+(let ((runner (test-runner-current)))
+  (test-end "register-growth-2035")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

Fixes #2035: the VM register file silently stopped growing at 4096 of its documented 65536, because the tail-position call opcodes (`tail_call`, `tail_apply`, `tail_call_global`, `tail_call_cc`, and tail `eval`) replace the current frame's code **in place** without re-ensuring room for the callee's `locals_count`. The overrun surfaced as a catchable `KP9001: internal error` — wrong diagnostic, and catchable, unlike every other VM limit (#1886).

## Changes

**`src/vm_dispatch_helpers.zig`**
- `registerIndex` now returns `StackOverflow` (→ KP3008, uncatchable) for a register-file overrun instead of `InvalidBytecode` (→ KP9001, catchable), matching what `ensureRegisterCapacity` already returns for the same resource.
- New `ensureTailWindow` helper: re-ensures the same bound `callClosure` guarantees for a fresh frame — `base + max(arg_count, locals_count) + 1`, so a variadic callee's rest slot is covered too.

**`src/vm_dispatch.zig`**
- Call `ensureTailWindow` at every in-place frame-replacement site: `.tail_call`, `.tail_apply`, `.tail_call_global`, `.tail_call_cc`'s receiver, and `.tail_eval`.

**Tests**
- Re-enabled the disabled `dynamic-wind: 1000 nested extents unwind cleanly` audit test.
- `tests/scheme/errors/error-format.sh`: pinned that register-file exhaustion reports `error[KP3008]: stack overflow` (never KP9001/KP9002) and that a `guard` cannot swallow it — for both the dynamic-wind shape and the unbounded `(delay (force p))` re-entrant-force shape.
- `gc-root-growth.scm` / `primitives_lazy-audit.scm`: two tests had been passing *because of the bug* — `(delay (force selfp))` died early at the 4096 cliff with a catchable-but-degenerate error. That recursion is genuinely unbounded (the SRFI-45 re-entrancy check only sees cycles whose thunk returns), so it now correctly runs to the register-file cap and is reported as an uncatchable stack overflow. The unbounded half moved to `error-format.sh`; the R7RS-legal *terminating* re-entrant form is pinned in their place.
- `CHANGELOG.md`: entry under Unreleased → Fixed.

## Verification

- `(nd 818)`, `(nd 1000)`, `(nd 5000)`, `(nd 10000)` all return `bottom` (register file grows to the documented cap).
- `(nd 15000)` → `error[KP3008]: stack overflow`; a `guard` cannot swallow it (register limit, not frame limit: ~13.1k frames vs the 32k frame cap).
- `zig build test` (incl. `-Dgc-stress=true`): pass. Full Scheme suite: 690 files + R7RS 1395, 0 fail. `zig build wasm` and `zig build lib`: pass.
