### PR TITLE
Require a delimiter after prefixed numeric tokens (#1929)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Every radix/exactness-prefixed numeric token now ends at a delimiter**
+  (#1929). `readNumberPrefixed` called the file-local `readNumber` /
+  `readIntegerWithRadix` directly, bypassing the delimiter check the
+  un-prefixed path gets from `Reader.readNumber`; the one wrapper that did
+  check, `Reader.readIntegerWithRadix`, had no callers at all — its guard
+  had never executed since it was added. A sweep of 19 prefix spellings × 26
+  trailing characters found 382 of 494 cells silently splitting one token
+  into two datums (`#b1p4` read as `(1 p4)`, changing an enclosing list's
+  length; `kaappi check` reported such a file clean). A single delimiter
+  check after the body read in `readNumberPrefixed` now guards every
+  spelling, and the dead wrapper is deleted: `#x1p4z`, `#e34zz`, `#b101foo`
+  and `#x1/2+3i` are all read errors, matching `string->number` and the
+  Chibi differential oracle, while hex floats (`#x1p4`), prefixed rationals
+  (`#x1/2`), decimal-prefixed complex (`#d1+2i`), SRFI-169 separators
+  (`#x1_f`) and two-prefix combinations (`#e#x1p4`) all still read.
+
 - **`(srfi 146 hash)` keys its tables with the comparator you passed** (#2044).
   Every constructor built a bare `(make-hash-table)` and stashed the
   comparator in the record, where `hashmap-key-comparator` handed it back —

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -727,13 +727,6 @@ pub const Reader = struct {
         return reader_tokens.readHash(self);
     }
 
-    fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
-        const tok = try reader_tokens.readIntegerWithRadix(self, radix);
-        if (self.pos < self.source.len and !isDelimiter(self.source[self.pos]))
-            return ReadError.UnexpectedChar;
-        return tok;
-    }
-
     fn readCharacter(self: *Reader) ReadError!Token {
         return reader_tokens.readCharacter(self);
     }
@@ -1007,4 +1000,53 @@ test "datum label forward reference in list" {
     const s = try readAndPrint(&gc, "(#0=42 #0#)");
     defer testing.allocator.free(s);
     try testing.expectEqualStrings("(42 42)", s);
+}
+
+test "prefixed numeric tokens require a trailing delimiter" {
+    // #1929: readNumberPrefixed bypassed the delimiter check that the
+    // un-prefixed path gets from the Reader.readNumber wrapper, so every
+    // radix/exactness-prefixed spelling silently split "#b1p4" into the
+    // fixnum 1 plus the symbol p4.  One check in readNumberPrefixed now
+    // guards them all; string->number already rejected every cell below.
+    var gc = memory.GC.init(testing.allocator);
+    defer gc.deinit();
+
+    // A glued tail is a read error in every prefix family.
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#b1p4"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#o1e3"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#d1a"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#e34zz"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#i7q"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x1p4z"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x1/2z"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x1/2+3i"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#e#b12"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#b#e12"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#b101foo"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x1zzz"));
+
+    // A whole list holding one is a read error too, never a longer list.
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "(#b1p4)"));
+
+    // Valid prefixed spellings still read: hex floats, rationals, complex
+    // with a decimal prefix, separators, and two-prefix combinations.
+    const f = try readAndPrint(&gc, "#x1p4");
+    defer testing.allocator.free(f);
+    try testing.expectEqualStrings("16.0", f);
+
+    const r = try readAndPrint(&gc, "#x1/2");
+    defer testing.allocator.free(r);
+    try testing.expectEqualStrings("1/2", r);
+
+    const c = try readAndPrint(&gc, "#d1+2i");
+    defer testing.allocator.free(c);
+    try testing.expectEqualStrings("1+2i", c);
+
+    const u = try readAndPrint(&gc, "#x1_f");
+    defer testing.allocator.free(u);
+    try testing.expectEqualStrings("31", u);
+
+    const exact = try readAndPrint(&gc, "#e#x1p4");
+    defer testing.allocator.free(exact);
+    try testing.expectEqualStrings("16", exact);
 }

--- a/src/reader_tokens.zig
+++ b/src/reader_tokens.zig
@@ -472,6 +472,19 @@ fn readNumberPrefixed(self: *Reader, radix0: u8, exact0: ?bool) ReadError!Token 
     const body_start = self.pos;
     const tok = if (radix == 10) try readNumber(self) else try readIntegerWithRadix(self, radix);
     if (numberTailTruncated(self)) return ReadError.UnexpectedEof;
+    // The token body must end at a delimiter or end of input (R7RS 7.1.1
+    // terminates numbers, like identifiers, at a <delimiter>). The file-local
+    // readNumber/readIntegerWithRadix do not check this -- the delimiter
+    // check lives in the Reader.readNumber wrapper used only by the
+    // un-prefixed path, so every prefixed spelling (`#b`, `#o`, `#d`, `#e`,
+    // `#i`, `#x`, and two-prefix combinations) skipped it: `#x1p4z`, `#e34zz`
+    // and `#b101foo` each read as a number plus a leftover symbol, silently
+    // changing an enclosing list's length (#1929). A single check here closes
+    // all 382 swept cells: tryReadInfNan already guards its own tail, the
+    // radix-10 complex grammar consumes `+...i` as part of the token, and
+    // readHexFloatSuffix/parseHexFloat reject malformed float bodies.
+    if (self.pos < self.source.len and !Reader.isDelimiter(self.source[self.pos]))
+        return invalidNumberOrEof(self);
     const want_exact = exact orelse return tok;
     switch (tok) {
         // Complex tokens keep their token-level parse: readNumber's complex

--- a/tests/scheme/compliance/reader-delimiter-gaps.scm
+++ b/tests/scheme/compliance/reader-delimiter-gaps.scm
@@ -133,14 +133,15 @@
   (test-assert "#\\az"     (rejects? "#\\az"))
   (test-assert "#\\spacez" (rejects? "#\\spacez"))
   (test-assert "#x+inf.0z" (rejects? "#x+inf.0z"))
-  ;; The bignum-rational token IS guarded (`bigRationalToken`,
-  ;; src/reader_tokens.zig:83) while the fixnum-rational token beside it is
-  ;; not -- the sharpest control in this file: the only difference between
-  ;; these two inputs is whether the numerator overflows i64.
+  ;; The bignum-rational token was the one guarded (`bigRationalToken`,
+  ;; src/reader_tokens.zig:83) while the fixnum-rational token beside it was
+  ;; not -- the sharpest control in this file pre-#1929: the only difference
+  ;; between these two inputs is whether the numerator overflows i64.  The
+  ;; #1929 fix (one delimiter check in `readNumberPrefixed`) now guards both.
   (test-assert "#x<bignum>/3z is rejected"
     (rejects? "#x99999999999999999999/3z"))
-  (test-assert "#x1/2z is NOT rejected -- same path, fixnum numerator"
-    (not (rejects? "#x1/2z"))))
+  (test-assert "#x1/2z is rejected -- same path, fixnum numerator"
+    (rejects? "#x1/2z")))
 
 ;;; ---------------------------------------------------------------------
 ;;; 4. Valid syntax that must keep working.  A fix for the gaps below must
@@ -230,12 +231,14 @@
   (test-assert "bare #e rejected" (rejects? "#e")))
 
 ;;; ---------------------------------------------------------------------
-;;; 5. The gaps.  `readNumberPrefixed` (src/reader_tokens.zig:481) calls the
-;;;    unguarded `reader_tokens.readNumber` / `reader_tokens.readIntegerWith-
-;;;    Radix` directly, bypassing the delimiter-checking wrappers
-;;;    `Reader.readNumber` (src/reader.zig:366) and
-;;;    `Reader.readIntegerWithRadix` (src/reader.zig:646).  The second wrapper
-;;;    has no callers at all -- it is dead code.
+;;; 5. The gaps, closed by #1929.  `readNumberPrefixed`
+;;;    (src/reader_tokens.zig:481) used to call the file-local unguarded
+;;;    `reader_tokens.readNumber` / `reader_tokens.readIntegerWithRadix`
+;;;    directly, bypassing the delimiter check; the one wrapper that did
+;;;    check, `Reader.readIntegerWithRadix` (src/reader.zig), had no callers
+;;;    at all -- dead code, since deleted.  A single delimiter check after
+;;;    the body read in `readNumberPrefixed` now guards every prefixed
+;;;    spelling.
 ;;;
 ;;;    Every assertion below is paired with an ENABLED `string->number`
 ;;;    assertion immediately above it, showing the oracle already rejects
@@ -245,100 +248,77 @@
 (test-group "radix prefix: trailing character must terminate the token"
   ;; --- #b: a digit from a higher radix ---
   (test-assert "s->n rejects #b12" (not (string->number "#b12")))
-  ;; FAIL: #1929 (#b12 reads as 1 followed by the symbol 2)
-  ;; (test-assert "#b12 rejected" (rejects? "#b12"))
+  (test-assert "#b12 rejected" (rejects? "#b12"))
 
   (test-assert "s->n rejects #b19" (not (string->number "#b19")))
-  ;; FAIL: #1929 (#b19 reads as 1 followed by the symbol 9)
-  ;; (test-assert "#b19 rejected" (rejects? "#b19"))
+  (test-assert "#b19 rejected" (rejects? "#b19"))
 
   (test-assert "s->n rejects #o18" (not (string->number "#o18")))
-  ;; FAIL: #1929 (#o18 reads as 1 followed by the symbol 8)
-  ;; (test-assert "#o18 rejected" (rejects? "#o18"))
+  (test-assert "#o18 rejected" (rejects? "#o18"))
 
   (test-assert "s->n rejects #d1a" (not (string->number "#d1a")))
-  ;; FAIL: #1929 (#d1a reads as 1 followed by the symbol a)
-  ;; (test-assert "#d1a rejected" (rejects? "#d1a"))
+  (test-assert "#d1a rejected" (rejects? "#d1a"))
 
   (test-assert "s->n rejects #x1g" (not (string->number "#x1g")))
-  ;; FAIL: #1929 (#x1g reads as 1 followed by the symbol g)
-  ;; (test-assert "#x1g rejected" (rejects? "#x1g"))
+  (test-assert "#x1g rejected" (rejects? "#x1g"))
 
   ;; --- exponent-marker-shaped letters ---
   (test-assert "s->n rejects #b1p4" (not (string->number "#b1p4")))
-  ;; FAIL: #1929 (#b1p4 reads as 1 followed by the symbol p4)
-  ;; (test-assert "#b1p4 rejected" (rejects? "#b1p4"))
+  (test-assert "#b1p4 rejected" (rejects? "#b1p4"))
 
   (test-assert "s->n rejects #o1e3" (not (string->number "#o1e3")))
-  ;; FAIL: #1929 (#o1e3 reads as 1 followed by the symbol e3)
-  ;; (test-assert "#o1e3 rejected" (rejects? "#o1e3"))
+  (test-assert "#o1e3 rejected" (rejects? "#o1e3"))
 
   (test-assert "s->n rejects #d1p" (not (string->number "#d1p")))
-  ;; FAIL: #1929 (#d1p reads as 1 followed by the symbol p)
-  ;; (test-assert "#d1p rejected" (rejects? "#d1p"))
+  (test-assert "#d1p rejected" (rejects? "#d1p"))
 
   (test-assert "s->n rejects #x1s" (not (string->number "#x1s")))
-  ;; FAIL: #1929 (#x1s reads as 1 followed by the symbol s)
-  ;; (test-assert "#x1s rejected" (rejects? "#x1s"))
+  (test-assert "#x1s rejected" (rejects? "#x1s"))
 
   (test-assert "s->n rejects #x1l" (not (string->number "#x1l")))
-  ;; FAIL: #1929 (#x1l reads as 1 followed by the symbol l)
-  ;; (test-assert "#x1l rejected" (rejects? "#x1l"))
+  (test-assert "#x1l rejected" (rejects? "#x1l"))
 
   ;; --- punctuation ---
   (test-assert "s->n rejects #b1/" (not (string->number "#b1/")))
-  ;; FAIL: #1929 (#b1/ reads as 1 followed by the symbol /)
-  ;; (test-assert "#b1/ rejected" (rejects? "#b1/"))
+  (test-assert "#b1/ rejected" (rejects? "#b1/"))
 
   (test-assert "s->n rejects #b1." (not (string->number "#b1.")))
-  ;; FAIL: #1929 (#b1. reads as 1 followed by a stray dot token)
-  ;; (test-assert "#b1. rejected" (rejects? "#b1."))
+  (test-assert "#b1. rejected" (rejects? "#b1."))
 
   (test-assert "s->n rejects #o1+" (not (string->number "#o1+")))
-  ;; FAIL: #1929 (#o1+ reads as 1 followed by the symbol +)
-  ;; (test-assert "#o1+ rejected" (rejects? "#o1+"))
+  (test-assert "#o1+ rejected" (rejects? "#o1+"))
 
   (test-assert "s->n rejects #x1-" (not (string->number "#x1-")))
-  ;; FAIL: #1929 (#x1- reads as 1 followed by the symbol -)
-  ;; (test-assert "#x1- rejected" (rejects? "#x1-"))
+  (test-assert "#x1- rejected" (rejects? "#x1-"))
 
   (test-assert "s->n rejects #b1#" (not (string->number "#b1#")))
-  ;; FAIL: #1929 (#b1# reads as 1 followed by a stray # token)
-  ;; (test-assert "#b1# rejected" (rejects? "#b1#"))
+  (test-assert "#b1# rejected" (rejects? "#b1#"))
 
   (test-assert "s->n rejects #x1'" (not (string->number "#x1'")))
-  ;; FAIL: #1929 (#x1' reads as 1 followed by a dangling quote)
-  ;; (test-assert "#x1' rejected" (rejects? "#x1'"))
+  (test-assert "#x1' rejected" (rejects? "#x1'"))
 
   ;; --- ordinary identifier characters ---
   (test-assert "s->n rejects #x1z"  (not (string->number "#x1z")))
-  ;; FAIL: #1929 (#x1z reads as 1 followed by the symbol z)
-  ;; (test-assert "#x1z rejected" (rejects? "#x1z"))
+  (test-assert "#x1z rejected" (rejects? "#x1z"))
 
   (test-assert "s->n rejects #b1!"  (not (string->number "#b1!")))
-  ;; FAIL: #1929 (#b1! reads as 1 followed by the symbol !)
-  ;; (test-assert "#b1! rejected" (rejects? "#b1!"))
+  (test-assert "#b1! rejected" (rejects? "#b1!"))
 
   (test-assert "s->n rejects #o1~"  (not (string->number "#o1~")))
-  ;; FAIL: #1929 (#o1~ reads as 1 followed by the symbol ~)
-  ;; (test-assert "#o1~ rejected" (rejects? "#o1~"))
+  (test-assert "#o1~ rejected" (rejects? "#o1~"))
 
   (test-assert "s->n rejects #d1:"  (not (string->number "#d1:")))
-  ;; FAIL: #1929 (#d1: reads as 1 followed by the symbol :)
-  ;; (test-assert "#d1: rejected" (rejects? "#d1:"))
+  (test-assert "#d1: rejected" (rejects? "#d1:"))
 
   (test-assert "s->n rejects #x1@"  (not (string->number "#x1@")))
-  ;; FAIL: #1929 (#x1@ reads as 1 followed by the symbol @)
-  ;; (test-assert "#x1@ rejected" (rejects? "#x1@"))
+  (test-assert "#x1@ rejected" (rejects? "#x1@"))
 
   ;; --- multi-character tails ---
   (test-assert "s->n rejects #b101foo" (not (string->number "#b101foo")))
-  ;; FAIL: #1929 (#b101foo reads as 5 followed by the symbol foo)
-  ;; (test-assert "#b101foo rejected" (rejects? "#b101foo"))
+  (test-assert "#b101foo rejected" (rejects? "#b101foo"))
 
   (test-assert "s->n rejects #x1zzz" (not (string->number "#x1zzz")))
-  ;; FAIL: #1929 (#x1zzz reads as 1 followed by the symbol zzz)
-  ;; (test-assert "#x1zzz rejected" (rejects? "#x1zzz"))
+  (test-assert "#x1zzz rejected" (rejects? "#x1zzz"))
   )
 
 (test-group "exactness-only prefix: the same gap on the DECIMAL path"
@@ -347,70 +327,54 @@
   ;; `reader_tokens.readNumber`.  (Phase 1A pins `#e1.5abc`, `#e12abc` and
   ;; `#d1e19/3`; these are different spellings of the same gap.)
   (test-assert "s->n rejects #e34zz" (not (string->number "#e34zz")))
-  ;; FAIL: #1929 (#e34zz reads as 34 followed by the symbol zz)
-  ;; (test-assert "#e34zz rejected" (rejects? "#e34zz"))
+  (test-assert "#e34zz rejected" (rejects? "#e34zz"))
 
   (test-assert "s->n rejects #e1.25xyz" (not (string->number "#e1.25xyz")))
-  ;; FAIL: #1929 (#e1.25xyz reads as 5/4 followed by the symbol xyz)
-  ;; (test-assert "#e1.25xyz rejected" (rejects? "#e1.25xyz"))
+  (test-assert "#e1.25xyz rejected" (rejects? "#e1.25xyz"))
 
   (test-assert "s->n rejects #i7q" (not (string->number "#i7q")))
-  ;; FAIL: #1929 (#i7q reads as 7.0 followed by the symbol q)
-  ;; (test-assert "#i7q rejected" (rejects? "#i7q"))
+  (test-assert "#i7q rejected" (rejects? "#i7q"))
 
   (test-assert "s->n rejects #i1.5abc" (not (string->number "#i1.5abc")))
-  ;; FAIL: #1929 (#i1.5abc reads as 1.5 followed by the symbol abc)
-  ;; (test-assert "#i1.5abc rejected" (rejects? "#i1.5abc"))
+  (test-assert "#i1.5abc rejected" (rejects? "#i1.5abc"))
 
   (test-assert "s->n rejects #d2e19/7" (not (string->number "#d2e19/7")))
-  ;; FAIL: #1929 (#d2e19/7 reads as 2e19 and silently drops the /7)
-  ;; (test-assert "#d2e19/7 rejected" (rejects? "#d2e19/7"))
+  (test-assert "#d2e19/7 rejected" (rejects? "#d2e19/7"))
 
   (test-assert "s->n rejects #e1e3x" (not (string->number "#e1e3x")))
-  ;; FAIL: #1929 (#e1e3x reads as 1000 followed by the symbol x)
-  ;; (test-assert "#e1e3x rejected" (rejects? "#e1e3x"))
+  (test-assert "#e1e3x rejected" (rejects? "#e1e3x"))
   )
 
 (test-group "two-prefix combinations, in both orders"
   (test-assert "s->n rejects #e#b12" (not (string->number "#e#b12")))
-  ;; FAIL: #1929 (#e#b12 reads as 1 followed by the symbol 2)
-  ;; (test-assert "#e#b12 rejected" (rejects? "#e#b12"))
+  (test-assert "#e#b12 rejected" (rejects? "#e#b12"))
 
   (test-assert "s->n rejects #b#e12" (not (string->number "#b#e12")))
-  ;; FAIL: #1929 (#b#e12 reads as 1 followed by the symbol 2)
-  ;; (test-assert "#b#e12 rejected" (rejects? "#b#e12"))
+  (test-assert "#b#e12 rejected" (rejects? "#b#e12"))
 
   (test-assert "s->n rejects #i#b1z" (not (string->number "#i#b1z")))
-  ;; FAIL: #1929 (#i#b1z reads as 1.0 followed by the symbol z)
-  ;; (test-assert "#i#b1z rejected" (rejects? "#i#b1z"))
+  (test-assert "#i#b1z rejected" (rejects? "#i#b1z"))
 
   (test-assert "s->n rejects #b#i1z" (not (string->number "#b#i1z")))
-  ;; FAIL: #1929 (#b#i1z reads as 1.0 followed by the symbol z)
-  ;; (test-assert "#b#i1z rejected" (rejects? "#b#i1z"))
+  (test-assert "#b#i1z rejected" (rejects? "#b#i1z"))
 
   (test-assert "s->n rejects #e#o19" (not (string->number "#e#o19")))
-  ;; FAIL: #1929 (#e#o19 reads as 1 followed by the symbol 9)
-  ;; (test-assert "#e#o19 rejected" (rejects? "#e#o19"))
+  (test-assert "#e#o19 rejected" (rejects? "#e#o19"))
 
   (test-assert "s->n rejects #o#e19" (not (string->number "#o#e19")))
-  ;; FAIL: #1929 (#o#e19 reads as 1 followed by the symbol 9)
-  ;; (test-assert "#o#e19 rejected" (rejects? "#o#e19"))
+  (test-assert "#o#e19 rejected" (rejects? "#o#e19"))
 
   (test-assert "s->n rejects #e#x1g" (not (string->number "#e#x1g")))
-  ;; FAIL: #1929 (#e#x1g reads as 1 followed by the symbol g)
-  ;; (test-assert "#e#x1g rejected" (rejects? "#e#x1g"))
+  (test-assert "#e#x1g rejected" (rejects? "#e#x1g"))
 
   (test-assert "s->n rejects #x#e1g" (not (string->number "#x#e1g")))
-  ;; FAIL: #1929 (#x#e1g reads as 1 followed by the symbol g)
-  ;; (test-assert "#x#e1g rejected" (rejects? "#x#e1g"))
+  (test-assert "#x#e1g rejected" (rejects? "#x#e1g"))
 
   (test-assert "s->n rejects #e#d1a" (not (string->number "#e#d1a")))
-  ;; FAIL: #1929 (#e#d1a reads as 1 followed by the symbol a)
-  ;; (test-assert "#e#d1a rejected" (rejects? "#e#d1a"))
+  (test-assert "#e#d1a rejected" (rejects? "#e#d1a"))
 
   (test-assert "s->n rejects #d#e1a" (not (string->number "#d#e1a")))
-  ;; FAIL: #1929 (#d#e1a reads as 1 followed by the symbol a)
-  ;; (test-assert "#d#e1a rejected" (rejects? "#d#e1a"))
+  (test-assert "#d#e1a rejected" (rejects? "#d#e1a"))
   )
 
 (test-group "SRFI 270 hex-float suffix path is unguarded too"
@@ -418,20 +382,16 @@
   ;; (src/reader_tokens.zig:829) -- beyond the fixnum and rational returns
   ;; named in #1892.
   (test-assert "s->n rejects #x1p4z" (not (string->number "#x1p4z")))
-  ;; FAIL: #1929 (#x1p4z reads as 16.0 followed by the symbol z)
-  ;; (test-assert "#x1p4z rejected" (rejects? "#x1p4z"))
+  (test-assert "#x1p4z rejected" (rejects? "#x1p4z"))
 
   (test-assert "s->n rejects #x1.8z" (not (string->number "#x1.8z")))
-  ;; FAIL: #1929 (#x1.8z reads as 1.5 followed by the symbol z)
-  ;; (test-assert "#x1.8z rejected" (rejects? "#x1.8z"))
+  (test-assert "#x1.8z rejected" (rejects? "#x1.8z"))
 
   (test-assert "s->n rejects #x1.g" (not (string->number "#x1.g")))
-  ;; FAIL: #1929 (#x1.g reads as 1.0 followed by the symbol g)
-  ;; (test-assert "#x1.g rejected" (rejects? "#x1.g"))
+  (test-assert "#x1.g rejected" (rejects? "#x1.g"))
 
   (test-assert "s->n rejects #x1p4/3" (not (string->number "#x1p4/3")))
-  ;; FAIL: #1929 (#x1p4/3 reads as 16.0 followed by the symbol /3)
-  ;; (test-assert "#x1p4/3 rejected" (rejects? "#x1p4/3"))
+  (test-assert "#x1p4/3 rejected" (rejects? "#x1p4/3"))
   )
 
 (test-group "bignum and rational token paths are unguarded too"
@@ -439,46 +399,38 @@
   ;; the same function is the control in group 3 above.
   (test-assert "s->n rejects #x<bignum>z"
     (not (string->number "#x99999999999999999999z")))
-  ;; FAIL: #1929 (#x99999999999999999999z reads as a bignum plus the symbol z)
-  ;; (test-assert "#x<bignum>z rejected" (rejects? "#x99999999999999999999z"))
+  (test-assert "#x<bignum>z rejected" (rejects? "#x99999999999999999999z"))
 
   (test-assert "s->n rejects #d<bignum>z"
     (not (string->number "#d99999999999999999999z")))
-  ;; FAIL: #1929 (#d99999999999999999999z reads as a bignum plus the symbol z)
-  ;; (test-assert "#d<bignum>z rejected" (rejects? "#d99999999999999999999z"))
+  (test-assert "#d<bignum>z rejected" (rejects? "#d99999999999999999999z"))
 
   (test-assert "s->n rejects #e<bignum>z"
     (not (string->number "#e99999999999999999999z")))
-  ;; FAIL: #1929 (#e99999999999999999999z reads as a bignum plus the symbol z)
-  ;; (test-assert "#e<bignum>z rejected" (rejects? "#e99999999999999999999z"))
+  (test-assert "#e<bignum>z rejected" (rejects? "#e99999999999999999999z"))
 
   ;; A binary literal one digit too wide for i64, with a `2` glued on.
   (test-assert "s->n rejects the wide binary literal"
     (not (string->number
           "#b1111111111111111111111111111111111111111111111111111111111111111112")))
-  ;; FAIL: #1929 (wide binary literal reads as a bignum plus the symbol 2)
-  ;; (test-assert "wide binary literal rejected"
-  ;;   (rejects?
-  ;;    "#b1111111111111111111111111111111111111111111111111111111111111111112"))
+  (test-assert "wide binary literal rejected"
+    (rejects?
+     "#b1111111111111111111111111111111111111111111111111111111111111111112"))
 
   ;; Fixnum rational.
   (test-assert "s->n rejects #x1/2z" (not (string->number "#x1/2z")))
-  ;; FAIL: #1929 (#x1/2z reads as 1/2 followed by the symbol z)
-  ;; (test-assert "#x1/2z rejected" (rejects? "#x1/2z"))
+  (test-assert "#x1/2z rejected" (rejects? "#x1/2z"))
 
   (test-assert "s->n rejects #e1/2z" (not (string->number "#e1/2z")))
-  ;; FAIL: #1929 (#e1/2z reads as 1/2 followed by the symbol z)
-  ;; (test-assert "#e1/2z rejected" (rejects? "#e1/2z"))
+  (test-assert "#e1/2z rejected" (rejects? "#e1/2z"))
 
   (test-assert "s->n rejects #b1/1z" (not (string->number "#b1/1z")))
-  ;; FAIL: #1929 (#b1/1z reads as 1 followed by the symbol z)
-  ;; (test-assert "#b1/1z rejected" (rejects? "#b1/1z"))
+  (test-assert "#b1/1z rejected" (rejects? "#b1/1z"))
 
   ;; A radix rational followed by a complex tail: the decimal path accepts
   ;; `1/2+3i`, the radix path silently splits it instead of rejecting it.
   (test-assert "s->n rejects #x1/2+3i" (not (string->number "#x1/2+3i")))
-  ;; FAIL: #1929 (#x1/2+3i reads as 1/2 followed by the symbol +3i)
-  ;; (test-assert "#x1/2+3i rejected or read whole" (not (splits? "#x1/2+3i")))
+  (test-assert "#x1/2+3i rejected or read whole" (not (splits? "#x1/2+3i")))
   )
 
 ;;; ---------------------------------------------------------------------
@@ -490,15 +442,17 @@
   (test-eqv "(#b101) has one element (control)" 1 (length (read1 "(#b101)")))
   (test-eqv "(#x1p4) has one element (control)" 1 (length (read1 "(#x1p4)")))
 
-  ;; FAIL: #1929 ('(#b1p4) reads as the two-element list (1 p4))
-  ;; (test-eqv "(#b1p4) is not two datums" 1 (length (read1 "(#b1p4)")))
-  ;; FAIL: #1929 ('(#o1e3) reads as the two-element list (1 e3))
-  ;; (test-eqv "(#o1e3) is not two datums" 1 (length (read1 "(#o1e3)")))
-  ;; FAIL: #1929 ('(#e12abc) reads as the two-element list (12 abc))
-  ;; (test-eqv "(#e12abc) is not two datums" 1 (length (read1 "(#e12abc)")))
-  ;; FAIL: #1929 ('(#x1p4z) reads as the two-element list (16.0 z))
-  ;; (test-eqv "(#x1p4z) is not two datums" 1 (length (read1 "(#x1p4z)")))
-  )
+  ;; A malformed prefixed token inside a list used to read as two datums,
+  ;; silently changing the list's length: '(#b1p4) became (1 p4).  Now the
+  ;; whole list is a read error -- never a longer list.
+  (test-assert "(#b1p4) is a read error, not two datums"
+    (rejects? "(#b1p4)"))
+  (test-assert "(#o1e3) is a read error, not two datums"
+    (rejects? "(#o1e3)"))
+  (test-assert "(#e12abc) is a read error, not two datums"
+    (rejects? "(#e12abc)"))
+  (test-assert "(#x1p4z) is a read error, not two datums"
+    (rejects? "(#x1p4z)")))
 
 ;;; ---------------------------------------------------------------------
 ;;; 7. Not a delimiter failure: an exactness/value divergence found by the

--- a/tests/scheme/compliance/reader-exactness-gaps.scm
+++ b/tests/scheme/compliance/reader-exactness-gaps.scm
@@ -27,8 +27,8 @@
 ;; #1910/#1921) was open, with the failing cells disabled.  Those are all
 ;; fixed -- the reader's `#e`/`#i` path now routes through the same
 ;; digit-exact parseNumberText as string->number -- and every cell is
-;; enabled as a regression guard, except section 9's trailing-junk cases
-;; (#1892, closed NOT_PLANNED), which stay disabled as documentation.
+;; enabled as a regression guard, including section 9's trailing-junk cases
+;; (#1892, closed by #1929).
 ;;
 ;; NOTE: numbers whose reading once crashed the process are exercised only
 ;; through `(read (open-input-string ...))`, never as source literals, so a
@@ -396,14 +396,14 @@
 (test-equal "parity #e1+2i" (rd "#e1+2i") (string->number "#e1+2i"))
 
 ;; ---------------------------------------------------------------------------
-;; 9. NEW: an exactness/radix prefix disables the trailing-delimiter check on
-;;    the DECIMAL path, so one token silently reads as two datums.
+;; 9. An exactness/radix prefix used to disable the trailing-delimiter check
+;;    on the DECIMAL path, so one token silently reads as two datums.
 ;;
-;;    Related to #1892, but that issue is scoped to RADIX prefixes and the
-;;    `readIntegerWithRadix` path; these cases need no radix prefix at all and
-;;    go through `readNumber`.  A fix confined to the radix path would leave
-;;    them live.  The unprefixed spelling correctly raises a read error, which
-;;    is the discriminating control.
+;;    Filed under #1892 (scoped to RADIX prefixes and the `readIntegerWith-
+;;    Radix` path); these cases need no radix prefix at all and go through
+;;    `readNumber`.  #1929's single delimiter check in `readNumberPrefixed`
+;;    guards both paths.  The unprefixed spelling correctly raises a read
+;;    error, which is the discriminating control.
 ;; ---------------------------------------------------------------------------
 
 ;; Controls: without a prefix, trailing junk IS rejected.
@@ -415,20 +415,17 @@
 (test-assert "string->number rejects #e12abc"  (not (string->number "#e12abc")))
 (test-assert "string->number rejects #e1e19/3" (not (string->number "#e1e19/3")))
 
-;; FAIL: #1892 (#e1.5abc reads as 3/2, leaving `abc`; cf. #1892 but decimal path)
-;; (test-assert "#e1.5abc is a read error" (eq? 'read-error (rd/safe "#e1.5abc")))
-;; FAIL: #1892 (#i1.5abc reads as 1.5, leaving `abc`)
-;; (test-assert "#i1.5abc is a read error" (eq? 'read-error (rd/safe "#i1.5abc")))
-;; FAIL: #1892 (#e12abc reads as 12, leaving `abc`)
-;; (test-assert "#e12abc is a read error" (eq? 'read-error (rd/safe "#e12abc")))
-;; FAIL: #1892 (#e12/3xyz reads as 4, leaving `xyz`)
-;; (test-assert "#e12/3xyz is a read error" (eq? 'read-error (rd/safe "#e12/3xyz")))
-;; FAIL: #1892 (#e1e19/3 drops `/3` entirely; '(#e1e19/3) reads as two datums)
-;; (test-assert "#e1e19/3 is a read error" (eq? 'read-error (rd/safe "#e1e19/3")))
-;; FAIL: #1892 (#d1e19/3 -- a pure radix-10 prefix triggers it too)
-;; (test-assert "#d1e19/3 is a read error" (eq? 'read-error (rd/safe "#d1e19/3")))
-;; FAIL: #1892 (one token becomes two datums)
-;; (test-equal "(#e1.5abc) is one datum" 1 (length (rd "(#e1.5abc)")))
+(test-assert "#e1.5abc is a read error" (eq? 'read-error (rd/safe "#e1.5abc")))
+(test-assert "#i1.5abc is a read error" (eq? 'read-error (rd/safe "#i1.5abc")))
+(test-assert "#e12abc is a read error"  (eq? 'read-error (rd/safe "#e12abc")))
+(test-assert "#e12/3xyz is a read error" (eq? 'read-error (rd/safe "#e12/3xyz")))
+(test-assert "#e1e19/3 is a read error" (eq? 'read-error (rd/safe "#e1e19/3")))
+(test-assert "#d1e19/3 is a read error" (eq? 'read-error (rd/safe "#d1e19/3")))
+;; A malformed prefixed token inside a list used to read as two datums,
+;; silently changing the list's length; now the whole list is a read error.
+(test-assert "(#e1.5abc) is one datum or a read error -- never two"
+  (guard (e (#t #t))
+    (= 1 (length (rd "(#e1.5abc)")))))
 
 ;; ---------------------------------------------------------------------------
 ;; 10. Round-trip invariant across the matrix.


### PR DESCRIPTION
Closes #1929.

## Summary

`readNumberPrefixed` (`src/reader_tokens.zig`) called the file-local `readNumber` / `readIntegerWithRadix` directly, bypassing the delimiter check the un-prefixed path gets from the `Reader.readNumber` wrapper. The one wrapper that did check — `Reader.readIntegerWithRadix` — had **zero callers**: its guard had never executed since it was added in `9e8cf95a`.

The Phase 1B sweep (19 prefix spellings × 26 trailing characters = 494 cells) found **382 cells** silently splitting one token into two datums:

```scheme
'(#b1p4)  ⟹ (1 p4)          ; length silently becomes 2
#x1p4z    ⟹ 16.0 + symbol z
#e34zz    ⟹ 34 + symbol zz
#x1/2+3i  ⟹ 1/2 + symbol +3i
```

and `kaappi check` reported such files as having "no issues found".

## Fix

One delimiter check after the body read in `readNumberPrefixed` closes all 382 cells:

- `tryReadInfNan` already guards its own tail
- the radix-10 complex grammar consumes `+...i` as part of the token (so `#d1+2i`, `#d1/2+3i` still read, matching Chibi)
- `readHexFloatSuffix` / `parseHexFloat` reject malformed float bodies

The dead `Reader.readIntegerWithRadix` wrapper is deleted.

`#x1p4z`, `#e34zz`, `#b101foo`, `#x1/2+3i` are now read errors — matching `string->number` and the Chibi 0.12 / Guile 3 differential oracles. The must-keep-working set is verified unchanged: hex floats (`#x1p4` ⟹ 16.0), prefixed rationals (`#x1/2`), decimal-prefixed complex (`#d1+2i`), SRFI-169 separators (`#x1_f`), bignums, two-prefix combinations (`#e#x1p4` ⟹ exact 16), and the incremental (incomplete-input) reader paths.

## Tests

- **Enables the 52 disabled `FAIL: #1929` assertions** in `tests/scheme/compliance/reader-delimiter-gaps.scm` (plus the 7 `#1892` decimal-path cells in `reader-exactness-gaps.scm` that the same fix closes), all paired with `string->number` oracle assertions.
- **Updates the group-3 discriminating control**: `#x1/2z` is now rejected too — both bignum and fixnum rational tails are guarded.
- **Adds a Zig unit test** (`prefixed numeric tokens require a trailing delimiter`) covering both the rejected and must-keep-working spellings.
- **CHANGELOG entry** under Unreleased → Fixed.

## Verification

- `zig build test` — full unit suite green (also under `-Dgc-stress=true` for the reader tests)
- `tests/scheme/run-all.sh` — 690 scheme files + 1395 R7RS, 0 failures
- `zig build wasm` green
- `kaappi check` now flags `(define x '(#b1p4))` with `KP1004: invalid number literal` (was "no issues found")