### PR TITLE
Bound fmt's prefix-chain depth and name dangling #; errors (#2141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`kaappi fmt` no longer stack-overflows on a long reader-prefix chain**
+  (#2141). The CST parser's depth cap (`max_nesting`, 1024) was enforced by
+  `parseList` and by nothing else: a chain of `'`, `` ` ``, `,`, `,@`, `#N=`
+  or `#;` recurses once per prefix through `parsePrefixTarget` without
+  touching `self.depth`, so ~158000 prefixes (an 8 MB stack; every prefix
+  kind verified at 200000) ran the native stack out — `fmt` exited 134, and
+  `fmt --check`, the documented CI gate, died the same way. The prefix and
+  datum-comment path now draws from the same `max_nesting` budget as
+  `parseList`, sharing one counter so mixed prefix+list nesting is rejected
+  at the reader's own 1025 level; the printer's `emitNode`/`computeMeasure`
+  recursion over the same chain is bounded by that cap. A dangling `#;` at
+  end of input is also reported as `syntax error: datum comment with no
+  datum` instead of being mislabelled `quote/unquote with no datum`.
+
 - **The register file grows to its documented 65536-register cap instead of
   silently stopping at 4096, and running off its end is an uncatchable KP3008**
   (#2035). A tail-position call (`tail_call`, `tail_apply`, `tail_call_global`,

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -107,6 +107,7 @@ pub const ParseError = error{
     UnterminatedBlockComment,
     UnexpectedRightParen,
     DanglingPrefix,
+    DanglingDatumComment,
     NestingTooDeep,
     OutOfMemory,
 };
@@ -443,7 +444,16 @@ const Parser = struct {
                 .newlines_before = tok.newlines_before,
             },
             .prefix, .datum_comment => {
-                const target = try self.parsePrefixTarget();
+                // A prefix / datum-comment chain recurses once per token via
+                // parsePrefixTarget, so it must draw from the same depth budget
+                // as parseList — an unguarded chain overflows the native stack
+                // (kaappi#2141). Sharing `self.depth` also keeps mixed
+                // prefix+list nesting within the reader's single 1025 cap.
+                if (self.depth >= max_nesting) return ParseError.NestingTooDeep;
+                self.depth += 1;
+                defer self.depth -= 1;
+                const dangling = if (tok.kind == .prefix) ParseError.DanglingPrefix else ParseError.DanglingDatumComment;
+                const target = try self.parsePrefixTarget(dangling);
                 const child = try self.arena.alloc(Node, 1);
                 child[0] = target;
                 return .{
@@ -460,10 +470,13 @@ const Parser = struct {
     /// The datum a prefix binds to. A prefix immediately followed by a comment
     /// (rather than a datum) is degenerate; binding to it verbatim keeps the CST
     /// simple, and the round-trip check catches any resulting divergence.
-    fn parsePrefixTarget(self: *Parser) ParseError!Node {
+    /// `dangling` is the error to report when the input ends (or a `)` closes
+    /// the list) before a datum appears — the caller picks the wording for the
+    /// kind it parsed, so a `#;` is not misreported as a quote.
+    fn parsePrefixTarget(self: *Parser, dangling: ParseError) ParseError!Node {
         const tok = try self.take();
         return switch (tok.kind) {
-            .eof, .rparen => ParseError.DanglingPrefix,
+            .eof, .rparen => dangling,
             else => self.nodeFromTok(tok),
         };
     }
@@ -652,6 +665,7 @@ fn parseErrorMessage(err: ParseError) []const u8 {
         ParseError.UnterminatedBlockComment => "syntax error: unterminated block comment",
         ParseError.UnexpectedRightParen => "syntax error: unexpected ')'",
         ParseError.DanglingPrefix => "syntax error: quote/unquote with no datum",
+        ParseError.DanglingDatumComment => "syntax error: datum comment with no datum",
         ParseError.NestingTooDeep => "syntax error: nesting too deep",
         ParseError.OutOfMemory => "out of memory",
     };

--- a/src/tests_fmt.zig
+++ b/src/tests_fmt.zig
@@ -287,6 +287,63 @@ test "unexpected close paren is a format error" {
     try testing.expectError(fmt.ParseError.UnexpectedRightParen, fmt.formatSource(arena.allocator(), "a)"));
 }
 
+// kaappi#2141: every reader-prefix kind recurses through parsePrefixTarget,
+// which once bypassed the parseList-only max_nesting check and overflowed the
+// native stack (exit 134 at ~158000 on an 8 MB stack). The chain must instead
+// hit the same NestingTooDeep the reader enforces at 1025.
+test "deep prefix chain of every kind is a format error, not a crash" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const prefixes = [_][]const u8{ "'", "`", ",", ",@", "#;", "#1=" };
+    for (prefixes) |pfx| {
+        var src: std.ArrayList(u8) = .empty;
+        defer src.deinit(testing.allocator);
+        for (0..2000) |_| try src.appendSlice(testing.allocator, pfx);
+        try src.append(testing.allocator, 'x');
+        try testing.expectError(fmt.ParseError.NestingTooDeep, fmt.formatSource(arena.allocator(), src.items));
+    }
+}
+
+// Prefixes and lists draw from one shared depth budget (the reader counts both
+// toward its single 1025 cap), so a chain that mixes them must be rejected at
+// the same total depth — not once per kind.
+test "prefix and list nesting share one depth budget" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var too_deep: std.ArrayList(u8) = .empty;
+    defer too_deep.deinit(testing.allocator);
+    try too_deep.appendNTimes(testing.allocator, '\'', 600);
+    try too_deep.appendNTimes(testing.allocator, '(', 600);
+    try too_deep.append(testing.allocator, 'x');
+    try too_deep.appendNTimes(testing.allocator, ')', 600);
+    try testing.expectError(fmt.ParseError.NestingTooDeep, fmt.formatSource(arena.allocator(), too_deep.items));
+
+    // 500 + 500 = 1000 stays under the cap and formats without recursion trouble.
+    var legal: std.ArrayList(u8) = .empty;
+    defer legal.deinit(testing.allocator);
+    try legal.appendNTimes(testing.allocator, '\'', 500);
+    try legal.appendNTimes(testing.allocator, '(', 500);
+    try legal.append(testing.allocator, 'x');
+    try legal.appendNTimes(testing.allocator, ')', 500);
+    const want = try std.mem.concat(testing.allocator, u8, &.{ legal.items, "\n" });
+    defer testing.allocator.free(want);
+    try expectFormat(legal.items, want);
+}
+
+test "a dangling datum comment is a distinct error from a dangling quote" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    // `#;` at EOF, at a close paren, or as a file's only content.
+    try testing.expectError(fmt.ParseError.DanglingDatumComment, fmt.formatSource(arena.allocator(), "#;"));
+    try testing.expectError(fmt.ParseError.DanglingDatumComment, fmt.formatSource(arena.allocator(), "#; \n"));
+    try testing.expectError(fmt.ParseError.DanglingDatumComment, fmt.formatSource(arena.allocator(), "(#;)"));
+    // The prefix wording is untouched for actual prefixes.
+    try testing.expectError(fmt.ParseError.DanglingPrefix, fmt.formatSource(arena.allocator(), "'"));
+    try testing.expectError(fmt.ParseError.DanglingPrefix, fmt.formatSource(arena.allocator(), "(`)"));
+    try testing.expectError(fmt.ParseError.DanglingPrefix, fmt.formatSource(arena.allocator(), ",@"));
+}
+
 test "empty input yields empty output" {
     try expectFormat("", "");
     try expectFormat("   \n\n  ", "");

--- a/tests/scheme/fmt/fmt-adversarial.sh
+++ b/tests/scheme/fmt/fmt-adversarial.sh
@@ -215,11 +215,31 @@ assert_clean_reject() {
 { repeat '(' 300000; repeat ')' 300000; echo; } > "$TMP/deep-list.scm"
 assert_clean_reject "depth: 300000 nested lists rejected cleanly" "$TMP/deep-list.scm"
 
-# FAIL: #2141 (max_nesting is checked in parseList only; parsePrefixTarget
-# recurses unguarded, so a long prefix chain overflows the native stack —
-# ~158000 on an 8 MB stack, and every prefix kind reaches it)
-# { repeat "'" 300000; echo x; } > "$TMP/deep-quote.scm"
-# assert_clean_reject "depth: 300000 quote prefixes rejected cleanly" "$TMP/deep-quote.scm"
+# Every reader-prefix kind recurses through parsePrefixTarget, which once
+# bypassed the parseList-only max_nesting check and overflowed the native
+# stack (~158000 on an 8 MB stack; all six verified at 200000). Each must now
+# be rejected cleanly like a deep list (kaappi#2141). Single-byte prefixes
+# reuse `repeat`; multi-byte ones come from awk (POSIX, unlike brace
+# expansion, and each byte of `,@` / `#;` / `#1=` is emitted once per
+# repetition, so the depth — not the byte count — is what the file exercises).
+for pfx in "'" '`' ','; do
+    { repeat "$pfx" 300000; echo x; } > "$TMP/deep-prefix.scm"
+    assert_clean_reject "depth: 300000 '$pfx' prefixes rejected cleanly" "$TMP/deep-prefix.scm"
+done
+for pfx in ',@' '#;' '#1='; do
+    awk -v p="$pfx" 'BEGIN { for (i = 0; i < 300000; i++) printf "%s", p }' > "$TMP/deep-prefix.scm"
+    echo x >> "$TMP/deep-prefix.scm"
+    assert_clean_reject "depth: 300000 '$pfx' prefixes rejected cleanly" "$TMP/deep-prefix.scm"
+done
+
+# A dangling #; names the datum comment, not quote/unquote (kaappi#2141).
+printf '(a) #;\n' > "$TMP/dangle.scm"
+err="$("$KAAPPI" fmt < "$TMP/dangle.scm" 2>&1)"
+if [[ "$err" == *"datum comment with no datum"* && "$err" != *"quote/unquote"* ]]; then
+    pass "dangling #; names the datum comment"
+else
+    fail "dangling #; names the datum comment" "stderr: [$err]"
+fi
 
 echo ""
 echo "fmt-adversarial: $PASS passed, $FAIL failed"


### PR DESCRIPTION
Fixes #2141.

## Problem

`kaappi fmt`'s CST parser bounded recursion for **lists only**. `parseList` checks `max_nesting` (1024), but a reader-prefix chain (`'`, `` ` ``, `,`, `,@`, `#N=`) or a `#;` datum comment recurses through `parsePrefixTarget` → `nodeFromTok` without touching `self.depth`. A long prefix chain therefore recurses once per prefix until the native stack runs out:

```bash
python3 -c "import sys; sys.stdout.write(\"'\"*158000 + 'x\n')" > deep.scm
kaappi fmt < deep.scm            # exit 134 (was)
kaappi fmt --check deep.scm      # exit 134 — the CI gate died too
```

Every prefix kind reaches it (verified at 200000). The real reader rejects the same input cleanly at its 1025 nesting cap — the number `fmt` writes down and then only half-enforced.

## Fix

- **`src/fmt.zig`**: the prefix/datum-comment path in `nodeFromTok` now draws from the same `max_nesting` budget as `parseList`, sharing one `self.depth` counter. Mixed prefix+list nesting is bounded at the reader's own 1025 level, and the printer's `emitNode`/`computeMeasure` recursion over the same chain is bounded by that cap (CSTs only ever come from the parser).
- **Adjacent**: a dangling `#;` at end of input is now reported as `syntax error: datum comment with no datum` (new `DanglingDatumComment` error) instead of being mislabelled `quote/unquote with no datum`.

## Tests

- `src/tests_fmt.zig`: every prefix kind rejects past the cap; prefix and list nesting share one depth budget (600+600 rejected, 500+500 formats); dangling `#;` is a distinct error from a dangling quote.
- `tests/scheme/fmt/fmt-adversarial.sh`: re-enabled the previously disabled #2141 cases, extended to all six prefix kinds at 300000 depth, plus the dangling-`#;` message check.
- `CHANGELOG.md`: entry under Unreleased → Fixed.

## Verification

- All six prefix kinds at 158k–300k now exit 1 with `nesting too deep` (was exit 134)
- 1023-deep chains still format; 1024-deep is round-trip-rejected — identical to lists and to the real reader
- `zig build test` green, including `-Dgc-stress=true`
- `fmt.sh` (37, incl. 921-file corpus round-trip + idempotence) green
- `fmt-adversarial.sh` (69) green
