### PR TITLE
LSP: isolate each document's macros so define-syntax cannot leak across documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **A `define-syntax` in one open LSP document no longer leaks into every other
+  document's diagnostics** (#1979). `runDiagnostics` compiled each document
+  against the server's single shared `vm.macros` table, so a macro defined in
+  one open file changed how every other file was diagnosed — byte-identical
+  text flipped from clean to `KP2001` depending on what else the editor had
+  open, and the leak survived `didClose` of the defining document (only a
+  server restart cleared it). Each document's diagnostics now reset the shared
+  table to the pre-document baseline first, so a file is diagnosed exactly as
+  if it were the only one open: macros its own text defines still accumulate
+  top-to-bottom (matching `kaappi check`), but nothing survives to another
+  document.
+
 - **`kaappi fmt` no longer stack-overflows on a long reader-prefix chain**
   (#2141). The CST parser's depth cap (`max_nesting`, 1024) was enforced by
   `parseList` and by nothing else: a chain of `'`, `` ` ``, `,`, `,@`, `#N=`

--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -239,6 +239,16 @@ fn sendNotification(allocator: std.mem.Allocator, method: []const u8, params: []
 var documents: std.StringHashMap([]const u8) = undefined;
 var doc_allocator: std.mem.Allocator = undefined;
 
+/// Snapshot of `vm.macros` taken after startup, before any document is opened.
+/// Every `runDiagnostics` run resets the shared `vm.macros` back to this
+/// baseline, so a `define-syntax` in one open document can never change how
+/// any other document is diagnosed (kaappi#1979). Values are rooted via
+/// `gc.extra_roots` at snapshot time: they are referenced only by this table
+/// from the moment a document shadows one of their names until the next run
+/// re-seeds `vm.macros` from it. Keys are interned symbol names, owned by the
+/// GC's symbol table, so the snapshot never owns them.
+var baseline_macros: std.StringHashMap(types.Value) = undefined;
+
 fn storeDocument(uri: []const u8, text: []const u8) void {
     const uri_copy = doc_allocator.dupe(u8, uri) catch return;
     const text_copy = doc_allocator.dupe(u8, text) catch {
@@ -659,6 +669,20 @@ fn runDiagnostics(allocator: std.mem.Allocator, vm: *vm_mod.VM, uri: []const u8,
     diag_buf.append(allocator, '[') catch return;
     var has_diag = false;
 
+    // Reset the shared macro table to the pre-document baseline: each document
+    // is diagnosed as if it were the only one open. The define-syntax forms
+    // compiled below accumulate in `vm.macros` across the document's own
+    // forms — the same top-to-bottom visibility `kaappi check` gives a
+    // standalone file — but nothing survives to another document, so byte-
+    // identical text gets the same verdict regardless of what else is open
+    // (kaappi#1979). Values written here are marked by the VM's GC exactly as
+    // before; they are simply retracted by the next run's reset.
+    vm.macros.clearRetainingCapacity();
+    var mit = baseline_macros.iterator();
+    while (mit.next()) |entry| {
+        vm.macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return;
+    }
+
     // Parse phase
     var r = reader.Reader.initWithName(vm.gc, text, uri);
     defer r.deinit();
@@ -788,6 +812,19 @@ pub fn main(init: std.process.Init.Minimal) !void {
     try primitives.registerAll(&vm);
     try vm_mod.vm_bootstrap.install(&vm);
     try library.registerStandardLibraries(&vm.libraries, vm.globals);
+
+    // Snapshot the macro table before any document is opened; runDiagnostics
+    // resets the shared `vm.macros` to this per run (kaappi#1979). `vm.macros`
+    // is empty here today, but the snapshot keeps the isolation correct if
+    // startup ever seeds it (e.g. a pre-imported library). The baseline values
+    // are rooted once via extra_roots — the GC cannot see this table, and the
+    // VM's own macro marking covers vm.macros only.
+    baseline_macros = std.StringHashMap(types.Value).init(gc.allocator);
+    var mit = vm.macros.iterator();
+    while (mit.next()) |entry| {
+        baseline_macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return;
+        gc.extra_roots.append(gc.allocator, entry.value_ptr.*) catch return;
+    }
 
     var initialized = false;
 

--- a/tests/scheme/lsp/lsp.sh
+++ b/tests/scheme/lsp/lsp.sh
@@ -852,11 +852,8 @@ msg "$EXITN"
 lsp_run
 assert_eq "leak: the same document text is diagnosed twice" \
     "$(count "$OUT" '"uri":"'"$BDOC"'"')" "2"
-# FAIL: #1979 (a define-syntax in one open document leaks into every other
-#            document's diagnostics through the shared vm.macros table, so
-#            byte-identical text flips from clean to KP2001)
-# assert_eq "leak: both diagnoses of identical text agree" \
-#     "$(count "$OUT" '"code":"KP2001"')" "0"
+assert_eq "leak: both diagnoses of identical text agree" \
+    "$(count "$OUT" '"code":"KP2001"')" "0"
 
 # The leak outlives didClose of the defining document.
 stream_reset
@@ -868,9 +865,11 @@ did_open "$BDOC" "$USE"
 msg "$EXITN"
 lsp_run
 # Control: closing A does publish its clearing notification, so didClose ran.
-assert_eq "leak control 3: didClose published its empty array" "$(count "$OUT" '"diagnostics":[]')" "2"
-# FAIL: #1979 (closing the defining document does not retract its macros)
-# assert_eq "leak: closing A restores B's clean verdict" "$(count "$OUT" '"code":"KP2001"')" "0"
+# (With the leak fixed, B's own open is clean too, so all three frames are
+# empty arrays; the count was 2 under the bug because B carried A's macro.)
+assert_eq "leak control 3: didClose published its empty array" "$(count "$OUT" '"diagnostics":[]')" "3"
+assert_eq "leak: closing A restores B's clean verdict" \
+    "$(count "$OUT" '"code":"KP2001"')" "0"
 
 # Control 4: a plain `define` of the same name does NOT leak, which isolates the
 # mechanism to the macro table rather than the globals map.
@@ -882,6 +881,34 @@ did_open "$BDOC" "$USE"
 msg "$EXITN"
 lsp_run
 assert_eq "leak control 4: a plain define of the same name does not leak" \
+    "$(count "$OUT" '"code":"KP2001"')" "0"
+
+# Regression guards for the fix itself, in both directions:
+#  * isolation must not disable macro diagnostics within a document — a file
+#    that defines AND misuses a macro is KP2001 even when another document is
+#    open (the misuse is judged against the macros its own text defines);
+#  * isolation must hold for a document that defines macros of its own: B
+#    defining `other` must not start seeing A's `my-if` mid-file. Under the
+#    leak, the second case is KP2001; with the fix it is a clean call to an
+#    unbound global, exactly B's verdict alone.
+stream_reset
+msg "$INIT"
+msg "$INITED"
+did_open "$ADOC" "$MACRO"
+did_open "$BDOC" "$MACRO$USE"
+msg "$EXITN"
+lsp_run
+assert_has "leak fix: own-document macro misuse stays KP2001" \
+    "$OUT" '"code":"KP2001"'
+
+stream_reset
+msg "$INIT"
+msg "$INITED"
+did_open "$ADOC" "$MACRO"
+did_open "$BDOC" '(define-syntax other (syntax-rules () ((_) 1)))\n(my-if)\n'
+msg "$EXITN"
+lsp_run
+assert_eq "leak fix: another doc's macro stays invisible after own define-syntax" \
     "$(count "$OUT" '"code":"KP2001"')" "0"
 
 # Compiling a document must not publish its globals to the whole server either:


### PR DESCRIPTION
Fixes #1979.

## Problem

`runDiagnostics` compiled every open document against the server's single shared `vm.macros` table. A `define-syntax` in one open file therefore changed how every other file was diagnosed:

| session | `b.scm` diagnostics |
|---|---|
| open `b.scm` alone | `[]` — clean |
| open `a.scm`, then `b.scm` | **`KP2001`** |

The leak survived `didClose` of the defining document — only a server restart cleared it. A plain `define` of the same name never leaked (globals are never written by the diagnostics path), isolating the mechanism to the macro table.

## Fix

Each `runDiagnostics` run now resets the shared `vm.macros` to a baseline snapshot taken at startup (before any document is opened):

- a document's **own** macros still accumulate top-to-bottom across its forms — the same visibility `kaappi check` gives a standalone file, so macro + misuse in one file is still `KP2001`;
- nothing written during a run survives to another document, so every file gets the verdict it would get alone, regardless of what else is open.

Baseline values are rooted once via `gc.extra_roots` (the VM's GC marking covers `vm.macros` only). `vm.macros` is empty at startup today, but the snapshot keeps the isolation correct if startup ever seeds it.

## Tests

- Enables the two `# FAIL: #1979` assertions in `tests/scheme/lsp/lsp.sh` (identical text diagnosed clean; `didClose` restores the clean verdict).
- Retunes the `didClose` control count (2 → 3): with the leak fixed, B's own open is clean too, so all three frames are empty arrays.
- Adds two regression guards: own-document macro misuse stays `KP2001` with another document open, and a document defining its own macro still cannot see another document's.

**Validation:** 156 LSP assertions pass, including under `-Dgc-stress=true`; `zig build test` passes.
