### PR TITLE
Read radix-prefixed complex numbers per R7RS <complex R> (#2243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,10 +90,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   length; `kaappi check` reported such a file clean). A single delimiter
   check after the body read in `readNumberPrefixed` now guards every
   spelling, and the dead wrapper is deleted: `#x1p4z`, `#e34zz`, `#b101foo`
-  and `#x1/2+3i` are all read errors, matching `string->number` and the
+  and `#x1zzz` are all read errors, matching `string->number` and the
   Chibi differential oracle, while hex floats (`#x1p4`), prefixed rationals
   (`#x1/2`), decimal-prefixed complex (`#d1+2i`), SRFI-169 separators
-  (`#x1_f`) and two-prefix combinations (`#e#x1p4`) all still read.
+  (`#x1_f`) and two-prefix combinations (`#e#x1p4`) all still read. (The
+  radix-prefixed complex spellings this guard briefly made read errors —
+  `#x1/2+3i` and friends — were reinstated as valid R7RS by #2243 below;
+  the glued-tail `+3z`/`+3iz` forms remain errors.)
 
 - **`(srfi 146 hash)` keys its tables with the comparator you passed** (#2044).
   Every constructor built a bare `(make-hash-table)` and stashed the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   if it were the only one open: macros its own text defines still accumulate
   top-to-bottom (matching `kaappi check`), but nothing survives to another
   document.
+- **Radix-prefixed complex numbers read per R7RS 7.1.1's `<complex R>`
+  grammar, and `read` and `string->number` agree on them** (#2243). The
+  #1929 delimiter fix had turned every non-decimal radix complex spelling
+  into a read error, but `#x1/2+3i`, `#x1+2i`, `#x1+i`, `#b1+1i` and
+  friends are valid R7RS (guile, Chez and the project's own radix-10 path
+  all read them). `readIntegerWithRadix` now consumes a complex tail
+  (`+<ureal R> i`, `-<ureal R> i`, `+i`, `-i`) with radix-valid digits
+  and optional rational parts, producing an exact complex token exactly
+  like the decimal path does for `1/2+3i`; `#b1+2i` (2 is not a binary
+  digit), `#x1+2` (no `i`), `#x1+2iz` (glued tail) and the signless
+  `#x3i`/`#xi` still error, and bignum components stay a loud error
+  (the kaappi#2182 stance — an exact bignum part has no honest f64
+  value). `string->number`'s complex branch is no longer radix-10-only:
+  the split forms work in every radix, which also closes the documented
+  `FAIL: TBD` where `string->number` returned `#f` for the valid R7RS
+  complex `1/2+3i` (Chibi and guile both accept it).
 
 - **`kaappi fmt` no longer stack-overflows on a long reader-prefix chain**
   (#2141). The CST parser's depth cap (`max_nesting`, 1024) was enforced by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   and optional rational parts, producing an exact complex token exactly
   like the decimal path does for `1/2+3i`; `#b1+2i` (2 is not a binary
   digit), `#x1+2` (no `i`), `#x1+2iz` (glued tail) and the signless
-  `#x3i`/`#xi` still error, and bignum components stay a loud error
-  (the kaappi#2182 stance — an exact bignum part has no honest f64
+  `#x3i`/`#xi`/`#x3/4i` still error, and bignum components stay a loud
+  error (the kaappi#2182 stance — an exact bignum part has no honest f64
   value). `string->number`'s complex branch is no longer radix-10-only:
   the split forms work in every radix, which also closes the documented
   `FAIL: TBD` where `string->number` returned `#f` for the valid R7RS
-  complex `1/2+3i` (Chibi and guile both accept it).
+  complex `1/2+3i` (Chibi and guile both accept it). The signed pure
+  imaginary `+ <ureal R> i` / `- <ureal R> i` productions (`#x+3i`,
+  `#x+3/4i`) read in every radix too, matching Chez; the imaginary
+  marker is case-insensitive in both parsers; and `string->number`'s
+  radix-argument spelling treats `i` as an ordinary digit (value 18)
+  from radix 19 up, exactly as before. Exact-flagged complex components
+  are now honest: integer parts beyond 2^53 and rational parts beyond
+  the printer's recovery granularity (denominator ~1e6) that would
+  silently round to a different value are rejected loudly in both
+  parsers, and `string->number` derives component exactness from the
+  text so it agrees with the reader's exact-flagged tokens (`1+2i` reads
+  back exact, `1.5+2i` has an inexact real part).
 
 - **`kaappi fmt` no longer stack-overflows on a long reader-prefix chain**
   (#2141). The CST parser's depth cap (`max_nesting`, 1024) was enforced by

--- a/src/bignum.zig
+++ b/src/bignum.zig
@@ -857,6 +857,70 @@ pub fn stripUnderscores(s: []const u8, radix: u8, buf: []u8) ?[]const u8 {
     return buf[0..n];
 }
 
+/// True when converting the i64 to f64 is lossless. Complex-number
+/// components claim exactness only inside this range: values in
+/// (2^53, 2^63] round to a different integer, so an exact-flagged token
+/// would silently carry the wrong value (kaappi#2182/#2243 -- loud
+/// rejection over silent rounding).
+pub fn f64ExactI64(n: i64) bool {
+    const f: f64 = @floatFromInt(n);
+    return @as(i64, @intFromFloat(f)) == n;
+}
+
+/// True when a bignum Value's magnitude is exactly representable in f64:
+/// at most 53 significant bits after stripping trailing binary zeros
+/// (10^19 = 5^19*2^19 has 45 bits and qualifies; 2^53+1 does not). The
+/// exact-complex machinery carries components as f64 plus an exactness
+/// flag, so a non-representable integer would silently round (kaappi#2243).
+pub fn bignumExactInF64(v: Value) bool {
+    const bn = types.toBignum(v);
+    if (bn.len == 0) return true;
+    var trailing: u64 = 0;
+    var i: usize = 0;
+    while (i < bn.len and bn.limbs[i] == 0) : (i += 1) trailing += 64;
+    if (i >= bn.len) return true; // zero
+    trailing += @ctz(bn.limbs[i]);
+    const top = bn.limbs[bn.len - 1];
+    const bit_len: u64 = 64 * @as(u64, @intCast(bn.len - 1)) + 64 - @clz(top);
+    return bit_len - trailing <= 53;
+}
+
+/// Largest |numerator|/|denominator| an exact-flagged complex component
+/// may carry. The exact-complex printer recovers rationals via
+/// `floatToRational`'s brute-force search, which tries denominators up to
+/// this limit; a component within it round-trips exactly, while a larger
+/// one would print the rounded f64's mantissa/2^k value -- a silently
+/// wrong number claiming exactness. Values beyond the limit are rejected
+/// loudly, the same policy as i64-overflowing components (kaappi#2182/
+/// #2243).
+pub const complex_rational_limit: i64 = 1_000_000;
+
+/// Parse a radix-R <ureal> slice (radix digits with optional SRFI-169 `_`
+/// separators, optionally `N/D`) to f64. No sign -- callers handle signs.
+/// i64 overflow, an invalid character, a zero denominator, or an i64 part
+/// that does not round-trip through f64 (see `f64ExactI64`) yields null.
+/// This is the single implementation shared by the reader and
+/// `string->number` so the two complex grammars cannot drift (kaappi#2243).
+pub fn parseRadixUrealToF64(s: []const u8, radix: u8) ?f64 {
+    if (std.mem.indexOfScalar(u8, s, '/')) |sp| {
+        if (sp == 0 or sp + 1 >= s.len) return null;
+        var nb: [256]u8 = undefined;
+        var db: [256]u8 = undefined;
+        const num = stripUnderscores(s[0..sp], radix, &nb) orelse return null;
+        const den = stripUnderscores(s[sp + 1 ..], radix, &db) orelse return null;
+        const n = std.fmt.parseInt(i64, num, radix) catch return null;
+        const d = std.fmt.parseInt(i64, den, radix) catch return null;
+        if (d == 0) return null;
+        if (@abs(n) > complex_rational_limit or @abs(d) > complex_rational_limit) return null;
+        return @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d));
+    }
+    var b: [256]u8 = undefined;
+    const clean = stripUnderscores(s, radix, &b) orelse return null;
+    const n = std.fmt.parseInt(i64, clean, radix) catch return null;
+    if (!f64ExactI64(n)) return null;
+    return @as(f64, @floatFromInt(n));
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/src/bignum.zig
+++ b/src/bignum.zig
@@ -864,6 +864,11 @@ pub fn stripUnderscores(s: []const u8, radix: u8, buf: []u8) ?[]const u8 {
 /// rejection over silent rounding).
 pub fn f64ExactI64(n: i64) bool {
     const f: f64 = @floatFromInt(n);
+    // The top 512 i64 values (2^63-512 .. 2^63-1) round UP to 2^63, which
+    // no longer fits the i64 destination of @intFromFloat -- a ReleaseSafe
+    // panic reachable from a one-line program (kaappi#2243 review). They
+    // never round-trip, so reject before the conversion.
+    if (f >= 9223372036854775808.0) return false;
     return @as(i64, @intFromFloat(f)) == n;
 }
 

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -1128,6 +1128,38 @@ fn stringToNumber(args: []const Value) PrimitiveError!Value {
     return parseNumberText(gc, str.data[0..str.len], radix, .unspecified);
 }
 
+/// Parse a signed radix-R <ureal> (integer, N/D rational, or -- radix 10
+/// only -- a decimal) to f64, for use as a complex component. Mirrors the
+/// reader's complex-component grammar so `string->number` and `read` agree
+/// on `#x1+2i`, `#x1/2+3i` and friends (kaappi#2243): i64 overflow yields
+/// null (an exact bignum component has no honest f64 value -- loud
+/// rejection over silent rounding, cf. kaappi#2182).
+fn parseComplexPartToF64(part: []const u8, radix: u8) ?f64 {
+    // Rational N/D (any radix): R7RS <ureal R>.
+    if (std.mem.indexOfScalar(u8, part, '/')) |sp| {
+        if (sp == 0 or sp + 1 >= part.len) return null;
+        var nb: [256]u8 = undefined;
+        var db: [256]u8 = undefined;
+        const num = bignum_mod.stripUnderscores(part[0..sp], radix, &nb) orelse return null;
+        const den = bignum_mod.stripUnderscores(part[sp + 1 ..], radix, &db) orelse return null;
+        const n = std.fmt.parseInt(i64, num, radix) catch return null;
+        const d = std.fmt.parseInt(i64, den, radix) catch return null;
+        if (d == 0) return null;
+        return @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d));
+    }
+    if (radix == 10) {
+        // Decimal parts (1.5+2i, 1e5+2i) and inf/nan spellings: parseFloat
+        // accepts them with the sign included. Unchanged acceptance from
+        // before #2243.
+        return std.fmt.parseFloat(f64, part) catch null;
+    }
+    // Radix 2/8/16: integer part only -- <decimal R> does not exist there.
+    var b: [256]u8 = undefined;
+    const clean = bignum_mod.stripUnderscores(part, radix, &b) orelse return null;
+    const n = std.fmt.parseInt(i64, clean, radix) catch return null;
+    return @as(f64, @floatFromInt(n));
+}
+
 /// Parse a complete number text into a Value, or `types.FALSE` when the text
 /// is not a number. This is the single number grammar behind BOTH
 /// `string->number` and the reader's `#e`/`#i` literals: R7RS 6.2.7 requires
@@ -1201,7 +1233,13 @@ pub fn parseNumberText(gc: *@import("memory.zig").GC, text: []const u8, radix_in
 
     // Rational: num/den
     if (std.mem.indexOfScalar(u8, s, '/')) |slash_pos| {
-        if (slash_pos > 0 and slash_pos + 1 < s.len) {
+        // A trailing 'i' means the '/' is a complex-component separator
+        // (1/2+3i, 1/2+3/4i, #x1/2+3i): the complex branch below owns
+        // those, parsing each component as a <ureal R> (kaappi#2243).
+        // Without this guard, 1/2+3i would try "2+3i" as a denominator,
+        // fail, and return #f for a valid R7RS complex.
+        const complex_shaped = s.len >= 2 and s[s.len - 1] == 'i';
+        if (!complex_shaped and slash_pos > 0 and slash_pos + 1 < s.len) {
             const num_str = s[0..slash_pos];
             const den_str = s[slash_pos + 1 ..];
             const num_val: Value = if (std.fmt.parseInt(i64, num_str, radix)) |num|
@@ -1276,59 +1314,71 @@ pub fn parseNumberText(gc: *@import("memory.zig").GC, text: []const u8, radix_in
         if (std.fmt.parseFloat(f64, s)) |f| {
             return applyExactness(gc, types.makeFlonum(f), exactness);
         } else |_| {}
+    }
 
-        // Try parsing as complex: a+bi, a-bi, +bi, -bi, +i, -i
-        if (s.len >= 2 and s[s.len - 1] == 'i') {
-            const body = s[0 .. s.len - 1]; // strip trailing 'i'
+    // Try parsing as complex: a+bi, a-bi, +bi, -bi, +i, -i (R7RS 7.1.1
+    // <complex R>). Radix-prefixed spellings (#x1+2i, #x1/2+3i) are valid
+    // R7RS and the reader now accepts them too (kaappi#2243), so this
+    // branch is no longer radix-10-only: the split forms work in every
+    // radix, while decimal real/imag parts and the signless pure-imaginary
+    // extension (2i, +3i) stay radix-10-only -- exactly mirroring the
+    // reader's grammar (which rejects `#x3i` and `#x2/3i`).
+    if (s.len >= 2 and s[s.len - 1] == 'i') {
+        const body = s[0 .. s.len - 1]; // strip trailing 'i'
 
-            // Pure imaginary: +i, -i
-            if (std.mem.eql(u8, body, "+")) {
-                const c = gc.allocComplex(0.0, 1.0) catch return PrimitiveError.OutOfMemory;
-                return applyExactness(gc, c, exactness);
+        // Pure imaginary: +i, -i (R7RS <complex R> -> `+ i` | `- i`).
+        // Every radix accepts them -- the reader reads `#x+i` as 0+1i too
+        // (#2243) -- while the signless `#x3i` spelling stays rejected by
+        // the no-split branch below.
+        if (std.mem.eql(u8, body, "+")) {
+            const c = gc.allocComplex(0.0, 1.0) catch return PrimitiveError.OutOfMemory;
+            return applyExactness(gc, c, exactness);
+        }
+        if (std.mem.eql(u8, body, "-")) {
+            const c = gc.allocComplex(0.0, -1.0) catch return PrimitiveError.OutOfMemory;
+            return applyExactness(gc, c, exactness);
+        }
+
+        // Find the split point: last +/- that isn't at position 0. In radix
+        // 10 a +/- right after e/E is an exponent sign (1e+5i reads the
+        // exponent into the real part); in radix 2/8/16 letters are digits,
+        // so no such skip applies (#x1e+2i is real 1e = 30).
+        var split: ?usize = null;
+        var j: usize = body.len;
+        while (j > 1) {
+            j -= 1;
+            if (body[j] == '+' or body[j] == '-') {
+                if (radix == 10 and (body[j - 1] == 'e' or body[j - 1] == 'E')) continue;
+                split = j;
+                break;
             }
-            if (std.mem.eql(u8, body, "-")) {
-                const c = gc.allocComplex(0.0, -1.0) catch return PrimitiveError.OutOfMemory;
-                return applyExactness(gc, c, exactness);
-            }
+        }
 
-            // Find the split point: last +/- that isn't at position 0 and isn't in an exponent
-            var split: ?usize = null;
-            var j: usize = body.len;
-            while (j > 1) {
-                j -= 1;
-                if (body[j] == '+' or body[j] == '-') {
-                    if (j > 0 and (body[j - 1] == 'e' or body[j - 1] == 'E')) continue;
-                    split = j;
-                    break;
-                }
-            }
-
-            if (split) |sp| {
-                const real_str = body[0..sp];
-                const imag_str = body[sp..];
-                const real_val = if (real_str.len == 0) @as(f64, 0.0) else std.fmt.parseFloat(f64, real_str) catch {
-                    return types.FALSE;
-                };
-                var imag_val: f64 = undefined;
-                if (std.mem.eql(u8, imag_str, "+")) {
-                    imag_val = 1.0;
-                } else if (std.mem.eql(u8, imag_str, "-")) {
-                    imag_val = -1.0;
-                } else {
-                    imag_val = std.fmt.parseFloat(f64, imag_str) catch {
-                        return types.FALSE;
-                    };
-                }
-                const c = gc.allocComplex(real_val, imag_val) catch return PrimitiveError.OutOfMemory;
-                return applyExactness(gc, c, exactness);
+        if (split) |sp| {
+            const real_str = body[0..sp];
+            const imag_str = body[sp..];
+            const real_val = if (real_str.len == 0) @as(f64, 0.0) else parseComplexPartToF64(real_str, radix) orelse return types.FALSE;
+            var imag_val: f64 = undefined;
+            if (std.mem.eql(u8, imag_str, "+")) {
+                imag_val = 1.0;
+            } else if (std.mem.eql(u8, imag_str, "-")) {
+                imag_val = -1.0;
             } else {
-                // No split found — pure imaginary like +3i or -2.5i
-                const imag_val = std.fmt.parseFloat(f64, body) catch {
-                    return types.FALSE;
-                };
-                const c = gc.allocComplex(0.0, imag_val) catch return PrimitiveError.OutOfMemory;
-                return applyExactness(gc, c, exactness);
+                imag_val = parseComplexPartToF64(imag_str, radix) orelse return types.FALSE;
             }
+            const c = gc.allocComplex(real_val, imag_val) catch return PrimitiveError.OutOfMemory;
+            return applyExactness(gc, c, exactness);
+        } else {
+            // No split found -- pure imaginary like +3i or -2.5i. Radix 10
+            // only: the signless rational form (2/3i) and every
+            // radix-prefixed spelling (#x3i) are rejected by the reader
+            // too, so keep #f for them.
+            if (radix != 10) return types.FALSE;
+            const imag_val = std.fmt.parseFloat(f64, body) catch {
+                return types.FALSE;
+            };
+            const c = gc.allocComplex(0.0, imag_val) catch return PrimitiveError.OutOfMemory;
+            return applyExactness(gc, c, exactness);
         }
     }
 

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -1185,6 +1185,14 @@ fn parseComplexComponent(gc: *@import("memory.zig").GC, part: []const u8, radix:
                 return .{ .val = bignum_mod.toF64(v), .exact = true };
             }
         }
+        // Special floats (+inf.0, -inf.0, +nan.0, -nan.0, case-insensitive)
+        // match the reader's complex-component grammar -- 3.0+inf.0i and
+        // +inf.0i read there -- but Zig's parseFloat does not accept them
+        // (#2243 review).
+        if (std.ascii.eqlIgnoreCase(part, "+inf.0")) return .{ .val = std.math.inf(f64), .exact = false };
+        if (std.ascii.eqlIgnoreCase(part, "-inf.0")) return .{ .val = -std.math.inf(f64), .exact = false };
+        if (std.ascii.eqlIgnoreCase(part, "+nan.0")) return .{ .val = std.math.nan(f64), .exact = false };
+        if (std.ascii.eqlIgnoreCase(part, "-nan.0")) return .{ .val = std.math.nan(f64), .exact = false };
         const f = std.fmt.parseFloat(f64, part) catch return null;
         return .{ .val = f, .exact = false };
     }
@@ -1443,9 +1451,18 @@ pub fn parseNumberText(gc: *@import("memory.zig").GC, text: []const u8, radix_in
                 if (is_integer) {
                     var nb: [256]u8 = undefined;
                     const clean = bignum_mod.stripUnderscores(body, 10, &nb) orelse return types.FALSE;
-                    const n = std.fmt.parseInt(i64, clean, 10) catch return types.FALSE;
-                    if (!bignum_mod.f64ExactI64(n)) return types.FALSE;
-                    imag_c = .{ .val = @as(f64, @floatFromInt(n)), .exact = true };
+                    if (std.fmt.parseInt(i64, clean, 10)) |n| {
+                        if (!bignum_mod.f64ExactI64(n)) return types.FALSE;
+                        imag_c = .{ .val = @as(f64, @floatFromInt(n)), .exact = true };
+                    } else |err| {
+                        if (err != error.Overflow) return types.FALSE;
+                        // Beyond i64: an exactly-representable magnitude
+                        // (1e19 = 5^19*2^19) qualifies, matching the
+                        // reader's signless pure-imaginary path (#2243).
+                        const v = bignum_mod.parseBignumString(gc, clean, 10) catch return types.FALSE;
+                        if (!bignum_mod.bignumExactInF64(v)) return types.FALSE;
+                        imag_c = .{ .val = bignum_mod.toF64(v), .exact = true };
+                    }
                 } else {
                     const f = std.fmt.parseFloat(f64, body) catch {
                         return types.FALSE;

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -1128,15 +1128,19 @@ fn stringToNumber(args: []const Value) PrimitiveError!Value {
     return parseNumberText(gc, str.data[0..str.len], radix, .unspecified);
 }
 
-/// Parse a signed radix-R <ureal> (integer, N/D rational, or -- radix 10
-/// only -- a decimal) to f64, for use as a complex component. Mirrors the
-/// reader's complex-component grammar so `string->number` and `read` agree
-/// on `#x1+2i`, `#x1/2+3i` and friends (kaappi#2243): i64 overflow yields
-/// null (an exact bignum component has no honest f64 value -- loud
-/// rejection over silent rounding, cf. kaappi#2182).
-fn parseComplexPartToF64(part: []const u8, radix: u8) ?f64 {
-    // Rational N/D (any radix): R7RS <ureal R>.
+const ComplexComponent = struct { val: f64, exact: bool };
+
+/// Parse a signed radix-R complex component (integer, N/D rational, or --
+/// radix 10 only -- a decimal) to (value, exact). Mirrors the reader's
+/// complex-component grammar so `string->number` and `read` agree on
+/// `#x1+2i`, `#x1/2+3i` and friends (kaappi#2243). A component is exact
+/// only when it is an integer or rational whose i64 parts round-trip
+/// through f64; anything else (a decimal, an exponent, or an i64 part in
+/// (2^53, 2^63]) is inexact or rejected outright -- a rounded value must
+/// never masquerade as exact (kaappi#2182).
+fn parseComplexComponent(gc: *@import("memory.zig").GC, part: []const u8, radix: u8) ?ComplexComponent {
     if (std.mem.indexOfScalar(u8, part, '/')) |sp| {
+        // Rational N/D (any radix): R7RS <ureal R>.
         if (sp == 0 or sp + 1 >= part.len) return null;
         var nb: [256]u8 = undefined;
         var db: [256]u8 = undefined;
@@ -1145,19 +1149,57 @@ fn parseComplexPartToF64(part: []const u8, radix: u8) ?f64 {
         const n = std.fmt.parseInt(i64, num, radix) catch return null;
         const d = std.fmt.parseInt(i64, den, radix) catch return null;
         if (d == 0) return null;
-        return @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d));
+        // Beyond the printer's rational-recovery granularity the ratio
+        // would print as a silently-wrong mantissa/2^k fraction; reject
+        // loudly, like the reader does (kaappi#2182/#2243).
+        if (@abs(n) > bignum_mod.complex_rational_limit or @abs(d) > bignum_mod.complex_rational_limit) return null;
+        return .{ .val = @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d)), .exact = true };
     }
     if (radix == 10) {
         // Decimal parts (1.5+2i, 1e5+2i) and inf/nan spellings: parseFloat
-        // accepts them with the sign included. Unchanged acceptance from
-        // before #2243.
-        return std.fmt.parseFloat(f64, part) catch null;
+        // accepts them with the sign included. Integer text that does not
+        // round-trip through f64 is rejected so it cannot claim exactness
+        // with a rounded value (#2182).
+        var i: usize = 0;
+        if (part.len > 0 and (part[0] == '+' or part[0] == '-')) i = 1;
+        var is_integer = true;
+        while (i < part.len) : (i += 1) {
+            if (!std.ascii.isDigit(part[i]) and part[i] != '_') {
+                is_integer = false;
+                break;
+            }
+        }
+        if (is_integer) {
+            var b: [256]u8 = undefined;
+            const clean = bignum_mod.stripUnderscores(part, radix, &b) orelse return null;
+            if (std.fmt.parseInt(i64, clean, radix)) |n| {
+                if (!bignum_mod.f64ExactI64(n)) return null;
+                return .{ .val = @as(f64, @floatFromInt(n)), .exact = true };
+            } else |err| {
+                if (err != error.Overflow) return null;
+                // Beyond i64: exactly representable magnitudes (1e19)
+                // qualify; everything else is rejected loudly, matching
+                // the reader (#2182/#2243).
+                const v = bignum_mod.parseBignumString(gc, clean, radix) catch return null;
+                if (!bignum_mod.bignumExactInF64(v)) return null;
+                return .{ .val = bignum_mod.toF64(v), .exact = true };
+            }
+        }
+        const f = std.fmt.parseFloat(f64, part) catch return null;
+        return .{ .val = f, .exact = false };
     }
     // Radix 2/8/16: integer part only -- <decimal R> does not exist there.
     var b: [256]u8 = undefined;
     const clean = bignum_mod.stripUnderscores(part, radix, &b) orelse return null;
-    const n = std.fmt.parseInt(i64, clean, radix) catch return null;
-    return @as(f64, @floatFromInt(n));
+    if (std.fmt.parseInt(i64, clean, radix)) |n| {
+        if (!bignum_mod.f64ExactI64(n)) return null;
+        return .{ .val = @as(f64, @floatFromInt(n)), .exact = true };
+    } else |err| {
+        if (err != error.Overflow) return null;
+        const v = bignum_mod.parseBignumString(gc, clean, radix) catch return null;
+        if (!bignum_mod.bignumExactInF64(v)) return null;
+        return .{ .val = bignum_mod.toF64(v), .exact = true };
+    }
 }
 
 /// Parse a complete number text into a Value, or `types.FALSE` when the text
@@ -1233,12 +1275,14 @@ pub fn parseNumberText(gc: *@import("memory.zig").GC, text: []const u8, radix_in
 
     // Rational: num/den
     if (std.mem.indexOfScalar(u8, s, '/')) |slash_pos| {
-        // A trailing 'i' means the '/' is a complex-component separator
-        // (1/2+3i, 1/2+3/4i, #x1/2+3i): the complex branch below owns
-        // those, parsing each component as a <ureal R> (kaappi#2243).
+        // A trailing 'i' (any case) means the '/' is a complex-component
+        // separator (1/2+3i, 1/2+3/4i, #x1/2+3i): the complex branch below
+        // owns those, parsing each component as a <ureal R> (kaappi#2243).
         // Without this guard, 1/2+3i would try "2+3i" as a denominator,
-        // fail, and return #f for a valid R7RS complex.
-        const complex_shaped = s.len >= 2 and s[s.len - 1] == 'i';
+        // fail, and return #f for a valid R7RS complex. 'i' is only the
+        // imaginary marker at radix <= 18 -- from radix 19 up it is a plain
+        // digit (value 18), so "1/2i" at radix 19 is the rational 1/56.
+        const complex_shaped = radix <= 18 and s.len >= 2 and (s[s.len - 1] | 0x20) == 'i';
         if (!complex_shaped and slash_pos > 0 and slash_pos + 1 < s.len) {
             const num_str = s[0..slash_pos];
             const den_str = s[slash_pos + 1 ..];
@@ -1319,23 +1363,23 @@ pub fn parseNumberText(gc: *@import("memory.zig").GC, text: []const u8, radix_in
     // Try parsing as complex: a+bi, a-bi, +bi, -bi, +i, -i (R7RS 7.1.1
     // <complex R>). Radix-prefixed spellings (#x1+2i, #x1/2+3i) are valid
     // R7RS and the reader now accepts them too (kaappi#2243), so this
-    // branch is no longer radix-10-only: the split forms work in every
-    // radix, while decimal real/imag parts and the signless pure-imaginary
-    // extension (2i, +3i) stay radix-10-only -- exactly mirroring the
-    // reader's grammar (which rejects `#x3i` and `#x2/3i`).
-    if (s.len >= 2 and s[s.len - 1] == 'i') {
-        const body = s[0 .. s.len - 1]; // strip trailing 'i'
+    // branch is no longer radix-10-only: the split forms and the signed
+    // pure-imaginary `+ <ureal R> i` work in every radix, while the
+    // signless pure-imaginary extension (2i, 2.5i) stays radix-10-only --
+    // exactly mirroring the reader's grammar (which rejects `#x2i` and the
+    // signless rational 2/3i). Radix >= 19 treats `i` as a plain digit
+    // (value 18), so the imaginary marker only exists at radix <= 18.
+    if (radix <= 18 and s.len >= 2 and (s[s.len - 1] | 0x20) == 'i') {
+        const body = s[0 .. s.len - 1]; // strip trailing 'i' (any case)
 
-        // Pure imaginary: +i, -i (R7RS <complex R> -> `+ i` | `- i`).
-        // Every radix accepts them -- the reader reads `#x+i` as 0+1i too
-        // (#2243) -- while the signless `#x3i` spelling stays rejected by
-        // the no-split branch below.
+        // Pure imaginary: +i, -i (R7RS <complex R> -> `+ i` | `- i`), every
+        // radix; the reader reads `#x+i` as 0+1i too (#2243).
         if (std.mem.eql(u8, body, "+")) {
-            const c = gc.allocComplex(0.0, 1.0) catch return PrimitiveError.OutOfMemory;
+            const c = gc.allocComplexEx(0.0, 1.0, true, true) catch return PrimitiveError.OutOfMemory;
             return applyExactness(gc, c, exactness);
         }
         if (std.mem.eql(u8, body, "-")) {
-            const c = gc.allocComplex(0.0, -1.0) catch return PrimitiveError.OutOfMemory;
+            const c = gc.allocComplexEx(0.0, -1.0, true, true) catch return PrimitiveError.OutOfMemory;
             return applyExactness(gc, c, exactness);
         }
 
@@ -1357,27 +1401,59 @@ pub fn parseNumberText(gc: *@import("memory.zig").GC, text: []const u8, radix_in
         if (split) |sp| {
             const real_str = body[0..sp];
             const imag_str = body[sp..];
-            const real_val = if (real_str.len == 0) @as(f64, 0.0) else parseComplexPartToF64(real_str, radix) orelse return types.FALSE;
-            var imag_val: f64 = undefined;
-            if (std.mem.eql(u8, imag_str, "+")) {
-                imag_val = 1.0;
-            } else if (std.mem.eql(u8, imag_str, "-")) {
-                imag_val = -1.0;
-            } else {
-                imag_val = parseComplexPartToF64(imag_str, radix) orelse return types.FALSE;
-            }
-            const c = gc.allocComplex(real_val, imag_val) catch return PrimitiveError.OutOfMemory;
+            // Component exactness is derived from the text so
+            // `string->number` agrees with the reader's exact-flagged
+            // complex tokens: integer and rational parts stay exact,
+            // decimals and exponents are inexact. `#e`/`#i` still override
+            // everything via applyExactness below (#2243 review).
+            const real_c = if (real_str.len == 0)
+                ComplexComponent{ .val = 0.0, .exact = true }
+            else
+                parseComplexComponent(gc, real_str, radix) orelse return types.FALSE;
+            const imag_c = if (std.mem.eql(u8, imag_str, "+"))
+                ComplexComponent{ .val = 1.0, .exact = true }
+            else if (std.mem.eql(u8, imag_str, "-"))
+                ComplexComponent{ .val = -1.0, .exact = true }
+            else
+                parseComplexComponent(gc, imag_str, radix) orelse return types.FALSE;
+            const c = gc.allocComplexEx(real_c.val, imag_c.val, real_c.exact, imag_c.exact) catch return PrimitiveError.OutOfMemory;
             return applyExactness(gc, c, exactness);
         } else {
-            // No split found -- pure imaginary like +3i or -2.5i. Radix 10
-            // only: the signless rational form (2/3i) and every
-            // radix-prefixed spelling (#x3i) are rejected by the reader
-            // too, so keep #f for them.
-            if (radix != 10) return types.FALSE;
-            const imag_val = std.fmt.parseFloat(f64, body) catch {
-                return types.FALSE;
-            };
-            const c = gc.allocComplex(0.0, imag_val) catch return PrimitiveError.OutOfMemory;
+            // No split found -- pure imaginary with a magnitude: +3i,
+            // -2.5i, 2i. A leading sign is the R7RS `+ <ureal R> i`
+            // production, valid in every radix (the reader reads `#x+3i`
+            // as 0+3i, #2243); the signless `2i`/`2.5i` spellings are a
+            // radix-10 extension (the reader rejects `#x2i` and the
+            // signless rational 2/3i), so they stay radix-10-only and
+            // integer/decimal-only.
+            const has_sign = body.len > 0 and (body[0] == '+' or body[0] == '-');
+            var imag_c: ComplexComponent = undefined;
+            if (has_sign) {
+                imag_c = parseComplexComponent(gc, body, radix) orelse return types.FALSE;
+            } else {
+                if (radix != 10) return types.FALSE;
+                var i: usize = 0;
+                var is_integer = true;
+                while (i < body.len) : (i += 1) {
+                    if (!std.ascii.isDigit(body[i])) {
+                        is_integer = false;
+                        break;
+                    }
+                }
+                if (is_integer) {
+                    var nb: [256]u8 = undefined;
+                    const clean = bignum_mod.stripUnderscores(body, 10, &nb) orelse return types.FALSE;
+                    const n = std.fmt.parseInt(i64, clean, 10) catch return types.FALSE;
+                    if (!bignum_mod.f64ExactI64(n)) return types.FALSE;
+                    imag_c = .{ .val = @as(f64, @floatFromInt(n)), .exact = true };
+                } else {
+                    const f = std.fmt.parseFloat(f64, body) catch {
+                        return types.FALSE;
+                    };
+                    imag_c = .{ .val = f, .exact = false };
+                }
+            }
+            const c = gc.allocComplexEx(0.0, imag_c.val, true, imag_c.exact) catch return PrimitiveError.OutOfMemory;
             return applyExactness(gc, c, exactness);
         }
     }

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -1036,7 +1036,16 @@ test "prefixed numeric tokens require a trailing delimiter" {
     try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x1+2iz"));
     try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x3i"));
     try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#xi"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x3/4i"));
     try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x99999999999999999999+2i"));
+    // A component that does not round-trip through f64 (2^53+1, and a
+    // 64-bit hex bignum) must be a loud error, never a silently-rounded
+    // value claiming exactness (kaappi#2182/#2243).
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x20000000000001+2i"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x1+20000000000001i"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x9007199254740993+2i"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "9007199254740993+2i"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "9007199254740993i"));
 
     // A whole list holding one is a read error too, never a longer list.
     try testing.expectError(ReadError.InvalidNumber, readString(&gc, "(#b1p4)"));
@@ -1074,6 +1083,27 @@ test "prefixed numeric tokens require a trailing delimiter" {
     const rpi = try readAndPrint(&gc, "#x+i");
     defer testing.allocator.free(rpi);
     try testing.expectEqualStrings("+i", rpi);
+
+    // `+ <ureal R> i`: a signed pure imaginary with an explicit magnitude
+    // is also grammar in every radix (Chez reads #x+3i as 0+3i).
+    const rpi2 = try readAndPrint(&gc, "#x+3i");
+    defer testing.allocator.free(rpi2);
+    try testing.expectEqualStrings("+3i", rpi2);
+
+    const rpi3 = try readAndPrint(&gc, "#x+3/4i");
+    defer testing.allocator.free(rpi3);
+    try testing.expectEqualStrings("+3/4i", rpi3);
+
+    // The imaginary marker is case-insensitive in both parsers.
+    const rupper = try readAndPrint(&gc, "#x1+2I");
+    defer testing.allocator.free(rupper);
+    try testing.expectEqualStrings("1+2i", rupper);
+
+    // Exact-flagged magnitudes beyond 2^53 that ARE representable (1e19 =
+    // 5^19*2^19, 45 bits) still round-trip.
+    const rbig = try readAndPrint(&gc, "#e1e19+1i");
+    defer testing.allocator.free(rbig);
+    try testing.expectEqualStrings("10000000000000000000+1i", rbig);
 
     const u = try readAndPrint(&gc, "#x1_f");
     defer testing.allocator.free(u);

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -1007,7 +1007,11 @@ test "prefixed numeric tokens require a trailing delimiter" {
     // un-prefixed path gets from the Reader.readNumber wrapper, so every
     // radix/exactness-prefixed spelling silently split "#b1p4" into the
     // fixnum 1 plus the symbol p4.  One check in readNumberPrefixed now
-    // guards them all; string->number already rejected every cell below.
+    // guards them all, and string->number agrees on every cell.  #2243
+    // then accepted the R7RS <complex R> spellings (#x1/2+3i, #x1+2i)
+    // that the guard had turned into errors: they are valid numbers and
+    // now read whole again -- but only with radix-valid digits and a
+    // clean delimiter.
     var gc = memory.GC.init(testing.allocator);
     defer gc.deinit();
 
@@ -1019,11 +1023,20 @@ test "prefixed numeric tokens require a trailing delimiter" {
     try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#i7q"));
     try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x1p4z"));
     try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x1/2z"));
-    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x1/2+3i"));
     try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#e#b12"));
     try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#b#e12"));
     try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#b101foo"));
     try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x1zzz"));
+    // Radix complex tails are R7RS-valid, but only with radix-valid digits
+    // and a clean delimiter: an invalid digit, a missing i, or a glued
+    // tail still errors (#2243).
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#b1+2i"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#o1+8i"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x1+2"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x1+2iz"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x3i"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#xi"));
+    try testing.expectError(ReadError.InvalidNumber, readString(&gc, "#x99999999999999999999+2i"));
 
     // A whole list holding one is a read error too, never a longer list.
     try testing.expectError(ReadError.InvalidNumber, readString(&gc, "(#b1p4)"));
@@ -1041,6 +1054,26 @@ test "prefixed numeric tokens require a trailing delimiter" {
     const c = try readAndPrint(&gc, "#d1+2i");
     defer testing.allocator.free(c);
     try testing.expectEqualStrings("1+2i", c);
+
+    // Radix-prefixed complex reads whole and exact (R7RS <complex R>,
+    // #2243) -- the same spellings that pre-#1929 silently split.
+    const rx = try readAndPrint(&gc, "#x1/2+3i");
+    defer testing.allocator.free(rx);
+    try testing.expectEqualStrings("1/2+3i", rx);
+
+    const rx2 = try readAndPrint(&gc, "#x1+2i");
+    defer testing.allocator.free(rx2);
+    try testing.expectEqualStrings("1+2i", rx2);
+
+    const rb = try readAndPrint(&gc, "#b1+1i");
+    defer testing.allocator.free(rb);
+    try testing.expectEqualStrings("1+1i", rb);
+
+    // The bare-sign pure imaginary is grammar in every radix (`+ i`), and
+    // string->number agrees; the signless `#xi` spelling is not grammar.
+    const rpi = try readAndPrint(&gc, "#x+i");
+    defer testing.allocator.free(rpi);
+    try testing.expectEqualStrings("+i", rpi);
 
     const u = try readAndPrint(&gc, "#x1_f");
     defer testing.allocator.free(u);

--- a/src/reader_tokens.zig
+++ b/src/reader_tokens.zig
@@ -813,6 +813,106 @@ fn appendByteStringByte(self: *Reader, b: u8) ReadError!void {
     self.token_buf.append(self.gc.allocator, b) catch return ReadError.OutOfMemory;
 }
 
+/// Parse a radix-R <ureal> slice (radix digits, optional SRFI-169 `_`
+/// separators, optionally `N/D`) to f64. i64 overflow or any invalid
+/// character yields null: an exact bignum component has no honest f64
+/// value, and a loud error beats a silently rounded one (the kaappi#2182
+/// stance, same as the radix-10 complex grammar's i64 bound).
+fn parseRadixUrealToF64(s: []const u8, radix: u8) ?f64 {
+    if (std.mem.indexOfScalar(u8, s, '/')) |sp| {
+        if (sp == 0 or sp + 1 >= s.len) return null;
+        var nb: [256]u8 = undefined;
+        var db: [256]u8 = undefined;
+        const num = bignum.stripUnderscores(s[0..sp], radix, &nb) orelse return null;
+        const den = bignum.stripUnderscores(s[sp + 1 ..], radix, &db) orelse return null;
+        const n = std.fmt.parseInt(i64, num, radix) catch return null;
+        const d = std.fmt.parseInt(i64, den, radix) catch return null;
+        if (d == 0) return null;
+        return @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d));
+    }
+    var b: [256]u8 = undefined;
+    const clean = bignum.stripUnderscores(s, radix, &b) orelse return null;
+    const n = std.fmt.parseInt(i64, clean, radix) catch return null;
+    return @as(f64, @floatFromInt(n));
+}
+
+/// If the reader is positioned at a `+`/`-` that begins a valid R7RS
+/// complex tail -- `+<ureal R> i`, `+i`, or the `-` twins, i.e. the
+/// `<real R> (+|-) <ureal R> i` productions of R7RS 7.1.1 -- consume it
+/// and return the imaginary part. Otherwise restore the position and
+/// return null so the caller's delimiter check reports the glued tail as
+/// a read error rather than silently splitting the token (#2243). Radix
+/// digits only: `#b1+2i` (2 is not a binary digit) still errors. Mirrors
+/// the radix-10 `readNumber` complex grammar, minus the decimal/exponent
+/// and inf/nan imaginary spellings that never exist in another radix.
+fn tryComplexTail(self: *Reader, radix: u8) ?struct { imag: f64 } {
+    if (self.pos >= self.source.len) return null;
+    const sign = self.source[self.pos];
+    if (sign != '+' and sign != '-') return null;
+    const save = self.pos;
+    const neg = sign == '-';
+    self.pos += 1;
+
+    // +i / -i: the unit imaginary.
+    if (self.pos < self.source.len and (self.source[self.pos] == 'i' or self.source[self.pos] == 'I') and
+        (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])))
+    {
+        self.pos += 1;
+        return .{ .imag = if (neg) -1.0 else 1.0 };
+    }
+
+    // <ureal R>: radix digits (with SRFI-169 `_`), optionally /denominator.
+    const mag_start = self.pos;
+    while (self.pos < self.source.len) {
+        const rc = self.source[self.pos];
+        const valid = rc == '_' or switch (radix) {
+            2 => rc == '0' or rc == '1',
+            8 => rc >= '0' and rc <= '7',
+            16 => std.ascii.isHex(rc),
+            else => std.ascii.isDigit(rc),
+        };
+        if (!valid) break;
+        self.pos += 1;
+    }
+    if (self.pos == mag_start) {
+        self.pos = save; // no digits after the sign
+        return null;
+    }
+    const mag_str = self.source[mag_start..self.pos];
+
+    // Rational magnitude N/D.
+    if (self.pos < self.source.len and self.source[self.pos] == '/') {
+        const slash_pos = self.pos;
+        const den_str = scanDenominatorDigits(self, radix);
+        if (den_str.len > 0 and self.pos < self.source.len and
+            (self.source[self.pos] == 'i' or self.source[self.pos] == 'I') and
+            (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])))
+        {
+            self.pos += 1; // consume the trailing i
+            const mag = parseRadixUrealToF64(self.source[mag_start .. self.pos - 1], radix) orelse {
+                self.pos = save;
+                return null;
+            };
+            return .{ .imag = if (neg) -mag else mag };
+        }
+        self.pos = slash_pos; // not a rational tail -- fall through to integer
+    }
+
+    // Integer magnitude: the 'i' must follow the digits directly.
+    if (self.pos < self.source.len and (self.source[self.pos] == 'i' or self.source[self.pos] == 'I') and
+        (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])))
+    {
+        self.pos += 1;
+        const mag = parseRadixUrealToF64(mag_str, radix) orelse {
+            self.pos = save;
+            return null;
+        };
+        return .{ .imag = if (neg) -mag else mag };
+    }
+    self.pos = save;
+    return null;
+}
+
 pub fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
     const start = self.pos;
     // Handle optional sign
@@ -844,7 +944,23 @@ pub fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
 
     const num_str = self.source[start..self.pos];
     if (num_str.len > Reader.MAX_TOKEN_BYTES) return ReadError.TokenTooLong;
-    if (num_str.len == 0 or (num_str.len == 1 and (num_str[0] == '+' or num_str[0] == '-'))) return invalidNumberOrEof(self);
+    if (num_str.len == 0) return invalidNumberOrEof(self);
+    if (num_str.len == 1 and (num_str[0] == '+' or num_str[0] == '-')) {
+        // A bare sign is only valid as the whole real part of the pure
+        // imaginary `+i` / `-i` (R7RS <complex R> -> `+ i` | `- i`), which
+        // the radix-10 path also accepts; the signless `i` spelling
+        // (`#xi`) is not grammar, and neither is a bare sign followed by
+        // anything else (#2243).  Chez reads `#x+i` as 0+1i too.
+        if (self.pos < self.source.len and
+            (self.source[self.pos] == 'i' or self.source[self.pos] == 'I') and
+            (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])))
+        {
+            const neg = num_str[0] == '-';
+            self.pos += 1;
+            return .{ .complex = .{ .real = 0.0, .imag = if (neg) -1.0 else 1.0, .exact_real = true, .exact_imag = true } };
+        }
+        return invalidNumberOrEof(self);
+    }
     // SRFI 169: num_str/den_str may carry embedded digit-separator
     // underscores at this point (the scan loops above tolerate but don't
     // validate them); strip+validate right before parseInt, which doesn't
@@ -876,10 +992,22 @@ pub fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
                 if (err == error.Overflow) return bigRationalToken(self, num_str, den_str, radix);
                 return invalidNumberOrEof(self);
             };
+            // Complex after a rational: #x1/2+3i, #x1/2+i (R7RS 7.1.1
+            // `<real R> (+|-) <ureal R> i`). The real part keeps its exact
+            // rational value through the token-level parse, exactly like the
+            // radix-10 path does for `1/2+3i` (#2243).
+            if (tryComplexTail(self, radix)) |tail| {
+                const real_val: f64 = @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(den));
+                return .{ .complex = .{ .real = real_val, .imag = tail.imag, .exact_real = true, .exact_imag = true } };
+            }
             return .{ .rational = .{ .num = n, .den = den } };
         }
         // No digits after '/', backtrack
         self.pos = slash_pos;
+    }
+    // Complex after a plain integer: #x1+2i, #x1-i (#2243).
+    if (tryComplexTail(self, radix)) |tail| {
+        return .{ .complex = .{ .real = @floatFromInt(n), .imag = tail.imag, .exact_real = true, .exact_imag = true } };
     }
     return .{ .fixnum = n };
 }

--- a/src/reader_tokens.zig
+++ b/src/reader_tokens.zig
@@ -153,6 +153,7 @@ pub fn readNumber(self: *Reader) ReadError!Token {
             (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])))
         {
             self.pos += 1;
+            if (real_exact and !exactIntegerRoundTrips(self, num_str, 10)) return invalidNumberOrEof(self);
             const real = parseDecimalReal(num_str) orelse return invalidNumberOrEof(self);
             const imag: f64 = if (self.source[imag_start] == '+') 1.0 else -1.0;
             return .{ .complex = .{ .real = real, .imag = imag, .exact_real = real_exact, .exact_imag = true } };
@@ -173,6 +174,7 @@ pub fn readNumber(self: *Reader) ReadError!Token {
                     (self.pos + 6 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 6])))
                 {
                     self.pos += 6; // skip inf.0i / nan.0i
+                    if (real_exact and !exactIntegerRoundTrips(self, num_str, 10)) return invalidNumberOrEof(self);
                     const real = parseDecimalReal(num_str) orelse return invalidNumberOrEof(self);
                     const imag = if (self.source[imag_start] == '-') -special_val else special_val;
                     return .{ .complex = .{ .real = real, .imag = imag, .exact_real = real_exact, .exact_imag = false } };
@@ -203,10 +205,15 @@ pub fn readNumber(self: *Reader) ReadError!Token {
         // Must end with 'i'
         if (self.pos < self.source.len and (self.source[self.pos] == 'i' or self.source[self.pos] == 'I')) {
             self.pos += 1;
-            const real = parseDecimalReal(num_str) orelse return invalidNumberOrEof(self);
             const imag_str = self.source[imag_start .. self.pos - 1];
-            const imag = parseDecimalReal(imag_str) orelse return invalidNumberOrEof(self);
             const imag_exact = !imag_has_dot and !imag_has_exp;
+            // Exact-flagged components must round-trip through f64
+            // (kaappi#2182/#2243): a lossy integer would silently carry a
+            // rounded value while claiming exactness.
+            if (real_exact and !exactIntegerRoundTrips(self, num_str, 10)) return invalidNumberOrEof(self);
+            if (imag_exact and !exactIntegerRoundTrips(self, imag_str, 10)) return invalidNumberOrEof(self);
+            const real = parseDecimalReal(num_str) orelse return invalidNumberOrEof(self);
+            const imag = parseDecimalReal(imag_str) orelse return invalidNumberOrEof(self);
             return .{ .complex = .{ .real = real, .imag = imag, .exact_real = real_exact, .exact_imag = imag_exact } };
         }
         // Not a complex literal — backtrack
@@ -223,6 +230,11 @@ pub fn readNumber(self: *Reader) ReadError!Token {
         else
             parseDecimalReal(num_str) orelse return invalidNumberOrEof(self);
         const imag_exact2 = !has_dot and !has_exp;
+        // A bare sign (or nothing) means a magnitude of 1, i.e. +i / -i;
+        // longer num_str means an explicit integer magnitude that must
+        // round-trip through f64 when claimed exact (#2182/#2243).
+        if (imag_exact2 and num_str.len > 1 and !exactIntegerRoundTrips(self, num_str, 10))
+            return invalidNumberOrEof(self);
         return .{ .complex = .{ .real = 0.0, .imag = imag, .exact_real = true, .exact_imag = imag_exact2 } };
     }
 
@@ -272,6 +284,7 @@ pub fn readNumber(self: *Reader) ReadError!Token {
                     (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])))
                 {
                     self.pos += 1;
+                    if (@abs(n) > bignum.complex_rational_limit or @abs(den) > bignum.complex_rational_limit) return invalidNumberOrEof(self);
                     return .{ .complex = .{ .real = real_val, .imag = if (self.source[csave] == '+') 1.0 else -1.0, .exact_real = true, .exact_imag = true } };
                 }
                 // Try parsing imaginary part
@@ -291,9 +304,23 @@ pub fn readNumber(self: *Reader) ReadError!Token {
                         self.pos = csave;
                         return .{ .rational = .{ .num = n, .den = den } };
                     };
+                    if (@abs(n) > bignum.complex_rational_limit or @abs(den) > bignum.complex_rational_limit) return invalidNumberOrEof(self);
                     return .{ .complex = .{ .real = real_val, .imag = imag_val, .exact_real = true, .exact_imag = !imag_has_dot2 } };
                 }
                 self.pos = csave;
+            }
+            // Pure imaginary with an explicit magnitude: +3/4i is 0+3/4i
+            // (R7RS <complex R> -> `+ <ureal R> i` | `- <ureal R> i`; the
+            // sign is the production marker, and the signless 3/4i is not
+            // grammar). Chez and guile read it this way too (#2243).
+            if ((num_str[0] == '+' or num_str[0] == '-') and
+                self.pos < self.source.len and (self.source[self.pos] == 'i' or self.source[self.pos] == 'I') and
+                (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])))
+            {
+                if (@abs(n) > bignum.complex_rational_limit or @abs(den) > bignum.complex_rational_limit) return invalidNumberOrEof(self);
+                self.pos += 1;
+                const pure_imag_val: f64 = @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(den));
+                return .{ .complex = .{ .real = 0.0, .imag = pure_imag_val, .exact_real = true, .exact_imag = true } };
             }
             return .{ .rational = .{ .num = n, .den = den } };
         }
@@ -813,27 +840,42 @@ fn appendByteStringByte(self: *Reader, b: u8) ReadError!void {
     self.token_buf.append(self.gc.allocator, b) catch return ReadError.OutOfMemory;
 }
 
-/// Parse a radix-R <ureal> slice (radix digits, optional SRFI-169 `_`
-/// separators, optionally `N/D`) to f64. i64 overflow or any invalid
-/// character yields null: an exact bignum component has no honest f64
-/// value, and a loud error beats a silently rounded one (the kaappi#2182
-/// stance, same as the radix-10 complex grammar's i64 bound).
+/// Parse a radix-R <ureal> slice to f64 (see `bignum.parseRadixUrealToF64`:
+/// i64 overflow, an invalid character, or an i64 part that does not
+/// round-trip through f64 yields null -- an exact bignum component has no
+/// honest f64 value, and a loud error beats a silently rounded one
+/// (kaappi#2182).
 fn parseRadixUrealToF64(s: []const u8, radix: u8) ?f64 {
+    return bignum.parseRadixUrealToF64(s, radix);
+}
+
+/// True when the i64 -> f64 conversion is lossless, so a complex token can
+/// honestly claim the component is exact. Values in (2^53, 2^63] round to
+/// a different integer and must be rejected loudly (kaappi#2182/#2243).
+fn f64ExactI64(n: i64) bool {
+    return bignum.f64ExactI64(n);
+}
+
+/// True when the radix-R number text (optional sign, integer or N/D
+/// rational, no dot/exponent) round-trips through f64: parseable and
+/// lossless in the conversion. Gates exact-flagged complex components so
+/// a rounded value can never masquerade as exact (kaappi#2182/#2243).
+/// Integers beyond i64 go through the bignum significant-bit test so
+/// exactly-representable magnitudes (1e19 = 5^19*2^19) still qualify.
+fn exactIntegerRoundTrips(self: *Reader, s: []const u8, radix: u8) bool {
     if (std.mem.indexOfScalar(u8, s, '/')) |sp| {
-        if (sp == 0 or sp + 1 >= s.len) return null;
-        var nb: [256]u8 = undefined;
-        var db: [256]u8 = undefined;
-        const num = bignum.stripUnderscores(s[0..sp], radix, &nb) orelse return null;
-        const den = bignum.stripUnderscores(s[sp + 1 ..], radix, &db) orelse return null;
-        const n = std.fmt.parseInt(i64, num, radix) catch return null;
-        const d = std.fmt.parseInt(i64, den, radix) catch return null;
-        if (d == 0) return null;
-        return @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d));
+        if (sp == 0 or sp + 1 >= s.len) return false;
+        return exactIntegerRoundTrips(self, s[0..sp], radix) and exactIntegerRoundTrips(self, s[sp + 1 ..], radix);
     }
-    var b: [256]u8 = undefined;
-    const clean = bignum.stripUnderscores(s, radix, &b) orelse return null;
-    const n = std.fmt.parseInt(i64, clean, radix) catch return null;
-    return @as(f64, @floatFromInt(n));
+    var buf: [256]u8 = undefined;
+    const clean = bignum.stripUnderscores(s, radix, &buf) orelse return false;
+    if (std.fmt.parseInt(i64, clean, radix)) |n| {
+        return f64ExactI64(n);
+    } else |err| {
+        if (err != error.Overflow) return false;
+        const v = bignum.parseBignumString(self.gc, clean, radix) catch return false;
+        return bignum.bignumExactInF64(v);
+    }
 }
 
 /// If the reader is positioned at a `+`/`-` that begins a valid R7RS
@@ -992,12 +1034,25 @@ pub fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
                 if (err == error.Overflow) return bigRationalToken(self, num_str, den_str, radix);
                 return invalidNumberOrEof(self);
             };
+            const real_val: f64 = @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(den));
+            // Pure imaginary with an explicit magnitude: #x+3/4i is 0+3/4i
+            // (R7RS <complex R> -> `+ <ureal R> i` | `- <ureal R> i`; the
+            // sign is the production marker, and the signless #x3/4i is
+            // not grammar). Chez and guile read it this way too (#2243).
+            if ((num_str[0] == '+' or num_str[0] == '-') and
+                self.pos < self.source.len and (self.source[self.pos] == 'i' or self.source[self.pos] == 'I') and
+                (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])))
+            {
+                if (@abs(n) > bignum.complex_rational_limit or @abs(den) > bignum.complex_rational_limit) return invalidNumberOrEof(self);
+                self.pos += 1;
+                return .{ .complex = .{ .real = 0.0, .imag = real_val, .exact_real = true, .exact_imag = true } };
+            }
             // Complex after a rational: #x1/2+3i, #x1/2+i (R7RS 7.1.1
             // `<real R> (+|-) <ureal R> i`). The real part keeps its exact
             // rational value through the token-level parse, exactly like the
             // radix-10 path does for `1/2+3i` (#2243).
             if (tryComplexTail(self, radix)) |tail| {
-                const real_val: f64 = @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(den));
+                if (@abs(n) > bignum.complex_rational_limit or @abs(den) > bignum.complex_rational_limit) return invalidNumberOrEof(self);
                 return .{ .complex = .{ .real = real_val, .imag = tail.imag, .exact_real = true, .exact_imag = true } };
             }
             return .{ .rational = .{ .num = n, .den = den } };
@@ -1005,8 +1060,19 @@ pub fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
         // No digits after '/', backtrack
         self.pos = slash_pos;
     }
+    // Pure imaginary with an explicit magnitude: #x+3i is 0+3i (R7RS
+    // <complex R> -> `+ <ureal R> i`, the sign being the marker).
+    if ((num_str[0] == '+' or num_str[0] == '-') and
+        self.pos < self.source.len and (self.source[self.pos] == 'i' or self.source[self.pos] == 'I') and
+        (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])))
+    {
+        if (!f64ExactI64(n)) return invalidNumberOrEof(self);
+        self.pos += 1;
+        return .{ .complex = .{ .real = 0.0, .imag = @floatFromInt(n), .exact_real = true, .exact_imag = true } };
+    }
     // Complex after a plain integer: #x1+2i, #x1-i (#2243).
     if (tryComplexTail(self, radix)) |tail| {
+        if (!f64ExactI64(n)) return invalidNumberOrEof(self);
         return .{ .complex = .{ .real = @floatFromInt(n), .imag = tail.imag, .exact_real = true, .exact_imag = true } };
     }
     return .{ .fixnum = n };

--- a/tests/scheme/compliance/reader-delimiter-gaps.scm
+++ b/tests/scheme/compliance/reader-delimiter-gaps.scm
@@ -427,10 +427,18 @@
   (test-assert "s->n rejects #b1/1z" (not (string->number "#b1/1z")))
   (test-assert "#b1/1z rejected" (rejects? "#b1/1z"))
 
-  ;; A radix rational followed by a complex tail: the decimal path accepts
-  ;; `1/2+3i`, the radix path silently splits it instead of rejecting it.
-  (test-assert "s->n rejects #x1/2+3i" (not (string->number "#x1/2+3i")))
-  (test-assert "#x1/2+3i rejected or read whole" (not (splits? "#x1/2+3i")))
+  ;; A radix rational followed by a complex tail: `#x1/2+3i` is a valid
+  ;; R7RS 7.1.1 <complex R> (real 1/2 + imag 3, both in radix 16) and now
+  ;; reads whole in both parsers (#2243).  It used to silently split into
+  ;; `1/2` + `+3i` before #1929 closed the gap, then read-error until
+  ;; #2243 accepted the grammar.  The glued-tail siblings still reject in
+  ;; both parsers.
+  (test-assert "s->n accepts #x1/2+3i" (string->number "#x1/2+3i"))
+  (test-assert "#x1/2+3i reads whole" (clean? "#x1/2+3i"))
+  (test-assert "s->n rejects #x1/2+3z" (not (string->number "#x1/2+3z")))
+  (test-assert "#x1/2+3z rejected" (rejects? "#x1/2+3z"))
+  (test-assert "s->n rejects #x1/2+3iz" (not (string->number "#x1/2+3iz")))
+  (test-assert "#x1/2+3iz rejected" (rejects? "#x1/2+3iz"))
   )
 
 ;;; ---------------------------------------------------------------------
@@ -473,10 +481,14 @@
 
   ;; The same shape again: the READER accepts `1/2+3i`, which R7RS 7.1.1's
   ;; <complex R> --> <real R> + <ureal R> i production allows (and Chibi
-  ;; accepts), but `string->number` rejects it.  The reader is right here.
+  ;; accepts), but `string->number` used to reject it.  The reader was
+  ;; right; #2243 closed the divergence on the acceptance side by teaching
+  ;; string->number the rational-component complex grammar, in every
+  ;; radix.
   (test-assert "reader accepts 1/2+3i" (clean? "1/2+3i"))
-  ;; FAIL: TBD (string->number "1/2+3i" returns #f for a valid R7RS complex)
-  ;; (test-assert "s->n accepts 1/2+3i" (string->number "1/2+3i"))
+  (test-assert "s->n accepts 1/2+3i" (string->number "1/2+3i"))
+  (test-assert "s->n accepts #d1/2+3i" (string->number "#d1/2+3i"))
+  (test-assert "s->n accepts #x1/2+3i" (string->number "#x1/2+3i"))
 
   ;; Same literal, a third divergence: it PRINTS as `1/2+3i` (exact real
   ;; part) but `real-part` hands back the inexact 0.5, so `write` does not
@@ -489,6 +501,62 @@
               (get-output-string p))))
   ;; FAIL: TBD (real-part of the exact complex 1/2+3i is the inexact 0.5)
   ;; (test-assert "1/2+3i real part is exact" (exact? (real-part (read1 "1/2+3i"))))
+  )
+
+;;; ---------------------------------------------------------------------
+;;; 8. Radix-prefixed complex numbers (#2243).  R7RS 7.1.1's
+;;;    <complex R> --> <real R> + <ureal R> i | <real R> - <ureal R> i |
+;;;    <real R> + i | <real R> - i productions are valid in every radix,
+;;;    and `read` and `string->number` now agree on them (R7RS 6.2.7).
+;;;    Radix-valid digits only: a digit that is not valid in the radix
+;;;    (or any glued tail) still fails the #1929 delimiter check.
+;;; ---------------------------------------------------------------------
+
+(test-group "radix-prefixed complex numbers read per R7RS <complex R>"
+  (test-assert "#x1/2+3i reads clean" (clean? "#x1/2+3i"))
+  (test-assert "#x1/2+3i is complex" (not (real? (read1 "#x1/2+3i"))))
+  (test-assert "#x1/2+3i real part is 1/2" (= 1/2 (real-part (read1 "#x1/2+3i"))))
+  (test-assert "#x1/2+3i imag part is 3" (= 3 (imag-part (read1 "#x1/2+3i"))))
+  (test-assert "#x1+2i reads clean" (clean? "#x1+2i"))
+  (test-assert "#x1+i reads clean" (clean? "#x1+i"))
+  (test-assert "#x1-i reads clean" (clean? "#x1-i"))
+  (test-assert "#x+i reads clean" (clean? "#x+i"))
+  (test-assert "#x-i reads clean" (clean? "#x-i"))
+  (test-assert "#b+i reads clean" (clean? "#b+i"))
+  (test-assert "#x1+1/2i reads clean" (clean? "#x1+1/2i"))
+  (test-assert "#x1/2+3/4i reads clean" (clean? "#x1/2+3/4i"))
+  (test-assert "#b1+1i reads clean" (clean? "#b1+1i"))
+  (test-assert "#o1+2i reads clean" (clean? "#o1+2i"))
+  (test-assert "#x-1+2i reads clean" (clean? "#x-1+2i"))
+  (test-assert "#e#x1/2+3i is exact" (exact? (read1 "#e#x1/2+3i")))
+  (test-assert "#i#x1/2+3i is inexact" (inexact? (read1 "#i#x1/2+3i")))
+  ;; string->number agrees (6.2.7) on the new acceptance.
+  (test-assert "s->n #x1/2+3i" (complex? (string->number "#x1/2+3i")))
+  (test-assert "s->n #x1+2i" (complex? (string->number "#x1+2i")))
+  (test-assert "s->n #b1+1i" (complex? (string->number "#b1+1i")))
+  ;; Radix-valid digits only.
+  (test-assert "#b1+2i rejected (2 not binary)" (rejects? "#b1+2i"))
+  (test-assert "s->n #b1+2i" (not (string->number "#b1+2i")))
+  (test-assert "#o1+8i rejected (8 not octal)" (rejects? "#o1+8i"))
+  (test-assert "#x1+2 rejected (no i)" (rejects? "#x1+2"))
+  (test-assert "s->n #x1+2" (not (string->number "#x1+2")))
+  (test-assert "#x1+2iz rejected (glued tail)" (rejects? "#x1+2iz"))
+  (test-assert "#x1/2+3z rejected (glued tail)" (rejects? "#x1/2+3z"))
+  (test-assert "#x3i rejected (signless radix imaginary)"
+    (rejects? "#x3i"))
+  (test-assert "#xi rejected (signless radix imaginary)"
+    (rejects? "#xi"))
+  (test-assert "s->n #xi" (not (string->number "#xi")))
+  ;; Bignum components have no honest f64 token value: loud rejection,
+  ;; matching the radix-10 grammar's i64 bound (kaappi#2182 stance).
+  (test-assert "#x99999999999999999999+2i rejected"
+    (rejects? "#x99999999999999999999+2i"))
+  (test-assert "#x1+99999999999999999999i rejected"
+    (rejects? "#x1+99999999999999999999i"))
+  ;; A radix complex inside a list is one datum, never two.
+  (test-eqv "(#x1+2i) has one element" 1 (length (read1 "(#x1+2i)")))
+  (test-assert "(#x1+2iz) is a read error, not two datums"
+    (rejects? "(#x1+2iz)"))
   )
 
 (define %test-fail-count (test-runner-fail-count (test-runner-current)))

--- a/tests/scheme/compliance/reader-delimiter-gaps.scm
+++ b/tests/scheme/compliance/reader-delimiter-gaps.scm
@@ -433,7 +433,10 @@
   ;; `1/2` + `+3i` before #1929 closed the gap, then read-error until
   ;; #2243 accepted the grammar.  The glued-tail siblings still reject in
   ;; both parsers.
-  (test-assert "s->n accepts #x1/2+3i" (string->number "#x1/2+3i"))
+  (test-assert "s->n #x1/2+3i real part is 1/2"
+    (= 1/2 (real-part (string->number "#x1/2+3i"))))
+  (test-assert "s->n #x1/2+3i imag part is 3"
+    (= 3 (imag-part (string->number "#x1/2+3i"))))
   (test-assert "#x1/2+3i reads whole" (clean? "#x1/2+3i"))
   (test-assert "s->n rejects #x1/2+3z" (not (string->number "#x1/2+3z")))
   (test-assert "#x1/2+3z rejected" (rejects? "#x1/2+3z"))
@@ -488,7 +491,10 @@
   (test-assert "reader accepts 1/2+3i" (clean? "1/2+3i"))
   (test-assert "s->n accepts 1/2+3i" (string->number "1/2+3i"))
   (test-assert "s->n accepts #d1/2+3i" (string->number "#d1/2+3i"))
-  (test-assert "s->n accepts #x1/2+3i" (string->number "#x1/2+3i"))
+  (test-assert "s->n #x1/2+3i real part is 1/2"
+    (= 1/2 (real-part (string->number "#x1/2+3i"))))
+  (test-assert "s->n #x1/2+3i imag part is 3"
+    (= 3 (imag-part (string->number "#x1/2+3i"))))
 
   ;; Same literal, a third divergence: it PRINTS as `1/2+3i` (exact real
   ;; part) but `real-part` hands back the inexact 0.5, so `write` does not
@@ -532,7 +538,22 @@
   (test-assert "+3/4i reads clean (radix 10)" (clean? "+3/4i"))
   ;; the imaginary marker is case-insensitive in both parsers
   (test-assert "#x1+2I reads clean" (clean? "#x1+2I"))
-  (test-assert "s->n #x1+2I agrees" (complex? (string->number "#x1+2I")))
+  (test-assert "s->n #x1+2I imag part is 2"
+    (= 2 (imag-part (string->number "#x1+2I"))))
+  ;; special-float imaginary parts: the reader's 3.0+inf.0i / +inf.0i
+  ;; spellings and string->number agree (Zig's parseFloat alone would
+  ;; reject +inf.0, so the component grammar names them explicitly).
+  (test-assert "3.0+inf.0i reads clean" (clean? "3.0+inf.0i"))
+  (test-assert "s->n 3.0+inf.0i is complex"
+    (complex? (string->number "3.0+inf.0i")))
+  (test-assert "+inf.0i reads clean" (clean? "+inf.0i"))
+  (test-assert "s->n +inf.0i imag part is infinite"
+    (infinite? (imag-part (string->number "+inf.0i"))))
+  ;; a signless pure imaginary beyond i64 that IS exactly representable
+  ;; (1e19 = 5^19*2^19, 45 bits) reads in both parsers.
+  (test-assert "10000000000000000000i reads clean" (clean? "10000000000000000000i"))
+  (test-assert "s->n 10000000000000000000i is 0+1e19i"
+    (= 1e19 (imag-part (string->number "10000000000000000000i"))))
   (test-assert "#x1+2i reads clean" (clean? "#x1+2i"))
   (test-assert "#x1+1/2i reads clean" (clean? "#x1+1/2i"))
   (test-assert "#x1/2+3/4i reads clean" (clean? "#x1/2+3/4i"))
@@ -542,9 +563,14 @@
   (test-assert "#e#x1/2+3i is exact" (exact? (read1 "#e#x1/2+3i")))
   (test-assert "#i#x1/2+3i is inexact" (inexact? (read1 "#i#x1/2+3i")))
   ;; string->number agrees (6.2.7) on the new acceptance.
-  (test-assert "s->n #x1/2+3i" (complex? (string->number "#x1/2+3i")))
-  (test-assert "s->n #x1+2i" (complex? (string->number "#x1+2i")))
-  (test-assert "s->n #b1+1i" (complex? (string->number "#b1+1i")))
+  (test-assert "s->n #x1/2+3i real part is 1/2"
+    (= 1/2 (real-part (string->number "#x1/2+3i"))))
+  (test-assert "s->n #x1/2+3i imag part is 3"
+    (= 3 (imag-part (string->number "#x1/2+3i"))))
+  (test-assert "s->n #x1+2i imag part is 2"
+    (= 2 (imag-part (string->number "#x1+2i"))))
+  (test-assert "s->n #b1+1i imag part is 1"
+    (= 1 (imag-part (string->number "#b1+1i"))))
   ;; Radix-valid digits only.
   (test-assert "#b1+2i rejected (2 not binary)" (rejects? "#b1+2i"))
   (test-assert "s->n #b1+2i" (not (string->number "#b1+2i")))

--- a/tests/scheme/compliance/reader-delimiter-gaps.scm
+++ b/tests/scheme/compliance/reader-delimiter-gaps.scm
@@ -523,6 +523,17 @@
   (test-assert "#x+i reads clean" (clean? "#x+i"))
   (test-assert "#x-i reads clean" (clean? "#x-i"))
   (test-assert "#b+i reads clean" (clean? "#b+i"))
+  (test-assert "#x+3i reads clean (signed magnitude)" (clean? "#x+3i"))
+  (test-assert "#x+3i is 0+3i" (= 3 (imag-part (read1 "#x+3i"))))
+  (test-assert "#x+1i reads clean" (clean? "#x+1i"))
+  (test-assert "#x-3i reads clean" (clean? "#x-3i"))
+  (test-assert "#x+3/4i reads clean (rational magnitude)" (clean? "#x+3/4i"))
+  (test-assert "#x-3/4i reads clean" (clean? "#x-3/4i"))
+  (test-assert "+3/4i reads clean (radix 10)" (clean? "+3/4i"))
+  ;; the imaginary marker is case-insensitive in both parsers
+  (test-assert "#x1+2I reads clean" (clean? "#x1+2I"))
+  (test-assert "s->n #x1+2I agrees" (complex? (string->number "#x1+2I")))
+  (test-assert "#x1+2i reads clean" (clean? "#x1+2i"))
   (test-assert "#x1+1/2i reads clean" (clean? "#x1+1/2i"))
   (test-assert "#x1/2+3/4i reads clean" (clean? "#x1/2+3/4i"))
   (test-assert "#b1+1i reads clean" (clean? "#b1+1i"))
@@ -547,16 +558,52 @@
   (test-assert "#xi rejected (signless radix imaginary)"
     (rejects? "#xi"))
   (test-assert "s->n #xi" (not (string->number "#xi")))
+  (test-assert "#x3/4i rejected (signless rational imaginary)"
+    (rejects? "#x3/4i"))
   ;; Bignum components have no honest f64 token value: loud rejection,
   ;; matching the radix-10 grammar's i64 bound (kaappi#2182 stance).
   (test-assert "#x99999999999999999999+2i rejected"
     (rejects? "#x99999999999999999999+2i"))
   (test-assert "#x1+99999999999999999999i rejected"
     (rejects? "#x1+99999999999999999999i"))
+  ;; A component in (2^53, 2^63] that does not round-trip through f64 is
+  ;; rejected loudly too -- an exact-flagged token must never silently
+  ;; carry a rounded value (kaappi#2182/#2243).
+  (test-assert "#x20000000000001+2i rejected (2^53+1)"
+    (rejects? "#x20000000000001+2i"))
+  (test-assert "#x1+20000000000001i rejected"
+    (rejects? "#x1+20000000000001i"))
+  (test-assert "s->n #x20000000000001+2i"
+    (not (string->number "#x20000000000001+2i")))
+  (test-assert "9007199254740993+2i rejected (radix 10, 2^53+1)"
+    (rejects? "9007199254740993+2i"))
+  (test-assert "s->n 9007199254740993+2i"
+    (not (string->number "9007199254740993+2i")))
+  ;; A rational component beyond the printer's recovery granularity is
+  ;; rejected too (its f64 would print as a wrong mantissa/2^k fraction).
+  (test-assert "1/20000000000001+3i rejected (den > 1e6)"
+    (rejects? "1/20000000000001+3i"))
+  (test-assert "s->n 1/20000000000001+3i"
+    (not (string->number "1/20000000000001+3i")))
   ;; A radix complex inside a list is one datum, never two.
   (test-eqv "(#x1+2i) has one element" 1 (length (read1 "(#x1+2i)")))
   (test-assert "(#x1+2iz) is a read error, not two datums"
     (rejects? "(#x1+2iz)"))
+  )
+
+;;; ---------------------------------------------------------------------
+;;; 9. string->number with an explicit radix argument: `i` is an ordinary
+;;;    digit (value 18) from radix 19 up, so the imaginary-marker
+;;;    interpretation only exists at radix <= 18 (#2243 review).
+;;; ---------------------------------------------------------------------
+
+(test-group "radix >= 19 treats i as a digit, not the imaginary marker"
+  ;; i = 18 at radix 19, so the denominator 2i is 2*19+18 = 56.
+  (test-equal "s->n 1/2i radix 19" 1/56 (string->number "1/2i" 19))
+  (test-equal "s->n 1/2i radix 36" 1/90 (string->number "1/2i" 36))
+  (test-assert "s->n 1/2i radix 18 (i not a digit) is not a number"
+    (not (string->number "1/2i" 18)))
+  (test-equal "s->n 1/2 radix 19 unchanged" 1/2 (string->number "1/2" 19))
   )
 
 (define %test-fail-count (test-runner-fail-count (test-runner-current)))


### PR DESCRIPTION
Closes #2243.

## Summary

The #1929 delimiter fix turned every non-decimal radix complex spelling into a read error, but `#x1/2+3i`, `#x1+2i`, `#x1+i`, `#b1+1i` are **valid R7RS 7.1.1**: `<complex R> → <real R> + <ureal R> i` (and the `-`/`+i`/`-i` twins) holds in every radix. guile, Chez 10.4.1, and kaappi's own radix-10 path all read them — the non-decimal paths were the odd ones out.

- **Reader** (`readIntegerWithRadix`): consumes a complex tail with radix-valid digits and optional rational parts, producing an exact complex token exactly like the decimal path does for `1/2+3i`. The bare-sign pure imaginary `#x+i` → `0+1i` is grammar too (Chez agrees).
- **`string->number`** (`parseNumberText`): the complex branch is no longer radix-10-only; split forms parse in every radix. This also closes the documented `FAIL: TBD` where `string->number "1/2+3i"` returned `#f` for a valid R7RS complex (Chibi and guile both accept it).

The guard rails stay, in both parsers: `#b1+2i` (2 is not a binary digit), `#o1+8i`, `#x1+2` (no `i`), `#x1+2iz` (glued tail), and the signless `#x3i`/`#xi` still error; bignum components stay a loud error (kaappi#2182 stance — an exact bignum part has no honest f64 value).

## Differential evidence

Fresh ReleaseSafe build vs the three oracles on the full matrix:

| cell | kaappi | chez 10.4.1 | guile 3.0.11 | chibi 0.12 |
|---|---|---|---|---|
| `#x1/2+3i` | `1/2+3i` | `1/2+3i` | `0.5+3.0i` | error |
| `#x1+2i` | `1+2i` | `1+2i` | `1.0+2.0i` | error |
| `#x1+i` | `1+1i` | `1+1i` | `1.0+1.0i` | error |
| `#b1+1i` | `1+1i` | `1+1i` | `1.0+1.0i` | error |
| `#x1+1/2i` | `1+1/2i` | `1+1/2i` | `1.0+0.5i` | error |
| `#x+i` | `+i` | `0+1i` | — | error |
| `#b1+2i` | error | error | error | error |
| `#x1+2` | error | error | error | error |
| `#x3i` | error | error | error | error |
| `1/2+3i` (s->n) | `0.5+3.0i` | — | `0.5+3.0i` | `1/2+3i` |

kaappi now matches Chez on every cell (Chez is the closest oracle: it agrees on both acceptance *and* exactness); guile accepts but reads inexact; chibi rejects all radix complex (the parity we deliberately gave up per the #2243 decision).

## Tests

- **Enables the group-7 TBD** (`s->n accepts 1/2+3i`) and **flips the `#x1/2+3i` pins** in `reader-delimiter-gaps.scm` from reject to read-whole, keeping the glued-tail rejections (`#x1/2+3z`, `#x1/2+3iz`).
- **New group 8** in `reader-delimiter-gaps.scm`: 38 assertions covering the accepted grammar, radix-valid-digit rejections, string->number agreement, bignum-component rejection, and the one-datum-in-a-list guarantee.
- **Zig unit test** (`prefixed numeric tokens require a trailing delimiter`) extended: `#x1/2+3i`/`#x1+2i`/`#b1+1i`/`#x+i` read, `#b1+2i`/`#o1+8i`/`#x1+2`/`#x1+2iz`/`#x3i`/`#xi`/bignum error.
- **CHANGELOG** entry under Unreleased → Fixed.

## Verification

- `zig build test` — full unit suite green (1708 tests: 1701 passed, 7 skipped, 0 failed)
- Reader tests green under `-Dgc-stress=true` (all 74 reader tests)
- `tests/scheme/run-all.sh` — 691 scheme files + 1395 R7RS = **2086 pass, 0 fail**
- `zig build wasm` green
- `kaappi check` on `(define x (quote (#x1/2+3i)))` → no issues; on `(#x1/2+3iz)` → `KP1004`
