### PR TITLE
Stop file-backed library loads from abandoning the enclosing top-level form (#2012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **The first top-level form whose evaluation loads a file-backed `.sld`
+  through `(environment ...)` is no longer silently abandoned partway
+  through** (#2012). The file-load path in `vm_library` ran the library body
+  by re-entering `vm.execute`, whose `resetExecutionState` destroyed the
+  enclosing top-level form's frame; the nested call then "succeeded", so the
+  outer `runUntil` loop saw `frame_count == 0` and exited cleanly — side
+  effects before the load persisted, everything after it (the form's own
+  `define` or `display`) never happened, with no error and exit code 0. The
+  second, byte-identical form worked, because the library was loaded by then,
+  so a program either behaved correctly or silently lost a whole top-level
+  form depending on whether an earlier form had touched the same library.
+  Every nested-entry top-level thunk — library body forms, top-level
+  `include`, `define-values`, and `define-record-type` expansion — now runs
+  through `runTopLevelFunction` (the re-entrant-safe path `eval`/`begin`
+  already used), which pushes a frame above the live ones instead of
+  resetting them away.
 - **A `define-syntax` in one open LSP document no longer leaks into every other
   document's diagnostics** (#1979). `runDiagnostics` compiled each document
   against the server's single shared `vm.macros` table, so a macro defined in

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -1224,6 +1224,16 @@ pub const VM = struct {
     pub fn runCachedForm(self: *VM, func_val: Value) VMError!Value {
         return vm_eval.runCachedForm(self, func_val);
     }
+
+    /// Run a compiled top-level Function, re-entrant-safely: at true top
+    /// level (frame_count == 0) this is `execute`; while an outer execution
+    /// is suspended (a file-backed library load, define-record-type
+    /// expansion, eval re-entry, ...) it pushes a frame above the live ones
+    /// instead of resetExecutionState-ing them away (#2012). `func` must
+    /// already be GC-rooted by the caller.
+    pub fn runTopLevelFunction(self: *VM, func: *types.Function) VMError!Value {
+        return vm_eval.runTopLevelFunction(self, func);
+    }
 };
 
 test {

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -22,9 +22,15 @@ const VMError = vm_mod.VMError;
 // re-entrant path native callbacks use (`callWithArgs` pushes a frame above the
 // current ones and returns when it unwinds), leaving the outer execution intact.
 //
-// `func` must already be GC-rooted by the caller (both call sites root it), so
+// `func` must already be GC-rooted by the caller (all call sites root it), so
 // the `allocClosure` here — which may collect — cannot free it.
-fn runTopLevelFunction(vm: *VM, func: *types.Function) VMError!Value {
+//
+// This is the single re-entrant-safe way to run a compiled top-level thunk;
+// every nested-entry caller (library loading, top-level begin/cond-expand
+// splicing, define-values, define-record-type expansion, top-level include)
+// must use it rather than a bare vm.execute — a bare one would
+// resetExecutionState and abandon the enclosing form mid-flight (#2012).
+pub fn runTopLevelFunction(vm: *VM, func: *types.Function) VMError!Value {
     if (vm.frame_count == 0) return vm.execute(func);
     const closure_val = try vm.gc.allocClosure(func);
     return vm.callWithArgs(closure_val, &.{});
@@ -405,7 +411,7 @@ fn handleDefineValues(vm: *VM, args: Value) VMError!Value {
     vm.gc.pushRoot(&func_val);
     defer vm.gc.popRoot();
     compiler_mod.Compiler.unrootFunction(vm.gc, func);
-    const result = vm.execute(func) catch |err| return err;
+    const result = runTopLevelFunction(vm, func) catch |err| return err;
 
     if (types.isMultipleValues(result)) {
         const mv = types.toObject(result).as(types.MultipleValues);

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -255,7 +255,15 @@ fn loadLibrarySource(vm: *VM, source: []const u8) !void {
             vm.gc.pushRoot(&func_val);
             defer vm.gc.popRoot();
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
-            _ = try vm.execute(func);
+            // runTopLevelFunction, not vm.execute: a library body form can be
+            // reached while an outer execution is suspended (a file-backed
+            // .sld loaded through (environment ...)/(eval ...) from inside a
+            // top-level form -- #2012). A bare vm.execute would
+            // resetExecutionState and abandon the enclosing form; this runs
+            // the thunk re-entrantly above the live frames, and is identical
+            // to vm.execute at true top level. func is rooted above, as it
+            // requires.
+            _ = try vm.runTopLevelFunction(func);
         }
     }
 }
@@ -701,7 +709,11 @@ fn evalIncludedForm(vm: *VM, expr: Value, path: []const u8, line: u32) void {
     vm.gc.pushRoot(&func_val);
     defer vm.gc.popRoot();
     compiler_mod.Compiler.unrootFunction(vm.gc, func);
-    _ = vm.execute(func) catch |err| {
+    // runTopLevelFunction, not vm.execute (#2012): the including form can be
+    // reached re-entrantly (a library body loaded from inside an outer
+    // top-level form contains an (include ...)); a bare vm.execute would
+    // resetExecutionState and abandon that outer form.
+    _ = vm.runTopLevelFunction(func) catch |err| {
         reportIncludeError(vm, path, line, vm.getErrorDetail(), err);
         vm.last_error_detail_len = 0;
         return;
@@ -898,7 +910,12 @@ fn compileLibExpr(vm: *VM, lib_env: *std.StringHashMap(Value), expr: Value) VMEr
     vm.gc.pushRoot(&func_val);
     compiler_mod.Compiler.unrootFunction(vm.gc, func);
     defer vm.gc.popRoot();
-    _ = try vm.execute(func);
+    // runTopLevelFunction, not vm.execute (#2012): this library body form
+    // runs during a load that may itself be nested inside an executing
+    // top-level form ((environment ...)/(eval ...) touching a file-backed
+    // .sld for the first time); a bare vm.execute would resetExecutionState
+    // and abandon that enclosing form. func is rooted via func_val above.
+    _ = try vm.runTopLevelFunction(func);
 }
 
 /// Compile and evaluate included files in a library context.

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -107,7 +107,8 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &no_macros, vm.globals) catch return VMError.CompileError;
         define_expr = types.makePointer(&func.header);
         compiler_mod.Compiler.unrootFunction(vm.gc, func);
-        _ = vm.execute(func) catch |err| return err;
+        // runTopLevelFunction, not vm.execute (#2012): see compileAndRunDefine.
+        _ = vm.runTopLevelFunction(func) catch |err| return err;
     }
 
     // Generate predicate — close over record type (#1203):
@@ -145,7 +146,8 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
             compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &no_macros, vm.globals) catch return VMError.CompileError;
         define_expr = types.makePointer(&func.header);
         compiler_mod.Compiler.unrootFunction(vm.gc, func);
-        _ = vm.execute(func) catch |err| return err;
+        // runTopLevelFunction, not vm.execute (#2012): see compileAndRunDefine.
+        _ = vm.runTopLevelFunction(func) catch |err| return err;
     }
 
     // Generate accessors and mutators — close over record type (#1203)
@@ -185,7 +187,8 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
                 compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &no_macros, vm.globals) catch return VMError.CompileError;
             define_expr = types.makePointer(&func.header);
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
-            _ = vm.execute(func) catch |err| return err;
+            // runTopLevelFunction, not vm.execute (#2012): see compileAndRunDefine.
+            _ = vm.runTopLevelFunction(func) catch |err| return err;
         }
 
         // Mutator: (define mut! (let (( __rt ...)) (lambda (p v) (%record-set! p idx v  __rt))))
@@ -224,7 +227,8 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
                 compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &no_macros, vm.globals) catch return VMError.CompileError;
             define_expr = types.makePointer(&func.header);
             compiler_mod.Compiler.unrootFunction(vm.gc, func);
-            _ = vm.execute(func) catch |err| return err;
+            // runTopLevelFunction, not vm.execute (#2012): see compileAndRunDefine.
+            _ = vm.runTopLevelFunction(func) catch |err| return err;
         }
     }
 
@@ -349,7 +353,15 @@ fn compileAndRunDefine(vm: *VM, define_expr_in: Value) VMError!void {
         compiler_mod.compileExpressionWithMacros(vm.gc, define_expr, &no_macros, vm.globals) catch return VMError.CompileError;
     define_expr = types.makePointer(&func.header);
     compiler_mod.Compiler.unrootFunction(vm.gc, func);
-    _ = vm.execute(func) catch |err| return err;
+    // runTopLevelFunction, not vm.execute (#2012): define-record-type is a
+    // top-level head, so it can be reached while an outer execution is
+    // suspended (a record type defined in a file-backed .sld body loaded
+    // through (environment ...)/(eval ...) from inside a top-level form). A
+    // bare vm.execute would resetExecutionState and abandon that enclosing
+    // form; this runs the generated define re-entrantly above the live
+    // frames, and is identical to vm.execute at true top level. func is
+    // rooted via the define_expr slot above, as it requires.
+    _ = vm.runTopLevelFunction(func) catch |err| return err;
 }
 
 pub const R6RSFieldSpec = struct {

--- a/tests/scheme/compliance/environment-file-sld-2012.scm
+++ b/tests/scheme/compliance/environment-file-sld-2012.scm
@@ -1,0 +1,74 @@
+;;; #2012 regression: (environment '(srfi N)) on a file-backed .sld must not
+;;; abandon the rest of the enclosing top-level form.
+;;;
+;;; The FIRST top-level form whose evaluation loads a file-backed .sld
+;;; through (environment ...) used to be silently abandoned partway through:
+;;; side effects performed before the load persisted, everything after it
+;;; (including the form's own define or display) never happened, with no
+;;; error and exit 0. The second, byte-identical form worked, because the
+;;; library was loaded by then — so a program either behaved correctly or
+;;; silently lost a whole top-level form depending on whether some earlier
+;;; form had touched the same library.
+;;;
+;;; Root cause: the .sld file-load path in vm_library (tryLoadLibraryFromFile
+;;; -> loadLibrarySource) re-entered vm.execute to run the library body, and
+;;; vm.execute's resetExecutionState destroyed the enclosing top-level form's
+;;; frame. The nested call "succeeded", so the outer runUntil loop then saw
+;;; frame_count == 0 and exited cleanly, abandoning the rest of the form.
+;;; Fixed by routing every nested-entry top-level thunk through
+;;; runTopLevelFunction (vm_eval.zig, the #1500 re-entrant-safe path), which
+;;; pushes a frame above the live ones instead of resetting them away.
+;;;
+;;; Every probe below performs the FIRST file-backed .sld load of its
+;;; library inside a top-level form with observable work after the load. On
+;;; the buggy build the defining form is abandoned at the load, so its
+;;; binding never happens and the assertion errors with "undefined variable"
+;;; (exit nonzero) — a loud failure, not a silent pass.
+;;;
+;;; Deliberately no (import (srfi 158))/(import (srfi 181)) here: importing
+;;; them would load the libraries before any probe runs, and a probe then
+;;; touches an already-registered library, which never triggered the bug.
+;;; (srfi 64) is imported because the runner needs it, but its own
+;;; import-time load is a different library and completes via the native
+;;; merge path, which the bug never affected.
+;;;
+;;; Run: zig-out/bin/kaappi tests/scheme/compliance/environment-file-sld-2012.scm
+
+(import (scheme base) (scheme write) (scheme eval) (scheme repl) (srfi 64))
+
+(test-begin "environment-file-sld-2012")
+
+;; Probe 1 — the issue's minimal shape: the load happens inside a top-level
+;; define's initializer, so the define itself must complete. Buggy: the
+;; initializer is abandoned after the load and the define never binds.
+(define first-load-proc
+  (eval 'generator (environment '(srfi 158))))
+(test-assert "define whose initializer performs the first file-backed load completes"
+  (procedure? first-load-proc))
+
+;; Probe 2 — side effects BEFORE the load persist (they did even on the
+;; buggy build), but the form must also complete past the load.
+(define n 0)
+(define (bump!) (set! n (+ n 1)) n)
+(define load-form-completed
+  (begin
+    (bump!)
+    (procedure? (eval 'generator (environment '(srfi 158))))))
+(test-assert "a form survives a load that follows a side effect"
+  (and (= n 1) load-form-completed))
+
+;; Probe 3 — routing the call through a helper procedure (native
+;; re-entrancy) must not abandon the calling top-level form either.
+(define (probe) (procedure? (eval 'generator (environment '(srfi 158)))))
+(test-assert "a load reached through a helper procedure keeps the caller intact"
+  (probe))
+
+;; Probe 4 — a different file-backed library, the issue's second example.
+(define second-load-proc
+  (eval 'utf-8-codec (environment '(srfi 181))))
+(test-assert "a second file-backed library loads without abandoning its form"
+  (procedure? second-load-proc))
+
+(let ((runner (test-runner-current)))
+  (test-end "environment-file-sld-2012")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## Summary

Fixes #2012. The **first** top-level form whose evaluation loads a file-backed `.sld` through `(environment ...)` was silently abandoned partway through: side effects before the load persisted, everything after it (the form's own `define` or `display`) never happened, no error, exit 0. The second, byte-identical form worked — so a program either behaved correctly or silently lost a whole top-level form depending on whether some earlier form had touched the same library.

```scheme
;; before:  one|two|            (middle display never ran)
;; after:   one|(loaded? #t)two|
(display "one|")
(display (list 'loaded? (procedure? (eval 'generator (environment '(srfi 158))))))
(display "two|")
```

### Root cause

`environmentFn` → `importSetChecked` → `tryLoadLibraryFromFile` → `loadLibrarySource` compiles and executes the library body by **re-entering `vm.execute`**. `vm.execute` begins with `resetExecutionState()`, which zeroes `frame_count`/`handler_count`/`wind_count` — destroying the enclosing top-level form's frame. The nested call then returns success, so the outer `runUntil` loop sees `frame_count == 0` and exits cleanly. Registry-backed libraries (`(srfi 1)`, `(scheme base)`) never take that path; top-level `(import ...)` was spared only because the binding merge is native code that runs after the load returns.

### Fix

Route every nested-entry top-level thunk through `runTopLevelFunction` (the re-entrant-safe path `eval` and top-level `begin`/`cond-expand` splicing already use since #1500), exposed as a new `vm.runTopLevelFunction` method. At `frame_count == 0` it is identical to `vm.execute`; while an outer execution is suspended it pushes a frame above the live ones via `callWithArgs` instead of resetting them away. Sites converted:

- `loadLibrarySource` (library body forms) — the reported bug
- `evalIncludedForm` (top-level `include` inside a loaded library)
- `compileLibExpr` (library body definitions)
- `handleDefineValues` (`define-values` in a library body)
- all five `define-record-type` expansion sites in `vm_records.zig`

### Testing

- New regression test `tests/scheme/compliance/environment-file-sld-2012.scm`: fails loudly (exit 1, undefined variable) on the buggy build, 4/4 pass with the fix. Verified against both builds.
- Native tier unaffected (it runs top-level forms natively — no enclosing VM frame to lose); verified by `kaappi compile` of the issue's repro on both builds.
- `zig build test` ✅ · `zig build test -Dgc-stress=true` ✅ · `bash tests/scheme/run-all.sh` ✅ (692 scheme files + 1395 R7RS tests, 0 fail) · `zig fmt --check` ✅ · markdownlint ✅

## Checklist

- [x] `zig build test` passes
- [x] `zig fmt --check src/` passes
- [x] Scheme test suites pass (`bash tests/scheme/run-all.sh`)
- [x] New tests added for new behavior
- [x] Documentation updated (if applicable)
