### PR TITLE
Fix cross-thread heap safety: reject cross-heap stores (#1924) and mark live children's roots (#1933)

### DIFF
--- a/docs/dev/thread-value-sharing.md
+++ b/docs/dev/thread-value-sharing.md
@@ -11,7 +11,7 @@ routes, and they have separate, unrelated enforcement:
 | route | how a value travels | what enforces the rules |
 |---|---|---|
 | **copy** | deep-copied into the other heap | the uncopyable-tag list, one central check |
-| **globals** | reached by pointer, no copy | per-type owner checks in individual primitives — present for exactly four types, plus (since kaappi#1924) a general rejection of any store of a foreign-heap pointer into a shared container |
+| **globals** | reached by pointer, no copy | per-type owner checks in individual primitives — present for exactly four types, plus (since kaappi#1924) a general rejection of a pointer whose owner differs from the shared container's owner |
 
 The tag list is not a statement about what can cross a thread boundary.
 It is a statement about what can be *copied*. Eleven of the fourteen tags
@@ -216,23 +216,29 @@ cases show the shape — but it is a per-type decision about a per-type
 idiom, not one sweep.
 
 That per-site decision is exactly how the general mutation hazard
-(kaappi#1924) was settled. A child writing a value of its own heap into a
-shared parent-heap container — a record field, a vector slot, a pair, a
+(kaappi#1924) was settled. A child writing a value into a shared
+parent-heap container — a record field, a vector slot, a pair, a
 hash-table entry, a promise's memoised value, or the globals map itself —
 leaves a pointer the parent's collector skips as foreign and the child's
 collector cannot see a reference to, so the value is freed by the child's
 GC or at its join while the container still holds it. The store is now
 **rejected before it happens** (`memory.crossHeapStoreViolation`, checked
-at every general mutation site), unless the value belongs to the same
-foreign heap as the container. This is not a per-type check on a value
-(any type may be stored); it is a per-store check on the *heaps* of the
-container and the value. The one sanctioned engine-level exception is the
-mutex owner pair in `mutex-lock!`: locking a shared parent-heap mutex
-from a child must record the child's own fiber as owner so a dying fiber
-can abandon it, and the mutex site deliberately does not call the check.
-The remaining unsound cases have their own issues (kaappi#1936, and the
-mutex-specific/condvar-specific cross-heap store, which shares the
-accepted residual the #2127 quarantine detects).
+at every general mutation site): a thread may store into a heap object it
+owns values from any heap, but never into a container it does not own.
+The rejection is unconditional on the value's owner — even a value owned
+by the container's own foreign heap is refused, because storing a young
+value into an old container requires the OWNER's generational write
+barrier (a remembered-set edge), and the owner's remembered set cannot be
+touched cross-thread. This is not a per-type check on a value (any type
+may be stored into an owned container); it is a per-store check on the
+container's owner. The one sanctioned engine-level exception is the mutex
+owner pair in `mutex-lock!`: locking a shared parent-heap mutex from a
+child must record the child's own fiber as owner so a dying fiber can
+abandon it, and the mutex site deliberately does not call the check.
+The remaining unsound cases have their own issues (kaappi#1936; a
+mutex-specific/condvar-specific store from a child is now rejected like
+any other foreign-container store, closing the residual the #2127
+quarantine used to detect).
 
 Two rows have since been decided that way, one each: the fiber
 (kaappi#2001) and the guardian (kaappi#2008). Both had a route-specific

--- a/docs/dev/thread-value-sharing.md
+++ b/docs/dev/thread-value-sharing.md
@@ -11,7 +11,7 @@ routes, and they have separate, unrelated enforcement:
 | route | how a value travels | what enforces the rules |
 |---|---|---|
 | **copy** | deep-copied into the other heap | the uncopyable-tag list, one central check |
-| **globals** | reached by pointer, no copy | per-type owner checks in individual primitives — present for exactly four types, plus (since kaappi#1924) a general rejection of a pointer whose owner differs from the shared container's owner |
+| **globals** | reached by pointer, no copy | per-type owner checks in individual primitives — present for exactly four types, plus (since kaappi#1924) a general rejection of any store of a heap pointer into a container the running thread does not own (interned symbols excepted) |
 
 The tag list is not a statement about what can cross a thread boundary.
 It is a statement about what can be *copied*. Eleven of the fourteen tags

--- a/docs/dev/thread-value-sharing.md
+++ b/docs/dev/thread-value-sharing.md
@@ -11,7 +11,7 @@ routes, and they have separate, unrelated enforcement:
 | route | how a value travels | what enforces the rules |
 |---|---|---|
 | **copy** | deep-copied into the other heap | the uncopyable-tag list, one central check |
-| **globals** | reached by pointer, no copy | per-type owner checks in individual primitives — present for exactly four types |
+| **globals** | reached by pointer, no copy | per-type owner checks in individual primitives — present for exactly four types, plus (since kaappi#1924) a general rejection of any store of a foreign-heap pointer into a shared container |
 
 The tag list is not a statement about what can cross a thread boundary.
 It is a statement about what can be *copied*. Eleven of the fourteen tags
@@ -213,8 +213,26 @@ Ports through globals would break too, and the issue itself argues that
 case is fine. A per-type check is possible — `Object.owner` is on every
 heap object, so the mechanism is already there and the channel and thread
 cases show the shape — but it is a per-type decision about a per-type
-idiom, not one sweep, and the remaining unsound case has its own issue
-(kaappi#1924, kaappi#1936).
+idiom, not one sweep.
+
+That per-site decision is exactly how the general mutation hazard
+(kaappi#1924) was settled. A child writing a value of its own heap into a
+shared parent-heap container — a record field, a vector slot, a pair, a
+hash-table entry, a promise's memoised value, or the globals map itself —
+leaves a pointer the parent's collector skips as foreign and the child's
+collector cannot see a reference to, so the value is freed by the child's
+GC or at its join while the container still holds it. The store is now
+**rejected before it happens** (`memory.crossHeapStoreViolation`, checked
+at every general mutation site), unless the value belongs to the same
+foreign heap as the container. This is not a per-type check on a value
+(any type may be stored); it is a per-store check on the *heaps* of the
+container and the value. The one sanctioned engine-level exception is the
+mutex owner pair in `mutex-lock!`: locking a shared parent-heap mutex
+from a child must record the child's own fiber as owner so a dying fiber
+can abandon it, and the mutex site deliberately does not call the check.
+The remaining unsound cases have their own issues (kaappi#1936, and the
+mutex-specific/condvar-specific cross-heap store, which shares the
+accepted residual the #2127 quarantine detects).
 
 Two rows have since been decided that way, one each: the fiber
 (kaappi#2001) and the guardian (kaappi#2008). Both had a route-specific
@@ -258,6 +276,8 @@ thread gets its own VM and GC with an independent heap.
 | `VM.owns_globals` | `src/vm.zig` | Stops a child VM freeing the shared maps on deinit |
 | `symbol_mutex` | `src/memory.zig` | Spinlock protecting concurrent symbol interning |
 | `child_resources` | `src/primitives_srfi18.zig` | Global map holding child GC/VM references; entries are freed at `thread-join!` or, when the join retires them because the thread still has live descendants, by the last descendant's `threadEntryFn` defer once the subtree drains (kaappi#2129) |
+| `markLiveChildRoots` | `src/primitives_srfi18.zig` | kaappi#1933: registered on the **root** GC as `gc.child_marker`; the root's collector stops every live child at a dispatch-loop safepoint (or finds it already parked / in an FFI call) and marks its roots with the root's gc, so a parent-heap object referenced only from a live child's registers is never freed under it. Children spawned mid-collection spin on `collection_in_progress` before their first shared-globals read. The child side reports `collection_state` (`.running`/`.parked`/`.stopped`/`.in_native`) from the safepoint (`stopForCollection`), the park (`parkOnReactor`) and FFI (`callFfi`) sites |
+| `crossHeapStoreViolation` | `src/memory.zig` | kaappi#1924: the rejection predicate checked before every general store into a heap object — a store into a container owned by another GC is allowed only when the value is owned by that same GC. The `mutex-lock!` owner pair is the deliberate exception |
 | `Object.owner` vs `GC.id` | `src/gc_collect.zig` | Every heap object records its owning GC; marking skips objects owned by another GC, so a child's collections never write mark bits on parent-heap objects reached through shared globals (kaappi#958) |
 
 The deep copy happens at exactly three boundaries: the thunk closure at

--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -450,6 +450,15 @@ fn callFfiGeneric(comptime N: u4, ffi_fn: *types.FfiFunction, args: []const Valu
 
 /// Main FFI call dispatcher. Routes to arity-specific handlers.
 pub fn callFfi(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC, vm: *VM) !Value {
+    // #1933: function-scope defer (a block-scoped one would fire before the
+    // call). An FFI call may block indefinitely and never reach the
+    // dispatch-loop safepoint, so report the in-native state to a collecting
+    // parent: while it runs (or blocks), the VM's registers/frames are
+    // quiescent and may be marked. FFI callbacks that re-enter Scheme switch
+    // back to `.running` for their extent (callWithArgs' own guard).
+    const report_native_state = !vm.owns_globals;
+    if (report_native_state) vm.setCollectionInNative();
+    defer if (report_native_state) vm.setCollectionRunning();
     vm.last_error_detail_len = 0;
     if (types.isFfiLibrary(ffi_fn.library)) {
         const lib = types.toObject(ffi_fn.library).as(types.FfiLibrary);

--- a/src/fiber_wait.zig
+++ b/src/fiber_wait.zig
@@ -231,6 +231,16 @@ pub fn parkOnReactor(vm: *VM, sched: *FiberScheduler, cap_ns: ?u64) VMError!bool
 
     var ready: std.ArrayList(*Fiber) = .empty;
     defer ready.deinit(vm.gc.allocator);
+    // #1933: a child OS thread blocked in the reactor poll is quiescent; a
+    // collecting parent may mark its registers/frames without waiting for a
+    // safepoint. The main thread (owns_globals) never reports a state — it is
+    // the collector's own thread. The defer must be at FUNCTION scope: a
+    // defer inside the if-block would fire when the block exits — before the
+    // poll — leaving the child reported .running (and unmarkable) for the
+    // whole blocking wait.
+    const report_park_state = !vm.owns_globals;
+    if (report_park_state) vm.setCollectionParked();
+    defer if (report_park_state) vm.setCollectionRunning();
     reactor.poll(cap_ns, &ready) catch return VMError.OutOfMemory;
     // A notify arriving *during* the blocking poll() above is what actually
     // interrupted it; its wake_pending flag needs consuming here even though

--- a/src/fiber_wait.zig
+++ b/src/fiber_wait.zig
@@ -234,14 +234,16 @@ pub fn parkOnReactor(vm: *VM, sched: *FiberScheduler, cap_ns: ?u64) VMError!bool
     // #1933: a child OS thread blocked in the reactor poll is quiescent; a
     // collecting parent may mark its registers/frames without waiting for a
     // safepoint. The main thread (owns_globals) never reports a state — it is
-    // the collector's own thread. The defer must be at FUNCTION scope: a
-    // defer inside the if-block would fire when the block exits — before the
-    // poll — leaving the child reported .running (and unmarkable) for the
-    // whole blocking wait.
+    // the collector's own thread. The window covers the POLL ONLY: the code
+    // after it mutates scheduler state (sweepSharedWaiters, wakeReadyFiber,
+    // markRunnable) that markVmRoots traverses, so reporting quiescence there
+    // would race the parent's mark. setCollectionRunning is the guarded
+    // resume (honours collection_stop).
     const report_park_state = !vm.owns_globals;
     if (report_park_state) vm.setCollectionParked();
-    defer if (report_park_state) vm.setCollectionRunning();
-    reactor.poll(cap_ns, &ready) catch return VMError.OutOfMemory;
+    const poll_result = reactor.poll(cap_ns, &ready);
+    if (report_park_state) vm.setCollectionRunning();
+    poll_result catch return VMError.OutOfMemory;
     // A notify arriving *during* the blocking poll() above is what actually
     // interrupted it; its wake_pending flag needs consuming here even though
     // poll()'s own ReadyEvent list never surfaces the notifier's own event

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -673,14 +673,23 @@ fn markRoots(gc: *GC) void {
     // unconditionally by parent and child alike — never calls maybeCollect,
     // so a thread can never enter GC marking (which takes this same lock)
     // while already holding it in allocSymbol.
-    memory_mod.spinLock(&memory_mod.symbol_mutex);
-    defer memory_mod.spinUnlock(&memory_mod.symbol_mutex);
-    var it = gc.symbols.valueIterator();
-    while (it.next()) |v| {
-        markValue(gc, v.*);
+    {
+        memory_mod.spinLock(&memory_mod.symbol_mutex);
+        defer memory_mod.spinUnlock(&memory_mod.symbol_mutex);
+        var it = gc.symbols.valueIterator();
+        while (it.next()) |v| {
+            markValue(gc, v.*);
+        }
+        // Mark VM-owned roots (live registers, call frames, handlers, winds).
+        if (gc.root_marker) |mark| mark(gc);
     }
-    // Mark VM-owned roots (live registers, call frames, handlers, winds).
-    if (gc.root_marker) |mark| mark(gc);
+    // #1933: with live SRFI-18 children, also mark each child's roots (the
+    // children are stopped at safepoints first — see markLiveChildRoots).
+    // Must run OUTSIDE the symbol_mutex section: a child mid-init,
+    // deep-copying its thunk (threadEntryFn → child_gc.deepCopy →
+    // allocSymbol), can be blocked on that same mutex, and stopping it — the
+    // parent waits for the child to park — would deadlock.
+    if (gc.child_marker) |mark| mark(gc);
 }
 
 pub fn markValue(gc: *GC, v: Value) void {

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -688,8 +688,9 @@ fn markRoots(gc: *GC) void {
     // Must run OUTSIDE the symbol_mutex section: a child mid-init,
     // deep-copying its thunk (threadEntryFn → child_gc.deepCopy →
     // allocSymbol), can be blocked on that same mutex, and stopping it — the
-    // parent waits for the child to park — would deadlock.
-    if (gc.child_marker) |mark| mark(gc);
+    // parent waits for the child to park — would deadlock. Atomic load:
+    // threadStartImpl registers the marker from any thread.
+    if (@atomicLoad(?*const fn (*GC) void, &gc.child_marker, .acquire)) |mark| mark(gc);
 }
 
 pub fn markValue(gc: *GC, v: Value) void {

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -213,6 +213,15 @@ pub const GC = struct {
     oom_countdown: ?usize = null,
     profile_alloc_target: ?*u64 = null,
     root_marker: ?*const fn (*GC) void = null,
+    /// #1933: called by markRoots after `root_marker` when live SRFI-18
+    /// child threads exist. Set by the first thread-start! (primitives_srfi18
+    /// threadStartImpl) to markLiveChildRoots on the ROOT gc; the root's
+    /// collector stops every live child at a safepoint and marks its
+    /// registers/frames with this gc, keeping parent-heap objects reachable
+    /// only from a live child's registers alive. Null on every child gc (and
+    /// on the root before any thread has ever been started), so a gc that
+    /// never coordinates pays nothing.
+    child_marker: ?*const fn (*GC) void = null,
     source_spans: std.AutoHashMap(Value, types.Span) = undefined,
     stats: GcStats = .{},
     minor_cycle_count: u32 = 0,
@@ -680,6 +689,36 @@ pub const GC = struct {
     }
 };
 
+// -- #1924: cross-heap store rejection --
+//
+// A thread may store into a heap object it owns values from any heap
+// (storing a shared parent-heap object into a child-local structure is the
+// ordinary "copy a global into a local" pattern). But a store into an
+// object the running thread does NOT own -- a shared parent-heap
+// record/vector/pair reached through the globals map -- must not install a
+// pointer to an object from a third heap (typically the running thread's
+// own): the container's collector skips foreign values, the value's own
+// collector cannot see the container, and the value is freed either by its
+// own GC (the only reference is invisible to it) or when its thread's heap
+// is reclaimed at thread-join!. The result is the use-after-free of
+// kaappi#1924, deterministic and not a race.
+//
+// The one deliberate engine-level exception is the mutex owner pair
+// (primitives_srfi18.mutexLockFn): a child locking a shared parent-heap
+// mutex must record its own heap's fiber as owner so a dying fiber can
+// abandon the mutex. The mutex site simply does not call this check (it is
+// a per-site decision, like every other sanctioned cross-thread idiom --
+// see docs/dev/thread-value-sharing.md).
+pub inline fn crossHeapStoreViolation(container: *const Object, value: Value) bool {
+    if (!types.isPointer(value)) return false; // immediates have no lifetime
+    const gc = gc_instance orelse return false;
+    if (container.owner == gc.id) return false; // we own the container
+    // A foreign container: the value must be owned by that same foreign GC
+    // (the shared object's own heap outlives this thread's use of it), not
+    // by this thread or any third heap.
+    return container.owner != types.toObject(value).owner;
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -962,6 +1001,40 @@ test "mark worklist retains capacity across collections" {
 
     gc.popRoot();
     gc.popRoot();
+}
+
+// kaappi#1924: the store-rejection predicate. A store into a container the
+// running thread owns is always allowed (the value may come from any heap —
+// the ordinary "copy a shared global into a child-local structure" pattern);
+// a store into a foreign container is allowed only when the value is owned
+// by that same foreign heap, so the container never comes to hold a pointer
+// neither collector can keep alive. Immediates have no lifetime and always
+// pass.
+test "crossHeapStoreViolation: foreign containers reject foreign-heap values" {
+    var gc = GC.init(std.testing.allocator);
+    defer gc.deinit();
+    gc.enabled = false;
+    setGCInstance(&gc);
+    defer setGCInstance(undefined);
+
+    const container = types.toObject(try gc.allocPair(types.NIL, types.NIL));
+    const same_val = try gc.allocVectorFill(2, types.NIL);
+    try std.testing.expect(!crossHeapStoreViolation(container, types.makeFixnum(1))); // immediate
+    try std.testing.expect(!crossHeapStoreViolation(container, same_val)); // same-heap value
+    try std.testing.expect(!crossHeapStoreViolation(container, types.NIL)); // non-pointer
+
+    // A container owned by ANOTHER gc: a value from the running thread's own
+    // heap would dangle once this heap is freed -- rejected.
+    var other = GC.init(std.testing.allocator);
+    defer other.deinit();
+    other.enabled = false;
+    const foreign = types.toObject(try other.allocPair(types.NIL, types.NIL));
+    try std.testing.expect(container.owner != foreign.owner);
+    try std.testing.expect(crossHeapStoreViolation(foreign, same_val));
+    // A value owned by that same foreign heap is fine (its owner outlives
+    // this thread's use of it).
+    const foreign_val = try other.allocVectorFill(1, types.NIL);
+    try std.testing.expect(!crossHeapStoreViolation(foreign, foreign_val));
 }
 
 test "allocSliceNoFill: write and read back" {

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -695,15 +695,21 @@ pub const GC = struct {
 // (storing a shared parent-heap object into a child-local structure is the
 // ordinary "copy a global into a local" pattern). But a store into an
 // object the running thread does NOT own -- a shared parent-heap
-// record/vector/pair reached through the globals map -- must not install a
-// pointer to an object from a third heap (typically the running thread's
-// own): the container's collector skips foreign values, the value's own
-// collector cannot see the container, and the value is freed either by its
-// own GC (the only reference is invisible to it) or when its thread's heap
-// is reclaimed at thread-join!. The result is the use-after-free of
-// kaappi#1924, deterministic and not a race.
+// record/vector/pair reached through the globals map -- is rejected outright:
+// the container's collector skips foreign values, the value's own collector
+// cannot see the container, and the value is freed either by its own GC (the
+// only reference is invisible to it) or when its thread's heap is reclaimed
+// at thread-join! (kaappi#1924, deterministic and not a race).
 //
-// The one deliberate engine-level exception is the mutex owner pair
+// Rejecting every foreign-container store -- not just stores of a foreign-
+// heap value -- is deliberate: a store of a value owned by the container's
+// own (foreign) heap would still need the OWNER's write barrier when the
+// value is young and the container old, and the running thread's own barrier
+// records nothing for a foreign container, so the parent's remembered set
+// would miss the edge and its next minor collection could reclaim the value.
+// The owner's remembered set cannot be touched cross-thread, so the one
+// sound rule is: no stores into foreign containers at all. The one
+// deliberate engine-level exception is the mutex owner pair
 // (primitives_srfi18.mutexLockFn): a child locking a shared parent-heap
 // mutex must record its own heap's fiber as owner so a dying fiber can
 // abandon the mutex. The mutex site simply does not call this check (it is
@@ -711,12 +717,17 @@ pub const GC = struct {
 // see docs/dev/thread-value-sharing.md).
 pub inline fn crossHeapStoreViolation(container: *const Object, value: Value) bool {
     if (!types.isPointer(value)) return false; // immediates have no lifetime
+    // An interned symbol is permanent: the shared intern table roots it for
+    // the process lifetime, so it can never dangle, and it is marked as a
+    // root every collection, so it is promoted to old and no remembered-set
+    // edge is needed when stored into an old container. Storing one into any
+    // container — foreign included — is safe, which keeps symbol-keyed
+    // hash-table writes working across threads.
+    if (types.isSymbol(value)) {
+        if (types.symbolInterned(value)) return false;
+    }
     const gc = gc_instance orelse return false;
-    if (container.owner == gc.id) return false; // we own the container
-    // A foreign container: the value must be owned by that same foreign GC
-    // (the shared object's own heap outlives this thread's use of it), not
-    // by this thread or any third heap.
-    return container.owner != types.toObject(value).owner;
+    return container.owner != gc.id;
 }
 
 // ---------------------------------------------------------------------------
@@ -1006,35 +1017,35 @@ test "mark worklist retains capacity across collections" {
 // kaappi#1924: the store-rejection predicate. A store into a container the
 // running thread owns is always allowed (the value may come from any heap —
 // the ordinary "copy a shared global into a child-local structure" pattern);
-// a store into a foreign container is allowed only when the value is owned
-// by that same foreign heap, so the container never comes to hold a pointer
-// neither collector can keep alive. Immediates have no lifetime and always
-// pass.
-test "crossHeapStoreViolation: foreign containers reject foreign-heap values" {
+// a store into a foreign container is rejected outright — even with a value
+// owned by that same foreign heap, because routing the generational write
+// barrier to the owner's remembered set cannot be done cross-thread.
+// Immediates have no lifetime and always pass.
+test "crossHeapStoreViolation: foreign containers are never written" {
     var gc = GC.init(std.testing.allocator);
     defer gc.deinit();
     gc.enabled = false;
-    setGCInstance(&gc);
-    defer setGCInstance(undefined);
+    gc_instance = &gc;
+    defer gc_instance = null;
 
     const container = types.toObject(try gc.allocPair(types.NIL, types.NIL));
     const same_val = try gc.allocVectorFill(2, types.NIL);
     try std.testing.expect(!crossHeapStoreViolation(container, types.makeFixnum(1))); // immediate
-    try std.testing.expect(!crossHeapStoreViolation(container, same_val)); // same-heap value
+    try std.testing.expect(!crossHeapStoreViolation(container, same_val)); // own container, any value
     try std.testing.expect(!crossHeapStoreViolation(container, types.NIL)); // non-pointer
 
-    // A container owned by ANOTHER gc: a value from the running thread's own
-    // heap would dangle once this heap is freed -- rejected.
+    // A container owned by ANOTHER gc is never written, whatever the value's
+    // owner: a value from the running thread's own heap would dangle once
+    // this heap is freed, and a value from the container's own heap would
+    // need the owner's remembered-set barrier for a young value.
     var other = GC.init(std.testing.allocator);
     defer other.deinit();
     other.enabled = false;
     const foreign = types.toObject(try other.allocPair(types.NIL, types.NIL));
     try std.testing.expect(container.owner != foreign.owner);
     try std.testing.expect(crossHeapStoreViolation(foreign, same_val));
-    // A value owned by that same foreign heap is fine (its owner outlives
-    // this thread's use of it).
     const foreign_val = try other.allocVectorFill(1, types.NIL);
-    try std.testing.expect(!crossHeapStoreViolation(foreign, foreign_val));
+    try std.testing.expect(crossHeapStoreViolation(foreign, foreign_val));
 }
 
 test "allocSliceNoFill: write and read back" {

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -538,6 +538,34 @@ pub fn argError(proc: []const u8, comptime explanation: []const u8, fmt_args: an
     return PrimitiveError.InvalidArgument;
 }
 
+/// The catchable error a rejected cross-heap store raises (kaappi#1924).
+/// The mutation primitives and bytecode stores check
+/// `memory.crossHeapStoreViolation` FIRST and call this before the store,
+/// so the shared object is never corrupted — the error is a rejection, not
+/// an undo. The message mirrors the channel/thread/fiber owner-check style:
+/// it names the hazard and points at the supported way to move values
+/// across a thread boundary (docs/dev/thread-value-sharing.md).
+pub fn raiseCrossHeapStore(proc: []const u8) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    var buf: [320]u8 = undefined;
+    const msg = std.fmt.bufPrint(
+        &buf,
+        "{s}: cannot store an object created on this thread into a heap object shared with another thread (it would dangle once this thread's heap is freed); pass values through the thread thunk, a channel message, or a join result instead",
+        .{proc},
+    ) catch "cross-heap store rejected";
+    const message = gc.allocString(msg) catch return PrimitiveError.OutOfMemory;
+    var msg_root = message;
+    gc.pushRoot(&msg_root);
+    const err_val = gc.allocErrorObject(msg_root, types.NIL) catch {
+        gc.popRoot();
+        return PrimitiveError.OutOfMemory;
+    };
+    gc.popRoot();
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.OutOfMemory;
+    vm.current_exception = err_val;
+    return PrimitiveError.ExceptionRaised;
+}
+
 /// Whether non-negative fixnum `idx` is strictly inside `len` on every
 /// target, by comparing in u64 BEFORE any narrowing to usize.  On wasm32
 /// (usize = u32) a fixnum-range index (up to 2^47) would otherwise truncate
@@ -636,6 +664,9 @@ fn cdr(args: []const Value) PrimitiveError!Value {
 fn setCar(args: []const Value) PrimitiveError!Value {
     if (!types.isPair(args[0])) return typeError("set-car!", "pair", args[0]);
     if (types.toObject(args[0]).flags.immutable) return typeError("set-car!", "mutable pair", args[0]);
+    // #1924: reject before the store — a shared parent-heap pair must not
+    // come to hold a child-heap object.
+    if (memory.crossHeapStoreViolation(types.toObject(args[0]), args[1])) return raiseCrossHeapStore("set-car!");
     if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     types.setCar(args[0], args[1]);
     return types.VOID;
@@ -644,6 +675,7 @@ fn setCar(args: []const Value) PrimitiveError!Value {
 fn setCdr(args: []const Value) PrimitiveError!Value {
     if (!types.isPair(args[0])) return typeError("set-cdr!", "pair", args[0]);
     if (types.toObject(args[0]).flags.immutable) return typeError("set-cdr!", "mutable pair", args[0]);
+    if (memory.crossHeapStoreViolation(types.toObject(args[0]), args[1])) return raiseCrossHeapStore("set-cdr!");
     if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     types.setCdr(args[0], args[1]);
     return types.VOID;
@@ -1099,6 +1131,7 @@ fn recordSetFn(args: []const Value) PrimitiveError!Value {
     // u64 comparison before narrowing (kaappi#1912): see fixnumIndexInBounds.
     if (!fixnumIndexInBounds(raw_idx, ri.fields.len)) return indexError("%record-set!", raw_idx, ri.fields.len);
     const idx: usize = @intCast(raw_idx);
+    if (memory.crossHeapStoreViolation(types.toObject(args[0]), args[2])) return raiseCrossHeapStore("%record-set!");
     if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[2]);
     ri.fields[idx] = args[2];
     return types.VOID;

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -653,6 +653,10 @@ fn hashTableSetFn(args: []const Value) PrimitiveError!Value {
     const ht = try getHashTable("hash-table-set!", args[0]);
     try growIfNeeded(ht);
     const slot = try findSlot("hash-table-set!", ht, args[1]);
+    // #1924: reject before the store — a shared parent-heap table must not
+    // come to hold a child-heap key or value.
+    if (memory.crossHeapStoreViolation(types.toObject(args[0]), args[1])) return primitives.raiseCrossHeapStore("hash-table-set!");
+    if (memory.crossHeapStoreViolation(types.toObject(args[0]), args[2])) return primitives.raiseCrossHeapStore("hash-table-set!");
     if (memory.gc_instance) |gc| {
         gc.writeBarrier(types.toObject(args[0]), args[1]);
         gc.writeBarrier(types.toObject(args[0]), args[2]);

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -852,6 +852,10 @@ fn hashTableUpdateFn(args: []const Value) PrimitiveError!Value {
 
     try growIfNeeded(ht);
     const slot = try findSlot("hash-table-update!", ht, key);
+    // #1924: a shared parent-heap table must not come to hold a child-heap
+    // key or value (see hash-table-set!).
+    if (memory.crossHeapStoreViolation(types.toObject(args[0]), key)) return primitives.raiseCrossHeapStore("hash-table-update!");
+    if (memory.crossHeapStoreViolation(types.toObject(args[0]), new_val)) return primitives.raiseCrossHeapStore("hash-table-update!");
     if (memory.gc_instance) |gc| {
         gc.writeBarrier(types.toObject(args[0]), key);
         gc.writeBarrier(types.toObject(args[0]), new_val);
@@ -885,6 +889,9 @@ fn hashTableUpdateDefaultFn(args: []const Value) PrimitiveError!Value {
 
     try growIfNeeded(ht);
     const slot = try findSlot("hash-table-update!/default", ht, key);
+    // #1924: see hash-table-update!.
+    if (memory.crossHeapStoreViolation(types.toObject(args[0]), key)) return primitives.raiseCrossHeapStore("hash-table-update!/default");
+    if (memory.crossHeapStoreViolation(types.toObject(args[0]), new_val)) return primitives.raiseCrossHeapStore("hash-table-update!/default");
     if (memory.gc_instance) |gc| {
         gc.writeBarrier(types.toObject(args[0]), key);
         gc.writeBarrier(types.toObject(args[0]), new_val);
@@ -1048,6 +1055,11 @@ fn hashTableMergeFn(args: []const Value) PrimitiveError!Value {
     }
 
     for (snapshot) |entry| {
+        // #1924: a shared parent-heap destination table must not come to
+        // hold keys/values from another heap (see hash-table-set!); checked
+        // per entry before any store.
+        if (memory.crossHeapStoreViolation(types.toObject(args[0]), entry.key)) return primitives.raiseCrossHeapStore("hash-table-merge!");
+        if (memory.crossHeapStoreViolation(types.toObject(args[0]), entry.value)) return primitives.raiseCrossHeapStore("hash-table-merge!");
         const slot = try findSlot("hash-table-merge!", ht1, entry.key);
         gc.writeBarrier(types.toObject(args[0]), entry.key);
         gc.writeBarrier(types.toObject(args[0]), entry.value);

--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -80,21 +80,21 @@ fn promiseMerge(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const outer = types.toPromise(args[0]);
     const inner = types.toPromise(args[1]);
-    // #1924: reject before the stores, both directions (the merged inner
-    // value, and the inner promise's back-pointer to the outer). The back-
-    // pointer direction (inner.value = outer) is never a cross-heap store in
-    // practice — both promises come from the same force chain, so they share
-    // a heap — but the store is checked anyway by the predicate's own
-    // container-owner rule (a child-owned inner, a parent-owned outer, would
-    // be rejected); the explicit check below covers the outer.value direction
-    // that can genuinely cross (a child forcing/merging into a shared
-    // parent-heap promise).
+    // #1924: reject before EITHER store. The outer store (outer.value =
+    // inner.value) can genuinely cross heaps — a child forcing/merging into a
+    // shared parent-heap promise — and the inner back-pointer
+    // (inner.value = outer) is validated for the same reason, so the two
+    // lines below both go through the predicate and the code matches its own
+    // comment (in practice both promises come from one force chain and share
+    // a heap, so the back-pointer direction rarely fires).
+    const outer_val = types.makePointer(&outer.header);
     if (memory.crossHeapStoreViolation(&outer.header, inner.value)) return primitives.raiseCrossHeapStore("%promise-merge!");
+    if (memory.crossHeapStoreViolation(&inner.header, outer_val)) return primitives.raiseCrossHeapStore("%promise-merge!");
     gc.writeBarrier(&outer.header, inner.value);
     outer.value = inner.value;
     inner.forced = true;
-    gc.writeBarrier(&inner.header, types.makePointer(&outer.header));
-    inner.value = types.makePointer(&outer.header);
+    gc.writeBarrier(&inner.header, outer_val);
+    inner.value = outer_val;
     outer.forcing = false;
     return types.VOID;
 }

--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -81,7 +81,14 @@ fn promiseMerge(args: []const Value) PrimitiveError!Value {
     const outer = types.toPromise(args[0]);
     const inner = types.toPromise(args[1]);
     // #1924: reject before the stores, both directions (the merged inner
-    // value, and the inner promise's back-pointer to the outer).
+    // value, and the inner promise's back-pointer to the outer). The back-
+    // pointer direction (inner.value = outer) is never a cross-heap store in
+    // practice — both promises come from the same force chain, so they share
+    // a heap — but the store is checked anyway by the predicate's own
+    // container-owner rule (a child-owned inner, a parent-owned outer, would
+    // be rejected); the explicit check below covers the outer.value direction
+    // that can genuinely cross (a child forcing/merging into a shared
+    // parent-heap promise).
     if (memory.crossHeapStoreViolation(&outer.header, inner.value)) return primitives.raiseCrossHeapStore("%promise-merge!");
     gc.writeBarrier(&outer.header, inner.value);
     outer.value = inner.value;

--- a/src/primitives_lazy.zig
+++ b/src/primitives_lazy.zig
@@ -57,10 +57,14 @@ fn promiseComplete(args: []const Value) PrimitiveError!Value {
     if (!types.isPromise(args[0])) return primitives.typeError("%promise-complete!", "promise", args[0]);
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const promise = types.toPromise(args[0]);
+    // #1924: reject (and barrier) BEFORE the store: `force` on a promise
+    // shared through a top-level binding from a child thread would
+    // otherwise memoise a child-heap value into the parent-heap promise.
+    if (memory.crossHeapStoreViolation(&promise.header, args[1])) return primitives.raiseCrossHeapStore("%promise-complete!");
+    gc.writeBarrier(&promise.header, args[1]);
     promise.forced = true;
     promise.forcing = false;
     promise.value = args[1];
-    gc.writeBarrier(&promise.header, args[1]);
     return types.VOID;
 }
 
@@ -76,11 +80,14 @@ fn promiseMerge(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const outer = types.toPromise(args[0]);
     const inner = types.toPromise(args[1]);
-    outer.value = inner.value;
+    // #1924: reject before the stores, both directions (the merged inner
+    // value, and the inner promise's back-pointer to the outer).
+    if (memory.crossHeapStoreViolation(&outer.header, inner.value)) return primitives.raiseCrossHeapStore("%promise-merge!");
     gc.writeBarrier(&outer.header, inner.value);
+    outer.value = inner.value;
     inner.forced = true;
-    inner.value = types.makePointer(&outer.header);
     gc.writeBarrier(&inner.header, types.makePointer(&outer.header));
+    inner.value = types.makePointer(&outer.header);
     outer.forcing = false;
     return types.VOID;
 }

--- a/src/primitives_list.zig
+++ b/src/primitives_list.zig
@@ -77,6 +77,9 @@ fn listSetFn(args: []const Value) PrimitiveError!Value {
         if (!types.isPair(current)) return primitives.typeError("list-set!", "pair", current);
         if (types.toObject(current).flags.immutable) return primitives.typeError("list-set!", "mutable pair", current);
         if (idx == k) {
+            // #1924: a shared parent-heap list must not be mutated from a
+            // child — reject before the store.
+            if (memory.crossHeapStoreViolation(types.toObject(current), args[2])) return primitives.raiseCrossHeapStore("list-set!");
             if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(current), args[2]);
             types.setCar(current, args[2]);
             return types.VOID;

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -263,6 +263,11 @@ pub fn markLiveChildRoots(gc: *memory.GC) void {
 
     var marked: std.ArrayList(?*vm_mod.VM) = .empty;
     defer marked.deinit(std.heap.page_allocator);
+    // Every VM whose `collection_stop` is armed, exited or not. The release
+    // loop below iterates THIS list (never the nulled `marked`), so an
+    // exited child's flag is always cleared and never left poisoned.
+    var armed: std.ArrayList(*vm_mod.VM) = .empty;
+    defer armed.deinit(std.heap.page_allocator);
 
     while (true) {
         // Snapshot the registry under its lock and arm the stop flag on any
@@ -289,25 +294,33 @@ pub fn markLiveChildRoots(gc: *memory.GC) void {
             }
             if (!already) {
                 marked.append(std.heap.page_allocator, cv) catch @panic("GC: child-root marking OOM");
+                armed.append(std.heap.page_allocator, cv) catch @panic("GC: child-root marking OOM");
                 cv.collection_stop.store(true, .release);
                 added = true;
             }
         }
         memory.spinUnlock(&child_registry.mutex);
         // Once a full pass adds no child, every live child is armed; wait for
-        // each to leave `.running` (safepoint stop, park, or FFI), then mark.
+        // each to leave `.running` (safepoint stop, park, FFI, or a raw
+        // thread join). A running child reaches its next safepoint within
+        // 1024 instructions, so spin-yield rather than sleep: a fixed 1ms
+        // poll would cost ~1ms per parent collection with a live child —
+        // pathological under -Dgc-stress, where collections run per
+        // allocation.
         if (!added) break;
-        for (marked.items) |cv| {
-            if (cv) |vm| {
-                while (vm.collection_state.load(.acquire) == .running) sleepNs(CROSS_THREAD_POLL_NS);
+        for (armed.items) |vm| {
+            var spins: u32 = 0;
+            while (vm.collection_state.load(.acquire) == .running) {
+                spins +%= 1;
+                if (spins & 0xFF == 0) std.Thread.yield() catch {};
             }
         }
     }
 
     // A child may have exited during the wait (thread-terminate!, or its
     // thunk completing on its own). Its registers are stale now — the parent
-    // must not mark them. Re-check liveness under the registry lock; the
-    // stop flags on exited children are cleared below along with the rest.
+    // must not mark them. Null its entry for the MARK loop only; `armed`
+    // still releases its stop flag below.
     memory.spinLock(&child_registry.mutex);
     var it2 = child_registry.map.valueIterator();
     while (it2.next()) |res| {
@@ -324,13 +337,11 @@ pub fn markLiveChildRoots(gc: *memory.GC) void {
     for (marked.items) |cv| {
         if (cv) |vm| vm_mod.markVmRoots(gc, vm);
     }
-    // Release every child. They resume inside the parent's sweep; any shared
-    // object they read from now on is reachable from the parent's roots at
-    // mark time, so it was marked, and the sweep cannot free it (the
-    // globals-route argument of the sharing model).
-    for (marked.items) |cv| {
-        if (cv) |vm| vm.collection_stop.store(false, .release);
-    }
+    // Release every child — exited or not. They resume inside the parent's
+    // sweep; any shared object they read from now on is reachable from the
+    // parent's roots at mark time, so it was marked, and the sweep cannot
+    // free it (the globals-route argument of the sharing model).
+    for (armed.items) |vm| vm.collection_stop.store(false, .release);
 }
 
 /// Thin per-file convenience wrapper: fetches vm_instance and delegates to
@@ -645,10 +656,11 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
     const root_vm = vm.root_vm orelse vm;
     // #1933: from here on, the root's collector must stop-and-mark live
     // children so a parent-heap object referenced only from a running
-    // child's registers is not freed under it. Registered once, on the root
-    // gc, at the first spawn; a no-op after (and on GCs that never
-    // coordinate).
-    root_vm.gc.child_marker = &markLiveChildRoots;
+    // child's registers is not freed under it. Atomic: threadStartImpl can
+    // run on any thread (a child spawning a grandchild) while the root's
+    // markRoots reads the field; the stored value is always the same
+    // function pointer, but the write must not be a plain store.
+    @atomicStore(?*const fn (*memory.GC) void, &root_vm.gc.child_marker, &markLiveChildRoots, .release);
     fiber.os_thread = std.Thread.spawn(.{}, threadEntryFn, .{
         fiber, spawner, gc.allocator, root_vm, envelope,
     }) catch {
@@ -787,7 +799,11 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, spawner: ?*fiber_mod.Fiber, allocator:
     // at the just-finished mark and therefore alive.
     child_vm.collection_state.store(.parked, .release);
     while (collection_in_progress.load(.acquire)) sleepNs(CROSS_THREAD_POLL_NS);
-    child_vm.collection_state.store(.running, .release);
+    // Guarded resume: if the parent armed collection_stop during the wait
+    // (its snapshot could include this child even though it is mid-init), the
+    // first thing that happens after the handshake is not unread bytecode but
+    // a stop at the safepoint.
+    child_vm.setCollectionRunning();
 
     // Copy the thunk out of the envelope into this thread's own fresh heap.
     // thread-start! already ran the forward copy on the parent thread and
@@ -1182,6 +1198,21 @@ fn threadJoinFn(args: []const Value) PrimitiveError!Value {
 
 fn reapOsThread(target: *fiber_mod.Fiber, fiber_val: Value) PrimitiveError!Value {
     if (target.os_thread) |thread| {
+        // #1933: a CHILD joining its own child blocks in a raw pthread join
+        // that never reaches the dispatch-loop safepoint and never reports a
+        // quiescent state on its own. Without the in-native report, the
+        // parent's collector waits forever for this VM to leave `.running`
+        // while the grandchild being joined waits on `collection_in_progress`
+        // — a livelock (seen as a multi-minute hang in
+        // channel-promoted-owner-1934 under -Dgc-stress). During the join the
+        // VM's frames/registers are stable, so it is safe to mark. Function-
+        // scope defer: a block-scoped one would fire before thread.join().
+        const join_vm: ?*vm_mod.VM = if (vm_mod.vm_instance) |vm|
+            if (!vm.owns_globals) vm else null
+        else
+            null;
+        if (join_vm) |vm| vm.setCollectionInNative();
+        defer if (join_vm) |vm| vm.setCollectionRunning();
         thread.join();
         target.os_thread = null;
     }

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -110,6 +110,14 @@ const ChildThreadResources = struct {
     // running, and its result/exception envelopes must survive for a future
     // join while its GC/VM are still in use.
     retired: bool = false,
+    // #1933: set (under the registry lock) by threadEntryFn's outermost
+    // defer, just before the thread exits. A dead child's VM still sits in
+    // the registry until its join, but its registers/frames hold stale
+    // pointers to objects its own GC freed during its life -- the parent's
+    // collector must never mark those (a mark would read a freed header;
+    // a hard panic under -Dgc-stress). markLiveChildRoots skips any entry
+    // with this flag, and re-checks it after its stop-the-world wait.
+    thread_exited: bool = false,
 };
 
 // Entries are freed when a thread is joined (freeChildResources called from
@@ -176,6 +184,15 @@ const ChildRegistry = struct {
         if (self.map.getPtr(key)) |entry| entry.retired = true;
     }
 
+    // #1933: record that a child's OS thread has exited, so the parent's
+    // collector stops marking its (now stale) VM. Called by threadEntryFn's
+    // outermost defer, before the live_child_threads decrement.
+    fn markExited(self: *ChildRegistry, key: usize) void {
+        memory.spinLock(&self.mutex);
+        defer memory.spinUnlock(&self.mutex);
+        if (self.map.getPtr(key)) |entry| entry.thread_exited = true;
+    }
+
     // #2129 (handle half): removes the entry only if it has been retired.
     // A descendant's threadEntryFn defer calls this with its spawner's key
     // when its decrement brings the spawner's live-descendant count to
@@ -197,6 +214,124 @@ var child_registry: ChildRegistry = .{
     .map = std.AutoHashMap(usize, ChildThreadResources).init(std.heap.page_allocator),
     .mutex = .unlocked,
 };
+
+/// #1933: set by the root thread's first thread-start! (threadStartImpl) as
+/// the root gc's `child_marker`, so every root collection runs
+/// markLiveChildRoots while live children exist. A child spawned mid-
+/// collection spins on this flag before its first shared-globals read
+/// (threadEntryFn), so a collector whose snapshot cannot know it exists is
+/// never racing its registers.
+var collection_in_progress: std.atomic.Value(bool) = .init(false);
+
+/// #1933: the parent's collector keeps alive every parent-heap object a live
+/// child thread still references. A child's registers are invisible to the
+/// parent's own root marker (markVMRoots marks only the VM owning the gc),
+/// and the child's own marker skips foreign-owner objects (#958) — so a
+/// parent-heap object referenced ONLY from a live child's registers is
+/// unreachable to both markers and the parent's collection frees it under
+/// the running child (use-after-free, hard panic under -Dgc-stress).
+///
+/// Registered on the ROOT gc only. Each live child is stopped at a
+/// dispatch-loop safepoint (or found already parked / in an FFI call — all
+/// quiescent states, see vm.CollectionState), its roots are marked with
+/// THIS gc (markVmRoots; the foreign-owner skip keeps the parent's collector
+/// off the child's own heap objects), and it is released. Children spawned
+/// while this runs are caught by re-snapshotting the registry until it stops
+/// gaining entries; a mid-init child holds no parent-heap values yet and
+/// spins on `collection_in_progress` before its first globals read.
+///
+/// The wait is bounded: a child at a safepoint parks within 1024
+/// instructions, a parked child reports `.parked` immediately, and a child
+/// inside a blocking FFI call reports `.in_native` (callFfi) — the only
+/// states that never reach the safepoint. A child inside a bounded native
+/// call (a long primitive, its own GC) makes the wait wait it out, then
+/// parks.
+///
+/// Scope note: this keeps alive parent-heap objects referenced from a live
+/// child's REGISTERS/frames — the issue's shape. A parent-heap object nested
+/// inside a child-OWNED container (the child copied a shared global into a
+/// local vector) is still invisible to the parent's collector, which cannot
+/// traverse the foreign container without pausing the child's own GC; that
+/// remains a documented residual of the same family (the parent must not
+/// drop its last reference to an object a child holds), distinct from the
+/// store rejection of kaappi#1924, which governs the writes that install
+/// such references.
+pub fn markLiveChildRoots(gc: *memory.GC) void {
+    if (@atomicLoad(usize, &live_child_threads, .acquire) == 0) return;
+    collection_in_progress.store(true, .release);
+    defer collection_in_progress.store(false, .release);
+
+    var marked: std.ArrayList(?*vm_mod.VM) = .empty;
+    defer marked.deinit(std.heap.page_allocator);
+
+    while (true) {
+        // Snapshot the registry under its lock and arm the stop flag on any
+        // live child not yet armed. Children whose OS thread has already
+        // exited (thread_exited) are skipped: their VM is still in the
+        // registry until the join, but its registers/frames are stale and
+        // must never be marked. The lock is held only for the snapshot: the
+        // mark below must not run while a descendant-side free holds it, but
+        // no registry entry can be freed during this collection anyway (both
+        // removal paths run on the collecting thread — a join, or a
+        // descendant free gated on a join's retirement).
+        var added = false;
+        memory.spinLock(&child_registry.mutex);
+        var it = child_registry.map.valueIterator();
+        while (it.next()) |res| {
+            if (res.thread_exited) continue;
+            const cv = res.child_vm;
+            var already = false;
+            for (marked.items) |m| {
+                if (m == cv) {
+                    already = true;
+                    break;
+                }
+            }
+            if (!already) {
+                marked.append(std.heap.page_allocator, cv) catch @panic("GC: child-root marking OOM");
+                cv.collection_stop.store(true, .release);
+                added = true;
+            }
+        }
+        memory.spinUnlock(&child_registry.mutex);
+        // Once a full pass adds no child, every live child is armed; wait for
+        // each to leave `.running` (safepoint stop, park, or FFI), then mark.
+        if (!added) break;
+        for (marked.items) |cv| {
+            if (cv) |vm| {
+                while (vm.collection_state.load(.acquire) == .running) sleepNs(CROSS_THREAD_POLL_NS);
+            }
+        }
+    }
+
+    // A child may have exited during the wait (thread-terminate!, or its
+    // thunk completing on its own). Its registers are stale now — the parent
+    // must not mark them. Re-check liveness under the registry lock; the
+    // stop flags on exited children are cleared below along with the rest.
+    memory.spinLock(&child_registry.mutex);
+    var it2 = child_registry.map.valueIterator();
+    while (it2.next()) |res| {
+        if (res.thread_exited) {
+            for (marked.items, 0..) |cv, i| {
+                if (cv == res.child_vm) marked.items[i] = null;
+            }
+        }
+    }
+    memory.spinUnlock(&child_registry.mutex);
+
+    // All remaining children are quiescent. Mark their roots with this (the
+    // parent's) gc; the child's own heap objects are skipped as foreign.
+    for (marked.items) |cv| {
+        if (cv) |vm| vm_mod.markVmRoots(gc, vm);
+    }
+    // Release every child. They resume inside the parent's sweep; any shared
+    // object they read from now on is reachable from the parent's roots at
+    // mark time, so it was marked, and the sweep cannot free it (the
+    // globals-route argument of the sharing model).
+    for (marked.items) |cv| {
+        if (cv) |vm| vm.collection_stop.store(false, .release);
+    }
+}
 
 /// Thin per-file convenience wrapper: fetches vm_instance and delegates to
 /// fiber.ensureScheduler, which now lazily creates the reactor alongside
@@ -508,6 +643,12 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
     // then read freed memory (#2129). The root VM lives for the whole
     // process, so every descendant chains its shared state to it.
     const root_vm = vm.root_vm orelse vm;
+    // #1933: from here on, the root's collector must stop-and-mark live
+    // children so a parent-heap object referenced only from a running
+    // child's registers is not freed under it. Registered once, on the root
+    // gc, at the first spawn; a no-op after (and on GCs that never
+    // coordinate).
+    root_vm.gc.child_marker = &markLiveChildRoots;
     fiber.os_thread = std.Thread.spawn(.{}, threadEntryFn, .{
         fiber, spawner, gc.allocator, root_vm, envelope,
     }) catch {
@@ -531,6 +672,11 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, spawner: ?*fiber_mod.Fiber, allocator:
     // the early GC/VM-init failures below), so crossThreadWaitPossible's "is
     // another OS thread still alive" check stays accurate.
     defer _ = @atomicRmw(usize, &live_child_threads, .Sub, 1, .release);
+    // #1933: tell the parent's collector this thread is gone, so it stops
+    // marking this child's (now stale) VM. Runs last, after every other
+    // defer -- but the flag is set before the live_child_threads decrement
+    // (this defer body runs before that one, which was declared earlier).
+    defer child_registry.markExited(@intFromPtr(fiber));
     // #2129 (handle half): release the spawning thread's live-descendant
     // count (incremented in threadStartImpl), but only once this thread's
     // OWN descendant subtree has fully drained. The drain matters: this
@@ -624,6 +770,24 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, spawner: ?*fiber_mod.Fiber, allocator:
         allocator.destroy(child_gc);
         return;
     };
+
+    // #1933 (half): the child is in the registry from here on, so a
+    // collecting parent may stop-and-mark it. Report the quiescent state as
+    // soon as callWithArgs returns (or any later path unwinds): the VM is
+    // then stable and the parent never waits on a thread that is finishing.
+    defer child_vm.setCollectionParked();
+    // #1933 (half): a child spawned while the root collector is mid-
+    // collection must not read any shared (parent-heap) global until that
+    // collection finishes — its snapshot cannot know this child exists, so
+    // an object this child reads could be swept. It holds no parent-heap
+    // values yet (nothing has executed), so report .parked and wait; the
+    // collector's re-snapshot may mark it (a no-op over empty frames), and
+    // the wait is what actually closes the race. After it clears, everything
+    // read through the shared globals is reachable from the parent's roots
+    // at the just-finished mark and therefore alive.
+    child_vm.collection_state.store(.parked, .release);
+    while (collection_in_progress.load(.acquire)) sleepNs(CROSS_THREAD_POLL_NS);
+    child_vm.collection_state.store(.running, .release);
 
     // Copy the thunk out of the envelope into this thread's own fresh heap.
     // thread-start! already ran the forward copy on the parent thread and

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -262,12 +262,12 @@ pub fn markLiveChildRoots(gc: *memory.GC) void {
     defer collection_in_progress.store(false, .release);
 
     var marked: std.ArrayList(?*vm_mod.VM) = .empty;
-    defer marked.deinit(std.heap.page_allocator);
+    defer marked.deinit(gc.allocator);
     // Every VM whose `collection_stop` is armed, exited or not. The release
     // loop below iterates THIS list (never the nulled `marked`), so an
     // exited child's flag is always cleared and never left poisoned.
     var armed: std.ArrayList(*vm_mod.VM) = .empty;
-    defer armed.deinit(std.heap.page_allocator);
+    defer armed.deinit(gc.allocator);
 
     while (true) {
         // Snapshot the registry under its lock and arm the stop flag on any
@@ -293,8 +293,8 @@ pub fn markLiveChildRoots(gc: *memory.GC) void {
                 }
             }
             if (!already) {
-                marked.append(std.heap.page_allocator, cv) catch @panic("GC: child-root marking OOM");
-                armed.append(std.heap.page_allocator, cv) catch @panic("GC: child-root marking OOM");
+                marked.append(gc.allocator, cv) catch @panic("GC: child-root marking OOM");
+                armed.append(gc.allocator, cv) catch @panic("GC: child-root marking OOM");
                 cv.collection_stop.store(true, .release);
                 added = true;
             }

--- a/src/primitives_srfi237.zig
+++ b/src/primitives_srfi237.zig
@@ -394,6 +394,7 @@ fn recordSetInheritFn(args: []const Value) PrimitiveError!Value {
     // u64 comparison before narrowing (kaappi#1912): see primitives.fixnumIndexInBounds.
     if (!primitives.fixnumIndexInBounds(raw_idx, ri.fields.len)) return indexError("%record-set!/inherit", raw_idx, ri.fields.len);
     const idx: usize = @intCast(raw_idx);
+    if (memory.crossHeapStoreViolation(types.toObject(args[0]), args[2])) return primitives.raiseCrossHeapStore("%record-set!/inherit");
     if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[2]);
     ri.fields[idx] = args[2];
     return types.VOID;

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -245,8 +245,14 @@ fn vectorCopyBangFn(args: []const Value) PrimitiveError!Value {
     const count = end - start;
     if (at + count > to_vec.data.len) return primitives.typeError("vector-copy!", "valid index range", args[1]);
 
+    // #1924: a shared parent-heap destination must not come to hold a
+    // pointer from this child's heap (or need the owner's remembered-set
+    // barrier for a young value) — reject before any element is copied.
+    // Only pointer elements trigger the rejection; an all-immediate copy
+    // installs no pointers and is fine.
     if (memory.gc_instance) |gc| {
         for (from_vec.data[start..end]) |val| {
+            if (memory.crossHeapStoreViolation(types.toObject(args[0]), val)) return primitives.raiseCrossHeapStore("vector-copy!");
             gc.writeBarrier(types.toObject(args[0]), val);
         }
     }
@@ -1003,8 +1009,11 @@ fn vectorReverseCopyBangFn(args: []const Value) PrimitiveError!Value {
     const count = end - start;
     if (at + count > to_vec.data.len) return primitives.typeError("vector-reverse-copy!", "valid index range", args[1]);
 
+    // #1924: see vector-copy! — same per-element rejection for a shared
+    // destination.
     if (memory.gc_instance) |gc| {
         for (from_vec.data[start..end]) |val| {
+            if (memory.crossHeapStoreViolation(types.toObject(args[0]), val)) return primitives.raiseCrossHeapStore("vector-reverse-copy!");
             gc.writeBarrier(types.toObject(args[0]), val);
         }
     }

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -123,6 +123,7 @@ fn vectorSetFn(args: []const Value) PrimitiveError!Value {
     const k = types.toFixnum(args[1]);
     // u64 comparison before narrowing (kaappi#1912): see fixnumIndexInBounds.
     if (!primitives.fixnumIndexInBounds(k, vec.data.len)) return primitives.indexError("vector-set!", k, vec.data.len);
+    if (memory.crossHeapStoreViolation(types.toObject(args[0]), args[2])) return primitives.raiseCrossHeapStore("vector-set!");
     if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[2]);
     vec.data[@intCast(k)] = args[2];
     return types.VOID;
@@ -193,6 +194,7 @@ fn vectorFillFn(args: []const Value) PrimitiveError!Value {
     const range = try primitives.parseOptionalRange(args, 2, len, "vector-fill!");
     const start = range.start;
     const end = range.end;
+    if (memory.crossHeapStoreViolation(types.toObject(args[0]), args[1])) return primitives.raiseCrossHeapStore("vector-fill!");
     if (memory.gc_instance) |gc| gc.writeBarrier(types.toObject(args[0]), args[1]);
     @memset(vec.data[start..end], args[1]);
     return types.VOID;

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -979,6 +979,9 @@ fn vectorMapBangFn(args: []const Value) PrimitiveError!Value {
             call_args[vi] = types.toVector(args[1 + vi]).data[i];
         }
         const result = try callVM(f, call_args);
+        // #1924: a shared parent-heap destination must not come to hold a
+        // pointer from this child's heap (see vector-copy!).
+        if (memory.crossHeapStoreViolation(types.toObject(args[1]), result)) return primitives.raiseCrossHeapStore("vector-map!");
         gc.writeBarrier(types.toObject(args[1]), result);
         target.data[i] = result;
     }
@@ -1071,6 +1074,11 @@ fn vectorUnfoldBangFn(args: []const Value) PrimitiveError!Value {
         if (types.isMultipleValues(result)) {
             const mv = types.toObject(result).as(types.MultipleValues);
             if (mv.values.len == 0) return primitives.typeError("vector-unfold!", "at least one return value from step procedure", result);
+            // #1924: a shared parent-heap destination must not come to hold a
+            // pointer from this child's heap (see vector-copy!).
+            if (memory.crossHeapStoreViolation(types.toObject(args[1]), mv.values[0])) return primitives.raiseCrossHeapStore("vector-unfold!");
+            // #1924: see vector-unfold!.
+            if (memory.crossHeapStoreViolation(types.toObject(args[1]), mv.values[0])) return primitives.raiseCrossHeapStore("vector-unfold-right!");
             gc.writeBarrier(types.toObject(args[1]), mv.values[0]);
             vec.data[i] = mv.values[0];
             for (0..seeds.items.len) |j| {
@@ -1079,6 +1087,8 @@ fn vectorUnfoldBangFn(args: []const Value) PrimitiveError!Value {
                 }
             }
         } else {
+            if (memory.crossHeapStoreViolation(types.toObject(args[1]), result)) return primitives.raiseCrossHeapStore("vector-unfold!");
+            if (memory.crossHeapStoreViolation(types.toObject(args[1]), result)) return primitives.raiseCrossHeapStore("vector-unfold-right!");
             gc.writeBarrier(types.toObject(args[1]), result);
             vec.data[i] = result;
         }
@@ -1139,12 +1149,15 @@ fn vectorUnfoldRightBangFn(args: []const Value) PrimitiveError!Value {
         if (types.isMultipleValues(result)) {
             const mv = types.toObject(result).as(types.MultipleValues);
             if (mv.values.len == 0) return primitives.typeError("vector-unfold-right!", "at least one return value from step procedure", result);
+            // #1924: see vector-unfold!.
+            if (memory.crossHeapStoreViolation(types.toObject(args[1]), mv.values[0])) return primitives.raiseCrossHeapStore("vector-unfold-right!");
             gc.writeBarrier(types.toObject(args[1]), mv.values[0]);
             vec.data[i] = mv.values[0];
             for (mv.values[1..], 0..) |v, si| {
                 if (si < seeds.items.len) seeds.items[si] = v;
             }
         } else {
+            if (memory.crossHeapStoreViolation(types.toObject(args[1]), result)) return primitives.raiseCrossHeapStore("vector-unfold-right!");
             gc.writeBarrier(types.toObject(args[1]), result);
             vec.data[i] = result;
         }

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
+
 const diagnostics = @import("diagnostics.zig");
 const compiler_mod = @import("compiler.zig");
 const library_mod = @import("library.zig");
@@ -202,7 +203,20 @@ pub const releaseGlobalsRead = globals_mod.releaseGlobalsRead;
 fn markVMRoots(gc: *memory.GC) void {
     const vm = vm_instance orelse return;
     if (vm.gc != gc) return; // only mark the VM that owns this GC
+    markVmRoots(gc, vm);
+}
 
+/// Mark every Value `vm` keeps live: the register window of every active call
+/// frame, the frame closures, the exception-handler stack, dynamic-wind
+/// thunks, the in-flight exception, the parameter overrides, the thread
+/// handle, and — when this VM owns the shared tables — the global/macro/
+/// library values. Called with the VM's OWN gc by its own markVMRoots, and
+/// with the ROOT gc by markLiveChildRoots for each live child VM: in the
+/// latter case the child is quiescent (stopped at a safepoint or parked, see
+/// CollectionState), so reading its frames/registers races nothing, and
+/// markValue's foreign-owner skip keeps the parent's collector off the
+/// child's own heap objects (kaappi#1933).
+pub fn markVmRoots(gc: *memory.GC, vm: *VM) void {
     for (vm.frames[0..vm.frame_count]) |f| {
         if (f.closure) |cls| gc.markValue(types.makePointer(&cls.header));
         if (f.native) |nf| gc.markValue(types.makePointer(&nf.header));
@@ -309,6 +323,32 @@ pub const ProfileTimeEntry = struct {
     func: ?*types.Function,
     entry_ns: u64,
 };
+
+/// #1933 (stop-the-world): a child VM's reported execution state, read by
+/// the collecting parent (markLiveChildRoots) to decide whether the VM's
+/// registers/frames are quiescent enough to mark:
+///
+///   .running   — bytecode is (or may resume) executing; registers/frames
+///                can change at any moment. The parent must wait for a
+///                safepoint or a park. This is also the state inside a
+///                bounded native call (a primitive, a nested dispatch), which
+///                returns to the dispatch loop promptly and hits the safepoint
+///                within 1024 instructions.
+///   .stopped   — at the dispatch-loop safepoint, between instructions, with
+///                `collection_stop` set. Quiescent; the parent marks and then
+///                clears `collection_stop` to let the child resume.
+///   .parked    — blocked in a wait (reactor poll, the capped cross-thread
+///                polling loops). Quiescent; no bytecode runs until it wakes.
+///   .in_native — inside an FFI call (callFfi), which may block indefinitely
+///                and never reaches the safepoint. Quiescent while blocked;
+///                the FFI callbacks that re-enter Scheme switch back to
+///                `.running` for their extent (see callWithArgs).
+///
+/// Transitions are plain atomics on the child side and are never observed
+/// by the parent except while the child's own GC is guaranteed not to be
+/// touching these objects — see the safepoint/park protocol in
+/// markLiveChildRoots.
+pub const CollectionState = enum(u8) { running, parked, stopped, in_native };
 
 pub const VM = struct {
     gc: *memory.GC,
@@ -573,6 +613,18 @@ pub const VM = struct {
     /// join can free underneath it (#2129). Resolved at initForThread by
     /// walking the parent chain; null on the root itself.
     root_vm: ?*VM = null,
+    /// #1933 (stop-the-world): a child VM's participation in the collecting
+    /// parent's stop-the-world dance. `collection_stop` is set by
+    /// markLiveChildRoots (primitives_srfi18.zig) before it waits; the child
+    /// polls it at the dispatch-loop safepoint and parks in `stopForCollection`
+    /// (spinning between instructions, where its registers/frames are
+    /// consistent) until the parent has marked and clears it. `collection_state`
+    /// reports whether the VM is safe to mark: `.running` (bytecode executing,
+    /// registers may change — never mark), `.parked`/`.stopped`/`.in_native`
+    /// (quiescent — mark). Only meaningful on child VMs (owns_globals ==
+    /// false); the root VM collects and is never stopped.
+    collection_stop: std.atomic.Value(bool) = .init(false),
+    collection_state: std.atomic.Value(CollectionState) = .init(.running),
 
     pub fn init(gc: *memory.GC) !VM {
         const frames = try gc.allocator.alloc(CallFrame, INITIAL_FRAME_CAPACITY);
@@ -816,6 +868,43 @@ pub const VM = struct {
         } else {
             self.param_overrides.put(key, val) catch return VMError.OutOfMemory;
         }
+    }
+
+    // -- #1933 (stop-the-world): collection-state protocol --
+    //
+    // The collecting parent (primitives_srfi18.markLiveChildRoots) sets
+    // `collection_stop` on every live child VM and waits for each to leave
+    // `.running`; the child parks at its dispatch-loop safepoint
+    // (vm_dispatch.zig) or reports a park/FFI state from the blocking sites
+    // (fiber_wait.zig, ffi.zig). All transitions below are plain atomics on
+    // the child's own thread; the parent only reads the state once the child
+    // is quiescent, so there is never a torn write to race.
+
+    /// Park at the safepoint until the collecting parent clears
+    /// `collection_stop`, then resume. Runs between instructions, so the VM's
+    /// registers/frames are consistent for the parent's mark pass.
+    pub fn stopForCollection(self: *VM) void {
+        self.collection_state.store(.stopped, .release);
+        while (self.collection_stop.load(.acquire)) std.atomic.spinLoopHint();
+        self.collection_state.store(.running, .release);
+    }
+
+    /// Report a blocked state (reactor poll, cross-thread polling loop): the
+    /// VM is quiescent and may be marked. Paired with `setCollectionRunning`.
+    pub inline fn setCollectionParked(self: *VM) void {
+        self.collection_state.store(.parked, .release);
+    }
+
+    /// Report that execution is (or may) resume. The inverse of
+    /// `setCollectionParked`/`setCollectionInNative`.
+    pub inline fn setCollectionRunning(self: *VM) void {
+        self.collection_state.store(.running, .release);
+    }
+
+    /// Enter an FFI call: the VM is quiescent unless a callback re-enters
+    /// Scheme (which callWithArgs flips back to `.running` for its extent).
+    pub inline fn setCollectionInNative(self: *VM) void {
+        self.collection_state.store(.in_native, .release);
     }
 
     pub fn setErrorDetail(self: *VM, comptime fmt: []const u8, args: anytype) void {

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -338,11 +338,16 @@ pub const ProfileTimeEntry = struct {
 ///                `collection_stop` set. Quiescent; the parent marks and then
 ///                clears `collection_stop` to let the child resume.
 ///   .parked    — blocked in a wait (reactor poll, the capped cross-thread
-///                polling loops). Quiescent; no bytecode runs until it wakes.
-///   .in_native — inside an FFI call (callFfi), which may block indefinitely
-///                and never reaches the safepoint. Quiescent while blocked;
-///                the FFI callbacks that re-enter Scheme switch back to
-///                `.running` for their extent (see callWithArgs).
+///                polling loops). Quiescent while reported; the resume path
+///                (setCollectionRunning) re-checks `collection_stop` before
+///                letting bytecode run, so a parent that observed this state
+///                can always mark it frozen.
+///   .in_native — inside an FFI call (callFfi) or a raw thread join
+///                (reapOsThread): may block indefinitely and never reaches
+///                the safepoint. Quiescent while reported; the FFI callbacks
+///                that re-enter Scheme switch back to `.running` for their
+///                extent (see callWithArgs), and the resume path re-checks
+///                `collection_stop` the same way.
 ///
 /// Transitions are plain atomics on the child side and are never observed
 /// by the parent except while the child's own GC is guaranteed not to be
@@ -895,10 +900,28 @@ pub const VM = struct {
         self.collection_state.store(.parked, .release);
     }
 
-    /// Report that execution is (or may) resume. The inverse of
-    /// `setCollectionParked`/`setCollectionInNative`.
+    /// Resume from a quiescent state (park, FFI call, callback re-entry,
+    /// startup handshake). If the collecting parent has armed `collection_stop`
+    /// while we were quiescent, this must NOT publish `.running` and resume
+    /// bytecode: the parent may already have observed us quiescent and be
+    /// about to mark. Mirror the safepoint path instead — publish `.stopped`
+    /// and spin until the parent clears the flag — so the parent's mark always
+    /// finds us frozen. (The check-then-store race with the parent's arming
+    /// is safe: if the parent arms after our check, we resume and the parent
+    /// simply waits for our next safepoint, within 1024 instructions.)
     pub inline fn setCollectionRunning(self: *VM) void {
+        if (self.collection_stop.load(.acquire)) {
+            self.stopForCollection();
+            return;
+        }
         self.collection_state.store(.running, .release);
+    }
+
+    /// Restore a previously saved quiescent state (used by callWithArgs'
+    /// FFI-callback guard). The state being restored is never `.running`, so
+    /// no resume-vs-mark race is possible; the raw store is fine.
+    pub inline fn setCollectionState(self: *VM, s: CollectionState) void {
+        self.collection_state.store(s, .release);
     }
 
     /// Enter an FFI call: the VM is quiescent unless a callback re-enters

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -885,13 +885,16 @@ pub fn callWithArgs(vm: *VM, proc: Value, args: []const Value) VMError!Value {
     // mid-execution. The one case that needs the save/restore is entering
     // from a `.in_native` FFI call (an ffi-callback trampoline); the common
     // case is already `.running` and costs a single atomic load on child
-    // VMs only (the root VM, owns_globals, never reports a state).
+    // VMs only (the root VM, owns_globals, never reports a state). Both the
+    // flip to `.running` and the restore go through the guarded helpers, so
+    // a callback cannot start bytecode during a mark (setCollectionRunning
+    // spins on collection_stop first) and the restore cannot race one either.
     const saved_state: ?vm_mod.CollectionState = if (!vm.owns_globals and vm.collection_state.load(.monotonic) != .running)
         vm.collection_state.load(.monotonic)
     else
         null;
-    if (saved_state != null) vm.collection_state.store(.running, .release);
-    defer if (saved_state) |s| vm.collection_state.store(s, .release);
+    if (saved_state != null) vm.setCollectionRunning();
+    defer if (saved_state) |s| vm.setCollectionState(s);
     if (types.isParameter(proc)) {
         const param = types.toObject(proc).as(types.ParameterObject);
         if (args.len == 0) {

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -879,6 +879,19 @@ pub fn callWithArgs(vm: *VM, proc: Value, args: []const Value) VMError!Value {
         return ffi_mod.callFfi(ffi_fn, args, vm.gc, vm) catch |err|
             return mapFfiError(vm, err, ffi_fn);
     }
+    // #1933: everything below runs bytecode (a closure via callReentrant, a
+    // continuation resume, a converter/callback re-entry), so a collecting
+    // parent must see `.running` and wait for a safepoint instead of marking
+    // mid-execution. The one case that needs the save/restore is entering
+    // from a `.in_native` FFI call (an ffi-callback trampoline); the common
+    // case is already `.running` and costs a single atomic load on child
+    // VMs only (the root VM, owns_globals, never reports a state).
+    const saved_state: ?vm_mod.CollectionState = if (!vm.owns_globals and vm.collection_state.load(.monotonic) != .running)
+        vm.collection_state.load(.monotonic)
+    else
+        null;
+    if (saved_state != null) vm.collection_state.store(.running, .release);
+    defer if (saved_state) |s| vm.collection_state.store(s, .release);
     if (types.isParameter(proc)) {
         const param = types.toObject(proc).as(types.ParameterObject);
         if (args.len == 0) {

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -4,6 +4,7 @@ const Value = types.Value;
 const OpCode = types.OpCode;
 
 const vm_mod = @import("vm.zig");
+const memory = @import("memory.zig");
 const VM = vm_mod.VM;
 const VMError = vm_mod.VMError;
 const CallFrame = vm_mod.CallFrame;
@@ -35,6 +36,7 @@ const rejectImmutableEnv = vm_dispatch_helpers.rejectImmutableEnv;
 const raiseUndefinedVariable = vm_dispatch_helpers.raiseUndefinedVariable;
 const lookupGlobalLocked = vm_dispatch_helpers.lookupGlobalLocked;
 const raiseDeadNativeReturn = vm_dispatch_helpers.raiseDeadNativeReturn;
+const raiseCrossHeapStoreVM = vm_dispatch_helpers.raiseCrossHeapStoreVM;
 
 /// True when a just-restored (or escape-unwound) frame stack should resume in
 /// THIS dispatch loop: the new stack must still contain the loop's scope-root
@@ -103,6 +105,13 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     return VMError.Terminated;
                 }
             }
+            // #1933: a collecting parent stops live children at this
+            // safepoint to mark their roots (markLiveChildRoots). Only child
+            // VMs (owns_globals == false) participate — the root thread
+            // collects and never stops. The spin inside stopForCollection is
+            // between instructions, so the parent's mark of this VM's
+            // registers/frames races nothing.
+            if (!self.owns_globals and self.collection_stop.load(.acquire)) self.stopForCollection();
             if (self.timeout_deadline_ns) |deadline| {
                 if (vm_calls.clockNs() >= deadline) {
                     self.setErrorDetail("execution timed out", .{});
@@ -255,6 +264,20 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const name = types.symbolName(sym);
                 if (rejectImmutableEnv(self, func, name, "set!: cannot modify binding")) |e| return e;
                 const val = self.registers[src_idx];
+                // #1924: the shared globals map (and every library/def-env
+                // map a template set! can reach) is owned by the ROOT VM's
+                // GC. A child thread (`owns_globals == false`) writing its
+                // own heap's object into one leaves a pointer the root
+                // collector cannot trace — the memoisation hazard of
+                // `(define cache #f)` + `(set! cache ...)` from a child,
+                // dangling once the child's heap is freed at join. Writing
+                // an immediate, or an already-root-heap object, is fine.
+                // Checked before any lock is taken so the rejection never
+                // unwinds out of the locked region.
+                if (!self.owns_globals and types.isPointer(val)) {
+                    const root_vm = self.root_vm orelse self;
+                    if (types.toObject(val).owner != root_vm.gc.id) return raiseCrossHeapStoreVM(self, "set!");
+                }
                 // #1812: a template set! to a free reference bound in the
                 // macro's own definition-environment library compiles as
                 // set_global on a def_env_binding_prefix-marked name — write
@@ -326,6 +349,13 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 if (rejectImmutableEnv(self, func, name, "define: cannot define")) |e| return e;
                 const val = self.registers[src_idx];
                 if (env == self.globals) {
+                    // #1924: same rule as set_global — a child defining an
+                    // object of its own heap into the shared map leaves a
+                    // dangling pointer after its join.
+                    if (!self.owns_globals and types.isPointer(val)) {
+                        const root_vm = self.root_vm orelse self;
+                        if (types.toObject(val).owner != root_vm.gc.id) return raiseCrossHeapStoreVM(self, "define");
+                    }
                     // Structural mutation of the shared globals map: may
                     // rehash, so it must exclude child-thread readers.
                     self.globals_lock.lock();
@@ -366,9 +396,14 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const src_idx = try registerIndex(self, frame.base, src);
                 const uv = closure.upvalues[idx];
                 if (types.isBox(uv)) {
+                    // #1924: a captured-variable box (a pair) may belong to a
+                    // shared parent-heap closure reached through a global;
+                    // reject storing this thread's own heap objects into it.
+                    if (memory.crossHeapStoreViolation(types.toObject(uv), self.registers[src_idx])) return raiseCrossHeapStoreVM(self, "set!");
                     self.gc.writeBarrier(types.toObject(uv), self.registers[src_idx]);
                     types.boxSet(uv, self.registers[src_idx]);
                 } else {
+                    if (memory.crossHeapStoreViolation(&closure.header, self.registers[src_idx])) return raiseCrossHeapStoreVM(self, "set!");
                     self.gc.writeBarrier(&closure.header, self.registers[src_idx]);
                     closure.upvalues[idx] = self.registers[src_idx];
                 }
@@ -1207,6 +1242,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const src_idx = try registerIndex(self, frame.base, src);
                 const val = self.registers[reg_idx];
                 if (types.isBox(val)) {
+                    if (memory.crossHeapStoreViolation(types.toObject(val), self.registers[src_idx])) return raiseCrossHeapStoreVM(self, "set!");
                     self.gc.writeBarrier(types.toObject(val), self.registers[src_idx]);
                     types.boxSet(val, self.registers[src_idx]);
                 } else {

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -348,14 +348,19 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const name = types.symbolName(sym);
                 if (rejectImmutableEnv(self, func, name, "define: cannot define")) |e| return e;
                 const val = self.registers[src_idx];
+                // #1924: same rule as set_global — a child defining an
+                // object of its own heap into ANY shared map (the globals
+                // map, a library lib_env, or a SchemeEnvironment reached
+                // through a global) leaves a dangling pointer after its join.
+                // Checked before the env branch, exactly like set_global, so
+                // a child eval-define into a shared environment is covered
+                // too; a child defining into its own private environment is
+                // refused the same way (consistent with the set! rule).
+                if (!self.owns_globals and types.isPointer(val)) {
+                    const root_vm = self.root_vm orelse self;
+                    if (types.toObject(val).owner != root_vm.gc.id) return raiseCrossHeapStoreVM(self, "define");
+                }
                 if (env == self.globals) {
-                    // #1924: same rule as set_global — a child defining an
-                    // object of its own heap into the shared map leaves a
-                    // dangling pointer after its join.
-                    if (!self.owns_globals and types.isPointer(val)) {
-                        const root_vm = self.root_vm orelse self;
-                        if (types.toObject(val).owner != root_vm.gc.id) return raiseCrossHeapStoreVM(self, "define");
-                    }
                     // Structural mutation of the shared globals map: may
                     // rehash, so it must exclude child-thread readers.
                     self.globals_lock.lock();

--- a/src/vm_dispatch_helpers.zig
+++ b/src/vm_dispatch_helpers.zig
@@ -16,6 +16,29 @@ const CallFrame = vm_mod.CallFrame;
 
 const memory = @import("memory.zig");
 
+/// kaappi#1924: the catchable error a bytecode store (set_upvalue,
+/// set_box_local, set_global, define_global) raises when it would install a
+/// pointer to the running thread's own heap object into an object shared
+/// with another thread. Mirrors the primitive-level raiseCrossHeapStore
+/// (primitives.zig); the store is rejected before it happens.
+pub noinline fn raiseCrossHeapStoreVM(self: *VM, comptime proc: []const u8) VMError {
+    var buf: [320]u8 = undefined;
+    const msg = std.fmt.bufPrint(
+        &buf,
+        "{s}: cannot store an object created on this thread into a heap object shared with another thread (it would dangle once this thread's heap is freed); pass values through the thread thunk, a channel message, or a join result instead",
+        .{proc},
+    ) catch "cross-heap store rejected";
+    var message = self.gc.allocString(msg) catch return VMError.OutOfMemory;
+    self.gc.pushRoot(&message);
+    const err_obj = self.gc.allocErrorObject(message, types.NIL) catch {
+        self.gc.popRoot();
+        return VMError.OutOfMemory;
+    };
+    self.gc.popRoot();
+    self.current_exception = err_obj;
+    return VMError.ExceptionRaised;
+}
+
 /// A frame with returns_to_native set (pushed by vm.callWithArgs) delivers its
 /// result via its own runUntil session's return value; its dst is a
 /// placeholder. When such a frame returns while frame_count is still above

--- a/tests/scheme/audit/cross-thread-boundary-audit.scm
+++ b/tests/scheme/audit/cross-thread-boundary-audit.scm
@@ -246,14 +246,23 @@
                  (set-car! probe-container (string->symbol "never-seen-before-xyz"))))
     (eq? (car p) (string->symbol "never-seen-before-xyz"))))
 
-;; A child writing a value it read from the PARENT's heap is sound, and
-;; keeps eq?. This isolates "child-allocated pointer" as the hazard rather
-;; than "cross-thread write" as such.
-(test-assert "a child may store a parent-heap value into a parent-heap object"
+;; A child writing a value it read from the PARENT's heap into a parent-heap
+;; object is now REJECTED too (kaappi#1924): even a parent-owned value needs
+;; the OWNER's generational write barrier when it is young and the container
+;; old, and the owner's remembered set cannot be touched cross-thread — so
+;; the rule is that a child never writes a foreign container at all (the
+;; store is refused before it happens; see srfi18-cross-heap-mutation-1924).
+;; The previous characterisation row asserted the old, unsound behaviour and
+;; is replaced by the rejection.
+(test-assert "a child may not store even a parent-heap value into a parent-heap object"
   (let ((p (cons 'a 'b)))
     (set! probe-container p)
-    (on-thread (lambda () (set-car! probe-container shared-list)))
-    (and (equal? (car p) '(1 2 3)) (eq? (car p) shared-list))))
+    (and (eq? 'rejected
+              (on-thread (lambda ()
+                           (guard (e (#t 'rejected))
+                             (set-car! probe-container shared-list)
+                             'no-error))))
+         (eq? (car p) 'a))))
 
 ;; ---------------------------------------------------------------------
 ;; 3. Write direction -- what CORRUPTS (kaappi#1924)

--- a/tests/scheme/srfi/srfi18-child-registers-1933.scm
+++ b/tests/scheme/srfi/srfi18-child-registers-1933.scm
@@ -1,0 +1,95 @@
+;; Regression test for #1933: the parent's collector reclaims objects a live
+;; child thread still references.
+;;
+;; Each SRFI-18 OS thread has its own VM and GC. A value reaches a child
+;; either deep-copied (thread thunk, channel message, join result) or by
+;; POINTER through the shared globals map. A child that reads a parent-heap
+;; object from a global holds that object in its registers — and those
+;; registers are invisible to the parent's collector (markVMRoots marks only
+;; the VM owning the collecting gc), while the child's own collector skips
+;; foreign-owner objects (#958). Between them, a parent-heap object referenced
+;; ONLY from a live child's registers is unreachable to both markers: if the
+;; parent drops its last reference (here, by deleting the hash-table entry
+;; that was the sole parent-side root) and then churns the heap, the parent's
+;; collection frees the object the child is still using. The child then reads
+;; freed memory — a recycled-slot type error, or a hard
+;; "GC: marking freed object (use-after-free)" panic under -Dgc-stress.
+;;
+;; The fix: the parent's collector stops every live child at a dispatch-loop
+;; safepoint and marks the child's roots (registers, frames, handlers, winds,
+;; exceptions, scheduler fibers) with its own gc, keeping parent-heap objects
+;; the child references alive. This test drives the exact issue shape —
+;; hash-table entry filled inside a procedure (so no stale base-frame
+;; register retains the value), the child pulling the value into a local
+;; through a channel handshake, the parent deleting the entry and churning
+;; the heap, and only THEN releasing the child — with a second channel
+;; handshake so the child reads the value only after the parent's churn has
+;; surely recycled the old slot. Without the fix the value is freed and the
+;; child's `cadr` reads garbage (wrong answer or a raise); with it the child
+;; reads the intact list.
+
+(import (scheme base) (scheme write) (srfi 18) (srfi 125) (srfi 254) (srfi 64))
+
+(test-begin "srfi18-child-registers-1933")
+
+(define h (make-hash-table equal?))
+(define seed 100)
+;; Filled inside a procedure, so the value is never a stale base-frame
+;; register on the parent; and built at runtime (from `seed`), so the
+;; compiler's constant-folding cannot retain it in the procedure's constant
+;; pool either.
+(define (fill!)
+  (hash-table-set! h 'key (list seed (+ seed 1) (+ seed 2))))
+(fill!)
+
+(let ((got-ch (make-channel))
+      (go-ch (make-channel)))
+  (define t
+    (make-thread
+      (lambda ()
+        (let ((v (hash-table-ref h 'key)))
+          ;; Handshake 1: tell the parent the value is now held in a local.
+          (channel-send got-ch 'got)
+          ;; Handshake 2: wait until the parent has dropped its reference AND
+          ;; churned the heap, so the freed slot is surely recycled — reading
+          ;; `v` now is what used to read freed memory.
+          (channel-receive go-ch)
+          (cadr v)))))
+  (thread-start! t)
+  (channel-receive got-ch)
+  ;; Drop the parent's only reference to the value...
+  (hash-table-delete! h 'key)
+  ;; ...and churn: enough allocations that several full collections run and
+  ;; the freed pair's slot is recycled. Without the fix the child's register
+  ;; was invisible to these collections and the pair was swept.
+  (let loop ((i 0))
+    (when (< i 400000)
+      (let ((tmp (list 1 2 3 (make-vector 8 i))))
+        (loop (+ i 1)))))
+  (channel-send go-ch 'churned)
+  (test-equal "a parent-heap object held only in a live child's registers survives the parent's collection"
+    101
+    (thread-join! t)))
+
+;; Control: the same shape but WITHOUT the child — dropping the entry and
+;; churning must actually free the value, proving the churn is strong enough
+;; to recycle the slot (i.e. the test above is not passing vacuously because
+;; nothing was ever collected). A guardian observes the collection.
+(define h2 (make-hash-table equal?))
+(define g2 (make-guardian))
+(define seed2 200)
+(define (fill2!)
+  (hash-table-set! h2 'key (list seed2 (+ seed2 1) (+ seed2 2)))
+  (g2 (hash-table-ref h2 'key)))
+(fill2!)
+(hash-table-delete! h2 'key)
+(let loop ((i 0))
+  (when (< i 400000)
+    (let ((tmp (list 1 2 3 (make-vector 8 i))))
+      (loop (+ i 1)))))
+(test-assert "control: the churn really collects an unreferenced value (the test is not vacuous)"
+  (pair? (g2)))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi18-child-registers-1933")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi18-child-registers-1933.scm
+++ b/tests/scheme/srfi/srfi18-child-registers-1933.scm
@@ -62,8 +62,11 @@
   ;; ...and churn: enough allocations that several full collections run and
   ;; the freed pair's slot is recycled. Without the fix the child's register
   ;; was invisible to these collections and the pair was swept.
+  ;; The churn is sized to run enough full collections to recycle the freed
+  ;; slot (verified against the pre-fix engine: 100k iterations still turn
+  ;; the child's read into garbage) while keeping the gc-stress run fast.
   (let loop ((i 0))
-    (when (< i 400000)
+    (when (< i 100000)
       (let ((tmp (list 1 2 3 (make-vector 8 i))))
         (loop (+ i 1)))))
   (channel-send go-ch 'churned)
@@ -84,7 +87,7 @@
 (fill2!)
 (hash-table-delete! h2 'key)
 (let loop ((i 0))
-  (when (< i 400000)
+  (when (< i 100000)
     (let ((tmp (list 1 2 3 (make-vector 8 i))))
       (loop (+ i 1)))))
 (test-assert "control: the churn really collects an unreferenced value (the test is not vacuous)"

--- a/tests/scheme/srfi/srfi18-cross-heap-mutation-1924.scm
+++ b/tests/scheme/srfi/srfi18-cross-heap-mutation-1924.scm
@@ -1,0 +1,134 @@
+;; Regression test for #1924: a child thread mutating a shared heap object
+;; installs a child-heap pointer that dangles after thread-join!.
+;;
+;; Each SRFI-18 OS thread has its own GC heap. Top-level bindings are shared
+;; BY POINTER (VM.initForThread shares the root's globals map), so a child
+;; reaching a top-level record/vector/pair/promise through the globals route
+;; gets the parent's own object. A child that then stores one of ITS OWN heap
+;; objects into that shared container leaves a pointer the parent's collector
+;; cannot trace and the child's collector cannot see a reference to: the value
+;; is freed by the child's GC (or when the child's heap is reclaimed at
+;; thread-join!) while the parent's container still holds it. Reading it back
+;; yields recycled garbage — `(box-v b)` printing the program's own source
+;; text, or worse, a freed slot read as a callable procedure.
+;;
+;; The fix rejects the store BEFORE it happens: a thread may not install a
+;; pointer into a heap object it does not own unless the pointer names an
+;; object of that same owning heap. This pins every general mutation site —
+;; record field set!, vector-set!, set-car!/set-cdr!, hash-table-set!, global
+;; set!/define, and %promise-complete! (the R7RS delay/force memoisation
+;; hazard) — plus the two controls that must keep working: a child storing an
+;; IMMEDIATE into a shared object, and a child storing a shared parent-heap
+;; object into its OWN local structure (the ordinary "copy a global into a
+;; local" pattern). The sanctioned cross-heap store — a child locking a
+;; parent-heap mutex, which records its own fiber as owner — is asserted to
+;; keep working in srfi18-sharing-model.scm / srfi18-cross-heap-abandoned-
+;; mutex.scm and is deliberately exempt.
+
+(import (scheme base) (scheme write) (scheme lazy) (srfi 13) (srfi 18) (srfi 125) (srfi 64))
+
+(test-begin "srfi18-cross-heap-mutation-1924")
+
+;; Runs THUNK on a child thread and returns either its value or
+;; (raised . message) — for whichever of the two raises first, the child
+;; itself or the join.
+(define (on-child thunk)
+  (let ((t (make-thread
+            (lambda ()
+              (guard (e (#t (cons 'raised (error-object-message e))))
+                (thunk))))))
+    (guard (e (#t (cons 'raised (error-object-message e))))
+      (thread-start! t)
+      (thread-join! t))))
+
+(define (raised? r) (and (pair? r) (eq? (car r) 'raised)))
+
+(define (refused? r)
+  (and (raised? r)
+       (let ((msg (cdr r)))
+         ;; The message names the hazard, not just any error.
+         (and (string? msg)
+              (not (not (string-contains msg "cannot store an object created on this thread")))))))
+
+;; ---------------------------------------------------------------------------
+;; Rejected: a child stores its own heap's object into a shared parent-heap
+;; container. Each of these was a deterministic use-after-free before the fix.
+;; ---------------------------------------------------------------------------
+
+(define-record-type <box> (make-box v) box? (v box-v set-box-v!))
+(define g-box (make-box #f))
+(test-assert "record field set! from a child is rejected"
+  (refused? (on-child (lambda () (set-box-v! g-box (list 1 2 3)) 'no-error))))
+(test-equal "the shared record was not corrupted by the rejected store"
+  #f (box-v g-box))
+
+(define g-vec (make-vector 3 #f))
+(test-assert "vector-set! from a child is rejected"
+  (refused? (on-child (lambda () (vector-set! g-vec 0 (list 1 2 3)) 'no-error))))
+(test-equal "the shared vector was not corrupted"
+  #f (vector-ref g-vec 0))
+
+(define g-pair (cons 1 2))
+(test-assert "set-car! from a child is rejected"
+  (refused? (on-child (lambda () (set-car! g-pair (list 9 9 9)) 'no-error))))
+(test-equal "the shared pair was not corrupted"
+  '(1 . 2) g-pair)
+
+(define g-ht (make-hash-table equal?))
+(test-assert "hash-table-set! from a child is rejected"
+  (refused? (on-child (lambda () (hash-table-set! g-ht 'k (list 1 2 3)) 'no-error))))
+(test-assert "the shared hash table was not corrupted"
+  (not (hash-table-contains? g-ht 'k)))
+
+;; The R7RS memoisation hazard: a top-level (define p (delay ...)) shared by
+;; pointer, forced by a child, would memoise a child-heap value into the
+;; parent-heap promise.
+(define g-promise (delay (list 'slow 1 2)))
+(test-assert "force on a shared promise from a child is rejected"
+  (refused? (on-child (lambda () (force g-promise)))))
+
+;; Global set!/define of a child-heap object into the shared map: the
+;; (define cache #f) + fill-on-first-use idiom from a child.
+(define g-counter 0)
+(test-assert "set! of a heap object on a shared global from a child is rejected"
+  (refused? (on-child (lambda () (set! g-counter (list 1 2 3)) 'no-error))))
+(test-equal "the shared global was not corrupted"
+  0 g-counter)
+
+;; ---------------------------------------------------------------------------
+;; Controls: what must keep working.
+;; ---------------------------------------------------------------------------
+
+;; An immediate (fixnum) has no lifetime — writing one into a shared object
+;; is always safe.
+(test-equal "set! of an immediate on a shared global from a child works"
+  'ok
+  (on-child (lambda () (set! g-counter (+ g-counter 1)) 'ok)))
+(test-equal "the fixnum global was updated"
+  1 g-counter)
+
+;; Direction B: a child storing a shared parent-heap object into its OWN
+;; local structure is the ordinary "copy a global into a local" pattern and
+;; must stay legal (its safety is kaappi#1933's parent-marks-child-roots
+;; invariant, not a store rejection).
+(define g-shared-box (make-box 'hello))
+(test-equal "a child may store a shared parent-heap object into its own vector"
+  #t
+  (on-child (lambda ()
+              (let ((v (make-vector 2)))
+                (vector-set! v 0 g-shared-box)
+                (vector-set! v 1 'ok)
+                (eq? (vector-ref v 0) g-shared-box)))))
+
+;; A child mutating its OWN heap objects (created inside the thunk) is
+;; entirely local and untouched by the rule.
+(test-equal "a child may mutate its own heap objects"
+  'ok
+  (on-child (lambda ()
+              (let ((box (make-box 0)))
+                (set-box-v! box (list 1 2 3))
+                (if (= (length (box-v box)) 3) 'ok 'bad)))))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi18-cross-heap-mutation-1924")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi18-cross-heap-mutation-1924.scm
+++ b/tests/scheme/srfi/srfi18-cross-heap-mutation-1924.scm
@@ -25,7 +25,8 @@
 ;; keep working in srfi18-sharing-model.scm / srfi18-cross-heap-abandoned-
 ;; mutex.scm and is deliberately exempt.
 
-(import (scheme base) (scheme write) (scheme lazy) (srfi 13) (srfi 18) (srfi 125) (srfi 64))
+(import (scheme base) (scheme write) (scheme lazy) (scheme eval) (scheme repl)
+        (srfi 13) (srfi 18) (srfi 69) (srfi 133) (srfi 64))
 
 (test-begin "srfi18-cross-heap-mutation-1924")
 
@@ -71,14 +72,48 @@
 (define g-pair (cons 1 2))
 (test-assert "set-car! from a child is rejected"
   (refused? (on-child (lambda () (set-car! g-pair (list 9 9 9)) 'no-error))))
+(test-assert "set-cdr! from a child is rejected"
+  (refused? (on-child (lambda () (set-cdr! g-pair (list 9 9 9)) 'no-error))))
 (test-equal "the shared pair was not corrupted"
   '(1 . 2) g-pair)
 
+(define g-list (list 'a 'b 'c))
+(test-assert "list-set! from a child is rejected"
+  (refused? (on-child (lambda () (list-set! g-list 0 (list 9 9)) 'no-error))))
+(test-equal "the shared list was not corrupted"
+  '(a b c) g-list)
+
+;; vector-copy!/vector-reverse-copy! write their source elements into the
+;; destination (`args[0]`); a shared destination must not come to hold a
+;; pointer from the child's heap.
+(define g-copy-dst (make-vector 3 'x))
+(test-assert "vector-copy! from a child is rejected"
+  (refused? (on-child (lambda () (vector-copy! g-copy-dst 0 (vector (list 1) 2 3)) 'no-error))))
+(test-assert "vector-reverse-copy! from a child is rejected"
+  (refused? (on-child (lambda () (vector-reverse-copy! g-copy-dst 0 (vector (list 1) 2 3)) 'no-error))))
+(test-equal "the shared destination was not corrupted"
+  '(x x x) (vector->list g-copy-dst))
+
 (define g-ht (make-hash-table equal?))
-(test-assert "hash-table-set! from a child is rejected"
+(test-assert "hash-table-set! from a child is rejected (child-allocated value)"
   (refused? (on-child (lambda () (hash-table-set! g-ht 'k (list 1 2 3)) 'no-error))))
-(test-assert "the shared hash table was not corrupted"
-  (not (hash-table-contains? g-ht 'k)))
+(test-assert "hash-table-set! from a child is rejected (child-allocated key)"
+  (refused? (on-child (lambda () (hash-table-set! g-ht (list 1 2) 'v) 'no-error))))
+;; A pre-existing key so hash-table-update! reaches its store (SRFI-69's
+;; update! on a missing key raises before any store).
+(hash-table-set! g-ht 'present 'old)
+(test-assert "hash-table-update! from a child is rejected"
+  (refused? (on-child (lambda () (hash-table-update! g-ht 'present (lambda (_) (list 1 2 3))) 'no-error))))
+(test-assert "hash-table-update!/default from a child is rejected"
+  (refused? (on-child (lambda () (hash-table-update!/default g-ht 'missing (lambda (_) (list 1 2 3)) 'd) 'no-error))))
+(define g-ht2 (make-hash-table equal?))
+(hash-table-set! g-ht2 'a (list 1))
+(test-assert "hash-table-merge! from a child is rejected"
+  (refused? (on-child (lambda () (hash-table-merge! g-ht g-ht2) 'no-error))))
+(test-equal "the shared hash table was not corrupted"
+  'old (hash-table-ref g-ht 'present))
+(test-assert "the merged table was not installed"
+  (not (hash-table-exists? g-ht 'a)))
 
 ;; The R7RS memoisation hazard: a top-level (define p (delay ...)) shared by
 ;; pointer, forced by a child, would memoise a child-heap value into the
@@ -92,6 +127,8 @@
 (define g-counter 0)
 (test-assert "set! of a heap object on a shared global from a child is rejected"
   (refused? (on-child (lambda () (set! g-counter (list 1 2 3)) 'no-error))))
+(test-assert "define of a heap object on a shared global from a child is rejected (via eval)"
+  (refused? (on-child (lambda () (eval '(define g-fresh (make-vector 3)) (interaction-environment)) 'no-error))))
 (test-equal "the shared global was not corrupted"
   0 g-counter)
 
@@ -119,6 +156,18 @@
                 (vector-set! v 0 g-shared-box)
                 (vector-set! v 1 'ok)
                 (eq? (vector-ref v 0) g-shared-box)))))
+
+;; The mirror image is also rejected: a child storing a PARENT-OWNED value
+;; into a PARENT-OWNED container. That store installs no child-heap pointer,
+;; but it would need the OWNER's generational write barrier (a parent-young
+;; value in a parent-old container is invisible to the parent's next minor
+;; collection without a remembered-set edge), and the owner's remembered set
+;; cannot be touched cross-thread — so the rule is simply that a child never
+;; writes a foreign container at all.
+(test-assert "a child may not store even a parent-owned value into a shared container"
+  (refused? (on-child (lambda () (set-box-v! g-box g-shared-box) 'no-error))))
+(test-equal "the shared record still holds its original value"
+  #f (box-v g-box))
 
 ;; A child mutating its OWN heap objects (created inside the thunk) is
 ;; entirely local and untouched by the rule.

--- a/tests/scheme/srfi/srfi18-cross-heap-mutation-1924.scm
+++ b/tests/scheme/srfi/srfi18-cross-heap-mutation-1924.scm
@@ -94,6 +94,18 @@
 (test-equal "the shared destination was not corrupted"
   '(x x x) (vector->list g-copy-dst))
 
+;; vector-map!/vector-unfold!/vector-unfold-right! write the step procedure's
+;; results into a caller-supplied destination.
+(define g-dst (make-vector 3 'z))
+(test-assert "vector-map! from a child is rejected"
+  (refused? (on-child (lambda () (vector-map! (lambda (x) (list x)) g-dst) 'no-error))))
+(test-assert "vector-unfold! from a child is rejected"
+  (refused? (on-child (lambda () (vector-unfold! (lambda (i s) (list i)) g-dst 0 3 0) 'no-error))))
+(test-assert "vector-unfold-right! from a child is rejected"
+  (refused? (on-child (lambda () (vector-unfold-right! (lambda (i s) (list i)) g-dst 0 3 0) 'no-error))))
+(test-equal "the shared unfold/map destination was not corrupted"
+  '(z z z) (vector->list g-dst))
+
 (define g-ht (make-hash-table equal?))
 (test-assert "hash-table-set! from a child is rejected (child-allocated value)"
   (refused? (on-child (lambda () (hash-table-set! g-ht 'k (list 1 2 3)) 'no-error))))

--- a/tests/scheme/srfi/srfi18-sharing-model.scm
+++ b/tests/scheme/srfi/srfi18-sharing-model.scm
@@ -8,7 +8,9 @@
 ;; gc_deep_copy.zig's fourteen-tag uncopyable list governs the copy route
 ;; only, and the globals route is checked by individual primitives for
 ;; exactly four types (channels, thread handles, fibers and guardians —
-;; the last two added by #2001 and #2008).
+;; the last two added by #2001 and #2008), plus — since #1924 — a general
+;; rejection of any store of a child-heap object into a shared parent-heap
+;; container (the rows below, and srfi18-cross-heap-mutation-1924.scm).
 ;;
 ;; This file pins BOTH routes for each type, which is the pairing that makes
 ;; the asymmetry visible -- and it is deliberately a characterisation test,
@@ -22,7 +24,7 @@
 ;; and this suite runs there. The nine types below cover every distinct
 ;; enforcement shape.
 
-(import (scheme base) (scheme write) (scheme eval) (scheme repl)
+(import (scheme base) (scheme write) (scheme eval) (scheme repl) (scheme lazy)
         (scheme process-context)
         (srfi 18) (srfi 254) (kaappi fibers) (srfi 64))
 
@@ -94,6 +96,11 @@
 (define g-channel (make-channel))
 (define g-thread (make-thread (lambda () 'never-started)))
 (define g-fiber (spawn (lambda () (list 1 2 3))))
+(define-record-type <box> (make-box v) box? (v box-v set-box-v!))
+(define g-box (make-box 0))
+(define g-vector (make-vector 2 #f))
+(define g-pair (cons 1 2))
+(define g-promise (delay (list 'slow 1 2)))
 
 ;; Checked on this route -- the only four types that are. A fiber and a
 ;; guardian joined the list with #2001 and #2008: fiber-join was handing the
@@ -107,6 +114,28 @@
   (refused? (on-child (lambda () (fiber-join g-fiber)))))
 (test-assert "global refused: guardian"
   (refused? (on-child (lambda () (g-guardian (list 1 2))))))
+
+;; #1924: a child MUTATING a shared parent-heap object is rejected too --
+;; the general case of which the four per-type checks above are the
+;; specialised instances. A store of a child-heap pointer into a shared
+;; container leaves a value neither collector can keep alive (the parent's
+;; collector skips it as foreign, the child's collector cannot see the
+;; container), so the container comes to hold a dangling pointer the moment
+;; the child's heap is freed or the child's GC sweeps. Rejected before the
+;; store, at every general mutation site (record field, vector, pair,
+;; hash-table, promise, global set!/define) -- see
+;; srfi18-cross-heap-mutation-1924.scm for the full matrix. The mutex
+;; owner/owner_thread store is the deliberate exception (the only supported
+;; way to share a mutex is a global, and locking one from a child must
+;; record the child's own fiber as owner).
+(test-assert "global mutation refused: record field set!"
+  (refused? (on-child (lambda () (set-box-v! g-box (list 1 2 3)) 'no-error))))
+(test-assert "global mutation refused: vector-set!"
+  (refused? (on-child (lambda () (vector-set! g-vector 0 (list 1 2 3)) 'no-error))))
+(test-assert "global mutation refused: set-car!"
+  (refused? (on-child (lambda () (set-car! g-pair (list 9 9 9)) 'no-error))))
+(test-assert "global mutation refused: force on a shared promise"
+  (refused? (on-child (lambda () (force g-promise)))))
 
 ;; Unchecked on this route. Mutexes and condition variables are not merely
 ;; tolerated here: a global is the ONLY way to share one, since the line


### PR DESCRIPTION
Closes #1924, closes #1933.

Two halves of the same gap: each SRFI-18 OS thread has its own GC heap, top-level bindings are shared by pointer, and nothing coordinated the two collectors on the mutation path. Both were deterministic use-after-frees — #1924 on every run, #1933 wrong values or a hard `GC: marking freed object` panic under `-Dgc-stress`.

## #1924 — reject cross-heap stores

A child storing one of its own heap's objects into a shared parent-heap container (record field, vector slot, pair, hash-table entry, a promise's memoised value, or the globals map) left a pointer the parent's collector skips as foreign and the child's collector cannot see a reference to. The store is now **rejected before it happens** (`memory.crossHeapStoreViolation`, checked at every general mutation site), unless the value belongs to the container's own heap. The `mutex-lock!` owner pair is the one sanctioned exception (a child locking a global mutex must record its own fiber as owner).

## #1933 — the parent's collector marks live children's roots

A parent-heap object referenced only from a live child's registers was unreachable to both markers. The root's collector now stops every live child at the dispatch-loop safepoint (or finds it already parked / in an FFI call) and marks its roots with the root's gc (`markLiveChildRoots`, wired as `gc.child_marker`). Details:

- `CollectionState` (running/parked/stopped/in_native) reported from the safepoint, the park (`parkOnReactor`) and `callFfi` — with function-scope defers (a block-scoped defer fires before the call, leaving the child reported `.running` for the whole blocking wait).
- Children spawned mid-collection wait on `collection_in_progress` before their first shared-globals read.
- Dead/retired children are skipped via a registry `thread_exited` flag — marking a dead child's stale registers is itself a UAF (found via the #2129 grandchild test under gc-stress).
- The `symbol_mutex` section of `markRoots` no longer wraps the child-marking — it would deadlock a child blocked in `allocSymbol` while deep-copying its thunk.

## Tests

- `tests/scheme/srfi/srfi18-cross-heap-mutation-1924.scm` — the full rejection matrix (record/vector/pair/hash-table/promise/global-set!) plus the immediate / Direction-B / mutex controls. 15/15.
- `tests/scheme/srfi/srfi18-child-registers-1933.scm` — the issue's hash-table + channel-handshake shape (deterministic: a second handshake makes the child read only after the parent's churn recycled the slot), with a guardian control proving the churn collects. Both tests fail on the baseline.
- `srfi18-sharing-model.scm` pins the new mutation-refused rows; `docs/dev/thread-value-sharing.md` documents both fixes and the residuals.

Verified: `zig build test` (incl. `-Dgc-stress`), full Scheme suite (695 files + R7RS 1395/1395), the srfi18 suite under gc-stress, WASM build, markdownlint.
