### PR TITLE
Fix macro hygiene: use-site bindings can no longer capture template free references (#2003, #2074)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A use-site local binding no longer captures a macro template's free
+  reference to a global procedure** (#2003). A template free reference to a
+  global procedure (`(define-syntax usecar (syntax-rules () ((_ l) (car
+  l))))`) was compiled as a by-name reference to the bare name, so an
+  ordinary local binding of the same name at the use site — `(let ((car
+  (lambda (x) 'HIJACKED))) (usecar (list 1 2)))` — captured it, calling the
+  local instead of the global, violating R7RS 4.3.2 ("the reference refers
+  to the binding that was visible where the transformer was specified").
+  Such references are now hygiene-renamed like any other template-introduced
+  identifier, and the run-time global lookup's hygienic-prefix fallback
+  resolves the rename to the base global by name — immune to use-site
+  locals while still observing a same-environment top-level redefinition
+  (the semantics chibi and guile implement). The one deliberate exception:
+  a template *lambda formal* colliding with a global procedure keeps its
+  bare spelling (the anaphoric-binding pattern SRFI 190's coroutine body
+  relies on), while template let-variables stay hygiene-renamed as before
+  (#681). Two companion fixes keep the renamed references correct: the
+  continuation-barrier gate (`isContinuationBarrier`) and the four
+  tail-position fast paths (`apply`, `call-with-values`, `call/cc`, `eval`)
+  now recognize a renamed spelling, which SRFI 248's guard re-raise needs
+  for correct multiple-value passing.
+
+- **A use-site local named after a syntactic keyword no longer captures it
+  inside any macro template** (#2074). Template operator keywords (`begin`,
+  `lambda`, `letrec`, `cond`, `and`, `or`, `set!`, `do`, …) were inserted
+  with their bare spelling, so `(let ((begin 5)) (m 7))` compiled the
+  template's `(begin e)` as the procedure call `(5 7)`. The operator
+  keywords among the well-known forms are now hygiene-renamed like every
+  other template identifier; the compiler recognizes them through
+  effective-name stripping. The small set that must keep its spelling for
+  structural matching — the definition/library forms, `syntax-rules`, the
+  aux syntax `else`, the pattern markers `...`/`_`, and the
+  quote/quasiquote *value* symbols — stays bare, while `quote`/`quasiquote`
+  *form* heads are renamed (with strip-aware quasiquote depth handling in
+  the compiler). `=>` in cond/case clauses is renamed too, and the clause
+  compiler now recognizes it through the hygiene strip, so a template's
+  arrow is immune to a use-site local `=>`.
+
 ## [0.22.3] - 2026-08-07
 
 ### Fixed

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -873,22 +873,34 @@ pub const Compiler = struct {
 
         if (is_tail and types.isSymbol(head)) {
             const sym_name = types.symbolName(head);
-            if (std.mem.eql(u8, sym_name, "apply")) {
+            // The four tail fast paths (apply / call-with-values / call/cc /
+            // eval) recognize their operator by spelling. Since #2003 a
+            // macro template's free reference to one of these globals is
+            // hygiene-renamed (__hyg_N_<name>), so compare the stripped name
+            // and dispatch on it; the resolveLocal/resolveUpvalue probes stay
+            // on the RAW name so a template-introduced binding of the same
+            // spelling (a lambda parameter named apply, say) still routes
+            // through the general call path instead of the builtin's fast
+            // path. The fast paths themselves resolve the true (scheme base)
+            // primitive, which is what a renamed free reference to one of
+            // these means under the hygienic-prefix fallback.
+            const eff_name = types.stripHygienicPrefix(sym_name);
+            if (std.mem.eql(u8, eff_name, "apply")) {
                 if (self.resolveLocal(sym_name) == null and
                     (try self.resolveUpvalue(sym_name)) == null)
                 {
                     return passthrough.compileApplyTail(self, expr, dst);
                 }
             }
-            if (std.mem.eql(u8, sym_name, "call-with-values")) {
+            if (std.mem.eql(u8, eff_name, "call-with-values")) {
                 if (self.resolveLocal(sym_name) == null and
                     (try self.resolveUpvalue(sym_name)) == null)
                 {
                     return passthrough.compileCallWithValuesTail(self, expr, dst);
                 }
             }
-            if (std.mem.eql(u8, sym_name, "call-with-current-continuation") or
-                std.mem.eql(u8, sym_name, "call/cc"))
+            if (std.mem.eql(u8, eff_name, "call-with-current-continuation") or
+                std.mem.eql(u8, eff_name, "call/cc"))
             {
                 if (self.resolveLocal(sym_name) == null and
                     (try self.resolveUpvalue(sym_name)) == null)
@@ -896,7 +908,7 @@ pub const Compiler = struct {
                     return passthrough.compileCallCCTail(self, expr, dst);
                 }
             }
-            if (std.mem.eql(u8, sym_name, "eval")) {
+            if (std.mem.eql(u8, eff_name, "eval")) {
                 if (self.resolveLocal(sym_name) == null and
                     (try self.resolveUpvalue(sym_name)) == null)
                 {

--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -167,18 +167,25 @@ pub fn compileCase(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
 
         // Check for else clause
         if (types.isSymbol(datums) and std.mem.eql(u8, types.symbolName(datums), "else")) {
-            // (else => proc): apply proc to the key value.
+            // (else => proc): apply proc to the key value. `=>` is
+            // recognized by its stripped name (a template-introduced arrow
+            // is hygiene-renamed, kaappi#2074) and a renamed arrow is
+            // always an arrow; a bare `=>` keeps the lexical-shadow check.
             if (types.isPair(clause_body)) {
                 const maybe_arrow = types.car(clause_body);
-                if (types.isSymbol(maybe_arrow) and std.mem.eql(u8, types.symbolName(maybe_arrow), "=>") and
-                    self.resolveLocal("=>") == null and
-                    (try self.resolveUpvalue("=>")) == null)
-                {
-                    const arrow_rest = types.cdr(clause_body);
-                    if (!types.isPair(arrow_rest)) return CompileError.InvalidSyntax;
-                    try conditionals.emitArrowCall(self, key_reg, types.car(arrow_rest), dst, is_tail);
-                    had_else = true;
-                    break;
+                if (types.isSymbol(maybe_arrow)) {
+                    const arrow_raw = types.symbolName(maybe_arrow);
+                    const arrow_eff = types.stripHygienicPrefix(arrow_raw);
+                    if (std.mem.eql(u8, arrow_eff, "=>") and
+                        (arrow_eff.len != arrow_raw.len or
+                            (self.resolveLocal(arrow_raw) == null and (try self.resolveUpvalue(arrow_raw)) == null)))
+                    {
+                        const arrow_rest = types.cdr(clause_body);
+                        if (!types.isPair(arrow_rest)) return CompileError.InvalidSyntax;
+                        try conditionals.emitArrowCall(self, key_reg, types.car(arrow_rest), dst, is_tail);
+                        had_else = true;
+                        break;
+                    }
                 }
             }
             try conditionals.compileCondBody(self, clause_body, dst, is_tail);
@@ -248,20 +255,24 @@ pub fn compileCase(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
         // Check for => form: ((datum ...) => proc)
         if (clause_body != types.NIL and types.isPair(clause_body)) {
             const maybe_arrow = types.car(clause_body);
-            if (types.isSymbol(maybe_arrow) and std.mem.eql(u8, types.symbolName(maybe_arrow), "=>") and
-                self.resolveLocal("=>") == null and
-                (try self.resolveUpvalue("=>")) == null)
-            {
-                const arrow_rest = types.cdr(clause_body);
-                if (arrow_rest == types.NIL or !types.isPair(arrow_rest)) return CompileError.InvalidSyntax;
-                try conditionals.emitArrowCall(self, key_reg, types.car(arrow_rest), dst, is_tail);
+            if (types.isSymbol(maybe_arrow)) {
+                const arrow_raw = types.symbolName(maybe_arrow);
+                const arrow_eff = types.stripHygienicPrefix(arrow_raw);
+                if (std.mem.eql(u8, arrow_eff, "=>") and
+                    (arrow_eff.len != arrow_raw.len or
+                        (self.resolveLocal(arrow_raw) == null and (try self.resolveUpvalue(arrow_raw)) == null)))
+                {
+                    const arrow_rest = types.cdr(clause_body);
+                    if (arrow_rest == types.NIL or !types.isPair(arrow_rest)) return CompileError.InvalidSyntax;
+                    try conditionals.emitArrowCall(self, key_reg, types.car(arrow_rest), dst, is_tail);
 
-                try self.emitOp(.jump);
-                end_jumps.append(self.gc.allocator, self.currentOffset()) catch return CompileError.TooManyLocals;
-                try self.emitI16(0);
+                    try self.emitOp(.jump);
+                    end_jumps.append(self.gc.allocator, self.currentOffset()) catch return CompileError.TooManyLocals;
+                    try self.emitI16(0);
 
-                try self.patchJump(next_clause_jump);
-                continue;
+                    try self.patchJump(next_clause_jump);
+                    continue;
+                }
             }
         }
 
@@ -303,6 +314,15 @@ pub fn compileQuasiquote(self: *Compiler, args: Value, dst: u16) CompileError!vo
     if (args == types.NIL) return CompileError.InvalidSyntax;
     const template = types.car(args);
     try compileQQ(self, template, dst, 0);
+}
+
+/// True when `head` is the quasiquote keyword `kw` — recognized through the
+/// hygiene strip so a template-introduced head (hygiene-renamed since
+/// kaappi#2074, e.g. `__hyg_N_quasiquote`) still drives the depth machinery
+/// that decides whether an unquote is data or code.
+fn isQQKeyword(head: Value, comptime kw: []const u8) bool {
+    if (!types.isSymbol(head)) return false;
+    return std.mem.eql(u8, types.stripHygienicPrefix(types.symbolName(head)), kw);
 }
 
 fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!void {
@@ -364,7 +384,7 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!voi
     const head = types.car(tmpl);
 
     // Check for (unquote expr)
-    if (types.isSymbol(head) and std.mem.eql(u8, types.symbolName(head), "unquote")) {
+    if (isQQKeyword(head, "unquote")) {
         if (depth == 0) {
             // Evaluate the expression
             const rest = types.cdr(tmpl);
@@ -375,8 +395,11 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!voi
             // Nested unquote: decrement depth, rebuild the form
             const rest = types.cdr(tmpl);
             if (rest == types.NIL) return CompileError.InvalidSyntax;
-            // Build (unquote <compiled-inner>) with decremented depth
-            const unquote_sym_idx = try self.addConstant(head);
+            // Build (unquote <compiled-inner>) with decremented depth.
+            // A template-introduced head may be hygiene-renamed (#2074);
+            // the rebuilt form is data, so strip the rename back off.
+            const unquote_sym_stripped = try expander.stripHygieneFromDatum(self.gc, head);
+            const unquote_sym_idx = try self.addConstant(unquote_sym_stripped);
             const sym_reg = try self.allocReg();
             try self.emitOp(.load_const);
             try self.emitU16(sym_reg);
@@ -414,11 +437,12 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!voi
     // as a list element. At depth > 0, we rebuild the form literally but
     // compile the subexpression at depth-1 so that inner unquotes at the
     // outermost level are correctly evaluated.
-    if (types.isSymbol(head) and std.mem.eql(u8, types.symbolName(head), "unquote-splicing") and depth > 0) {
+    if (isQQKeyword(head, "unquote-splicing") and depth > 0) {
         const rest = types.cdr(tmpl);
         if (rest == types.NIL) return CompileError.InvalidSyntax;
         // Build (unquote-splicing <compiled-inner>) with decremented depth
-        const us_sym_idx = try self.addConstant(head);
+        const us_sym_stripped = try expander.stripHygieneFromDatum(self.gc, head);
+        const us_sym_idx = try self.addConstant(us_sym_stripped);
         const sym_reg = try self.allocReg();
         try self.emitOp(.load_const);
         try self.emitU16(sym_reg);
@@ -451,12 +475,15 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!voi
     }
 
     // Check for (quasiquote expr) -- nested quasiquote
-    if (types.isSymbol(head) and std.mem.eql(u8, types.symbolName(head), "quasiquote")) {
+    if (isQQKeyword(head, "quasiquote")) {
         const rest = types.cdr(tmpl);
         if (rest == types.NIL) return CompileError.InvalidSyntax;
         if (depth == std.math.maxInt(u8)) return CompileError.InvalidSyntax;
-        // Rebuild (quasiquote <compiled-inner>) with incremented depth
-        const qq_sym_idx = try self.addConstant(head);
+        // Rebuild (quasiquote <compiled-inner>) with incremented depth.
+        // The head may be a template-introduced hygienic rename (#2074);
+        // the rebuilt form is data, so strip the rename back off.
+        const qq_sym_stripped = try expander.stripHygieneFromDatum(self.gc, head);
+        const qq_sym_idx = try self.addConstant(qq_sym_stripped);
         const sym_reg = try self.allocReg();
         try self.emitOp(.load_const);
         try self.emitU16(sym_reg);
@@ -516,7 +543,7 @@ fn hasUnquoteSplicing(tmpl: Value, depth: u8) bool {
         if (types.isPair(elem)) {
             const elem_head = types.car(elem);
             if (types.isSymbol(elem_head) and
-                std.mem.eql(u8, types.symbolName(elem_head), "unquote-splicing") and
+                isQQKeyword(elem_head, "unquote-splicing") and
                 depth == 0)
             {
                 return true;
@@ -564,7 +591,7 @@ fn compileQQSplicing(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileE
         // segment so that `append` uses it as the tail.
         if (depth == 0 and types.isSymbol(types.car(current))) {
             const maybe_uq_name = types.symbolName(types.car(current));
-            if (std.mem.eql(u8, maybe_uq_name, "unquote")) {
+            if (std.mem.eql(u8, types.stripHygienicPrefix(maybe_uq_name), "unquote")) {
                 const uq_args = types.cdr(current);
                 if (types.isPair(uq_args) and types.cdr(uq_args) == types.NIL) {
                     // Flush pending group
@@ -590,7 +617,7 @@ fn compileQQSplicing(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileE
         if (types.isPair(elem) and depth == 0) {
             const elem_head = types.car(elem);
             if (types.isSymbol(elem_head) and
-                std.mem.eql(u8, types.symbolName(elem_head), "unquote-splicing"))
+                isQQKeyword(elem_head, "unquote-splicing"))
             {
                 // Flush group: build (list (quote e1) (quote e2) ...)
                 if (group_count > 0) {
@@ -616,7 +643,7 @@ fn compileQQSplicing(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileE
         // expand them. Check if element is (unquote expr) at depth 0
         if (types.isPair(elem) and depth == 0) {
             const elem_head = types.car(elem);
-            if (types.isSymbol(elem_head) and std.mem.eql(u8, types.symbolName(elem_head), "unquote")) {
+            if (isQQKeyword(elem_head, "unquote")) {
                 const uq_rest = types.cdr(elem);
                 if (uq_rest == types.NIL) return CompileError.InvalidSyntax;
                 // This element should be evaluated, not quoted
@@ -689,7 +716,7 @@ fn buildQQListExpr(gc: *@import("memory.zig").GC, quote_sym: Value, list_sym: Va
         const elem = elems[i];
         if (types.isPair(elem)) {
             const elem_head = types.car(elem);
-            if (types.isSymbol(elem_head) and std.mem.eql(u8, types.symbolName(elem_head), "unquote")) {
+            if (isQQKeyword(elem_head, "unquote")) {
                 const uq_rest = types.cdr(elem);
                 if (uq_rest != types.NIL) {
                     args = gc.allocPair(types.car(uq_rest), args) catch return CompileError.OutOfMemory;

--- a/src/compiler_conditionals.zig
+++ b/src/compiler_conditionals.zig
@@ -160,28 +160,37 @@ pub fn compileCond(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
         // Compile test
         try self.compileExprViaIR(test_expr, dst, false);
 
-        // Check for => form (only if => is not rebound as a local variable)
+        // Check for => form (only if => is not rebound as a local variable).
+        // A template-introduced `=>` is hygiene-renamed (__hyg_N_=>) since
+        // kaappi#2074, so it is recognized by its stripped name and is
+        // always an arrow — immune to a use-site local named `=>`. A bare
+        // `=>` (use-site text) keeps the shadow check: a lexical `=>` there
+        // wins (R7RS has no reserved words, #788).
         if (clause_body != types.NIL and types.isPair(clause_body)) {
             const maybe_arrow = types.car(clause_body);
-            if (types.isSymbol(maybe_arrow) and std.mem.eql(u8, types.symbolName(maybe_arrow), "=>") and
-                self.resolveLocal("=>") == null and
-                (try self.resolveUpvalue("=>")) == null)
-            {
-                try self.emitOp(.jump_false);
-                try self.emitU16(dst);
-                const next_clause = self.currentOffset();
-                try self.emitI16(0);
+            if (types.isSymbol(maybe_arrow)) {
+                const arrow_raw = types.symbolName(maybe_arrow);
+                const arrow_eff = types.stripHygienicPrefix(arrow_raw);
+                if (std.mem.eql(u8, arrow_eff, "=>") and
+                    (arrow_eff.len != arrow_raw.len or
+                        (self.resolveLocal(arrow_raw) == null and (try self.resolveUpvalue(arrow_raw)) == null)))
+                {
+                    try self.emitOp(.jump_false);
+                    try self.emitU16(dst);
+                    const next_clause = self.currentOffset();
+                    try self.emitI16(0);
 
-                const arrow_rest = types.cdr(clause_body);
-                if (!types.isPair(arrow_rest)) return CompileError.InvalidSyntax;
-                try emitArrowCall(self, dst, types.car(arrow_rest), dst, is_tail);
+                    const arrow_rest = types.cdr(clause_body);
+                    if (!types.isPair(arrow_rest)) return CompileError.InvalidSyntax;
+                    try emitArrowCall(self, dst, types.car(arrow_rest), dst, is_tail);
 
-                try self.emitOp(.jump);
-                end_jumps.append(self.gc.allocator, self.currentOffset()) catch return CompileError.TooManyLocals;
-                try self.emitI16(0);
+                    try self.emitOp(.jump);
+                    end_jumps.append(self.gc.allocator, self.currentOffset()) catch return CompileError.TooManyLocals;
+                    try self.emitI16(0);
 
-                try self.patchJump(next_clause);
-                continue;
+                    try self.patchJump(next_clause);
+                    continue;
+                }
             }
         }
 
@@ -276,7 +285,10 @@ pub fn evalFeatureReq(self: *Compiler, req: Value) bool {
     if (types.isPair(req)) {
         const head = types.car(req);
         if (!types.isSymbol(head)) return false;
-        const op = types.symbolName(head);
+        // A feature-combinator keyword introduced by a macro template is
+        // hygiene-renamed since kaappi#2074 (__hyg_N_and etc.), so compare
+        // the stripped name.
+        const op = types.stripHygienicPrefix(types.symbolName(head));
 
         if (std.mem.eql(u8, op, "and")) {
             var rest = types.cdr(req);

--- a/src/compiler_define_syntax.zig
+++ b/src/compiler_define_syntax.zig
@@ -589,7 +589,7 @@ fn resolveTransformerSpecRec(self: *Compiler, spec_in: Value, merged_macros: *st
             self.gc.popRoot();
             return tx_val;
         }
-        if (std.mem.eql(u8, head_name, "begin")) {
+        if (std.mem.eql(u8, head_name, "begin") or std.mem.eql(u8, types.stripHygienicPrefix(head_name), "begin")) {
             // spec = (begin def1 def2 ... final-spec). Each def must be a
             // literal (define-syntax NAME SPEC); SPEC may itself need
             // further resolution (another macro-use, alias, or nested

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -65,6 +65,46 @@ pub fn isWellKnown(name: []const u8) bool {
     return false;
 }
 
+/// Template-introduced keywords that keep their exact spelling even though
+/// the compiler recognizes them — the complement of the operator keywords
+/// that are hygiene-renamed (see instantiateTemplate step 3, kaappi#2074).
+/// These must stay bare because something matches them structurally by
+/// spelling, not by effective-name dispatch:
+///
+///  * the definition/library forms (`define`, `define-syntax`,
+///    `define-values`, `define-record-type`, `let-syntax`, `letrec-syntax`,
+///    `import`, `export`, `define-library`, `include`, `include-ci`) —
+///    matched by the body scanner, the transformer-spec resolver, and the
+///    library loader on raw forms;
+///  * `syntax-rules` — the head of a nested transformer spec, matched bare
+///    by resolveTransformerSpecRec;
+///  * the aux syntax `else` and the pattern markers `...` and `_`, matched
+///    bare by cond/case/guard clause processing and the pattern matcher;
+///  * `quote`/`quasiquote`/`unquote`/`unquote-splicing` — a bare one of
+///    these used as a VALUE (e.g. `(list quote)`) must still evaluate to the
+///    symbol itself, so the symbol walk leaves them alone; the `(quote ...)`
+///    / `(quasiquote ...)` FORM heads are renamed separately by the form
+///    branches in instantiateTemplate.
+const reserved_template_forms = [_][]const u8{
+    "define",         "define-syntax", "define-values",    "define-record-type",
+    "let-syntax",     "letrec-syntax", "syntax-rules",     "quote",
+    "quasiquote",     "unquote",       "unquote-splicing", "else",
+    "...",            "_",             "import",           "export",
+    "define-library", "include",       "include-ci",
+};
+
+/// True when a template-introduced identifier must keep its exact spelling
+/// (see `reserved_template_forms`). Every other well-known form is a
+/// compiler keyword the expander can hygiene-rename: the compiler
+/// recognizes it through effective-name stripping, and renaming makes a
+/// use-site local of the same spelling unable to capture it (kaappi#2074).
+pub fn isTemplateReserved(name: []const u8) bool {
+    for (&reserved_template_forms) |rt| {
+        if (std.mem.eql(u8, rt, name)) return true;
+    }
+    return false;
+}
+
 /// Monotonically increasing counter for generating unique hygienic names.
 /// Shared across threads (renames must be process-unique), so bumped
 /// atomically; see freshGensymId.
@@ -470,12 +510,14 @@ fn erRenameDatum(gc: *GC, v: Value) anyerror!Value {
 
 /// Mirror of instantiateTemplate's template-introduced-symbol path (minus
 /// pattern variables and literals, which procedural macros don't have):
-/// well-known forms and in-scope macro keywords keep their names,
+/// the reserved forms and in-scope macro keywords keep their names,
 /// everything else goes through renameForHygiene under this invocation's
 /// scope — globals-bound names stay unrenamed (definition-environment
-/// resolution), fresh names gensym consistently.
+/// resolution), fresh names gensym consistently. The operator keywords
+/// among well_known_forms are renamed like any other template identifier
+/// (kaappi#2074), matching syntax-rules.
 fn erRenameSymbol(gc: *GC, name: []const u8) anyerror!Value {
-    if (isWellKnown(name)) return gc.allocSymbol(name);
+    if (isTemplateReserved(name)) return gc.allocSymbol(name);
     if (er_macros) |m| {
         if (m.contains(name)) return gc.allocSymbol(name);
     }

--- a/src/expander_instantiate.zig
+++ b/src/expander_instantiate.zig
@@ -41,7 +41,7 @@ const QUOTE_FLAG: u32 = 0x40000000; // inside (quote ...): substitute, hygiene-r
 const BINDING_FLAG: u32 = 0x20000000; // identifier is in binding position
 const NESTED_SR_FLAG: u32 = 0x10000000; // inside a nested syntax-rules template
 const LET_PAIR_FLAG: u32 = 0x08000000; // template is a single let-binding (var init) pair
-const FORMAL_FLAG: u32 = 0x04000000; // identifier is a lambda/case-lambda formal
+const FORMAL_FLAG: u32 = 0x04000000; // identifier is a lambda formal (anaphoric-binding position)
 // Re-walking a usertext-marker-protected splice (an enclosing expansion's
 // pattern-var value, spliced verbatim into a nested syntax-rules template) in
 // substitute-only mode. Reuses QUOTE_FLAG's "substitute, expand ellipses"
@@ -404,18 +404,22 @@ pub fn instantiateTemplate(gc: *GC, template: Value, bindings: []Binding, intro_
             }
         }
         // Function formals are binding positions too. Marked with
-        // FORMAL_FLAG so renameForHygiene treats a formal colliding with a
-        // global procedure as an anaphoric binding (kept bare — SRFI 190's
-        // coroutine body binds to the template's `yield` formal) rather than
-        // as a free reference (renamed, #2003). Distinct from BINDING_FLAG
-        // (let variables): #681 pins that a template LET variable named
-        // after a built-in must NOT capture use-site text, so let-vars stay
-        // hygiene-renamed; only function formals keep the pre-#2003
-        // anaphoric spelling. The formals are walked through the ordinary
-        // instantiateTemplate path (not a custom walk) so ellipsis in a
-        // formals list — `(lambda (slot ...) ...)`, SRFI 26's cut — still
-        // expands through the regular ellipsis machinery; the flag rides
-        // along on every formal symbol.
+        // FORMAL_FLAG so renameForHygiene treats a lambda formal colliding
+        // with a global procedure as an anaphoric binding (kept bare — SRFI
+        // 190's coroutine body binds to the template's `yield` formal)
+        // rather than as a free reference (renamed, #2003). Distinct from
+        // BINDING_FLAG (let variables): #681 pins that a template LET
+        // variable named after a built-in must NOT capture use-site text, so
+        // let-vars stay hygiene-renamed; only LAMBDA formals keep the
+        // pre-#2003 anaphoric spelling (#2252 — case-lambda formals are NOT
+        // included: nothing depends on case-lambda anaphora, and renaming
+        // them hygienically like let-variables is the more consistent
+        // behaviour; a case-lambda clause's formals go through the ordinary
+        // pair recursion below without the flag). The formals are walked
+        // through the ordinary instantiateTemplate path (not a custom walk)
+        // so ellipsis in a formals list — `(lambda (slot ...) ...)`, SRFI
+        // 26's cut — still expands through the regular ellipsis machinery;
+        // the flag rides along on every formal symbol.
         if (std.mem.eql(u8, form_name, "lambda")) {
             const new_car = try instantiateTemplate(gc, elem, bindings, intro_scope, literals, macro_keyword, globals, macros);
             var car_root = new_car;
@@ -956,16 +960,14 @@ pub fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.St
                 // falls through and is hygiene-renamed like any other
                 // template-introduced identifier, so a use-site local of the
                 // same name cannot capture it (R7RS 4.3.2). The one
-                // exception: a LAMBDA/CASE-LAMBDA FORMAL (FORMAL_FLAG)
-                // colliding with a global procedure keeps its bare spelling,
-                // recorded as an identity rename — the deliberate
-                // anaphoric-binding pattern (SRFI 190's coroutine body, whose
-                // `yield` must reach the template's formal by name). This
-                // mirrors the pre-#2003 behaviour for function formals
-                // exactly, and is deliberately NOT extended to let variables:
-                // #681 pins that a template let variable named after a
-                // built-in must not capture use-site text, so let-vars stay
-                // hygiene-renamed.
+                // exception: a LAMBDA FORMAL (FORMAL_FLAG) colliding with a
+                // global procedure keeps its bare spelling, recorded as an
+                // identity rename — the deliberate anaphoric-binding pattern
+                // (SRFI 190's coroutine body, whose `yield` must reach the
+                // template's formal by name). This mirrors the pre-#2003
+                // behaviour for lambda formals exactly, and is deliberately
+                // NOT extended to let variables (#681) or to case-lambda
+                // formals (#2252): those stay hygiene-renamed.
                 const is_formal = (scope & FORMAL_FLAG) != 0;
                 if (is_formal and !in_binding and !scopeTableContains(clean_scope, name)) {
                     if (expander.scope_table_count >= MAX_SCOPE_ENTRIES) return ExpandError.ScopeTableFull;

--- a/src/expander_instantiate.zig
+++ b/src/expander_instantiate.zig
@@ -41,6 +41,7 @@ const QUOTE_FLAG: u32 = 0x40000000; // inside (quote ...): substitute, hygiene-r
 const BINDING_FLAG: u32 = 0x20000000; // identifier is in binding position
 const NESTED_SR_FLAG: u32 = 0x10000000; // inside a nested syntax-rules template
 const LET_PAIR_FLAG: u32 = 0x08000000; // template is a single let-binding (var init) pair
+const FORMAL_FLAG: u32 = 0x04000000; // identifier is a lambda/case-lambda formal
 // Re-walking a usertext-marker-protected splice (an enclosing expansion's
 // pattern-var value, spliced verbatim into a nested syntax-rules template) in
 // substitute-only mode. Reuses QUOTE_FLAG's "substitute, expand ellipses"
@@ -106,8 +107,12 @@ pub fn instantiateTemplate(gc: *GC, template: Value, bindings: []Binding, intro_
             }
         }
 
-        // 3. Well-known form or built-in -- keep as-is
-        if (isWellKnown(name)) {
+        // 3. Well-known form or built-in -- keep as-is. Only the reserved
+        //    subset stays bare (see isTemplateReserved): the operator
+        //    keywords among well_known_forms fall through to the hygienic
+        //    rename below so a use-site local of the same spelling cannot
+        //    capture them (kaappi#2074).
+        if (expander.isTemplateReserved(name)) {
             return template;
         }
 
@@ -208,8 +213,20 @@ pub fn instantiateTemplate(gc: *GC, template: Value, bindings: []Binding, intro_
                 var nq_root = new_quoted;
                 gc.pushRoot(&nq_root);
                 defer gc.popRoot();
+                // The FORM head is hygiene-renamed too (#2074): a use-site
+                // local named `quote` must not capture the template's quote
+                // special form. The compiler recognizes the renamed head via
+                // effective-name stripping and strips renames from the datum
+                // (stripHygieneFromDatum), so a template `(quote x)` still
+                // yields the symbol x; a BARE `quote` used as a VALUE (e.g.
+                // `(list quote)`) stays unrenamed because the symbol walk
+                // keeps reserved_template_forms bare.
+                const new_head = try renameForHygiene(gc, "quote", intro_scope, globals);
+                var head_root = new_head;
+                gc.pushRoot(&head_root);
+                defer gc.popRoot();
                 const tail = try gc.allocPair(nq_root, types.NIL);
-                return gc.allocPair(tmpl_head, tail);
+                return gc.allocPair(head_root, tail);
             }
             // More than 2 elements: `quote` is not forming a quote special
             // form here, just an ordinary (possibly data) value in head
@@ -239,8 +256,16 @@ pub fn instantiateTemplate(gc: *GC, template: Value, bindings: []Binding, intro_
                 var ni_root = new_inner;
                 gc.pushRoot(&ni_root);
                 defer gc.popRoot();
+                // Form head renamed like the quote head above (#2074);
+                // compileQuasiquote recognizes it via effective-name
+                // stripping, and inner unquotes are handled by the branch
+                // below keeping their bare heads.
+                const new_head = try renameForHygiene(gc, "quasiquote", intro_scope, globals);
+                var head_root = new_head;
+                gc.pushRoot(&head_root);
+                defer gc.popRoot();
                 const tail = try gc.allocPair(ni_root, types.NIL);
-                return gc.allocPair(tmpl_head, tail);
+                return gc.allocPair(head_root, tail);
             }
         } else if (unary and qq_depth > 0 and
             (std.mem.eql(u8, hname, "unquote") or std.mem.eql(u8, hname, "unquote-splicing")))
@@ -375,6 +400,38 @@ pub fn instantiateTemplate(gc: *GC, template: Value, bindings: []Binding, intro_
                 gc.pushRoot(&body_root);
                 defer gc.popRoot();
                 const inner = try gc.allocPair(bindings_root, body_root);
+                return gc.allocPair(car_root, inner);
+            }
+        }
+        // Function formals are binding positions too. Marked with
+        // FORMAL_FLAG so renameForHygiene treats a formal colliding with a
+        // global procedure as an anaphoric binding (kept bare — SRFI 190's
+        // coroutine body binds to the template's `yield` formal) rather than
+        // as a free reference (renamed, #2003). Distinct from BINDING_FLAG
+        // (let variables): #681 pins that a template LET variable named
+        // after a built-in must NOT capture use-site text, so let-vars stay
+        // hygiene-renamed; only function formals keep the pre-#2003
+        // anaphoric spelling. The formals are walked through the ordinary
+        // instantiateTemplate path (not a custom walk) so ellipsis in a
+        // formals list — `(lambda (slot ...) ...)`, SRFI 26's cut — still
+        // expands through the regular ellipsis machinery; the flag rides
+        // along on every formal symbol.
+        if (std.mem.eql(u8, form_name, "lambda")) {
+            const new_car = try instantiateTemplate(gc, elem, bindings, intro_scope, literals, macro_keyword, globals, macros);
+            var car_root = new_car;
+            gc.pushRoot(&car_root);
+            defer gc.popRoot();
+            const fn_rest = types.cdr(template);
+            if (fn_rest != types.NIL and types.isPair(fn_rest)) {
+                const new_formals = try instantiateTemplate(gc, types.car(fn_rest), bindings, intro_scope | FORMAL_FLAG, literals, macro_keyword, globals, macros);
+                var formals_root = new_formals;
+                gc.pushRoot(&formals_root);
+                defer gc.popRoot();
+                const new_body = try instantiateTemplate(gc, types.cdr(fn_rest), bindings, intro_scope & ~(BINDING_FLAG | FORMAL_FLAG), literals, macro_keyword, globals, macros);
+                var body_root = new_body;
+                gc.pushRoot(&body_root);
+                defer gc.popRoot();
+                const inner = try gc.allocPair(formals_root, body_root);
                 return gc.allocPair(car_root, inner);
             }
         }
@@ -819,7 +876,7 @@ pub fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.St
         // still behave exactly as before once the code actually runs: two
         // unrelated macro expansions that both quote the same literal tag
         // still produce `eq?` symbols.
-        const clean_scope = scope & ~(BINDING_FLAG | NESTED_SR_FLAG | LET_PAIR_FLAG | QQ_DEPTH_MASK | QUOTE_FLAG);
+        const clean_scope = scope & ~(BINDING_FLAG | NESTED_SR_FLAG | LET_PAIR_FLAG | FORMAL_FLAG | QQ_DEPTH_MASK | QUOTE_FLAG);
         for (expander.scope_table[0..expander.scope_table_count]) |entry| {
             if (entry.scope == clean_scope and std.mem.eql(u8, entry.original_name, name)) {
                 return gc.allocSymbol(entry.renamed_to);
@@ -832,7 +889,7 @@ pub fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.St
     // Strip context flags that don't change renaming, so the same template
     // identifier gets the same gensym inside and outside those contexts
     // (e.g. an outer binding referenced from a nested syntax-rules template).
-    const clean_scope = scope & ~(BINDING_FLAG | NESTED_SR_FLAG | LET_PAIR_FLAG | QQ_DEPTH_MASK);
+    const clean_scope = scope & ~(BINDING_FLAG | NESTED_SR_FLAG | LET_PAIR_FLAG | FORMAL_FLAG | QQ_DEPTH_MASK);
     const gmod = @import("globals.zig");
 
     // #1812: a free reference bound in the macro's OWN definition-
@@ -889,11 +946,44 @@ pub fn renameForHygiene(gc: *GC, name: []const u8, scope: u32, globals: ?*std.St
         const glk = gmod.acquireGlobalsRead(g);
         defer gmod.releaseGlobalsRead(glk);
         if (g.get(name)) |val| {
-            if (types.isProcedure(val) or types.isTransformer(val)) {
-                // A template binding of the same name in this expansion
-                // shadows the global procedure (e.g. a template let variable
-                // named exp must not resolve to the builtin exp), so the
-                // reference must follow the rename recorded for the binding.
+            // A template binding of the same name in this expansion shadows
+            // the global procedure (e.g. a template let variable named exp
+            // must not resolve to the builtin exp), so the reference must
+            // follow the rename recorded for the binding — handled by falling
+            // through to the scope-table lookup below.
+            if (types.isProcedure(val)) {
+                // #2003: a free template reference to a global procedure
+                // falls through and is hygiene-renamed like any other
+                // template-introduced identifier, so a use-site local of the
+                // same name cannot capture it (R7RS 4.3.2). The one
+                // exception: a LAMBDA/CASE-LAMBDA FORMAL (FORMAL_FLAG)
+                // colliding with a global procedure keeps its bare spelling,
+                // recorded as an identity rename — the deliberate
+                // anaphoric-binding pattern (SRFI 190's coroutine body, whose
+                // `yield` must reach the template's formal by name). This
+                // mirrors the pre-#2003 behaviour for function formals
+                // exactly, and is deliberately NOT extended to let variables:
+                // #681 pins that a template let variable named after a
+                // built-in must not capture use-site text, so let-vars stay
+                // hygiene-renamed.
+                const is_formal = (scope & FORMAL_FLAG) != 0;
+                if (is_formal and !in_binding and !scopeTableContains(clean_scope, name)) {
+                    if (expander.scope_table_count >= MAX_SCOPE_ENTRIES) return ExpandError.ScopeTableFull;
+                    expander.scope_table[expander.scope_table_count] = .{
+                        .original_name = name,
+                        .scope = clean_scope,
+                        .renamed_to = name,
+                    };
+                    expander.scope_table_count += 1;
+                    return gc.allocSymbol(name);
+                }
+            } else if (types.isTransformer(val)) {
+                // A macro keyword the template references (e.g. a
+                // macro-generating macro's helper, SRFI 41's smp/smt) must
+                // stay bare so the compiler's lookupMacro still recognizes
+                // it as a macro; renaming would sever the keyword from the
+                // transformer registered in the macro namespace (#2003 keeps
+                // this exemption explicit).
                 if (!in_binding and !scopeTableContains(clean_scope, name)) {
                     return gc.allocSymbol(name);
                 }

--- a/src/tests_pipeline.zig
+++ b/src/tests_pipeline.zig
@@ -70,6 +70,45 @@ fn expectExpands(setup: ?[]const u8, src: []const u8, expected: []const u8) !voi
     };
 }
 
+/// Like expectExpands, but collapses `__hyg_<id>_` to `__hyg_N_` in the
+/// actual output before comparing — for templates whose free references to a
+/// global procedure are hygiene-renamed (issue #2003). The gensym id comes
+/// from a process-global counter, so pinning the exact spelling in a snapshot
+/// would be brittle across test additions; the rename itself (the `__hyg_`
+/// prefix on the referenced name) is the behaviour these tests document.
+fn expectExpandsNorm(setup: ?[]const u8, src: []const u8, expected: []const u8) !void {
+    var h: Harness = .{};
+    try h.init();
+    defer h.deinit();
+    if (setup) |s| try h.setup(s);
+    const raw = try h.expand(src);
+    defer testing.allocator.free(raw);
+    const got = testing.allocator.alloc(u8, raw.len) catch return error.OutOfMemory;
+    defer testing.allocator.free(got);
+    var out_len: usize = 0;
+    var i: usize = 0;
+    while (i < raw.len) {
+        if (std.mem.startsWith(u8, raw[i..], "__hyg_")) {
+            var j = i + "__hyg_".len;
+            while (j < raw.len and raw[j] >= '0' and raw[j] <= '9') j += 1;
+            if (j < raw.len and raw[j] == '_') {
+                const piece = "__hyg_N_";
+                @memcpy(got[out_len..][0..piece.len], piece);
+                out_len += piece.len;
+                i = j + 1;
+                continue;
+            }
+        }
+        got[out_len] = raw[i];
+        out_len += 1;
+        i += 1;
+    }
+    testing.expectEqualStrings(expected, got[0..out_len]) catch |e| {
+        std.debug.print("expand mismatch for: {s}\n  got: {s}\n", .{ src, got[0..out_len] });
+        return e;
+    };
+}
+
 fn contains(haystack: []const u8, needle: []const u8) bool {
     return std.mem.indexOf(u8, haystack, needle) != null;
 }
@@ -77,13 +116,15 @@ fn contains(haystack: []const u8, needle: []const u8) bool {
 // ── expand: basic macro use ─────────────────────────────────────────────────
 
 test "expand: simple alias macro" {
-    // Template keyword `begin` is well-known, so hygiene leaves it un-renamed —
-    // keeping this an exact, stable match. (`if`/`let` are deliberately renamed
-    // by the expander, which the recursive-macro test below exercises instead.)
-    try expectExpands(
+    // Template keyword `begin` is hygiene-renamed like every other operator
+    // keyword since kaappi#2074 (so a use-site local named `begin` cannot
+    // capture it), so the expansion is compared through the gensym-id
+    // normalizer. (`if`/`let` are renamed too, which the recursive-macro
+    // test below exercises with substring checks.)
+    try expectExpandsNorm(
         "(define-syntax seq (syntax-rules () ((_ a b) (begin a b))))",
         "(seq x y)",
-        "(begin x y)",
+        "(__hyg_N_begin x y)",
     );
 }
 
@@ -92,61 +133,61 @@ test "expand: no macros — form unchanged" {
 }
 
 test "expand: macro use nested in a call argument" {
-    try expectExpands(
+    try expectExpandsNorm(
         "(define-syntax dbl (syntax-rules () ((_ x) (* 2 x))))",
         "(f (dbl n) 3)",
-        "(f (* 2 n) 3)",
+        "(f (__hyg_N_* 2 n) 3)",
     );
 }
 
 // ── expand: recursion into binding/body positions ───────────────────────────
 
 test "expand: macro use inside a let body" {
-    try expectExpands(
+    try expectExpandsNorm(
         "(define-syntax dbl (syntax-rules () ((_ x) (* 2 x))))",
         "(let ((n 1)) (dbl n))",
-        "(let ((n 1)) (* 2 n))",
+        "(let ((n 1)) (__hyg_N_* 2 n))",
     );
 }
 
 test "expand: macro use inside a let init expression" {
-    try expectExpands(
+    try expectExpandsNorm(
         "(define-syntax dbl (syntax-rules () ((_ x) (* 2 x))))",
         "(let ((y (dbl 5))) y)",
-        "(let ((y (* 2 5))) y)",
+        "(let ((y (__hyg_N_* 2 5))) y)",
     );
 }
 
 test "expand: macro use inside a lambda body" {
-    try expectExpands(
+    try expectExpandsNorm(
         "(define-syntax dbl (syntax-rules () ((_ x) (* 2 x))))",
         "(lambda (x) (dbl x))",
-        "(lambda (x) (* 2 x))",
+        "(lambda (x) (__hyg_N_* 2 x))",
     );
 }
 
 test "expand: macro use inside a cond clause body" {
-    try expectExpands(
+    try expectExpandsNorm(
         "(define-syntax dbl (syntax-rules () ((_ x) (* 2 x))))",
         "(cond (a (dbl b)) (else (dbl c)))",
-        "(cond (a (* 2 b)) (else (* 2 c)))",
+        "(cond (a (__hyg_N_* 2 b)) (else (__hyg_N_* 2 c)))",
     );
 }
 
 test "expand: macro use inside a case clause body, datum list untouched" {
     // The `(dbl)` in datum position is *data* and must stay; the body expands.
-    try expectExpands(
+    try expectExpandsNorm(
         "(define-syntax dbl (syntax-rules () ((_ x) (* 2 x))))",
         "(case k ((dbl) (dbl 1)) (else (dbl 2)))",
-        "(case k ((dbl) (* 2 1)) (else (* 2 2)))",
+        "(case k ((dbl) (__hyg_N_* 2 1)) (else (__hyg_N_* 2 2)))",
     );
 }
 
 test "expand: macro use inside a do body and step" {
-    try expectExpands(
+    try expectExpandsNorm(
         "(define-syntax dbl (syntax-rules () ((_ x) (* 2 x))))",
         "(do ((i 0 (dbl i))) ((= i 8) i) (dbl i))",
-        "(do ((i 0 (* 2 i))) ((= i 8) i) (* 2 i))",
+        "(do ((i 0 (__hyg_N_* 2 i))) ((= i 8) i) (__hyg_N_* 2 i))",
     );
 }
 

--- a/src/types.zig
+++ b/src/types.zig
@@ -1090,7 +1090,11 @@ pub fn isContinuationBarrier(name: []const u8) bool {
     // identifier, so a barrier spelled through that rename must be
     // recognized too — otherwise a macro whose template calls call/cc or
     // call-with-values would take the call_global fast path, which is
-    // exactly what this gate exists to prevent.
+    // exactly what this gate exists to prevent. (Only `__hyg_` needs the
+    // strip here: `__nlet_` named-let loop names are always local bindings,
+    // so resolveLocal in the call path resolves them before this barrier
+    // check is ever reached — a `__nlet_` alternative would be dead code,
+    // since stripHygienicPrefix does not strip it.)
     const n = if (std.mem.startsWith(u8, name, base_binding_prefix))
         name[base_binding_prefix.len..]
     else if (std.mem.startsWith(u8, name, def_env_binding_prefix))
@@ -1098,7 +1102,7 @@ pub fn isContinuationBarrier(name: []const u8) bool {
             name[sep + def_env_binding_sep.len ..]
         else
             name)
-    else if (std.mem.startsWith(u8, name, "__hyg_") or std.mem.startsWith(u8, name, "__nlet_"))
+    else if (std.mem.startsWith(u8, name, "__hyg_"))
         stripHygienicPrefix(name)
     else
         name;

--- a/src/types.zig
+++ b/src/types.zig
@@ -1084,7 +1084,13 @@ pub fn isContinuationBarrier(name: []const u8) bool {
     // introduced this exclusion, fa6ecf47), and that requirement doesn't
     // change just because the reference is spelled differently. Same
     // reasoning applies to a def_env_binding_prefix-marked name (#1812): the
-    // original name is whatever follows the def_env_binding_sep.
+    // original name is whatever follows the def_env_binding_sep. And since
+    // #2003 a template's free reference to a global procedure is
+    // hygiene-renamed (__hyg_N_<name>) like any other template-introduced
+    // identifier, so a barrier spelled through that rename must be
+    // recognized too — otherwise a macro whose template calls call/cc or
+    // call-with-values would take the call_global fast path, which is
+    // exactly what this gate exists to prevent.
     const n = if (std.mem.startsWith(u8, name, base_binding_prefix))
         name[base_binding_prefix.len..]
     else if (std.mem.startsWith(u8, name, def_env_binding_prefix))
@@ -1092,6 +1098,8 @@ pub fn isContinuationBarrier(name: []const u8) bool {
             name[sep + def_env_binding_sep.len ..]
         else
             name)
+    else if (std.mem.startsWith(u8, name, "__hyg_") or std.mem.startsWith(u8, name, "__nlet_"))
+        stripHygienicPrefix(name)
     else
         name;
     return std.mem.eql(u8, n, "call-with-current-continuation") or

--- a/tests/scheme/audit/primitives_smallbatch-audit.scm
+++ b/tests/scheme/audit/primitives_smallbatch-audit.scm
@@ -836,17 +836,18 @@
 (define-syntax er-gp (er-macro-transformer (lambda (f r c) (list (r 'gp2p11)))))
 (define-syntax sr-car (syntax-rules () ((_ l) (car l))))
 (define-syntax sr-add (syntax-rules () ((_ a b) (+ a b))))
-;; FAIL: #2003 (a use-site local binding captures a template's free reference to a global procedure)
-;; (test-equal "hygiene (e) syntax-rules: a global procedure resists a local shadow"
-;;             'global-proc (let ((gp2p11 (lambda () 'shadowed))) (sr-gp)))
-;; (test-equal "hygiene (e) ER: a global procedure resists a local shadow"
-;;             'global-proc (let ((gp2p11 (lambda () 'shadowed))) (er-gp)))
-;; (test-equal "hygiene (e) syntax-rules: the builtin car resists a local shadow"
-;;             1 (let ((car (lambda (z) 'shadowed))) (sr-car (list 1 2))))
-;; (test-equal "hygiene (e) syntax-rules: the builtin + resists a lambda-parameter shadow"
-;;             7 ((lambda (+) (sr-add 3 4)) (lambda (a b) (* a b))))
-;; (test-equal "hygiene (e) syntax-rules: a global procedure resists an internal-define shadow"
-;;             'global-proc (let () (define (gp2p11) 'shadowed) (sr-gp)))
+;; #2003 fixed: a use-site local binding no longer captures a template's
+;; free reference to a global procedure.
+(test-equal "hygiene (e) syntax-rules: a global procedure resists a local shadow"
+            'global-proc (let ((gp2p11 (lambda () 'shadowed))) (sr-gp)))
+(test-equal "hygiene (e) ER: a global procedure resists a local shadow"
+            'global-proc (let ((gp2p11 (lambda () 'shadowed))) (er-gp)))
+(test-equal "hygiene (e) syntax-rules: the builtin car resists a local shadow"
+            1 (let ((car (lambda (z) 'shadowed))) (sr-car (list 1 2))))
+(test-equal "hygiene (e) syntax-rules: the builtin + resists a lambda-parameter shadow"
+            7 ((lambda (+) (sr-add 3 4)) (lambda (a b) (* a b))))
+(test-equal "hygiene (e) syntax-rules: a global procedure resists an internal-define shadow"
+            'global-proc (let () (define (gp2p11) 'shadowed) (sr-gp)))
 
 ;; (f) Both paths agree on whatever they do — the parity claim itself. This
 ;;     stays ENABLED even while (e) is broken, because it asserts equality

--- a/tests/scheme/hygiene/template-binds-builtin-name.scm
+++ b/tests/scheme/hygiene/template-binds-builtin-name.scm
@@ -44,4 +44,23 @@
     ((_ v) (let ((list v)) list))))
 (check "template binding shadows builtin list" 5 (capture-list 5))
 
+;; 5. case-lambda formal colliding with a builtin: hygiene-renamed like a
+;;    let variable, so a spliced body resolves to the builtin, not the
+;;    formal (#2252 — the anaphoric FORMAL_FLAG exception covers lambda
+;;    formals only). The body `(car '(1 2))` must call the global car.
+(define-syntax capture-car-cl
+  (syntax-rules ()
+    ((_ b) (case-lambda ((car) b) (() 'none)))))
+(check "case-lambda formal does not capture spliced body" 1
+       ((capture-car-cl (car '(1 2))) (lambda (x) 'formal-was-called)))
+
+;; 6. Contrast: a lambda formal colliding with a builtin keeps its bare
+;;    anaphoric spelling (SRFI 190's pattern), so the same spliced body
+;;    binds to the formal — here, the argument passed to the closure.
+(define-syntax capture-car-lambda
+  (syntax-rules ()
+    ((_ b) (lambda (car) b))))
+(check "lambda formal keeps its anaphoric spelling" 'formal-was-called
+       ((capture-car-lambda (car 1)) (lambda (x) 'formal-was-called)))
+
 (when (> fails 0) (exit 1))

--- a/tests/scheme/srfi/srfi-notest-batch.scm
+++ b/tests/scheme/srfi/srfi-notest-batch.scm
@@ -518,26 +518,27 @@
 ;; FAIL: #2003 (a use-site local binding captures a macro template's free
 ;; reference to a global procedure). receive's template refers to
 ;; call-with-values; assume's refers to error.
-;; (test-equal "hygiene: a use-site local named `call-with-values' is inert" '(1 2)
-;;             (let ((call-with-values (lambda (a b) 'HIJACKED)))
-;;               (receive (a b) (values 1 2) (list a b))))
-;; (test-equal "hygiene: a use-site local named `error' is inert" #t
-;;             (let ((error (lambda args 'HIJACKED)))
-;;               (guard (e (#t #t)) (assume #f "boom") #f)))
+;; #2003 fixed: a use-site local binding no longer captures a macro template's
+;; free reference to a global procedure.
+(test-equal "hygiene: a use-site local named `call-with-values' is inert" '(1 2)
+            (let ((call-with-values (lambda (a b) 'HIJACKED)))
+              (receive (a b) (values 1 2) (list a b))))
+(test-equal "hygiene: a use-site local named `error' is inert" #t
+            (let ((error (lambda args 'HIJACKED)))
+              (guard (e (#t #t)) (assume #f "boom") #f)))
 
-;; FAIL: #2074 (a use-site local named after a syntactic keyword captures it
-;; inside any macro template). rec's template uses letrec; receive's uses
-;; lambda; assume's uses or.
-;; (test-equal "hygiene: a use-site local named `letrec' does not disturb rec" 120
-;;             (let ((letrec 5))
-;;               ((rec (fact n) (if (= n 0) 1 (* n (fact (- n 1))))) 5)))
-;; (test-equal "hygiene: a use-site local named `lambda' does not disturb receive" '(1 2)
-;;             (let ((lambda 5)) (receive (a b) (values 1 2) (list a b))))
-;; (test-equal "hygiene: a use-site local named `or' does not disturb assume" 42
-;;             (let ((or 5)) (assume 42)))
-;; (test-equal "hygiene: a use-site local named `case-lambda' is inert" 'T
-;;             (let ((case-lambda 5))
-;;               (procedure-tag (case-lambda/tag 'T ((a) 'one)))))
+;; #2074 fixed: a use-site local named after a syntactic keyword no longer
+;; captures it inside a macro template.
+(test-equal "hygiene: a use-site local named `letrec' does not disturb rec" 120
+            (let ((letrec 5))
+              ((rec (fact n) (if (= n 0) 1 (* n (fact (- n 1))))) 5)))
+(test-equal "hygiene: a use-site local named `lambda' does not disturb receive" '(1 2)
+            (let ((lambda 5)) (receive (a b) (values 1 2) (list a b))))
+(test-equal "hygiene: a use-site local named `or' does not disturb assume" 42
+            (let ((or 5)) (assume 42)))
+(test-equal "hygiene: a use-site local named `case-lambda' is inert" 'T
+            (let ((case-lambda 5))
+              (procedure-tag (case-lambda/tag 'T ((a) 'one)))))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-notest-batch")

--- a/tests/scheme/srfi/srfi190.scm
+++ b/tests/scheme/srfi/srfi190.scm
@@ -94,8 +94,20 @@
 
 (define-syntax srfi190-gen-of
   (syntax-rules () ((_ v) (coroutine-generator (yield v) (yield v)))))
-(test-equal "a yield written in another macro's template still binds"
-  '(5 5)
+;; The template's `yield` here is a FREE reference at srfi190-gen-of's own
+;; definition site (the test file, where `yield` is not an imported name —
+;; (srfi 190) exports coroutine-generator, not yield). Under the pre-#2003
+;; hygiene that kept a template identifier colliding with a global procedure
+;; unrenamed, that free `yield` happened to resolve to the coroutine's own
+;; formal once the expansion landed inside coroutine-generator, so a yield
+;; written in ANOTHER macro's template still bound. That capture is the
+;; hygiene violation #2003 fixes: a template's free reference now resolves at
+;; its own definition site, where `yield` denotes the (kaappi fibers)
+;; zero-argument primitive, so (yield v) is an arity error. Reaching the
+;; coroutine's yield from a helper macro's template requires the helper to
+;; reference the exported syntax parameter instead; (srfi 190) deliberately
+;; does not export one (matching the SRFI reference implementation).
+(test-error "a yield written in another macro's template no longer binds (#2003)"
   (generator->list (srfi190-gen-of 5)))
 
 (define-syntax srfi190-gen-body


### PR DESCRIPTION
Fixes #2003 and #2074 — the two sibling R7RS 4.3.2 macro-hygiene defects from audit v2 (Phase 2.11 / 3.7). Both let an ordinary use-site local binding capture part of a macro template; both are marked `priority: high`, milestone 0.23.

## #2003 — use-site local captures a template's free reference to a global procedure

```scheme
(define (helper x) (* x 10))
(define-syntax use (syntax-rules () ((_ n) (helper n))))
(write (let ((helper (lambda (x) (- x)))) (use 3)))   ; was -3, now 30
(define-syntax usecar (syntax-rules () ((_ l) (car l))))
(write (let ((car (lambda (x) 'HIJACKED))) (usecar (list 1 2))))  ; was HIJACKED, now 1
```

The template's free reference to a global *procedure* was left unrenamed, so it compiled through the use site's lexical scope. It is now hygiene-renamed like any other template-introduced identifier; the run-time global lookup's existing hygienic-prefix fallback resolves the rename to the base global by name — immune to use-site locals, while still observing a same-environment top-level redefinition (the semantics chibi and guile implement). Companion changes: `isContinuationBarrier` and the four legacy tail-position fast paths (`apply` / `call-with-values` / `call/cc` / `eval`) now recognize a renamed spelling — SRFI 248's guard re-raise needs the `call-with-values` one for correct multiple-value passing (the exact case #1812's notes warned about).

**Deliberate exception:** a template *lambda formal* colliding with a global procedure keeps its bare spelling (identity rename) — SRFI 190's coroutine body binds to the template's `yield` formal by name. This is *not* extended to let variables (#681 pins the opposite).

## #2074 — use-site local named after a syntactic keyword captures it in templates

```scheme
(define-syntax m (syntax-rules () ((_ e) (begin e))))
(display (let ((begin 5)) (m 7)))   ; was "not a procedure", now 7
```

15 of 17 swept operator keywords (`let`/`if` were already renamed) were inserted bare, so a use-site local of the same spelling captured them. The operator keywords among the well-known forms are now hygiene-renamed; the compiler already recognized renamed special forms via effective-name stripping. Kept bare: the definition/library forms, `syntax-rules`, the aux `else`, the pattern markers `...`/`_`, and the quote/quasiquote *value* symbols. `quote`/`quasiquote` *form* heads are renamed too, with strip-aware quasiquote depth handling in `compileQQ` (and hygiene-stripped rebuilt heads). `=>` in cond/case clauses is renamed and recognized through the strip; cond-expand feature combinators likewise.

## Tests

- Re-enabled the previously disabled audit `hygiene (e)` tests and the `srfi-notest-batch` #2003/#2074 tests.
- Updated two SRFI 190 tests that pinned the old anaphoric capture through *another* macro's template — under correct hygiene a free `yield` there resolves at its own definition site (chibi and the SRFI reference implementation's syntax-parameter design agree); the direct-anaphora tests still pass.
- Expand snapshot tests now compare through a gensym-id normalizer (the exact `__hyg_N_` id is a process-global counter).
- Full verification: unit suite + `-Dgc-stress`, R7RS suite (1395), all 694 Scheme test files, and the native `compile` tier — all green.

## Notes

- A library macro's template reference to a *base* binding still resolves by name at the use site (so a use-site top-level redefinition of e.g. `car` reaches it) — the pre-existing, documented #1812 leftover, deliberately out of scope here; chibi/guile bind it to the library's own env. Same-file top-level redefinition stays visible, matching both oracles.
- Template *definition* keywords (`define`, `define-syntax`, `let-syntax`, …) are deliberately kept bare (#2074's sweep does not include them and renaming them would interact with the body scanner / transformer-spec resolver) — a documented residual.


---

## Review follow-ups (commit 7d9970f8)

- **#2252** — the `FORMAL_FLAG` comments claimed the bare-spelling anaphoric exception covers *lambda or case-lambda* formals, but only `lambda` is handled. Per the issue's Option 1 (nothing depends on case-lambda anaphora; renaming case-lambda formals hygienically like let-variables is the more consistent behaviour), the comments now state the lambda-only scope and cite #2252. `tests/scheme/hygiene/template-binds-builtin-name.scm` gains a pair of tests pinning the distinction: a case-lambda formal does *not* capture a spliced body (resolves to the global), a lambda formal keeps its anaphoric spelling.
- **Review comment (types.zig)** — dropped the `__nlet_` alternative in `isContinuationBarrier`: `stripHygienicPrefix` does not strip `__nlet_`, so the branch was dead (named-let loop names are always locals, resolved by the call path before the barrier check is reached).
- **Review FYI (llvm_emit_freevars.zig)** — acknowledged: the native free-var scanners still match `lambda`/`quote`/`define` by bare spelling, but macro-expanded forms are eval'd (not natively emitted) in the native tier, so `__hyg_N_` heads never reach them; left unchanged as a latent-consistency note.
