### PR TITLE
Fix Windows LSP tests: build native file URIs for sibling-library cases

### DIFF
--- a/tests/scheme/lsp/lsp.sh
+++ b/tests/scheme/lsp/lsp.sh
@@ -95,6 +95,23 @@ pos_req() {
     msg '{"jsonrpc":"2.0","id":'"$1"',"method":"'"$2"'","params":{"textDocument":{"uri":"'"$3"'"},"position":{"line":'"$4"',"character":'"$5"'}}}'
 }
 
+# file_uri <path>: a `file://` URI a *native* kaappi-lsp can turn back into this
+# on-disk path. On Windows the Git-Bash path (`/c/Users/...`, or a `/tmp/...`
+# mount) is not something the native binary understands, so `native_path`
+# (cygpath -m) first rewrites it to `C:/Users/...`; the drive-lettered form gets
+# a third slash (`file:///C:/...`), the Unix absolute form is already rooted
+# (`file:///tmp/...`). This only matters for cases that make the server resolve a
+# real sibling file (an `(import (lib))` of a neighbouring `.sld`, an `include`);
+# a URI used only as a document key needs no round-trippable path.
+file_uri() {
+    local p
+    p="$(native_path "$1")"
+    case "$p" in
+        /*) printf 'file://%s\n' "$p" ;;
+        *) printf 'file:///%s\n' "$p" ;;
+    esac
+}
+
 OUT=""
 RC=0
 # lsp_run: feed the built stream to the server, capture stdout and exit status.
@@ -369,7 +386,7 @@ printf '%b' "$USER_SRC" > "$TMP/proj/user.scm"
 stream_reset
 msg "$INIT"
 msg "$INITED"
-did_open "file://$TMP/proj/user.scm" "$USER_SRC"
+did_open "$(file_uri "$TMP/proj/user.scm")" "$USER_SRC"
 msg "$EXITN"
 lsp_run
 assert_has "sibling-sld: an import of a .sld beside the document resolves" "$OUT" \
@@ -397,8 +414,8 @@ printf '%b' "$OTHER_SRC" > "$TMP/other/other.scm"
 stream_reset
 msg "$INIT"
 msg "$INITED"
-did_open "file://$TMP/proj/user.scm" "$USER_SRC"
-did_open "file://$TMP/other/other.scm" "$OTHER_SRC"
+did_open "$(file_uri "$TMP/proj/user.scm")" "$USER_SRC"
+did_open "$(file_uri "$TMP/other/other.scm")" "$OTHER_SRC"
 msg "$EXITN"
 lsp_run
 assert_has "sibling-sld isolation: a fresh lib under proj/ is unreachable from other/" "$OUT" \
@@ -424,7 +441,7 @@ printf '%b' "$NOISY_SRC" > "$TMP/proj/noisy-user.scm"
 stream_reset
 msg "$INIT"
 msg "$INITED"
-did_open "file://$TMP/proj/noisy-user.scm" "$NOISY_SRC"
+did_open "$(file_uri "$TMP/proj/noisy-user.scm")" "$NOISY_SRC"
 msg "$EXITN"
 lsp_run
 assert_lacks "stdout-guard: library-body output never reaches the wire" "$OUT" 'SIDE-EFFECT-BOOM'
@@ -446,9 +463,9 @@ printf '%b' "$NOB_SRC" > "$TMP/proj/nob.scm"
 stream_reset
 msg "$INIT"
 msg "$INITED"
-did_open "file://$TMP/proj/user.scm" "$USER_SRC"
-did_open "file://$TMP/proj/nob.scm" "$NOB_SRC"
-pos_req 92 "textDocument/hover" "file://$TMP/proj/nob.scm" 0 9
+did_open "$(file_uri "$TMP/proj/user.scm")" "$USER_SRC"
+did_open "$(file_uri "$TMP/proj/nob.scm")" "$NOB_SRC"
+pos_req 92 "textDocument/hover" "$(file_uri "$TMP/proj/nob.scm")" 0 9
 msg "$EXITN"
 lsp_run
 assert_has "globals-isolation: an imported binding is not hoverable in another doc" "$OUT" \
@@ -458,8 +475,8 @@ assert_has "globals-isolation: an imported binding is not hoverable in another d
 stream_reset
 msg "$INIT"
 msg "$INITED"
-did_open "file://$TMP/proj/user.scm" "$USER_SRC"
-pos_req 93 "textDocument/hover" "file://$TMP/proj/user.scm" 1 10
+did_open "$(file_uri "$TMP/proj/user.scm")" "$USER_SRC"
+pos_req 93 "textDocument/hover" "$(file_uri "$TMP/proj/user.scm")" 1 10
 msg "$EXITN"
 lsp_run
 assert_has "globals-isolation control: the importing doc resolves its own import" "$OUT" \

--- a/tests/scheme/lsp/lsp.sh
+++ b/tests/scheme/lsp/lsp.sh
@@ -95,17 +95,31 @@ pos_req() {
     msg '{"jsonrpc":"2.0","id":'"$1"',"method":"'"$2"'","params":{"textDocument":{"uri":"'"$3"'"},"position":{"line":'"$4"',"character":'"$5"'}}}'
 }
 
+# uri_encode: percent-encode stdin as UTF-8, preserving `/` separators and a
+# drive-letter `:`. The LSP's fileUriToPath decodes `%XX` back, so a directory
+# named "proj with #% space" round-trips; a literal space, `#` (starts a URI
+# fragment), `?` (query), `%` (unescaped %XX is ambiguous), or non-ASCII byte in
+# the textDocument/uri would otherwise break resolution or the editor's own URI
+# parsing.
+uri_encode() {
+    python3 -c 'import sys, urllib.parse
+sys.stdout.buffer.write(urllib.parse.quote(sys.stdin.buffer.read().decode("utf-8"), safe="/:").encode("ascii"))'
+}
+
 # file_uri <path>: a `file://` URI a *native* kaappi-lsp can turn back into this
 # on-disk path. On Windows the Git-Bash path (`/c/Users/...`, or a `/tmp/...`
 # mount) is not something the native binary understands, so `native_path`
 # (cygpath -m) first rewrites it to `C:/Users/...`; the drive-lettered form gets
 # a third slash (`file:///C:/...`), the Unix absolute form is already rooted
-# (`file:///tmp/...`). This only matters for cases that make the server resolve a
+# (`file:///tmp/...`). The converted path is then percent-encoded (uri_encode),
+# so a space or reserved character in the directory or file name survives the
+# URI round-trip. This only matters for cases that make the server resolve a
 # real sibling file (an `(import (lib))` of a neighbouring `.sld`, an `include`);
 # a URI used only as a document key needs no round-trippable path.
 file_uri() {
     local p
     p="$(native_path "$1")"
+    p="$(printf '%s' "$p" | uri_encode)"
     case "$p" in
         /*) printf 'file://%s\n' "$p" ;;
         *) printf 'file:///%s\n' "$p" ;;
@@ -393,6 +407,37 @@ assert_has "sibling-sld: an import of a .sld beside the document resolves" "$OUT
     '"uri":"[^"]*user\.scm","diagnostics":\[\]'
 assert_eq "sibling-sld control: check resolves it too" \
     "$(run_timeout 30 "$KAAPPI" check "$TMP/proj/user.scm" > /dev/null 2>&1 && echo 0 || echo 1)" "0"
+
+# A directory whose name carries a space and reserved characters must still
+# resolve: `native_path` normalizes filesystem syntax only, so the URI would
+# hold a literal `#` (a URI fragment) and `%`/spaces unless file_uri
+# percent-encodes them. fileUriToPath decodes %XX back, so the native server
+# finds the sibling .sld exactly as for a plain path. (A `?` is deliberately
+# not used: Windows filenames cannot contain it.)
+mkdir -p "$TMP/proj with #% space"
+cat > "$TMP/proj with #% space/mylib-sp.sld" << 'SLD'
+(define-library (mylib-sp)
+  (export sp-const)
+  (import (scheme base))
+  (begin (define sp-const 99)))
+SLD
+SPACE_SRC='(import (scheme base) (scheme write) (mylib-sp))\n(display sp-const)\n(newline)\n'
+printf '%b' "$SPACE_SRC" > "$TMP/proj with #% space/user.scm"
+stream_reset
+msg "$INIT"
+msg "$INITED"
+did_open "$(file_uri "$TMP/proj with #% space/user.scm")" "$SPACE_SRC"
+msg "$EXITN"
+lsp_run
+assert_has "sibling-sld: space and reserved chars in the path still resolve" "$OUT" \
+    '"uri":"[^"]*user\.scm","diagnostics":\[\]'
+# The server echoes the URI it was given, so the percent-encoded form proves
+# file_uri encoded the path (space %20, # %23, % %25) — without the encoding
+# this would be a raw space/#/% URI that no real editor would produce or parse.
+assert_has "sibling-sld: the response URI is percent-encoded" "$OUT" \
+    '"uri":"[^"]*proj%20with%20%23%25%20space/user\.scm"'
+assert_eq "sibling-sld space control: check resolves it too" \
+    "$(run_timeout 30 "$KAAPPI" check "$TMP/proj with #% space/user.scm" > /dev/null 2>&1 && echo 0 || echo 1)" "0"
 
 # Negative control: the doc-directory entry must be scoped to its own run, not
 # leaked into the next. `mylibb` lives only in proj/ and is imported *only* from


### PR DESCRIPTION
## Problem

After #2253 merged, `windows-x64-test` and `windows-arm-test` failed (the Windows *cross-compile builds* were green — only the test jobs failed):

```
FAIL: sibling-sld: an import of a .sld beside the document resolves
FAIL: stdout-guard: the importing document is still diagnosed clean
FAIL: globals-isolation control: the importing doc resolves its own import
kaappi-lsp: 166 passed, 3 failed
```

All three are the LSP tests that make the server resolve a real sibling `.sld` **from disk**.

## Root cause

Those tests built the document URI as `file://$TMP/...`. Under Git Bash on Windows, `$TMP` (from `mktemp -d`) is an MSYS path like `/tmp/tmp.XXXX`, and it was passed verbatim to a **native** `kaappi-lsp.exe`. The server's `fileUriToPath` then produced an MSYS-style path the native binary can't resolve, so the sibling library wasn't found and the imports failed.

The `check` controls next to each assertion passed because MSYS auto-rewrites path **arguments** to Windows paths — but nothing rewrites a path embedded inside a URI **string**. So only the LSP side (which receives a URI) broke. This is a test-harness gap, not an LSP bug: `fileUriToPath` already handles real editor URIs (`file:///C:/...`, percent-encoding, the drive-letter slash).

## Fix

A `file_uri` test helper runs the path through the existing `native_path` helper (`cygpath -m` on Windows → `C:/...`, identity elsewhere) and frames a proper URI:

- drive-lettered path → `file:///C:/...`
- Unix absolute path → `file:///tmp/...`

Only the cases that resolve a real on-disk file are converted; URIs used purely as document keys are left as-is.

## Verification

- Local (macOS): full LSP suite **169/169**, no behaviour change (`native_path` is identity off-Windows, so `file_uri` yields the same `file:///…` these tests already used).
- Windows: I can't run the Windows jobs locally; this targets the exact three failures with `native_path`, which the suite already relies on for Windows output assertions. CI on this PR is the authoritative check.

Source is unchanged — **test-only**.

## Follow-up (CodeRabbit review, 5ee22728)

`file_uri` now percent-encodes the native-path-converted output as UTF-8
(preserving `/` and the drive-letter `:`), so a space, `#`, `?`, `%`, or
non-ASCII byte in `$TMP` or a fixture path no longer lands unescaped in the
`textDocument/uri`. A new regression case opens a document under
`proj with #% space/`; the response-URI assertion (`%20`/`%23`/`%25`) is the
guard that fails if the encoding is removed, and a `kaappi check` control
confirms sibling resolution with special characters in the path.
