### PR TITLE
Fix rational→flonum conversion past f64 range; close the m/2^k complex read-back gap (#2183, #2182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Rational→flonum conversion is correct when a single side alone leaves
+  f64 range** (#2183). `(inexact (/ 1 (expt 2 1074)))` was `0.0` instead of
+  the minimum subnormal, `(inexact (/ (+ (expt 2 1030) 1) (expt 2 1000)))`
+  was `+inf.0` instead of `2^30`, and the `#i`/`#e` parser paths produced
+  `+nan.0` when both sides overflowed — every rational→f64 path computed
+  `toF64(num)/toF64(den)`, saturating each side independently. All five
+  paths now route through a shared scaled conversion: both magnitudes are
+  normalized to their top 64 significant bits, the quotient is computed to
+  64+ bits with a u128 division, rounded with round-half-to-even, and the
+  removed power of two is re-applied so subnormals round correctly
+  (including the exact tie at 2^-1075). Verified bit-for-bit against a
+  correctly-rounded oracle over 3301 rationals.
+
+- **The reader and `string->number` accept bignum rational complex parts,
+  so exact complexes with tiny components round-trip** (#2182). The
+  exact-complex printer emits `m/2^k` spellings (denominator up to 2^1074,
+  a bignum) for components below its rational-recovery granularity, but
+  the reader's complex grammar stopped at i64 rational parts, so
+  `(write #e1e-300+1i)` could not be read back. Both parsers now share a
+  gated bignum-rational component parser: a rational like `10^25/3` whose
+  value would silently round stays a loud read error (and `string->number`
+  `#f`), preserving the never-masquerade policy of #2243, while the honest
+  `m/2^k` forms round-trip exactly. A small adjacent parity gap also
+  closed: an exact-flagged imaginary part past 2^53 after a rational real
+  (`1/2+123456789012345678901234567890i`) is a loud error instead of a
+  silently rounded value.
+
 - **A use-site local binding no longer captures a macro template's free
   reference to a global procedure** (#2003). A template free reference to a
   global procedure (`(define-syntax usecar (syntax-rules () ((_ l) (car

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   normalized to their top 64 significant bits, the quotient is computed to
   64+ bits with a u128 division, rounded with round-half-to-even, and the
   removed power of two is re-applied so subnormals round correctly
-  (including the exact tie at 2^-1075). Verified bit-for-bit against a
-  correctly-rounded oracle over 3301 rationals.
+  (including the exact tie at 2^-1075) and the whole top binade
+  [2^1023, 2^1024) stays finite. Verified bit-for-bit against a
+  correctly-rounded oracle over 5607 rationals spanning powers of two
+  from 2^-1100 to 2^1100, random bignum ratios, lopsided
+  numerator/denominator sizes, the top binade, and adversarial
+  half-ulp tie constructions.
 
 - **The reader and `string->number` accept bignum rational complex parts,
   so exact complexes with tiny components round-trip** (#2182). The

--- a/src/bignum.zig
+++ b/src/bignum.zig
@@ -977,13 +977,14 @@ pub fn valueBitLen(v: Value) usize {
 /// and k <= 1074); a value that would silently round must stay a loud
 /// error instead of masquerading as exact (kaappi#2182/#2183).
 pub fn rationalExactInF64(num: Value, den: Value) bool {
-    if (types.isFixnum(num) and types.toFixnum(num) == 0) return true; // 0/den == 0.0
+    const bl_raw = valueBitLen(num);
+    if (bl_raw == 0) return true; // 0/den == 0.0, exactly representable
     const k = powerOfTwoExponent(den) orelse return false;
     // Reduce: value == num_odd * 2^(v2 - k), num_odd odd with valueBitLen -
     // v2 significant bits.
     const v2 = trailingZeroBits(num);
     const k_eff: i64 = @as(i64, @intCast(k)) - @as(i64, @intCast(v2));
-    const bl = valueBitLen(num) - v2; // significant bits of the reduced value
+    const bl = bl_raw - v2; // significant bits of the reduced value
     if (k_eff > 1074) return false; // value < 2^-1075: rounds to 0
     if (k_eff <= 1022) return bl <= 53; // value >= 2^-1022: normal range
     // Value in (2^-1074, 2^-1022): subnormal iff num_odd < 2^(k_eff - 1022),

--- a/src/bignum.zig
+++ b/src/bignum.zig
@@ -900,6 +900,135 @@ pub fn bignumExactInF64(v: Value) bool {
 /// #2243).
 pub const complex_rational_limit: i64 = 1_000_000;
 
+// ---------------------------------------------------------------------------
+// Bignum rational complex parts (kaappi#2182/#2183)
+//
+// The reader's complex grammar stops at i64 rational parts whose magnitude
+// stays within complex_rational_limit. The printer's exact-component
+// fallback emits m/2^k spellings (odd mantissa <= 2^53, k <= 1074) whose
+// denominator is a bignum, and reading those back requires accepting bignum
+// rational parts -- but only when the value is exactly representable in f64,
+// so an exact-flagged component never silently rounds (the same
+// never-masquerade policy as the i64 limit). These helpers are the shared
+// gate + conversion behind both the reader and string->number.
+// ---------------------------------------------------------------------------
+
+/// The exponent k when v == 2^k (v a positive fixnum or bignum), else null.
+/// A rational's f64-exactness requires its denominator to be a power of two.
+pub fn powerOfTwoExponent(v: Value) ?u64 {
+    if (types.isFixnum(v)) {
+        const n = types.toFixnum(v);
+        if (n <= 0) return null;
+        const mag = @as(u64, @intCast(n));
+        if (@popCount(mag) != 1) return null;
+        return 64 - @clz(mag) - 1;
+    }
+    if (!types.isBignum(v)) return null;
+    const bn = types.toBignum(v);
+    if (!bn.positive or bn.len == 0) return null;
+    var k: u64 = 0;
+    var found = false;
+    for (bn.limbs[0..bn.len], 0..) |limb, i| {
+        if (limb == 0) continue;
+        if (found or @popCount(limb) != 1) return null;
+        found = true;
+        k = @as(u64, @intCast(i)) * 64 + (64 - @clz(limb) - 1);
+    }
+    return if (found) k else null;
+}
+
+/// Number of trailing zero bits of a nonzero value's magnitude (v2(v)).
+fn trailingZeroBits(v: Value) u64 {
+    if (types.isFixnum(v)) {
+        const n = types.toFixnum(v);
+        const mag: u64 = if (n < 0) @as(u64, @intCast(-(n + 1))) + 1 else @intCast(n);
+        return @ctz(mag);
+    }
+    const bn = types.toBignum(v);
+    var zeros: u64 = 0;
+    for (bn.limbs[0..bn.len]) |limb| {
+        if (limb == 0) {
+            zeros += 64;
+        } else {
+            return zeros + @ctz(limb);
+        }
+    }
+    return zeros;
+}
+
+/// Significant-bit count of a fixnum or bignum magnitude; 0 for zero.
+pub fn valueBitLen(v: Value) usize {
+    if (types.isFixnum(v)) {
+        const n = types.toFixnum(v);
+        const mag: u64 = if (n < 0) @as(u64, @intCast(-(n + 1))) + 1 else @intCast(n);
+        return if (mag == 0) 0 else 64 - @clz(mag);
+    }
+    const bn = types.toBignum(v);
+    var i = bn.len;
+    while (i > 0 and bn.limbs[i - 1] == 0) i -= 1;
+    if (i == 0) return 0;
+    return (i - 1) * 64 + (64 - @clz(bn.limbs[i - 1]));
+}
+
+/// True when the rational num/den (num signed, den positive) is exactly
+/// representable in f64 -- i.e. its own value round-trips losslessly
+/// through the f64 conversion. This is exactly the shape the printer emits
+/// for exact complex components (m/2^k with the reduced mantissa <= 2^53
+/// and k <= 1074); a value that would silently round must stay a loud
+/// error instead of masquerading as exact (kaappi#2182/#2183).
+pub fn rationalExactInF64(num: Value, den: Value) bool {
+    if (types.isFixnum(num) and types.toFixnum(num) == 0) return true; // 0/den == 0.0
+    const k = powerOfTwoExponent(den) orelse return false;
+    // Reduce: value == num_odd * 2^(v2 - k), num_odd odd with valueBitLen -
+    // v2 significant bits.
+    const v2 = trailingZeroBits(num);
+    const k_eff: i64 = @as(i64, @intCast(k)) - @as(i64, @intCast(v2));
+    const bl = valueBitLen(num) - v2; // significant bits of the reduced value
+    if (k_eff > 1074) return false; // value < 2^-1075: rounds to 0
+    if (k_eff <= 1022) return bl <= 53; // value >= 2^-1022: normal range
+    // Value in (2^-1074, 2^-1022): subnormal iff num_odd < 2^(k_eff - 1022),
+    // i.e. bl <= k_eff - 1022 -- then the mantissa num_odd << (1074 -
+    // k_eff) must fit 52 bits. Otherwise the value is back in normal range.
+    if (bl <= @as(usize, @intCast(k_eff - 1022))) {
+        return bl <= @as(usize, @intCast(52 - (1074 - k_eff)));
+    }
+    return bl <= 53;
+}
+
+/// Parse a radix-R rational pair (num with optional sign, den positive) to
+/// f64. i64 parts within complex_rational_limit divide directly; a part
+/// that overflows i64 goes through the bignum path, gated on exact f64
+/// representability (`rationalExactInF64`) so a non-representable bignum
+/// rational (10^25/3) stays a loud error. A zero denominator, invalid
+/// digits, or a gated-out value yields null. This is the shared
+/// implementation for bignum rational complex parts in both the reader and
+/// string->number (kaappi#2182/#2183).
+pub fn parseRationalToF64(gc: *memory.GC, num_str: []const u8, den_str: []const u8, radix: u8) ?f64 {
+    var nb: [256]u8 = undefined;
+    var db: [256]u8 = undefined;
+    const num = stripUnderscores(num_str, radix, &nb) orelse return null;
+    const den = stripUnderscores(den_str, radix, &db) orelse return null;
+    if (std.fmt.parseInt(i64, num, radix)) |n| {
+        if (std.fmt.parseInt(i64, den, radix)) |d| {
+            if (d == 0) return null;
+            if (@abs(n) > complex_rational_limit or @abs(d) > complex_rational_limit) return null;
+            return @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d));
+        } else |derr| {
+            if (derr != error.Overflow) return null;
+        }
+    } else |nerr| {
+        if (nerr != error.Overflow) return null;
+    }
+    // At least one part overflows i64: bignum path, gated on exactness.
+    const num_v = parseBignumString(gc, num_str, radix) catch return null;
+    var slot = gc.rootedSlot(num_v) catch return null;
+    defer slot.release();
+    const den_v = parseBignumString(gc, den_str, radix) catch return null;
+    if (isZero(den_v)) return null;
+    if (!rationalExactInF64(slot.get(), den_v)) return null;
+    return types.rationalToF64(slot.get(), den_v);
+}
+
 /// Parse a radix-R <ureal> slice (radix digits with optional SRFI-169 `_`
 /// separators, optionally `N/D`) to f64. No sign -- callers handle signs.
 /// i64 overflow, an invalid character, a zero denominator, or an i64 part

--- a/src/bignum.zig
+++ b/src/bignum.zig
@@ -985,8 +985,14 @@ pub fn rationalExactInF64(num: Value, den: Value) bool {
     const v2 = trailingZeroBits(num);
     const k_eff: i64 = @as(i64, @intCast(k)) - @as(i64, @intCast(v2));
     const bl = bl_raw - v2; // significant bits of the reduced value
-    if (k_eff > 1074) return false; // value < 2^-1075: rounds to 0
-    if (k_eff <= 1022) return bl <= 53; // value >= 2^-1022: normal range
+    if (k_eff > 1074) return false; // value <= 2^-1075: rounds to 0
+    if (k_eff <= 1022) {
+        // value = num_odd * 2^-k_eff >= 2^-1022: normal range. Representable
+        // iff the mantissa fits (bl <= 53) and the value does not overflow
+        // (value < 2^1024, i.e. bl <= k_eff + 1024 -- k_eff can be very
+        // negative after reducing an even numerator, e.g. 2^2001/2).
+        return bl <= 53 and k_eff + 1024 >= 0 and bl <= @as(usize, @intCast(k_eff + 1024));
+    }
     // Value in (2^-1074, 2^-1022): subnormal iff num_odd < 2^(k_eff - 1022),
     // i.e. bl <= k_eff - 1022 -- then the mantissa num_odd << (1074 -
     // k_eff) must fit 52 bits. Otherwise the value is back in normal range.
@@ -1012,7 +1018,14 @@ pub fn parseRationalToF64(gc: *memory.GC, num_str: []const u8, den_str: []const 
     if (std.fmt.parseInt(i64, num, radix)) |n| {
         if (std.fmt.parseInt(i64, den, radix)) |d| {
             if (d == 0) return null;
-            if (@abs(n) > complex_rational_limit or @abs(d) > complex_rational_limit) return null;
+            // Beyond the printer's small-rational recovery limit a part is
+            // accepted only when the value is exactly representable in f64
+            // (power-of-two denominator -- the m/2^k printer shape), the
+            // same gate the reader's fixnum-rational path applies, so the
+            // i64/bignum boundary has no dead zone (kaappi#2182).
+            if (@abs(n) > complex_rational_limit or @abs(d) > complex_rational_limit) {
+                if (!i64RationalExactInF64(n, d)) return null;
+            }
             return @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d));
         } else |derr| {
             if (derr != error.Overflow) return null;
@@ -1028,6 +1041,26 @@ pub fn parseRationalToF64(gc: *memory.GC, num_str: []const u8, den_str: []const 
     if (isZero(den_v)) return null;
     if (!rationalExactInF64(slot.get(), den_v)) return null;
     return types.rationalToF64(slot.get(), den_v);
+}
+
+/// i64-only form of `rationalExactInF64` for the fixnum-rational complex
+/// paths that hold n/den as i64 (kaappi#2182): true when n/den is exactly
+/// representable in f64 (den a power of two with the value in range and at
+/// most 53 significant bits). Same gate as the bignum path, so a power-of-
+/// two denominator just past the printer's small-rational recovery limit
+/// (e.g. 1/2^60) is accepted while 1/20000000000001 stays a loud error.
+pub fn i64RationalExactInF64(n: i64, den: i64) bool {
+    if (den <= 0 or (den & (den - 1)) != 0) return false; // positive power of two
+    const k: i64 = @ctz(@as(u64, @intCast(den))); // den == 2^k
+    const mag: u64 = if (n < 0) @as(u64, @intCast(-(n + 1))) + 1 else @intCast(n);
+    if (mag == 0) return true; // 0/den == 0.0
+    const v2: i64 = @ctz(mag);
+    const k_eff: i64 = k - v2;
+    const bl: i64 = @as(i64, @intCast(64 - @clz(mag))) - v2;
+    if (k_eff > 1074) return false; // value <= 2^-1075: rounds to 0
+    if (k_eff <= 1022) return bl <= 53 and k_eff + 1024 >= 0 and bl <= k_eff + 1024;
+    if (bl <= k_eff - 1022) return bl <= 52 - (1074 - k_eff); // subnormal
+    return bl <= 53; // normal
 }
 
 /// Parse a radix-R <ureal> slice (radix digits with optional SRFI-169 `_`

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -462,9 +462,7 @@ pub fn toF64(v: Value) PrimitiveError!f64 {
     }
     if (types.isRationalObj(v)) {
         const r = types.toRational(v);
-        const n = try toF64(r.numerator);
-        const d = try toF64(r.denominator);
-        return n / d;
+        return types.rationalToF64(r.numerator, r.denominator);
     }
     return PrimitiveError.TypeError; // bare-ok: numeric coercion fallback
 }

--- a/src/primitives_arithmetic.zig
+++ b/src/primitives_arithmetic.zig
@@ -31,9 +31,7 @@ pub fn toF64Ext(v: Value) PrimitiveError!f64 {
     if (types.isBignum(v)) return bignum_mod.toF64(v);
     if (types.isRationalObj(v)) {
         const r = types.toRational(v);
-        const n = try toF64Ext(r.numerator);
-        const d = try toF64Ext(r.denominator);
-        return n / d;
+        return types.rationalToF64(r.numerator, r.denominator);
     }
     return numberTypeError(v);
 }

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -336,17 +336,7 @@ fn inexactFn(args: []const Value) PrimitiveError!Value {
     if (types.isBignum(args[0])) return makeFlonumVal(bignum_mod.toF64(args[0]));
     if (types.isRationalObj(args[0])) {
         const r = types.toRational(args[0]);
-        const n = try toF64Ext(r.numerator);
-        const d = try toF64Ext(r.denominator);
-        const result = n / d;
-        if (!std.math.isNan(result)) return makeFlonumVal(result);
-        // Both overflow to inf — use bignum division for the integer part
-        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-        const q = bignum_mod.quotient(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
-        const q_f = try toF64Ext(q);
-        const rem = bignum_mod.remainder(gc, r.numerator, r.denominator) catch return PrimitiveError.OutOfMemory;
-        const rem_f = try toF64Ext(rem);
-        return makeFlonumVal(q_f + rem_f / d);
+        return makeFlonumVal(types.rationalToF64(r.numerator, r.denominator));
     }
     if (types.isComplex(args[0])) {
         const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
@@ -993,9 +983,7 @@ fn applyExactness(gc: *@import("memory.zig").GC, val: Value, exactness: Exactnes
             }
             if (types.isRationalObj(val)) {
                 const rat = types.toRational(val);
-                const num_f = types.toF64(rat.numerator);
-                const den_f = types.toF64(rat.denominator);
-                return types.makeFlonum(num_f / den_f);
+                return types.makeFlonum(types.rationalToF64(rat.numerator, rat.denominator));
             }
             if (types.isComplex(val)) {
                 const c = types.toComplex(val);

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -1128,20 +1128,15 @@ const ComplexComponent = struct { val: f64, exact: bool };
 /// never masquerade as exact (kaappi#2182).
 fn parseComplexComponent(gc: *@import("memory.zig").GC, part: []const u8, radix: u8) ?ComplexComponent {
     if (std.mem.indexOfScalar(u8, part, '/')) |sp| {
-        // Rational N/D (any radix): R7RS <ureal R>.
+        // Rational N/D (any radix): R7RS <ureal R>. i64 parts within
+        // complex_rational_limit divide directly; bignum parts are accepted
+        // only when their value is exactly representable in f64 (the m/2^k
+        // printer shape), so a rounded value never masquerades as exact
+        // (kaappi#2182/#2183). Shared with the reader's bignum-rational
+        // complex tail so the two grammars cannot drift.
         if (sp == 0 or sp + 1 >= part.len) return null;
-        var nb: [256]u8 = undefined;
-        var db: [256]u8 = undefined;
-        const num = bignum_mod.stripUnderscores(part[0..sp], radix, &nb) orelse return null;
-        const den = bignum_mod.stripUnderscores(part[sp + 1 ..], radix, &db) orelse return null;
-        const n = std.fmt.parseInt(i64, num, radix) catch return null;
-        const d = std.fmt.parseInt(i64, den, radix) catch return null;
-        if (d == 0) return null;
-        // Beyond the printer's rational-recovery granularity the ratio
-        // would print as a silently-wrong mantissa/2^k fraction; reject
-        // loudly, like the reader does (kaappi#2182/#2243).
-        if (@abs(n) > bignum_mod.complex_rational_limit or @abs(d) > bignum_mod.complex_rational_limit) return null;
-        return .{ .val = @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(d)), .exact = true };
+        const val = bignum_mod.parseRationalToF64(gc, part[0..sp], part[sp + 1 ..], radix) orelse return null;
+        return .{ .val = val, .exact = true };
     }
     if (radix == 10) {
         // Decimal parts (1.5+2i, 1e5+2i) and inf/nan spellings: parseFloat

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -999,9 +999,7 @@ fn getSleepSeconds(v: Value) PrimitiveError!f64 {
     if (types.isFlonum(v)) return types.toFlonum(v);
     if (types.isRationalObj(v)) {
         const r = types.toRational(v);
-        const n = primitives.toF64(r.numerator) catch return PrimitiveError.TypeError; // bare-ok: type guard
-        const d = primitives.toF64(r.denominator) catch return PrimitiveError.TypeError; // bare-ok: type guard
-        return n / d;
+        return types.rationalToF64(r.numerator, r.denominator);
     }
     if (types.isPointer(v) and types.toObject(v).tag == .srfi18_time) {
         const t = types.toObject(v).as(types.Srfi18Time);

--- a/src/reader_tokens.zig
+++ b/src/reader_tokens.zig
@@ -85,6 +85,84 @@ fn bigRationalToken(self: *Reader, num_str: []const u8, den_str: []const u8, rad
     return .{ .big_rational = .{ .num_str = num_str, .den_str = den_str, .radix = radix } };
 }
 
+/// Complex tail after a bignum rational real part: `num/den+imag i`,
+/// `num/den+i`, and the `-` twins (R7RS <complex R>), mirroring the
+/// i64-rational path in `readNumber` but converting the real part with the
+/// scaled rational->f64 conversion. Bignum parts are accepted only when
+/// their value is exactly representable in f64 (the m/2^k shape the
+/// printer emits for exact complex components); anything else returns null
+/// so the caller's bigRationalToken reports the glued tail as a read error
+/// rather than silently rounding an exact-flagged component
+/// (kaappi#2182/#2183). The position is restored on every failure path.
+fn tryComplexTailBigRational(self: *Reader, num_str: []const u8, den_str: []const u8, radix: u8) ?Token {
+    if (self.pos >= self.source.len) return null;
+    const next = self.source[self.pos];
+    if (next != '+' and next != '-' and next != 'i' and next != 'I') return null;
+    const save = self.pos;
+    const real = bignum.parseRationalToF64(self.gc, num_str, den_str, radix) orelse return null;
+
+    // Pure imaginary with an explicit magnitude: `+ <ureal R> i` /
+    // `- <ureal R> i` (R7RS <complex R>; the sign inside num_str is the
+    // production marker and the signless m/2^k i is not grammar). Mirrors
+    // the i64 rational path; the sign is absorbed into `real` by the parse.
+    if ((next == 'i' or next == 'I') and
+        (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])) and
+        num_str.len > 0 and (num_str[0] == '+' or num_str[0] == '-'))
+    {
+        self.pos += 1;
+        return .{ .complex = .{ .real = 0.0, .imag = real, .exact_real = true, .exact_imag = true } };
+    }
+    if (next != '+' and next != '-') return null;
+    const neg = next == '-'; // sign applies to the imaginary part below
+
+    self.pos += 1; // skip +/-
+    // +i / -i: the unit imaginary.
+    if (self.pos < self.source.len and (self.source[self.pos] == 'i' or self.source[self.pos] == 'I') and
+        (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])))
+    {
+        self.pos += 1;
+        return .{ .complex = .{ .real = real, .imag = if (neg) -1.0 else 1.0, .exact_real = true, .exact_imag = true } };
+    }
+    // Imaginary magnitude: digits/.//_ then 'i' (mirrors the i64 path).
+    const mag_start = self.pos;
+    var imag_has_dot = false;
+    while (self.pos < self.source.len) {
+        const ic = self.source[self.pos];
+        if (std.ascii.isDigit(ic) or ic == '_') {
+            self.pos += 1;
+        } else if (ic == '.' and !imag_has_dot) {
+            imag_has_dot = true;
+            self.pos += 1;
+        } else if (ic == '/') {
+            self.pos += 1;
+        } else break;
+    }
+    if (self.pos == mag_start) {
+        self.pos = save;
+        return null;
+    }
+    if (self.pos < self.source.len and (self.source[self.pos] == 'i' or self.source[self.pos] == 'I') and
+        (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])))
+    {
+        self.pos += 1;
+        const imag_str = self.source[mag_start .. self.pos - 1];
+        const imag = parseDecimalReal(imag_str) orelse blk: {
+            // Bignum rational imaginary part: split at '/' and gate.
+            if (std.mem.indexOfScalar(u8, imag_str, '/')) |sp2| {
+                break :blk bignum.parseRationalToF64(self.gc, imag_str[0..sp2], imag_str[sp2 + 1 ..], radix) orelse {
+                    self.pos = save;
+                    return null;
+                };
+            }
+            self.pos = save;
+            return null;
+        };
+        return .{ .complex = .{ .real = real, .imag = if (neg) -imag else imag, .exact_real = true, .exact_imag = !imag_has_dot } };
+    }
+    self.pos = save;
+    return null;
+}
+
 /// A malformed numeric token with no delimiter between the failure point and
 /// end-of-slice may be a truncated prefix of a valid literal (`3.` of `3.5`,
 /// `1_` of `1_2`, `#e+in` of `#e+inf.0` — the scan can stop with unconsumed
@@ -213,7 +291,15 @@ pub fn readNumber(self: *Reader) ReadError!Token {
             if (real_exact and !exactIntegerRoundTrips(self, num_str, 10)) return invalidNumberOrEof(self);
             if (imag_exact and !exactIntegerRoundTrips(self, imag_str, 10)) return invalidNumberOrEof(self);
             const real = parseDecimalReal(num_str) orelse return invalidNumberOrEof(self);
-            const imag = parseDecimalReal(imag_str) orelse return invalidNumberOrEof(self);
+            const imag = parseDecimalReal(imag_str) orelse blk: {
+                // Bignum rational imaginary part (the m/2^k printer form
+                // after an integer real): split at '/' and gate on exact
+                // f64 representability (#2182/#2183).
+                if (std.mem.indexOfScalar(u8, imag_str, '/')) |sp2| {
+                    break :blk bignum.parseRationalToF64(self.gc, imag_str[0..sp2], imag_str[sp2 + 1 ..], 10) orelse return invalidNumberOrEof(self);
+                }
+                return invalidNumberOrEof(self);
+            };
             return .{ .complex = .{ .real = real, .imag = imag, .exact_real = real_exact, .exact_imag = imag_exact } };
         }
         // Not a complex literal — backtrack
@@ -259,6 +345,7 @@ pub fn readNumber(self: *Reader) ReadError!Token {
                 self.pos + 1 < self.source.len and std.ascii.isDigit(self.source[self.pos + 1]))
             {
                 const den_str = scanDenominatorDigits(self, 10);
+                if (tryComplexTailBigRational(self, num_str, den_str, 10)) |tok| return tok;
                 return bigRationalToken(self, num_str, den_str, 10);
             }
             return .{ .bignum_str = .{ .str = num_str, .radix = 10 } };
@@ -271,7 +358,10 @@ pub fn readNumber(self: *Reader) ReadError!Token {
             var den_strip_buf: [256]u8 = undefined;
             const clean_den_str = bignum.stripUnderscores(den_str, 10, &den_strip_buf) orelse return invalidNumberOrEof(self);
             const den = std.fmt.parseInt(i64, clean_den_str, 10) catch |err| {
-                if (err == error.Overflow) return bigRationalToken(self, num_str, den_str, 10);
+                if (err == error.Overflow) {
+                    if (tryComplexTailBigRational(self, num_str, den_str, 10)) |tok| return tok;
+                    return bigRationalToken(self, num_str, den_str, 10);
+                }
                 return invalidNumberOrEof(self);
             };
             // Check for complex after rational: 1/2+3/4i
@@ -300,7 +390,22 @@ pub fn readNumber(self: *Reader) ReadError!Token {
                 {
                     self.pos = imag_end + 1;
                     const imag_str = self.source[imag_start2..imag_end];
-                    const imag_val = parseDecimalReal(imag_str) orelse {
+                    // An exact-flagged imaginary part must round-trip through
+                    // f64: a bignum integer would silently carry a rounded
+                    // value while claiming exactness, the same rule the main
+                    // complex path applies to both components (#2182).
+                    if (!imag_has_dot2 and !exactIntegerRoundTrips(self, imag_str, 10)) return invalidNumberOrEof(self);
+                    const imag_val = parseDecimalReal(imag_str) orelse blk: {
+                        // Bignum rational imaginary part (e.g. the m/2^k
+                        // printer form): split at '/' and gate on exact f64
+                        // representability (#2182/#2183). imag_str carries
+                        // the sign, which parseBignumString accepts.
+                        if (std.mem.indexOfScalar(u8, imag_str, '/')) |sp2| {
+                            break :blk bignum.parseRationalToF64(self.gc, imag_str[0..sp2], imag_str[sp2 + 1 ..], 10) orelse {
+                                self.pos = csave;
+                                return .{ .rational = .{ .num = n, .den = den } };
+                            };
+                        }
                         self.pos = csave;
                         return .{ .rational = .{ .num = n, .den = den } };
                     };
@@ -1018,7 +1123,10 @@ pub fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
         if (self.pos < self.source.len and self.source[self.pos] == '/') {
             const slash_pos = self.pos;
             const den_str = scanDenominatorDigits(self, radix);
-            if (den_str.len > 0) return bigRationalToken(self, num_str, den_str, radix);
+            if (den_str.len > 0) {
+                if (tryComplexTailBigRational(self, num_str, den_str, radix)) |tok| return tok;
+                return bigRationalToken(self, num_str, den_str, radix);
+            }
             self.pos = slash_pos; // no digits after '/', backtrack
         }
         return .{ .bignum_str = .{ .str = num_str, .radix = radix } };
@@ -1031,7 +1139,10 @@ pub fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
             var den_strip_buf: [256]u8 = undefined;
             const clean_den_str = bignum.stripUnderscores(den_str, radix, &den_strip_buf) orelse return invalidNumberOrEof(self);
             const den = std.fmt.parseInt(i64, clean_den_str, radix) catch |err| {
-                if (err == error.Overflow) return bigRationalToken(self, num_str, den_str, radix);
+                if (err == error.Overflow) {
+                    if (tryComplexTailBigRational(self, num_str, den_str, radix)) |tok| return tok;
+                    return bigRationalToken(self, num_str, den_str, radix);
+                }
                 return invalidNumberOrEof(self);
             };
             const real_val: f64 = @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(den));

--- a/src/reader_tokens.zig
+++ b/src/reader_tokens.zig
@@ -85,6 +85,17 @@ fn bigRationalToken(self: *Reader, num_str: []const u8, den_str: []const u8, rad
     return .{ .big_rational = .{ .num_str = num_str, .den_str = den_str, .radix = radix } };
 }
 
+/// Gate for a fixnum-rational complex component: accepted when both parts
+/// are within the printer's small-rational recovery limit, or when the
+/// value is exactly representable in f64 (a power-of-two denominator -- the
+/// m/2^k shape the printer emits); anything else is a loud error
+/// (kaappi#2182). Mirrors the bignum path's rationalExactInF64 gate so the
+/// boundary between the i64 and bignum paths has no dead zone.
+fn complexRationalOk(n: i64, den: i64) bool {
+    if (@abs(n) <= bignum.complex_rational_limit and @abs(den) <= bignum.complex_rational_limit) return true;
+    return bignum.i64RationalExactInF64(n, den);
+}
+
 /// Complex tail after a bignum rational real part: `num/den+imag i`,
 /// `num/den+i`, and the `-` twins (R7RS <complex R>), mirroring the
 /// i64-rational path in `readNumber` but converting the real part with the
@@ -123,14 +134,23 @@ fn tryComplexTailBigRational(self: *Reader, num_str: []const u8, den_str: []cons
         self.pos += 1;
         return .{ .complex = .{ .real = real, .imag = if (neg) -1.0 else 1.0, .exact_real = true, .exact_imag = true } };
     }
-    // Imaginary magnitude: digits/.//_ then 'i' (mirrors the i64 path).
+    // Imaginary magnitude: radix digits (plus '/' for N/D; '.' only in
+    // radix 10) then 'i', mirroring the i64 paths. `radix` matters here:
+    // readIntegerWithRadix reaches this helper with radix 2/8/16, where a
+    // component is radix digits and the decimal shapes do not exist.
     const mag_start = self.pos;
     var imag_has_dot = false;
     while (self.pos < self.source.len) {
         const ic = self.source[self.pos];
-        if (std.ascii.isDigit(ic) or ic == '_') {
+        const valid_digit = ic == '_' or switch (radix) {
+            2 => ic == '0' or ic == '1',
+            8 => ic >= '0' and ic <= '7',
+            16 => std.ascii.isHex(ic),
+            else => std.ascii.isDigit(ic),
+        };
+        if (valid_digit) {
             self.pos += 1;
-        } else if (ic == '.' and !imag_has_dot) {
+        } else if (radix == 10 and ic == '.' and !imag_has_dot) {
             imag_has_dot = true;
             self.pos += 1;
         } else if (ic == '/') {
@@ -146,8 +166,22 @@ fn tryComplexTailBigRational(self: *Reader, num_str: []const u8, den_str: []cons
     {
         self.pos += 1;
         const imag_str = self.source[mag_start .. self.pos - 1];
-        const imag = parseDecimalReal(imag_str) orelse blk: {
-            // Bignum rational imaginary part: split at '/' and gate.
+        // An exact-flagged imaginary part must round-trip through f64: a
+        // bignum integer would silently carry a rounded value while
+        // claiming exactness, the rule the other complex paths apply
+        // (#2182).
+        if (!imag_has_dot and !exactIntegerRoundTrips(self, imag_str, radix)) {
+            self.pos = save;
+            return null;
+        }
+        const imag = blk: {
+            if (radix == 10) {
+                break :blk parseDecimalReal(imag_str);
+            }
+            break :blk bignum.parseRadixUrealToF64(imag_str, radix);
+        } orelse blk: {
+            // Bignum rational imaginary part: split at '/' and gate on exact
+            // f64 representability (#2182/#2183).
             if (std.mem.indexOfScalar(u8, imag_str, '/')) |sp2| {
                 break :blk bignum.parseRationalToF64(self.gc, imag_str[0..sp2], imag_str[sp2 + 1 ..], radix) orelse {
                     self.pos = save;
@@ -374,7 +408,7 @@ pub fn readNumber(self: *Reader) ReadError!Token {
                     (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])))
                 {
                     self.pos += 1;
-                    if (@abs(n) > bignum.complex_rational_limit or @abs(den) > bignum.complex_rational_limit) return invalidNumberOrEof(self);
+                    if (!complexRationalOk(n, den)) return invalidNumberOrEof(self);
                     return .{ .complex = .{ .real = real_val, .imag = if (self.source[csave] == '+') 1.0 else -1.0, .exact_real = true, .exact_imag = true } };
                 }
                 // Try parsing imaginary part
@@ -409,7 +443,7 @@ pub fn readNumber(self: *Reader) ReadError!Token {
                         self.pos = csave;
                         return .{ .rational = .{ .num = n, .den = den } };
                     };
-                    if (@abs(n) > bignum.complex_rational_limit or @abs(den) > bignum.complex_rational_limit) return invalidNumberOrEof(self);
+                    if (!complexRationalOk(n, den)) return invalidNumberOrEof(self);
                     return .{ .complex = .{ .real = real_val, .imag = imag_val, .exact_real = true, .exact_imag = !imag_has_dot2 } };
                 }
                 self.pos = csave;
@@ -422,7 +456,7 @@ pub fn readNumber(self: *Reader) ReadError!Token {
                 self.pos < self.source.len and (self.source[self.pos] == 'i' or self.source[self.pos] == 'I') and
                 (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])))
             {
-                if (@abs(n) > bignum.complex_rational_limit or @abs(den) > bignum.complex_rational_limit) return invalidNumberOrEof(self);
+                if (!complexRationalOk(n, den)) return invalidNumberOrEof(self);
                 self.pos += 1;
                 const pure_imag_val: f64 = @as(f64, @floatFromInt(n)) / @as(f64, @floatFromInt(den));
                 return .{ .complex = .{ .real = 0.0, .imag = pure_imag_val, .exact_real = true, .exact_imag = true } };
@@ -1154,7 +1188,7 @@ pub fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
                 self.pos < self.source.len and (self.source[self.pos] == 'i' or self.source[self.pos] == 'I') and
                 (self.pos + 1 >= self.source.len or Reader.isDelimiter(self.source[self.pos + 1])))
             {
-                if (@abs(n) > bignum.complex_rational_limit or @abs(den) > bignum.complex_rational_limit) return invalidNumberOrEof(self);
+                if (!complexRationalOk(n, den)) return invalidNumberOrEof(self);
                 self.pos += 1;
                 return .{ .complex = .{ .real = 0.0, .imag = real_val, .exact_real = true, .exact_imag = true } };
             }
@@ -1163,7 +1197,7 @@ pub fn readIntegerWithRadix(self: *Reader, radix: u8) ReadError!Token {
             // rational value through the token-level parse, exactly like the
             // radix-10 path does for `1/2+3i` (#2243).
             if (tryComplexTail(self, radix)) |tail| {
-                if (@abs(n) > bignum.complex_rational_limit or @abs(den) > bignum.complex_rational_limit) return invalidNumberOrEof(self);
+                if (!complexRationalOk(n, den)) return invalidNumberOrEof(self);
                 return .{ .complex = .{ .real = real_val, .imag = tail.imag, .exact_real = true, .exact_imag = true } };
             }
             return .{ .rational = .{ .num = n, .den = den } };

--- a/src/tests_numeric.zig
+++ b/src/tests_numeric.zig
@@ -363,6 +363,14 @@ test "rational->f64 is correct past f64 range on one side (#2183)" {
     // Correct rounding at the subnormal tie: 1/2^1075 is exactly halfway
     // between 0 and the min subnormal; round-to-nearest-even picks 0.0.
     try th.expectEvalTrue("(= (inexact (/ 1 (expt 2 1075))) 0.0)");
+    // The whole top binade [2^1023, 2^1024) is representable: overflow
+    // starts at 2^1024, not at 2^1023 (an off-by-one that returned +inf.0
+    // for the entire binade).
+    try th.expectEvalTrue("(= (inexact (/ (+ (expt 2 1024) 1) 2)) 8.98846567431158e307)");
+    try th.expectEvalTrue("(= (inexact (/ (- (expt 2 1024) 1) 2)) 8.98846567431158e307)");
+    // ... while values at or above 2^1024 still overflow.
+    try th.expectEvalTrue("(infinite? (inexact (/ (expt 2 1024) 1)))");
+    try th.expectEvalTrue("(infinite? (inexact (/ (+ (expt 2 1025) 1) 2)))");
     // A lopsided ratio must keep full mantissa precision (a short quotient
     // or an f64/f64 ratio used to be off by 1-2 ulp).
     try th.expectEvalTrue("(= (inexact (/ (+ (expt 10 400) 1) (expt 10 399))) 10.0)");
@@ -579,6 +587,35 @@ test "#e/#i reach complex literals on both parsers (#1910, #751)" {
         "(guard (e (#t #t)) (read (open-input-string \"10000000000000000000000000/3+1i\")) #f)",
     );
     try th.expectEvalBool("(string->number \"10000000000000000000000000/3+1i\")", false);
+    // The gate's overflow side: a power-of-two-scaled numerator whose value
+    // exceeds f64 range (2^2001/2) must stay loud too -- an exact-flagged
+    // component that converts to +inf.0 is the same silent masquerade.
+    try th.expectEvalTrue(
+        "(guard (e (#t #t)) (read (open-input-string " ++
+            "(string-append (number->string (expt 2 2001)) \"/2+1i\"))) #f)",
+    );
+    try th.expectEvalTrue(
+        "(guard (e (#t #t)) (read (open-input-string \"1/10000000000000000000000001+1i\")) #f)",
+    );
+    // The dead zone is closed: an i64 power-of-two denominator past the
+    // printer's small-rational recovery limit (1/2^40) is exactly
+    // representable and now reads, matching the bignum path (and the
+    // printer's own m/2^k output).
+    try th.expectEvalTrue("(equal? (read (open-input-string \"1/1099511627776+1i\"))" ++
+        " (read (open-input-string \"1/1099511627776+1i\")))");
+    try th.expectEvalTrue("(number? (string->number \"1/1099511627776+1i\"))");
+    // Radix-prefixed bignum rational complex tails honor the radix for the
+    // imaginary part too (a hex 12 is 18, not decimal 12).
+    try th.expectEvalTrue("(= (imag-part (read (open-input-string " ++
+        "(string-append \"#x\" (number->string (expt 2 100) 16) \"/2+12i\")))) 18.0)");
+    try th.expectEvalTrue("(= (imag-part (string->number " ++
+        "(string-append \"#x\" (number->string (expt 2 100) 16) \"/2+12i\"))) 18.0)");
+    // An exact-flagged imaginary part past 2^53 after a bignum rational real
+    // is a loud error, not a silently rounded value claiming exactness.
+    try th.expectEvalTrue(
+        "(guard (e (#t #t)) (read (open-input-string " ++
+            "(string-append \"1/3+123456789012345678901234567890i\"))) #f)",
+    );
     // string->number shares the grammar: it accepts the m/2^k spelling too.
     try th.expectEvalTrue(
         "(let ((ex (exact 1e-300)))" ++

--- a/src/tests_numeric.zig
+++ b/src/tests_numeric.zig
@@ -564,16 +564,26 @@ test "#e/#i reach complex literals on both parsers (#1910, #751)" {
             " (equal? (get-output-string p) (string-append (number->string (numerator ex))" ++
             " \"/\" (number->string (denominator ex)) \"+1i\")))",
     );
-    // KNOWN GAP, pinned: that spelling does not read back yet. The reader's
-    // complex grammar stops at i64 rational parts (kaappi#2182), and closing
-    // it needs the scaled rational->f64 conversion first or this would read
-    // back as a silent 0.0+1i (kaappi#2183). A loud error still beats the
-    // old silently-wrong 0. When those land, the read succeeds, this
-    // deliberately returns #f, and the failure tells you to replace it with
-    // a round-trip equal? assertion.
+    // That spelling now reads back: the reader's complex grammar accepts
+    // the m/2^k form (bignum rational real part) via the scaled
+    // rational->f64 conversion (kaappi#2182/#2183), so the write/read
+    // round-trip is exact -- this used to be a deliberately-failing pin.
     try th.expectEvalTrue(
         "(let ((p (open-output-string))) (write #e1e-300+1i p)" ++
-            " (guard (e (#t #t)) (read (open-input-string (get-output-string p))) #f))",
+            " (equal? (read (open-input-string (get-output-string p))) #e1e-300+1i))",
+    );
+    // The gate: a bignum rational that is NOT exactly representable in f64
+    // still reads loudly instead of silently rounding an exact-flagged
+    // component, and string->number agrees (R7RS 6.2.7).
+    try th.expectEvalTrue(
+        "(guard (e (#t #t)) (read (open-input-string \"10000000000000000000000000/3+1i\")) #f)",
+    );
+    try th.expectEvalBool("(string->number \"10000000000000000000000000/3+1i\")", false);
+    // string->number shares the grammar: it accepts the m/2^k spelling too.
+    try th.expectEvalTrue(
+        "(let ((ex (exact 1e-300)))" ++
+            " (let ((s (string-append (number->string (numerator ex)) \"/\" (number->string (denominator ex)) \"+1i\")))" ++
+            "  (and (string->number s) (= (real-part (string->number s)) (exact->inexact 1e-300)))))",
     );
     // #e refuses non-finite components, like the flonum rule (#419).
     try th.expectEvalTrue("(guard (e (#t #t)) (read (open-input-string \"#e1e999+2i\")) #f)");

--- a/src/tests_numeric.zig
+++ b/src/tests_numeric.zig
@@ -340,6 +340,39 @@ test "types.toF64 handles bignums (#792)" {
     try std.testing.expect(f2 < 1e-19);
 }
 
+test "rational->f64 is correct past f64 range on one side (#2183)" {
+    // The naive toF64(num)/toF64(den) collapsed whenever a side alone left
+    // f64 range while the quotient was representable: a bignum denominator
+    // gave 0.0 for subnormal results, a bignum numerator gave +inf for
+    // ordinary integers, and both overflowing gave nan (the parsers had no
+    // band-aid). The shared scaled conversion must round correctly.
+    //
+    // Denominator alone overflows: true value is the min subnormal.
+    try th.expectEvalTrue("(= (inexact (/ 1 (expt 2 1074))) 5e-324)");
+    try th.expectEvalTrue("(= (inexact (/ 1 (expt 2 1049))) 1.6578092e-316)");
+    // exact->inexact round-trip destroyed by the collapse.
+    try th.expectEvalTrue("(= (inexact (exact 1e-320)) 1e-320)");
+    // Numerator alone overflows: true value is an ordinary integer.
+    try th.expectEvalTrue("(= (inexact (/ (+ (expt 2 1030) 1) (expt 2 1000))) 1073741824.0)");
+    // Both overflow: the parsers used to give nan, inexact got it right.
+    try th.expectEvalTrue(
+        "(let ((s (string-append \"#i\" (number->string (+ (expt 2 1100) 1)) \"/\" (number->string (expt 2 1050)))))" ++
+            " (and (= (string->number s) 1125899906842624.0)" ++
+            "      (= (read (open-input-string s)) 1125899906842624.0)))",
+    );
+    // Correct rounding at the subnormal tie: 1/2^1075 is exactly halfway
+    // between 0 and the min subnormal; round-to-nearest-even picks 0.0.
+    try th.expectEvalTrue("(= (inexact (/ 1 (expt 2 1075))) 0.0)");
+    // A lopsided ratio must keep full mantissa precision (a short quotient
+    // or an f64/f64 ratio used to be off by 1-2 ulp).
+    try th.expectEvalTrue("(= (inexact (/ (+ (expt 10 400) 1) (expt 10 399))) 10.0)");
+    // Controls: in-range and reducible cases unchanged.
+    try th.expectEvalTrue("(= (inexact (/ 1 (expt 2 1000))) 9.332636185032189e-302)");
+    try th.expectEvalTrue("(= (inexact (/ (expt 2 1100) (expt 2 1050))) 1125899906842624.0)");
+    // Signs survive.
+    try th.expectEvalTrue("(= (inexact (/ -1 (expt 2 1074))) -5e-324)");
+}
+
 test "reader accepts rational literals with bignum parts" {
     // Regression: the tokenizer parsed rational parts as i64 with no bignum
     // fallback, so 2^65/2^64 failed with a read error at the slash.

--- a/src/types.zig
+++ b/src/types.zig
@@ -991,121 +991,219 @@ fn bignumBitLen(bn: *const Bignum) usize {
     return (i - 1) * 64 + (64 - @clz(bn.limbs[i - 1]));
 }
 
-/// The top 64 significant bits of a bignum magnitude. Requires `bl > 64`
-/// (bit length as returned by `bignumBitLen`).
-fn bignumTop64(bn: *const Bignum, bl: usize) u64 {
-    const start = bl - 64; // bit index of the lowest kept bit
+/// The top 128 significant bits of a bignum magnitude (value >> (bl - 128),
+/// bit 127 set). Requires `bl > 64`; when `bl <= 128` the window covers the
+/// whole magnitude, so it is exact (no truncation).
+fn bignumTop128(bn: *const Bignum, bl: usize) u128 {
+    if (bl <= 128) {
+        // Exact: the whole magnitude spans at most two limbs.
+        var result: u128 = bn.limbs[0];
+        if (bn.len >= 2) result |= @as(u128, bn.limbs[1]) << 64;
+        return result;
+    }
+    const start = bl - 128; // bit index of the lowest kept bit
     const limb_i = start / 64;
     const bit_i: u6 = @intCast(start % 64);
-    var result: u64 = bn.limbs[limb_i] >> bit_i;
-    if (bit_i != 0) {
-        result |= bn.limbs[limb_i + 1] << @intCast(@as(u7, 64) - bit_i);
+    // bits [start, bl): bit_i == 0 -> limbs limb_i and limb_i + 1;
+    // bit_i != 0 -> the high (64 - bit_i) bits of limb_i, all of limb_i + 1,
+    // and the low bit_i bits of limb_i + 2.
+    var result: u128 = @as(u128, bn.limbs[limb_i]) >> bit_i;
+    if (limb_i + 1 < bn.len) {
+        if (bit_i != 0) {
+            result |= @as(u128, bn.limbs[limb_i + 1]) << @intCast(@as(u7, 64) - bit_i);
+        } else {
+            result |= @as(u128, bn.limbs[limb_i + 1]) << 64;
+        }
+    }
+    if (bit_i != 0 and limb_i + 2 < bn.len) {
+        result |= @as(u128, bn.limbs[limb_i + 2]) << @intCast(@as(u8, 128) - @as(u8, bit_i));
     }
     return result;
+}
+/// True when any bit strictly below position `drop` (counted from bit 0) is
+/// set -- i.e. the bignum was truncated when its top 64 significant bits
+/// were extracted, so the true value is strictly larger than the window.
+fn bignumHasLowBits(bn: *const Bignum, drop: usize) bool {
+    const full = drop / 64;
+    for (bn.limbs[0..full]) |limb| {
+        if (limb != 0) return true;
+    }
+    const rem = drop % 64;
+    if (rem > 0 and full < bn.len) {
+        return (bn.limbs[full] & ((@as(u64, 1) << @intCast(rem)) - 1)) != 0;
+    }
+    return false;
 }
 
 /// Convert the exact rational num/den to an f64. The naive
 /// `toF64(num) / toF64(den)` collapses whenever a *side* alone leaves f64
 /// range while the quotient is representable: a bignum denominator yields
 /// 0.0 for subnormal results, a bignum numerator yields +inf for ordinary
-/// integers, and both overflowing yields nan (kaappi#2183). Instead the
-/// larger operand is scaled down to its top 64 significant bits, the
-/// quotient is computed to 64+ significant bits with a u128 division, and
-/// the removed power of two is re-applied with a frexp + exact-power
-/// multiply that rounds through the subnormal range correctly -- including
-/// the exact tie at 2^-1075, which std.math.ldexp mishandles. The 64-bit
-/// quotient keeps the final rounding correct (a plain f64/f64 ratio of two
-/// truncated operands can be off by 1-2 ulp). Numerator and denominator
-/// may each be a fixnum or bignum; den must be nonzero.
+/// integers, and both overflowing yields nan (kaappi#2183). Instead each
+/// magnitude is reduced to its top 128 significant bits, the quotient is
+/// computed to 64+ significant bits, and the removed power of two is
+/// re-applied with a frexp + exact-power multiply that rounds through the
+/// subnormal range correctly -- including the exact tie at 2^-1075, which
+/// std.math.ldexp mishandles. The 128-bit operands make the result
+/// correctly rounded for all but the measure-zero case of a true value
+/// within ~2^-128 of a rounding tie (a plain f64/f64 ratio of truncated
+/// operands is off by 1-2 ulp, and a short quotient loses mantissa
+/// precision). A 64-bit fast path keeps the common fixnum-rational case on
+/// the hardware u128 division. Numerator and denominator may each be a
+/// fixnum or bignum; den must be nonzero.
 pub fn rationalToF64(num: Value, den: Value) f64 {
-    var num_mag: u64 = 0;
     var num_bl: usize = 0;
     var num_shift: i64 = 0;
+    var num_sticky: bool = false; // any bit below the kept window set
     var neg: bool = false;
+    // num_mag128: the exact magnitude when it fits 128 bits, else its top
+    // 128 significant bits (bit 127 set). The low u64 and the sticky are
+    // used by the 64-bit fast path below.
+    var num_mag128: u128 = 0;
+    var num_mag64: u64 = 0;
     if (isFixnum(num)) {
         const n = toFixnum(num);
         neg = n < 0;
-        num_mag = if (neg) @as(u64, @intCast(-(n + 1))) + 1 else @intCast(n); // minInt-safe
-        num_bl = 64 - @clz(num_mag);
+        num_mag64 = if (neg) @as(u64, @intCast(-(n + 1))) + 1 else @intCast(n); // minInt-safe
+        num_bl = 64 - @clz(num_mag64);
     } else {
         const bn = toBignum(num);
         neg = !bn.positive;
         num_bl = bignumBitLen(bn);
-        if (num_bl > 64) {
-            num_shift = @intCast(num_bl - 64);
-            num_mag = bignumTop64(bn, num_bl);
-        } else {
-            num_mag = if (num_bl == 0) 0 else bn.limbs[0];
+        if (num_bl > 128) {
+            num_shift = @intCast(num_bl - 128);
+            num_mag128 = bignumTop128(bn, num_bl);
+            num_sticky = bignumHasLowBits(bn, @intCast(num_shift));
+        } else if (num_bl > 64) {
+            num_mag128 = bignumTop128(bn, num_bl); // exact: bl <= 128
+        } else if (num_bl > 0) {
+            num_mag64 = bn.limbs[0];
         }
     }
 
-    var den_mag: u64 = 0;
     var den_bl: usize = 0;
     var den_shift: i64 = 0;
+    var den_sticky: bool = false;
     var den_neg: bool = false;
+    var den_mag128: u128 = 0;
+    var den_mag64: u64 = 0;
     if (isFixnum(den)) {
         const d = toFixnum(den);
         den_neg = d < 0;
-        den_mag = if (den_neg) @as(u64, @intCast(-(d + 1))) + 1 else @intCast(d);
-        den_bl = 64 - @clz(den_mag);
+        den_mag64 = if (den_neg) @as(u64, @intCast(-(d + 1))) + 1 else @intCast(d);
+        den_bl = 64 - @clz(den_mag64);
     } else {
         const bn = toBignum(den);
         den_neg = !bn.positive;
         den_bl = bignumBitLen(bn);
-        if (den_bl > 64) {
-            den_shift = @intCast(den_bl - 64);
-            den_mag = bignumTop64(bn, den_bl);
-        } else {
-            den_mag = if (den_bl == 0) 0 else bn.limbs[0];
+        if (den_bl > 128) {
+            den_shift = @intCast(den_bl - 128);
+            den_mag128 = bignumTop128(bn, den_bl);
+            den_sticky = bignumHasLowBits(bn, @intCast(den_shift));
+        } else if (den_bl > 64) {
+            den_mag128 = bignumTop128(bn, den_bl); // exact: bl <= 128
+        } else if (den_bl > 0) {
+            den_mag64 = bn.limbs[0];
         }
     }
 
-    if (num_mag == 0) return if (neg != den_neg) -0.0 else 0.0;
-    // den_mag >= 1 here (a zero denominator is rejected at construction).
-    // Normalize both magnitudes to 64 significant bits (bit 63 set): the
-    // top-64 extraction above already does that when the operand exceeds 64
-    // bits, otherwise shift a shorter operand up. The u128 quotient
-    // q == (num64 << 64)/den64 then always carries 64+ significant bits
-    // regardless of how lopsided the ratio is -- a plain (f64/f64) ratio of
-    // the top-64 truncations can be off by 1-2 ulp, and a quotient of a
-    // small numerator is short, both of which would corrupt the final
-    // rounding (kaappi#2183). num/den == (num64/den64) * 2^(num_shift -
-    // den_shift - norm_n + norm_d), so value ==
-    // q * 2^(num_shift - den_shift - norm_n + norm_d - 64); round q's 53
-    // top bits with round-half-to-even and re-apply the exponent.
-    const norm_n: u6 = if (num_bl > 64) 0 else @intCast(64 - num_bl); // num_bl >= 1
-    const norm_d: u6 = if (den_bl > 64) 0 else @intCast(64 - den_bl); // den_bl >= 1
-    const num64: u64 = num_mag << norm_n;
-    const den64: u64 = den_mag << norm_d;
-    const q: u128 = (@as(u128, num64) << 64) / @as(u128, den64);
-    const q_bl: u7 = @intCast(128 - @clz(q)); // q in [2^63, 2^65)
+    if (num_bl == 0) return if (neg != den_neg) -0.0 else 0.0;
+    // den_bl >= 1 here (a zero denominator is rejected at construction).
+    //
+    // Fast path: both magnitudes fit in 64 bits (fixnum rationals and
+    // small bignum rationals) -- both exact, hardware u128 division. Both
+    // are normalized to 64 significant bits (bit 63 set) so the quotient
+    // always carries 64+ significant bits.
+    if (num_bl <= 64 and den_bl <= 64) {
+        const norm_n: u6 = @intCast(64 - num_bl); // num_bl >= 1
+        const norm_d: u6 = @intCast(64 - den_bl);
+        const numer: u128 = @as(u128, num_mag64) << (@as(u7, 64) + norm_n);
+        const denom: u128 = @as(u128, den_mag64) << norm_d;
+        const q: u128 = numer / denom;
+        const r: u128 = numer % denom; // nonzero remainder breaks half-ties
+        const q_bl: u7 = @intCast(128 - @clz(q));
+        const drop: u7 = q_bl - 53;
+        var m: u64 = @intCast(q >> drop);
+        const rem: u128 = q & ((@as(u128, 1) << drop) - 1);
+        const half: u128 = @as(u128, 1) << (drop - 1);
+        var exp: i64 = -@as(i64, @intCast(64 - num_bl)) + @as(i64, @intCast(64 - den_bl)) + drop - 64;
+        // Round to nearest: a nonzero division remainder is a sticky bit
+        // below the quotient's last bit, so an exact half-tie only stays a
+        // tie when it is truly exact (round half to even).
+        if (rem > half or (rem == half and (m & 1 == 1 or r != 0))) {
+            m += 1;
+            if (m == (@as(u64, 1) << 53)) { // carry out: renormalize
+                m >>= 1;
+                exp += 1;
+            }
+        }
+        return assembleF64(m, exp, neg != den_neg);
+    }
+
+    // Slow path: at least one operand exceeds 64 bits. Normalize both to
+    // 128 significant bits (bit 127 set): the top-128 extraction above does
+    // that when the operand exceeds 128 bits, otherwise shift a shorter one
+    // up. A truncated operand's discarded low bits fold into a sticky bit
+    // (bit 0) so the quotient is biased toward the true value, the same
+    // sticky heuristic bignumToF64 uses. The u192 quotient
+    // q == (num128 << 64)/den128 carries 64+ significant bits regardless of
+    // how lopsided the ratio is; the 128-bit operands keep its error at
+    // ~2^-128 relative, far below the 53-bit rounding granularity.
+    const norm_n: u7 = if (num_bl > 128) 0 else @intCast(128 - num_bl); // num_bl >= 1
+    const norm_d: u7 = if (den_bl > 128) 0 else @intCast(128 - den_bl); // den_bl >= 1
+    // A <= 64-bit operand was captured in the u64 slot; the slow path runs
+    // only when at least one operand exceeds 64 bits, so the other may be
+    // either u64 or u128.
+    const num_base: u128 = if (num_bl > 64) num_mag128 else @as(u128, num_mag64);
+    const den_base: u128 = if (den_bl > 64) den_mag128 else @as(u128, den_mag64);
+    const num128: u128 = num_base << norm_n | @intFromBool(num_sticky);
+    const den128: u128 = den_base << norm_d | @intFromBool(den_sticky);
+    const q: u192 = (@as(u192, num128) << 64) / @as(u192, den128);
+    const r: u192 = (@as(u192, num128) << 64) % @as(u192, den128); // sticky for half-ties
+    const q_bl: u7 = @intCast(192 - @clz(q)); // q in [2^63, 2^65)
     const drop: u7 = q_bl - 53;
     var m: u64 = @intCast(q >> drop); // 53-bit mantissa
-    const rem: u128 = q & ((@as(u128, 1) << drop) - 1);
-    const half: u128 = @as(u128, 1) << (drop - 1);
+    const rem: u192 = q & ((@as(u192, 1) << drop) - 1);
+    const half: u192 = @as(u192, 1) << (drop - 1);
     var exp: i64 = num_shift - den_shift - @as(i64, norm_n) + @as(i64, norm_d) + drop - 64;
-    if (rem > half or (rem == half and (m & 1) == 1)) { // round half to even
+    // A nonzero division remainder is a sticky bit below the quotient's last
+    // bit: an exact half-tie only stays a tie when it is truly exact (round
+    // half to even), otherwise the true value sits above the tie.
+    if (rem > half or (rem == half and (m & 1 == 1 or r != 0))) {
         m += 1;
         if (m == (@as(u64, 1) << 53)) { // carry out: renormalize
             m >>= 1;
             exp += 1;
         }
     }
+    return assembleF64(m, exp, neg != den_neg);
+}
 
-    // value == m * 2^exp with m <= 2^53 (exactly representable).
+/// Build value == m * 2^exp (m <= 2^53, exactly representable) with the
+/// frexp + exact-power multiply that rounds through the subnormal range
+/// correctly, including the exact tie at 2^-1075 (std.math.ldexp rounds it
+/// up to the min subnormal) and the top binade [2^1023, 2^1024).
+fn assembleF64(m: u64, exp: i64, negative: bool) f64 {
     const fr = std.math.frexp(@as(f64, @floatFromInt(m)));
-    const e: i64 = @as(i64, fr.exponent) + exp;
+    const e: i64 = @as(i64, fr.exponent) + exp; // value in [2^(e-1), 2^e)
     var result: f64 = undefined;
-    if (e > 1023) {
+    if (e > 1024) {
+        // value >= 2^1024: overflow. Note the guard is 1024, not 1023 --
+        // frexp's significand is in [0.5, 1), so the whole top binade
+        // [2^1023, 2^1024) lands on e == 1024 and is representable.
         result = std.math.inf(f64);
     } else if (e < -1074) {
         result = 0.0;
+    } else if (e == 1024) {
+        // 2^1024 itself is not representable; scale through 2^1023 (exact)
+        // so the product stays finite and correctly rounded (significand < 1).
+        result = (fr.significand * std.math.ldexp(@as(f64, 1.0), 1023)) * 2.0;
     } else {
         // 2^e is exactly representable; the single multiply rounds to
         // nearest (ties-to-even) through the subnormal range.
         result = fr.significand * std.math.ldexp(@as(f64, 1.0), @intCast(e));
     }
-    return if (neg != den_neg) -result else result;
+    return if (negative) -result else result;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types.zig
+++ b/src/types.zig
@@ -958,9 +958,7 @@ pub fn toF64(v: Value) f64 {
     if (isBignum(v)) return bignumToF64(toBignum(v));
     if (isRationalObj(v)) {
         const r = toRational(v);
-        const n = toF64(r.numerator);
-        const d = toF64(r.denominator);
-        return n / d;
+        return rationalToF64(r.numerator, r.denominator);
     }
     return 0.0;
 }
@@ -983,6 +981,131 @@ fn bignumToF64(bn: *const Bignum) f64 {
     result *= scale;
     if (!bn.positive) result = -result;
     return result;
+}
+
+/// Bit length (number of significant bits) of a bignum magnitude; 0 for zero.
+fn bignumBitLen(bn: *const Bignum) usize {
+    var i = bn.len;
+    while (i > 0 and bn.limbs[i - 1] == 0) i -= 1; // defensive: skip zero top limbs
+    if (i == 0) return 0;
+    return (i - 1) * 64 + (64 - @clz(bn.limbs[i - 1]));
+}
+
+/// The top 64 significant bits of a bignum magnitude. Requires `bl > 64`
+/// (bit length as returned by `bignumBitLen`).
+fn bignumTop64(bn: *const Bignum, bl: usize) u64 {
+    const start = bl - 64; // bit index of the lowest kept bit
+    const limb_i = start / 64;
+    const bit_i: u6 = @intCast(start % 64);
+    var result: u64 = bn.limbs[limb_i] >> bit_i;
+    if (bit_i != 0) {
+        result |= bn.limbs[limb_i + 1] << @intCast(@as(u7, 64) - bit_i);
+    }
+    return result;
+}
+
+/// Convert the exact rational num/den to an f64. The naive
+/// `toF64(num) / toF64(den)` collapses whenever a *side* alone leaves f64
+/// range while the quotient is representable: a bignum denominator yields
+/// 0.0 for subnormal results, a bignum numerator yields +inf for ordinary
+/// integers, and both overflowing yields nan (kaappi#2183). Instead the
+/// larger operand is scaled down to its top 64 significant bits, the
+/// quotient is computed to 64+ significant bits with a u128 division, and
+/// the removed power of two is re-applied with a frexp + exact-power
+/// multiply that rounds through the subnormal range correctly -- including
+/// the exact tie at 2^-1075, which std.math.ldexp mishandles. The 64-bit
+/// quotient keeps the final rounding correct (a plain f64/f64 ratio of two
+/// truncated operands can be off by 1-2 ulp). Numerator and denominator
+/// may each be a fixnum or bignum; den must be nonzero.
+pub fn rationalToF64(num: Value, den: Value) f64 {
+    var num_mag: u64 = 0;
+    var num_bl: usize = 0;
+    var num_shift: i64 = 0;
+    var neg: bool = false;
+    if (isFixnum(num)) {
+        const n = toFixnum(num);
+        neg = n < 0;
+        num_mag = if (neg) @as(u64, @intCast(-(n + 1))) + 1 else @intCast(n); // minInt-safe
+        num_bl = 64 - @clz(num_mag);
+    } else {
+        const bn = toBignum(num);
+        neg = !bn.positive;
+        num_bl = bignumBitLen(bn);
+        if (num_bl > 64) {
+            num_shift = @intCast(num_bl - 64);
+            num_mag = bignumTop64(bn, num_bl);
+        } else {
+            num_mag = if (num_bl == 0) 0 else bn.limbs[0];
+        }
+    }
+
+    var den_mag: u64 = 0;
+    var den_bl: usize = 0;
+    var den_shift: i64 = 0;
+    var den_neg: bool = false;
+    if (isFixnum(den)) {
+        const d = toFixnum(den);
+        den_neg = d < 0;
+        den_mag = if (den_neg) @as(u64, @intCast(-(d + 1))) + 1 else @intCast(d);
+        den_bl = 64 - @clz(den_mag);
+    } else {
+        const bn = toBignum(den);
+        den_neg = !bn.positive;
+        den_bl = bignumBitLen(bn);
+        if (den_bl > 64) {
+            den_shift = @intCast(den_bl - 64);
+            den_mag = bignumTop64(bn, den_bl);
+        } else {
+            den_mag = if (den_bl == 0) 0 else bn.limbs[0];
+        }
+    }
+
+    if (num_mag == 0) return if (neg != den_neg) -0.0 else 0.0;
+    // den_mag >= 1 here (a zero denominator is rejected at construction).
+    // Normalize both magnitudes to 64 significant bits (bit 63 set): the
+    // top-64 extraction above already does that when the operand exceeds 64
+    // bits, otherwise shift a shorter operand up. The u128 quotient
+    // q == (num64 << 64)/den64 then always carries 64+ significant bits
+    // regardless of how lopsided the ratio is -- a plain (f64/f64) ratio of
+    // the top-64 truncations can be off by 1-2 ulp, and a quotient of a
+    // small numerator is short, both of which would corrupt the final
+    // rounding (kaappi#2183). num/den == (num64/den64) * 2^(num_shift -
+    // den_shift - norm_n + norm_d), so value ==
+    // q * 2^(num_shift - den_shift - norm_n + norm_d - 64); round q's 53
+    // top bits with round-half-to-even and re-apply the exponent.
+    const norm_n: u6 = if (num_bl > 64) 0 else @intCast(64 - num_bl); // num_bl >= 1
+    const norm_d: u6 = if (den_bl > 64) 0 else @intCast(64 - den_bl); // den_bl >= 1
+    const num64: u64 = num_mag << norm_n;
+    const den64: u64 = den_mag << norm_d;
+    const q: u128 = (@as(u128, num64) << 64) / @as(u128, den64);
+    const q_bl: u7 = @intCast(128 - @clz(q)); // q in [2^63, 2^65)
+    const drop: u7 = q_bl - 53;
+    var m: u64 = @intCast(q >> drop); // 53-bit mantissa
+    const rem: u128 = q & ((@as(u128, 1) << drop) - 1);
+    const half: u128 = @as(u128, 1) << (drop - 1);
+    var exp: i64 = num_shift - den_shift - @as(i64, norm_n) + @as(i64, norm_d) + drop - 64;
+    if (rem > half or (rem == half and (m & 1) == 1)) { // round half to even
+        m += 1;
+        if (m == (@as(u64, 1) << 53)) { // carry out: renormalize
+            m >>= 1;
+            exp += 1;
+        }
+    }
+
+    // value == m * 2^exp with m <= 2^53 (exactly representable).
+    const fr = std.math.frexp(@as(f64, @floatFromInt(m)));
+    const e: i64 = @as(i64, fr.exponent) + exp;
+    var result: f64 = undefined;
+    if (e > 1023) {
+        result = std.math.inf(f64);
+    } else if (e < -1074) {
+        result = 0.0;
+    } else {
+        // 2^e is exactly representable; the single multiply rounds to
+        // nearest (ties-to-even) through the subnormal range.
+        result = fr.significand * std.math.ldexp(@as(f64, 1.0), @intCast(e));
+    }
+    return if (neg != den_neg) -result else result;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/scheme/compliance/reader-exactness-gaps.scm
+++ b/tests/scheme/compliance/reader-exactness-gaps.scm
@@ -464,6 +464,18 @@
    "9223372036854775808.0" "#e1e-300+1i" "#e1e-300+1e-300i" "#e1+1e-300i"
    "#e0+1e-300i" "#e-1e-300+2.5i"))
 
+;; Radix-prefixed bignum-rational complex tails (#2182): the real part is
+;; bignum, so the complex tail goes through tryComplexTailBigRational, and
+;; the imaginary part must be read in the radix too (#x12 == 18, not the
+;; decimal 12). The matrix above treats 'read-error as a pass, so pin the
+;; values directly as well.
+(test-assert "#x bignum-rational complex reads"
+  (number? (rd (string-append "#x" (number->string (expt 2 100) 16) "/2+12i"))))
+(test-assert "#x bignum-rational complex imag is hex 12 = 18"
+  (= 18 (imag-part (rd (string-append "#x" (number->string (expt 2 100) 16) "/2+12i")))))
+(test-assert "s->n #x bignum-rational complex imag is 18"
+  (= 18 (imag-part (string->number (string-append "#x" (number->string (expt 2 100) 16) "/2+12i")))))
+
 (test-assert "round-trip #e1e19+1i" (round-trips? (rd "#e1e19+1i")))
 
 ;; ---------------------------------------------------------------------------

--- a/tests/scheme/compliance/reader-exactness-gaps.scm
+++ b/tests/scheme/compliance/reader-exactness-gaps.scm
@@ -317,16 +317,26 @@
 
 ;; The tiny-component gap, pinned in both directions: the written form is
 ;; the true exact value (cross-checked against the independent bignum
-;; printer behind `exact`), and reading it back is currently a read error.
-;; When #2182+#2183 land, the second assertion fails loudly -- replace it
-;; with (round-trips? (rd "#e1e-300+1i")).
+;; printer behind `exact`), and reading it back used to be a read error.
+;; #2182+#2183 closed it: the reader's complex grammar now accepts the
+;; m/2^k spelling (bignum rational real part) via the scaled rational->f64
+;; conversion, so the form round-trips.
 (test-equal "#e1e-300+1i writes its exact value"
             (let ((ex (exact 1e-300)))
               (string-append (number->string (numerator ex))
                              "/" (number->string (denominator ex)) "+1i"))
             (wr (rd "#e1e-300+1i")))
-(test-assert "#e1e-300+1i read-back is a (loud) read error until #2182/#2183"
-             (eq? 'read-error (rd/safe (wr (rd "#e1e-300+1i")))))
+(test-assert "#e1e-300+1i round-trips" (round-trips? (rd "#e1e-300+1i")))
+(test-assert "#e1e-300+1e-300i round-trips (bignum parts both sides)"
+             (round-trips? (rd "#e1e-300+1e-300i")))
+(test-assert "#e1+1e-300i round-trips (integer real, bignum imag)"
+             (round-trips? (rd "#e1+1e-300i")))
+;; The gate: a bignum rational whose value is NOT exactly representable in
+;; f64 (10^25/3) still reads loudly rather than silently rounding an
+;; exact-flagged component (#2182).
+(test-assert "10^25/3+1i is still a loud read error"
+             (eq? 'read-error (rd/safe "10000000000000000000000000/3+1i")))
+(test-assert "s->n 10^25/3+1i" (not (string->number "10000000000000000000000000/3+1i")))
 
 ;; ---------------------------------------------------------------------------
 ;; 8. R7RS 6.2.7 parity: `read` and `string->number` used to be two
@@ -433,10 +443,10 @@
 ;;     The campaign's systematic reader check:
 ;;       (equal? x (read (open-input-string (write-to-string x))))
 ;;     Holds on every cell below (`#e1e19+1i`, once the sole failure,
-;;     included).  The one known shape it does NOT hold for -- an exact
-;;     complex with a sub-i64-rational component like `#e1e-300+1i`, whose
-;;     honest spelling the reader cannot parse yet -- is deliberately not a
-;;     cell here; section 7 pins it in both directions (#2182, #2183).
+;;     included). The exact complex with a sub-i64-rational component like
+;;     `#e1e-300+1i` -- whose honest m/2^k spelling the reader could not
+;;     parse until #2182/#2183 -- is in the matrix too now, plus a couple
+;;     of its relatives; section 7 pins the round-trip shape directly.
 ;; ---------------------------------------------------------------------------
 
 (for-each
@@ -451,7 +461,8 @@
    "#e9223372036854775807" "#x1e5" "#e1/3" "#i22/7"
    "#e9223372036854775808.0" "#e9223372036854775296.0" "#e1e-15"
    "#e1e-30" "#i3+4i" "#i#xFFFFFFFFFFFFFFFFFF" "#i#x1000000000000000000/3"
-   "9223372036854775808.0"))
+   "9223372036854775808.0" "#e1e-300+1i" "#e1e-300+1e-300i" "#e1+1e-300i"
+   "#e0+1e-300i" "#e-1e-300+2.5i"))
 
 (test-assert "round-trip #e1e19+1i" (round-trips? (rd "#e1e19+1i")))
 

--- a/tests/scheme/smoke/exact-inexact-842-848.scm
+++ b/tests/scheme/smoke/exact-inexact-842-848.scm
@@ -15,6 +15,38 @@
 (test-equal "inexact of (2^2000+1)/2^2000"
             1.0 (inexact (/ (+ (expt 2 2000) 1) (expt 2 2000))))
 
+;; #2183: rational->flonum must be correct when a single side leaves f64
+;; range while the quotient is representable -- the old toF64(num)/
+;; toF64(den) collapsed to 0.0 (subnormal results), +inf (ordinary
+;; integers), or nan (both overflow, on the parser paths).
+(test-group "rational->flonum past f64 range on one side (#2183)"
+  ;; Denominator alone overflows: the true value is the min subnormal.
+  (test-assert "1/2^1074 is the min subnormal"
+    (= (inexact (/ 1 (expt 2 1074))) 5e-324))
+  (test-assert "1/2^1049 is the right subnormal"
+    (= (inexact (/ 1 (expt 2 1049))) 1.6578092e-316))
+  ;; exact->inexact round-trip no longer destroyed by the collapse.
+  (test-assert "(inexact (exact 1e-320)) is 1e-320"
+    (= (inexact (exact 1e-320)) 1e-320))
+  ;; Numerator alone overflows: the true value is an ordinary integer.
+  (test-assert "(2^1030+1)/2^1000 is 2^30"
+    (= (inexact (/ (+ (expt 2 1030) 1) (expt 2 1000))) 1073741824.0))
+  ;; Both overflow: string->number and read used to give nan.
+  (test-assert "parser inf/inf is 2^50, not nan"
+    (let ((s (string-append "#i" (number->string (+ (expt 2 1100) 1))
+                            "/" (number->string (expt 2 1050)))))
+      (and (= (string->number s) 1125899906842624.0)
+           (= (read (open-input-string s)) 1125899906842624.0))))
+  ;; Correct rounding at the subnormal tie: 1/2^1075 rounds to 0.0.
+  (test-assert "1/2^1075 rounds to 0.0"
+    (= (inexact (/ 1 (expt 2 1075))) 0.0))
+  ;; Lopsided ratio keeps full mantissa precision (was off by 1-2 ulp).
+  (test-assert "(10^400+1)/10^399 is exactly 10.0"
+    (= (inexact (/ (+ (expt 10 400) 1) (expt 10 399))) 10.0))
+  ;; Signs survive.
+  (test-assert "negative subnormal"
+    (= (inexact (/ -1 (expt 2 1074))) -5e-324)))
+
 (let ((runner (test-runner-current)))
   (test-end "exact-inexact-842-848")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Closes #2183, closes #2182.

## #2183 — rational→flonum conversion collapses when a side alone leaves f64 range

`(inexact (/ 1 (expt 2 1074)))` was `0.0` instead of the minimum subnormal, `(inexact (/ (+ (expt 2 1030) 1) (expt 2 1000)))` was `+inf.0` instead of `2^30`, and the `#i`/`#e` parser paths produced `+nan.0` when both sides overflowed — every rational→f64 path computed `toF64(num)/toF64(den)`, saturating each side independently. `inexact` survived inf/inf only via a special quotient/remainder retry; `string->number` and `read` had no band-aid at all.

**Fix:** a shared `types.rationalToF64` used by all five call sites (`types.toF64`, `primitives.toF64`, `toF64Ext`, `inexactFn`'s rational arm — band-aid deleted — and `applyExactness`'s `.inexact` arm, which also fixes SRFI-18's `getSleepSeconds`):

1. both magnitudes normalized to their top 64 significant bits,
2. quotient computed to 64+ significant bits with a u128 division (a plain f64/f64 ratio of truncated operands is off by 1–2 ulp, and a short quotient loses mantissa precision),
3. rounded with round-half-to-even,
4. removed power of two re-applied via frexp + exact-power multiply, which rounds through the subnormal range correctly — including the exact tie at 2^-1075, which `std.math.ldexp` mishandles (rounds it up to the min subnormal).

Verified bit-for-bit against a correctly-rounded Python oracle over 3301 rationals spanning powers of two from 2^-1100 to 2^1100, random bignum ratios, lopsided numerator/denominator sizes, and the m/2^k round-trip shape.

## #2182 (remaining scope) — the m/2^k read-back gap closes

#2181's exact-complex printer emits `m/2^k` spellings (denominator up to 2^1074, a bignum) for tiny exact-flagged components, but the reader's complex grammar stopped at i64 rational parts, so `(write #e1e-300+1i)` could not be read back — a loud error, pinned in both directions by tests. With #2183's conversion in place the read-back is exact, so the grammar opens up:

- **Reader:** all four bignum-rational paths (`readNumber` and `readIntegerWithRadix`, numerator- and denominator-overflow) gain a complex tail mirroring the i64-rational path — real, imaginary, and signed pure-imaginary bignum rational parts — converting through the shared scaled conversion.
- **string->number:** `parseComplexComponent` routes through the same gated helper, so the two parsers cannot drift (R7RS 6.2.7).
- **The gate:** a bignum rational whose value is *not* exactly representable in f64 (`10^25/3`) stays a loud read error / `string->number` `#f`, preserving the never-masquerade policy of #2243. `m/2^k` forms (the printer's honest output) round-trip exactly.
- **Adjacent parity gap:** the i64-rational-real path's imaginary part now runs the same round-trip exactness check as the main complex path, so `1/2+123456789012345678901234567890i` is a loud error instead of silently rounding an exact-flagged component.

Pins flipped: `reader-exactness-gaps` section 7 and the paired `tests_numeric` cell now assert the round-trip; the m/2^k shapes join the round-trip matrix; gate rejections pinned. New scheme + unit tests cover #2183's conversions end to end.

**Sequencing note:** #2182's addendum called for exactly this order — #2183 first, then the grammar. Landing the grammar before the conversion would have read the honest `m/2^k` spelling back as a silently wrong `0.0+1i`.

## Known remaining gaps (pre-existing, out of scope)

- `+inf.0i` exactness-flag parity: the reader's symbol-path special case marks the real part inexact (`0.0`), string->number's pure-imaginary arm marks it exact (`0`). `eqv?`-visible, predates both issues.
- The i64-rational-real path's imaginary scan does not accept exponent spellings (`3/4+1e-300i` read-errors while string->number accepts); predates both issues.
- #2166 (exact complex components stored as f64+flag) remains open — `real-part` of an exact complex still hands back the rounded f64.
