### PR TITLE
Fix SRFI-178 bitvector-logical-shift shifting the wrong way (#2083)

### DIFF
--- a/lib/srfi/178.sld
+++ b/lib/srfi/178.sld
@@ -497,14 +497,17 @@
 
     ;; --- quasi-integer ops ------------------------------------------------
 
+    ;; A logical left shift moves bits toward lower indices (out[i] = bv[i + count])
+    ;; and a right shift toward upper indices (out[i] = bv[i - shift]); indices
+    ;; read outside the source are filled with bit (#2083).
     (define (bitvector-logical-shift bv count bit)
       (let* ((n (%len bv)) (b (%norm-bit bit)) (out (make-bytevector n b)))
         (if (>= count 0)
-            (do ((i (- n 1) (- i 1))) ((< i count) (%raw-make-bitvector out))
-              (bytevector-u8-set! out i (bitvector-ref/int bv (- i count))))
+            (do ((i 0 (+ i 1))) ((>= i (- n count)) (%raw-make-bitvector out))
+              (bytevector-u8-set! out i (bitvector-ref/int bv (+ i count))))
             (let ((shift (- count)))
-              (do ((i 0 (+ i 1))) ((>= i (- n shift)) (%raw-make-bitvector out))
-                (bytevector-u8-set! out i (bitvector-ref/int bv (+ i shift))))))))
+              (do ((i shift (+ i 1))) ((>= i n) (%raw-make-bitvector out))
+                (bytevector-u8-set! out i (bitvector-ref/int bv (- i shift))))))))
 
     (define (bitvector-count bit bv)
       (let ((b (%norm-bit bit)) (n (%len bv)))

--- a/tests/scheme/srfi/srfi178-audit.scm
+++ b/tests/scheme/srfi/srfi178-audit.scm
@@ -168,24 +168,22 @@
 ;;;  left shift (toward lower indices) when count>=0 or the right shift
 ;;;  (toward upper indices) when count<0. Newly vacated elements are filled
 ;;;  with bit."
-;;; The two assertions below are the SRFI's own test suite verbatim
-;;; (test/quasi-ints.scm lines 8-13).
 ;;; ------------------------------------------------------------------
 
-;; FAIL: #2083 (bitvector-logical-shift moves bits the wrong way for both signs)
-;; (test-equal "logical-shift +2 moves toward lower indices"
-;;             '(1 1 0 0) (L (bitvector-logical-shift (bitvector 1 0 1 1) 2 0)))
-;; FAIL: #2083
-;; (test-equal "logical-shift -2 moves toward upper indices, filling with the bit"
-;;             '(1 1 1 0) (L (bitvector-logical-shift (bitvector 1 0 1 1) -2 #t)))
-;; FAIL: #2083
-;; (test-equal "logical-shift +1 of (0 0 0 1)"
-;;             '(0 0 1 0) (L (bitvector-logical-shift (bitvector 0 0 0 1) 1 0)))
-;; FAIL: #2083
-;; (test-equal "logical-shift -1 of (1 0 0 0)"
-;;             '(0 1 0 0) (L (bitvector-logical-shift (bitvector 1 0 0 0) -1 0)))
+;; Regression, #2083: both sign branches were inverted, so a left shift
+;; moved bits toward higher indices and a right shift toward lower ones.
+;; The first two assertions are the SRFI's own test suite verbatim
+;; (test/quasi-ints.scm lines 8-13).
+(test-equal "logical-shift +2 moves toward lower indices"
+            '(1 1 0 0) (L (bitvector-logical-shift (bitvector 1 0 1 1) 2 0)))
+(test-equal "logical-shift -2 moves toward upper indices, filling with the bit"
+            '(1 1 1 0) (L (bitvector-logical-shift (bitvector 1 0 1 1) -2 #t)))
+(test-equal "logical-shift +1 of (0 0 0 1)"
+            '(0 0 1 0) (L (bitvector-logical-shift (bitvector 0 0 0 1) 1 0)))
+(test-equal "logical-shift -1 of (1 0 0 0)"
+            '(0 1 0 0) (L (bitvector-logical-shift (bitvector 1 0 0 0) -1 0)))
 
-;; Discriminating control: count 0 is the identity, and it is correct today.
+;; Discriminating control: count 0 is the identity.
 (test-equal "logical-shift 0 is the identity"
             '(1 0 1 1) (L (bitvector-logical-shift (bitvector 1 0 1 1) 0 0)))
 (test-equal "logical-shift by the full length leaves only the fill bit"

--- a/tests/scheme/srfi/srfi178.scm
+++ b/tests/scheme/srfi/srfi178.scm
@@ -136,8 +136,11 @@
 (test-equal "bitvector-andc2" '(0 1 0 0) (bitvector->list/int (bitvector-andc2 (bitvector 1 1 0 0) (bitvector 1 0 0 1))))
 
 ;;; --- quasi-integer ops ---
-(test-equal "bitvector-logical-shift: left" '(0 1 1 0) (bitvector->list/int (bitvector-logical-shift (bitvector 1 1 0 0) 1 0)))
-(test-equal "bitvector-logical-shift: right" '(1 0 0 0) (bitvector->list/int (bitvector-logical-shift (bitvector 1 1 0 0) -1 0)))
+;; count >= 0 shifts toward lower indices, count < 0 toward upper indices
+;; (the pre-#2083 code had both inverted; these values match the SRFI's own
+;; reference implementation).
+(test-equal "bitvector-logical-shift: left" '(1 0 0 0) (bitvector->list/int (bitvector-logical-shift (bitvector 1 1 0 0) 1 0)))
+(test-equal "bitvector-logical-shift: right" '(0 1 1 0) (bitvector->list/int (bitvector-logical-shift (bitvector 1 1 0 0) -1 0)))
 (test-equal "bitvector-count" 3 (bitvector-count 1 (bitvector 1 1 0 1)))
 (test-equal "bitvector-count-run" 2 (bitvector-count-run 1 (bitvector 1 1 0 1) 0))
 (test-equal "bitvector-if" '(1 0 1) (bitvector->list/int (bitvector-if (bitvector 1 0 1) (bitvector 1 1 1) (bitvector 0 0 0))))


### PR DESCRIPTION
## Summary

Fixes #2083: `bitvector-logical-shift` in `lib/srfi/178.sld` moved bits the wrong way for **both** signs, failing SRFI 178's own test suite.

The spec says `count>=0` is a logical **left** shift (toward lower indices, `out[i] = bvec[i + count]`) and `count<0` a logical **right** shift (toward upper indices, `out[i] = bvec[i - |count|]`), with vacated elements filled with `bit`. Both branches were inverted relative to the reference implementation's `%bitvector-left-shift` / `%bitvector-right-shift`:

- left branch wrote `out[i] = bv[i - count]` instead of `bv[i + count]`
- right branch wrote `out[i] = bv[i + |count|]` instead of `bv[i - |count|]`

The loop bounds were coupled to the wrong formulas, so they moved with the fix (left: `i` in `[0, n-count)`; right: `i` in `[|count|, n)`).

## Changes

- `lib/srfi/178.sld` — corrected both branches (the `count=0` path was already correct and is unchanged).
- `tests/scheme/srfi/srfi178-audit.scm` — enabled the 4 assertions that were disabled pending this fix (the first two are the SRFI's own `test/quasi-ints.scm` cases verbatim). The 2 discriminating controls (identity at count 0, full-length shift) still pass.
- `tests/scheme/srfi/srfi178.scm` — corrected the two `bitvector-logical-shift` values that had pinned the buggy behavior.

`bitvector-count-run` / `bitvector-first-bit` were verified byte-for-byte correct against the reference and left untouched, as were the spec-ambiguous `bitvector-pad` / `bitvector-pad-right` shrinking cases (not part of this issue).

## Verification

- Repros from the issue now produce the expected `(1 1 0 0)` and `(1 1 1 0)`.
- 1024 differential cases (16 patterns x 16 counts x 4 fill bits) agree with a direct translation of the reference implementation.
- `zig-out/bin/kaappi --lib-path lib tests/scheme/srfi/srfi178-audit.scm` -> 375 passes.
- `bash tests/scheme/run-all.sh` -> 2089 pass, 0 fail.
- `zig build test` passes; `zig fmt --check src/` passes.

## Checklist

- [x] `zig build test` passes
- [x] `zig fmt --check src/` passes
- [x] Scheme test suites pass (`bash tests/scheme/run-all.sh`)
- [x] New tests added for new behavior (4 previously-disabled audit assertions enabled; 2 conformance values corrected)
- [x] Documentation updated (if applicable) — none needed; `docs/audit-strategy.md` only references the issue number
