### PR TITLE
Persist #!fold-case across read calls on the same port

### DIFF
--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -1854,6 +1854,7 @@ fn readFromPeekByteOnly(gc: *@import("memory.zig").GC, port: *types.Port) Primit
     const source: [1]u8 = .{b};
     var reader = reader_mod.Reader.init(gc, &source);
     reader.mark_immutable = false;
+    reader.fold_case = port.fold_case; // a lone byte can't hold a #! directive, so no write-back
     defer reader.deinit();
     const maybe_datum = parseDatumForRead(&reader) catch |err| {
         if (err == reader_mod.ReadError.OutOfMemory) return PrimitiveError.OutOfMemory;
@@ -1889,12 +1890,17 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
 
         var reader = reader_mod.Reader.init(gc, source);
         reader.mark_immutable = false;
+        reader.fold_case = port.fold_case;
         defer reader.deinit();
         const maybe_datum = parseDatumForRead(&reader) catch |err| {
             if (err == reader_mod.ReadError.OutOfMemory) return PrimitiveError.OutOfMemory;
             return raiseReadError(gc, err);
         };
         const datum = maybe_datum orelse return types.EOF;
+        // The parse saw the whole remaining source, so its final flag is
+        // the port's state from this point on (a directive may have been
+        // consumed before the datum) — persist it for the next call (#2175).
+        port.fold_case = reader.fold_case;
         // Advance string_pos by amount consumed
         port.string_pos += reader.pos;
         if (combined.items.len > 0 and reader.pos > 0) {
@@ -1948,10 +1954,15 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
             var reader = reader_mod.Reader.init(gc, buf.items);
             reader.mark_immutable = false;
             reader.incomplete_input = true;
+            reader.fold_case = port.fold_case;
             defer reader.deinit();
             const result = parseDatumForRead(&reader);
             if (result) |maybe_datum| {
                 if (maybe_datum) |datum| {
+                    // The datum parse succeeded, so any directive was fully
+                    // inside the consumed span: persist the final flag for
+                    // the next call on this port (#2175).
+                    port.fold_case = reader.fold_case;
                     // Save unconsumed bytes back to port buffer.
                     const remaining = buf.items[reader.pos..];
                     if (remaining.len > 0) {
@@ -2027,12 +2038,16 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
 
     var reader = reader_mod.Reader.init(gc, buf.items);
     reader.mark_immutable = false;
+    reader.fold_case = port.fold_case;
     defer reader.deinit();
     const maybe_datum = parseDatumForRead(&reader) catch |err| {
         if (err == reader_mod.ReadError.OutOfMemory) return PrimitiveError.OutOfMemory;
         return raiseReadError(gc, err);
     };
     const datum = maybe_datum orelse return types.EOF;
+    // Whole remaining input parsed: persist the final flag for the next
+    // call on this port (#2175).
+    port.fold_case = reader.fold_case;
 
     const remaining = buf.items[reader.pos..];
     if (remaining.len > 0) {

--- a/src/tests_gc_tracing.zig
+++ b/src/tests_gc_tracing.zig
@@ -1325,14 +1325,14 @@ test "gc tracing: heap-struct field inventory is unchanged" {
     // Value-bearing, so they add no marking or sweeping obligation -- only
     // this re-pin.
     expectFields(types.Port, &.{
-        "header",         "fd",              "is_input",       "is_output",
-        "is_open",        "input_closed",    "output_closed",  "name",
-        "owns_name",      "peek_byte",       "peek_extra",     "peek_extra_len",
-        "is_string_port", "string_data",     "string_pos",     "string_out_buf",
-        "string_out_len", "string_out_cap",  "string_out_pos", "is_binary",
-        "read_buf",       "read_buf_len",    "random_gen",     "nonblocking",
-        "write_buf",      "write_buf_start", "write_buf_len",  "fd_state",
-        "custom_backend", "transcode",
+        "header",         "fd",             "is_input",        "is_output",
+        "is_open",        "input_closed",   "output_closed",   "name",
+        "owns_name",      "peek_byte",      "peek_extra",      "peek_extra_len",
+        "fold_case",      "is_string_port", "string_data",     "string_pos",
+        "string_out_buf", "string_out_len", "string_out_cap",  "string_out_pos",
+        "is_binary",      "read_buf",       "read_buf_len",    "random_gen",
+        "nonblocking",    "write_buf",      "write_buf_start", "write_buf_len",
+        "fd_state",       "custom_backend", "transcode",
     });
     // `has_protocol` (kaappi#1974) is a plain bool and `identity`
     // (kaappi#1932) a plain u64 -- neither is Value-bearing, so they add no

--- a/src/types_port.zig
+++ b/src/types_port.zig
@@ -25,6 +25,12 @@ pub const Port = struct {
     peek_byte: ?u8, // lead byte lookahead for peek-char
     peek_extra: [3]u8 = .{ 0, 0, 0 }, // UTF-8 continuation bytes from peek-char
     peek_extra_len: u2 = 0,
+    /// R7RS 7.1.1 `#!fold-case` reader-directive state, persisted across
+    /// separate `(read port)` calls on the same port: each call's fresh
+    /// Reader is seeded from this and writes its final flag back after a
+    /// successful parse (#2175). A plain bool, so it needs no GC tracing
+    /// (forEachValue skips it) and no write barrier when mutated.
+    fold_case: bool = false,
     // String port fields:
     is_string_port: bool = false,
     string_data: ?[]const u8 = null, // for input string ports (owned copy)

--- a/tests/scheme/compliance/fold-case-persists.scm
+++ b/tests/scheme/compliance/fold-case-persists.scm
@@ -1,0 +1,93 @@
+;; Regression test for #2175: a #!fold-case directive does not persist
+;; across separate `(read port)` calls on the same port.
+;;
+;; R7RS 7.1.1: a #!fold-case directive affects reading "from the same
+;; port" from the point it appears on. readDatumFn built a fresh Reader per
+;; call, so the flag died with it: the first (read p) folded, the second
+;; did not. The mode now lives on the Port (Port.fold_case), seeding each
+;; call's Reader and written back after a successful parse.
+;;
+;; Both port kinds readDatumFn serves are covered: fd-backed file ports
+;; (the incremental refill path) and string ports (whole-source path), plus
+;; the 4096-byte chunk-boundary straddle that the refill machinery must not
+;; regress.
+
+(import (scheme base) (scheme read) (scheme write) (scheme file)
+        (scheme time) (scheme process-context) (srfi 64))
+
+(test-begin "fold-case-persists")
+
+;; --- fixture plumbing (same temp-dir dance as reader-port-refill-gaps) ---
+
+(define tmp-dir
+  (let loop ((names '("TMPDIR" "TMP" "TEMP")))
+    (if (null? names)
+        "/tmp"
+        (let ((v (get-environment-variable (car names))))
+          (if (and v (> (string-length v) 0))
+              (if (char=? (string-ref v (- (string-length v) 1)) #\/)
+                  (substring v 0 (- (string-length v) 1))
+                  v)
+              (loop (cdr names)))))))
+
+(define fixture-file
+  (string-append tmp-dir "/kaappi-fold-case-"
+                 (number->string (current-jiffy)) ".scm"))
+
+(define (write-fixture text)
+  (if (file-exists? fixture-file) (delete-file fixture-file))
+  (call-with-output-file fixture-file
+    (lambda (p) (write-string text p))))
+
+;; The repro from the issue: the directive and the first datum arrive in the
+;; same read call, the second datum in a separate call. Both must fold.
+(test-equal "fold-case persists across read calls on a file port"
+  '(foo bar)
+  (let ()
+    (write-fixture "#!fold-case\nFOO\nBAR\n")
+    (let* ((p (open-input-file fixture-file))
+           (r (list (read p) (read p))))
+      (close-port p)
+      (delete-file fixture-file)
+      r)))
+
+;; String ports take the whole-source path in readDatumFn (a different
+;; fresh-Reader site); the mode must persist there too.
+(test-equal "fold-case persists across read calls on a string port"
+  '(foo bar)
+  (let ((p (open-input-string "#!fold-case\nFOO\nBAR\n")))
+    (list (read p) (read p))))
+
+;; #!no-fold-case resets the mode, and the reset also persists.
+(test-equal "no-fold-case reset persists across read calls"
+  '(foo BAR BAZ)
+  (let ((p (open-input-string "#!fold-case\nFOO\n#!no-fold-case\nBAR\nBAZ\n")))
+    (list (read p) (read p) (read p))))
+
+;; A directive that appears after the first datum applies from that point
+;; on — the folded state must not leak backwards either.
+(test-equal "mid-stream directive applies to later read calls"
+  '(FOO bar)
+  (let ((p (open-input-string "FOO #!fold-case\nBAR\n")))
+    (list (read p) (read p))))
+
+;; Directive straddling the 4096-byte read chunk boundary (it starts at
+;; byte 4089 of the file). The within-call refill must still fold the first
+;; datum — the saw_directive buffer-keep behavior — and the folded state
+;; must then carry into the next read call.
+(test-equal "boundary-straddling directive persists to next read"
+  '(foo bar)
+  (let ()
+    (write-fixture (string-append (make-string 4089 #\space)
+                                  "#!fold-case\nFOO\nBAR\n"))
+    (let* ((p (open-input-file fixture-file))
+           (r (list (read p) (read p))))
+      (close-port p)
+      (delete-file fixture-file)
+      r)))
+
+(if (file-exists? fixture-file) (delete-file fixture-file))
+
+(let ((runner (test-runner-current)))
+  (test-end "fold-case-persists")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Fixes #2175.

R7RS 7.1.1 says a `#!fold-case` directive affects reading "from the same port" from the point it appears on. Kaappi applied it only within the current read call: `readDatumFn` builds a fresh `Reader` per call, so `Reader.fold_case` lived and died with it.

## Change

- Add `Port.fold_case` (`src/types_port.zig`) — a plain bool, no GC tracing or write-barrier obligation.
- In `readDatumFn` (`src/primitives_io.zig`), seed each call's fresh Reader from `port.fold_case` and write the Reader's final flag back after a successful parse, at all four Reader sites:
  - string-port path (seeds + writes back),
  - incremental fd path (seeds + writes back on datum return),
  - post-EOF path (seeds + writes back on datum return),
  - peek-byte-only path (seeds only — a lone byte cannot hold a directive).
- `#!no-fold-case` resets the same field, so it persists too.
- Re-pin the `Port` field inventory in `src/tests_gc_tracing.zig` (compiler-enforced; bool adds no GC obligation).

The within-one-call chunk-boundary handling (`Reader.saw_directive`) is untouched: a directive split across the 4096-byte boundary is still re-parsed from the kept buffer, and the write-back only fires once a datum parse succeeds.

## Tests

New `tests/scheme/compliance/fold-case-persists.scm` (SRFI-64): file port, string port, `#!no-fold-case` reset, mid-stream directive, and a boundary-straddling directive persisting to the next read call. The three discriminating cases fail without the fix and pass with it.

- `zig build test` — 1710 pass, 7 skip
- `zig build test -Dgc-stress=true` — 1788/1788 pass
- `bash tests/scheme/run-all.sh` — 695 scheme files + 1395 R7RS tests, 0 fail
- Existing `fold-case-unicode.scm` (8) and `reader-port-refill-gaps.scm` (53) still pass.

Signed-off-by: Baiju Muthukadan <baiju.m.mail@gmail.com>