### PR TITLE
Make syntax-rules count-consistency depth-aware; seed empty-match depths (Fixes #682, #2082)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   consumes it, and `instantiateTemplate` rejects a list binding used with no
   ellipsis at all. Legitimate uses — nested `((a ...) ...)`, consecutive
   `(x ... ...)` flattening, SRFI 149's excess-ellipsis replication with a
-  deeper sibling — are untouched.
+  deeper sibling — are untouched. The repeat-count check is depth-aware:
+  R7RS requires equal counts only among variables matched at the same
+  depth, so SRFI 149's excess case with an empty or shorter driver now zips
+  (min counts) like the SRFI's reference implementation instead of
+  erroring, and a nested variable that matched zero repetitions —
+  `((b ...) ...)` against `()` — reports its true depth rather than the
+  placeholder 1.
 
 - **`syntax-rules` now rejects a pattern with more than one ellipsis in one
   list or vector pattern** (#2082). The R7RS 4.3.2 `<pattern>` grammar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,11 +93,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `(x ... ...)` flattening, SRFI 149's excess-ellipsis replication with a
   deeper sibling — are untouched. The repeat-count check is depth-aware:
   R7RS requires equal counts only among variables matched at the same
-  depth, so SRFI 149's excess case with an empty or shorter driver now zips
-  (min counts) like the SRFI's reference implementation instead of
-  erroring, and a nested variable that matched zero repetitions —
-  `((b ...) ...)` against `()` — reports its true depth rather than the
-  placeholder 1.
+  depth (validated per depth, so a shallower sibling cannot mask a
+  same-depth mismatch among the drivers), and SRFI 149's excess case with
+  an empty or shorter driver zips (min counts) like the SRFI's reference
+  implementation instead of erroring. A nested variable that matched zero
+  repetitions — `((b ...) ...)` against `()` — reports its true depth
+  rather than the placeholder 1 (including inside vector patterns, which
+  match through list semantics), and under-use is checked structurally, so
+  an empty outer match can no longer skip the inner template and let a
+  depth mismatch silently expand to `()`.
 
 - **`syntax-rules` now rejects a pattern with more than one ellipsis in one
   list or vector pattern** (#2082). The R7RS 4.3.2 `<pattern>` grammar

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -784,7 +784,15 @@ fn matchEllipsis(elem_pattern: Value, rest_pattern: Value, input: Value, literal
             if (count.* >= MAX_BINDINGS) return false;
             bindings[count.*].name = elem_var_names[vi];
             bindings[count.*].value = types.NIL;
-            bindings[count.*].depth = 1;
+            // Seed the binding's depth from the PATTERN structure rather
+            // than the constant 1: the per-repetition `sub.depth + 1` update
+            // below never runs when the ellipsis matches ZERO repetitions,
+            // so a nested variable -- ((b ...) ...) matched against () --
+            // would otherwise stay at depth 1, under-reporting its true
+            // depth and breaking the depth/driver checks in
+            // instantiateEllipsis (kaappi#682). `nesting + 1` agrees with
+            // the per-repetition formula whenever a repetition does run.
+            bindings[count.*].depth = @intCast((patternVarNesting(elem_pattern, elem_var_names[vi], literals) orelse 0) + 1);
             bindings[count.*].is_list = true;
             bindings[count.*].ellipsis_count = 0;
             count.* += 1;
@@ -864,6 +872,62 @@ fn collectPatternVars(pattern: Value, literals: []const Value, names: *[128][]co
             collectPatternVars(elem, literals, names, count, overflowed);
         }
     }
+}
+
+/// Ellipsis nesting depth of pattern variable `name` inside `pattern` — the
+/// number of inner ellipses enclosing it, 0 for a variable directly in the
+/// pattern (so its full pattern depth is `1 + nesting` at the ellipsis site
+/// that created the binding). Mirrors the ellipsis detection in
+/// matchListPattern: an element followed by an ellipsis token is one level
+/// deeper; the ellipsis-escape `(... ...)` contributes no variable. Used to
+/// seed ellipsis bindings whose match was EMPTY (see matchEllipsis).
+fn patternVarNesting(pattern: Value, name: []const u8, literals: []const Value) ?u32 {
+    return patternVarNestingWalk(pattern, name, literals, 0);
+}
+
+fn patternVarNestingWalk(pattern: Value, name: []const u8, literals: []const Value, nesting: u32) ?u32 {
+    if (types.isSymbol(pattern)) {
+        const nm = types.symbolName(pattern);
+        if (isEllipsis(nm)) return null;
+        for (literals) |lit| {
+            if (types.isSymbol(lit) and std.mem.eql(u8, types.symbolName(lit), nm)) return null;
+        }
+        if (std.mem.eql(u8, nm, "_")) return null;
+        if (std.mem.eql(u8, nm, name)) return nesting;
+        return null;
+    }
+    if (types.isPair(pattern)) {
+        var p = pattern;
+        while (types.isPair(p)) {
+            const elem = types.car(p);
+            const rest = types.cdr(p);
+            // (elem ...): an inner ellipsis — variables in elem sit one
+            // level deeper; the tail after the ellipsis stays at this level.
+            if (types.isPair(rest)) {
+                const maybe_ell = types.car(rest);
+                if (types.isSymbol(maybe_ell) and isEllipsis(types.symbolName(maybe_ell))) {
+                    if (patternVarNestingWalk(elem, name, literals, nesting + 1)) |d| return d;
+                    p = types.cdr(rest);
+                    continue;
+                }
+            }
+            if (patternVarNestingWalk(elem, name, literals, nesting)) |d| return d;
+            p = rest;
+        }
+        // Dotted tail: (a ... . z) — walk the final non-pair at this level.
+        if (p != types.NIL) {
+            if (patternVarNestingWalk(p, name, literals, nesting)) |d| return d;
+        }
+        return null;
+    }
+    if (types.isVector(pattern)) {
+        const vec = types.toObject(pattern).as(types.Vector);
+        for (vec.data) |elem| {
+            if (patternVarNestingWalk(elem, name, literals, nesting)) |d| return d;
+        }
+        return null;
+    }
+    return null;
 }
 
 // Provenance marker for pattern-var values substituted into a NESTED

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -880,8 +880,10 @@ fn collectPatternVars(pattern: Value, literals: []const Value, names: *[128][]co
 /// that created the binding). Mirrors the ellipsis detection in
 /// matchListPattern: an element followed by an ellipsis token is one level
 /// deeper; the ellipsis-escape `(... ...)` contributes no variable. Used to
-/// seed ellipsis bindings whose match was EMPTY (see matchEllipsis).
-fn patternVarNesting(pattern: Value, name: []const u8, literals: []const Value) ?u32 {
+/// seed ellipsis bindings whose match was EMPTY (see matchEllipsis) and to
+/// compute the template consumption depth of a binding in
+/// expander_instantiate.zig.
+pub fn patternVarNesting(pattern: Value, name: []const u8, literals: []const Value) ?u32 {
     return patternVarNestingWalk(pattern, name, literals, 0);
 }
 
@@ -921,9 +923,21 @@ fn patternVarNestingWalk(pattern: Value, name: []const u8, literals: []const Val
         return null;
     }
     if (types.isVector(pattern)) {
+        // Vector patterns match through list semantics (matchPattern
+        // vectorToList's them before matchListPattern), so an element
+        // followed by the ellipsis identifier inside the vector data sits
+        // one level deeper — same shape as the list branch above.
         const vec = types.toObject(pattern).as(types.Vector);
-        for (vec.data) |elem| {
-            if (patternVarNestingWalk(elem, name, literals, nesting)) |d| return d;
+        var i: usize = 0;
+        while (i < vec.data.len) : (i += 1) {
+            if (i + 1 < vec.data.len and types.isSymbol(vec.data[i + 1]) and
+                isEllipsis(types.symbolName(vec.data[i + 1])))
+            {
+                if (patternVarNestingWalk(vec.data[i], name, literals, nesting + 1)) |d| return d;
+                i += 1; // skip the ellipsis token
+                continue;
+            }
+            if (patternVarNestingWalk(vec.data[i], name, literals, nesting)) |d| return d;
         }
         return null;
     }

--- a/src/expander_instantiate.zig
+++ b/src/expander_instantiate.zig
@@ -623,36 +623,57 @@ fn sharesInnerEllipsisWithDriver(template: Value, candidate_name: []const u8, bi
 }
 
 /// Join a referenced binding into the repeat-count computation for this
-/// ellipsis run, enforcing R7RS count consistency only between bindings
-/// matched at the SAME ellipsis depth.
+/// ellipsis run, enforcing R7RS count consistency per pattern depth and
+/// deriving the run's repeat count as the minimum across depths.
 ///
-/// R7RS 4.3.2 (kaappi#78): pattern variables matched at the same depth and
-/// used under the same template ellipsis must have equal counts; a mismatch
-/// is a syntax error (and previously read uninitialized memory).
+/// R7RS 4.3.2 (kaappi#78): pattern variables matched at the same ellipsis
+/// depth and used under the same template ellipsis must have equal counts;
+/// a mismatch is a syntax error (and previously read uninitialized memory).
 ///
-/// SRFI 149 rule 2 (excess ellipsis): a variable matched SHALLOWER than the
-/// driver -- e.g. a depth-1 variable used at a depth-2 template position --
-/// is zipped against the driver's groups, so the run repeats min(counts)
-/// times and any surplus is dropped, exactly as the SRFI's reference
-/// implementation (chibi-scheme) maps the two. Before this check was
-/// depth-aware, an empty or shorter driver was rejected with
-/// EllipsisCountMismatch even though R7RS's count rule does not apply
-/// across depths (kaappi#682).
+/// SRFI 149 rule 2 (excess ellipsis): a variable matched SHALLOWER than
+/// the driver -- e.g. a depth-1 variable used at a depth-2 template
+/// position -- is zipped against the driver's groups, so the run repeats
+/// min(counts) times and any surplus is dropped, exactly as the SRFI's
+/// reference implementation (chibi-scheme) maps the two. Validating one
+/// count per depth before taking the minimum keeps the same-depth check
+/// order-independent: a shallower sibling can no longer mask a genuine
+/// same-depth mismatch among the deeper drivers by shrinking the shared
+/// repeat count first (kaappi#78).
 fn joinRepeatCount(
     repeat_count: *usize,
     count_set: *bool,
-    driver_depth: *u32,
+    depth_count: *[256]usize,
+    depth_seen: *[256]bool,
+    elem_template: Value,
+    literals: []const Value,
+    extra_ellipsis: u32,
+    b_name: []const u8,
     b_depth: u8,
     b_count: usize,
 ) ExpandError!void {
-    if (!count_set.*) {
-        repeat_count.* = b_count;
-        count_set.* = true;
-        driver_depth.* = b_depth;
-    } else if (b_depth == driver_depth.*) {
-        if (b_count != repeat_count.*) return error.EllipsisCountMismatch;
-    } else if (b_count < repeat_count.*) {
-        repeat_count.* = b_count;
+    // Under-use (R7RS 4.3.2 / SRFI 149 rule 1): a binding matched deeper
+    // than the template consumes it is a syntax error, not `()`. A direct
+    // reference is consumed by this ellipsis run (1 + extra_ellipsis
+    // consecutive ellipses); a reference under inner ellipses in
+    // elem_template sits deeper still. The consuming run's own check would
+    // catch this, but only if that run is instantiated — an outer ellipsis
+    // matching ZERO repetitions never reaches it, so under-use would
+    // silently expand to () (kaappi#682). Check the full consumption depth
+    // here, at the outermost run that references the binding.
+    const consumption = 1 + extra_ellipsis + (expander.patternVarNesting(elem_template, b_name, literals) orelse 0);
+    if (b_depth > consumption) return error.EllipsisDepthMismatch;
+
+    if (!depth_seen.*[b_depth]) {
+        depth_seen.*[b_depth] = true;
+        depth_count.*[b_depth] = b_count;
+        if (!count_set.*) {
+            repeat_count.* = b_count;
+            count_set.* = true;
+        } else if (b_count < repeat_count.*) {
+            repeat_count.* = b_count;
+        }
+    } else if (depth_count.*[b_depth] != b_count) {
+        return error.EllipsisCountMismatch;
     }
 }
 
@@ -686,17 +707,22 @@ fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bind
             }
         }
 
-        // Find the repeat count from ellipsis bindings referenced in elem_template.
-        // R7RS 4.3.2 requires pattern variables matched at the same ellipsis
-        // depth and used under the same template ellipsis to have equal counts
-        // (kaappi#78); SRFI 149's excess-ellipsis extension relaxes that across
-        // depths (see joinRepeatCount below). Bindings with depth > 1 (nested
-        // ellipses) participate too: their ellipsis_count at this level is the
-        // outer repetition count, and each iteration below unpacks them one
-        // level for the inner ellipsis to consume.
+        // Find the repeat count from ellipsis bindings referenced in
+        // elem_template. R7RS 4.3.2 requires pattern variables matched at
+        // the same ellipsis depth and used under the same template ellipsis
+        // to have equal counts (kaappi#78); SRFI 149's excess-ellipsis
+        // extension zips variables across depths (min counts), following the
+        // SRFI's reference implementation (chibi). Track one validated count
+        // per depth, then take the minimum across depths — order-independent,
+        // so a shallower sibling cannot mask a same-depth mismatch among the
+        // drivers (kaappi#78). Bindings with depth > 1 (nested ellipses)
+        // participate too: their ellipsis_count at this level is the outer
+        // repetition count, and each iteration below unpacks them one level
+        // for the inner ellipsis to consume.
+        var depth_count: [256]usize = @splat(0);
+        var depth_seen: [256]bool = @splat(false);
         var repeat_count: usize = 0;
         var count_set = false;
-        var driver_depth: u32 = 0;
         var referenced: [MAX_BINDINGS]bool = @splat(false);
         var indirect: [MAX_BINDINGS]bool = @splat(false);
 
@@ -721,10 +747,10 @@ fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bind
                 // under-using it errors.
                 if (b.depth > 1 + extra_ellipsis) return ExpandError.EllipsisDepthMismatch;
                 referenced[bi] = true;
-                try joinRepeatCount(&repeat_count, &count_set, &driver_depth, b.depth, b.ellipsis_count);
+                try joinRepeatCount(&repeat_count, &count_set, &depth_count, &depth_seen, elem_template, literals, extra_ellipsis, b.name, b.depth, b.ellipsis_count);
             } else if (b.depth > 1 and templateReferencesVar(elem_template, b.name)) {
                 referenced[bi] = true;
-                try joinRepeatCount(&repeat_count, &count_set, &driver_depth, b.depth, b.ellipsis_count);
+                try joinRepeatCount(&repeat_count, &count_set, &depth_count, &depth_seen, elem_template, literals, extra_ellipsis, b.name, b.depth, b.ellipsis_count);
             }
         }
 
@@ -732,7 +758,7 @@ fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bind
             if (b.is_list and !referenced[bi] and templateReferencesVar(elem_template, b.name)) {
                 if (sharesInnerEllipsisWithDriver(elem_template, b.name, bindings, &referenced)) {
                     referenced[bi] = true;
-                    try joinRepeatCount(&repeat_count, &count_set, &driver_depth, b.depth, b.ellipsis_count);
+                    try joinRepeatCount(&repeat_count, &count_set, &depth_count, &depth_seen, elem_template, literals, extra_ellipsis, b.name, b.depth, b.ellipsis_count);
                 } else {
                     indirect[bi] = true;
                 }

--- a/src/expander_instantiate.zig
+++ b/src/expander_instantiate.zig
@@ -622,6 +622,40 @@ fn sharesInnerEllipsisWithDriver(template: Value, candidate_name: []const u8, bi
         sharesInnerEllipsisWithDriver(tail, candidate_name, bindings, referenced);
 }
 
+/// Join a referenced binding into the repeat-count computation for this
+/// ellipsis run, enforcing R7RS count consistency only between bindings
+/// matched at the SAME ellipsis depth.
+///
+/// R7RS 4.3.2 (kaappi#78): pattern variables matched at the same depth and
+/// used under the same template ellipsis must have equal counts; a mismatch
+/// is a syntax error (and previously read uninitialized memory).
+///
+/// SRFI 149 rule 2 (excess ellipsis): a variable matched SHALLOWER than the
+/// driver -- e.g. a depth-1 variable used at a depth-2 template position --
+/// is zipped against the driver's groups, so the run repeats min(counts)
+/// times and any surplus is dropped, exactly as the SRFI's reference
+/// implementation (chibi-scheme) maps the two. Before this check was
+/// depth-aware, an empty or shorter driver was rejected with
+/// EllipsisCountMismatch even though R7RS's count rule does not apply
+/// across depths (kaappi#682).
+fn joinRepeatCount(
+    repeat_count: *usize,
+    count_set: *bool,
+    driver_depth: *u32,
+    b_depth: u8,
+    b_count: usize,
+) ExpandError!void {
+    if (!count_set.*) {
+        repeat_count.* = b_count;
+        count_set.* = true;
+        driver_depth.* = b_depth;
+    } else if (b_depth == driver_depth.*) {
+        if (b_count != repeat_count.*) return error.EllipsisCountMismatch;
+    } else if (b_count < repeat_count.*) {
+        repeat_count.* = b_count;
+    }
+}
+
 fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bindings: []Binding, intro_scope: u32, literals: []const Value, macro_keyword: ?[]const u8, globals: ?*std.StringHashMap(Value), macros: ?*const std.StringHashMap(Value)) (std.mem.Allocator.Error || ExpandError)!Value {
     // Per-iteration sub-binding scratch, hoisted out of the loop and written
     // field-by-field there: whole-struct assignment re-initializes or copies
@@ -653,12 +687,16 @@ fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bind
         }
 
         // Find the repeat count from ellipsis bindings referenced in elem_template.
-        // All referenced list bindings must have equal counts (R7RS). Bindings
-        // with depth > 1 (nested ellipses) participate too: their ellipsis_count
-        // at this level is the outer repetition count, and each iteration below
-        // unpacks them one level for the inner ellipsis to consume.
+        // R7RS 4.3.2 requires pattern variables matched at the same ellipsis
+        // depth and used under the same template ellipsis to have equal counts
+        // (kaappi#78); SRFI 149's excess-ellipsis extension relaxes that across
+        // depths (see joinRepeatCount below). Bindings with depth > 1 (nested
+        // ellipses) participate too: their ellipsis_count at this level is the
+        // outer repetition count, and each iteration below unpacks them one
+        // level for the inner ellipsis to consume.
         var repeat_count: usize = 0;
         var count_set = false;
+        var driver_depth: u32 = 0;
         var referenced: [MAX_BINDINGS]bool = @splat(false);
         var indirect: [MAX_BINDINGS]bool = @splat(false);
 
@@ -683,20 +721,10 @@ fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bind
                 // under-using it errors.
                 if (b.depth > 1 + extra_ellipsis) return ExpandError.EllipsisDepthMismatch;
                 referenced[bi] = true;
-                if (!count_set) {
-                    repeat_count = b.ellipsis_count;
-                    count_set = true;
-                } else if (b.ellipsis_count != repeat_count) {
-                    return ExpandError.EllipsisCountMismatch;
-                }
+                try joinRepeatCount(&repeat_count, &count_set, &driver_depth, b.depth, b.ellipsis_count);
             } else if (b.depth > 1 and templateReferencesVar(elem_template, b.name)) {
                 referenced[bi] = true;
-                if (!count_set) {
-                    repeat_count = b.ellipsis_count;
-                    count_set = true;
-                } else if (b.ellipsis_count != repeat_count) {
-                    return ExpandError.EllipsisCountMismatch;
-                }
+                try joinRepeatCount(&repeat_count, &count_set, &driver_depth, b.depth, b.ellipsis_count);
             }
         }
 
@@ -704,12 +732,7 @@ fn instantiateEllipsis(gc: *GC, elem_template: Value, rest_template: Value, bind
             if (b.is_list and !referenced[bi] and templateReferencesVar(elem_template, b.name)) {
                 if (sharesInnerEllipsisWithDriver(elem_template, b.name, bindings, &referenced)) {
                     referenced[bi] = true;
-                    if (!count_set) {
-                        repeat_count = b.ellipsis_count;
-                        count_set = true;
-                    } else if (b.ellipsis_count != repeat_count) {
-                        return ExpandError.EllipsisCountMismatch;
-                    }
+                    try joinRepeatCount(&repeat_count, &count_set, &driver_depth, b.depth, b.ellipsis_count);
                 } else {
                     indirect[bi] = true;
                 }

--- a/src/tests_ellipsis.zig
+++ b/src/tests_ellipsis.zig
@@ -171,3 +171,41 @@ test "syntax-rules: ellipsis-named literals and legal tail shapes survive #2082 
         \\  (equal? (nested (1 2 3) (4 5)) '(((1 2) 3) ((4) 5))))
     );
 }
+
+test "syntax-rules: SRFI 149 excess with empty/unequal drivers zips, not errors (#682)" {
+    // A depth-1 variable used at a depth-2 template position is zipped
+    // against the depth-2 driver (SRFI 149 rule 2, chibi reference impl):
+    // the outer run repeats min(counts) times. Before the count check
+    // became depth-aware, an empty or shorter driver raised
+    // EllipsisCountMismatch on legal input, and a binding that matched
+    // ZERO repetitions kept its placeholder depth 1, so the driver never
+    // qualified and EllipsisNoPatternVariable fired instead.
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax ragged (syntax-rules ()
+        \\    ((_ (a ...) ((b ...) ...)) '(((a b) ...) ...))))
+        \\  (and (equal? (ragged (x y) ()) '())
+        \\       (equal? (ragged () ()) '())
+        \\       (equal? (ragged (x y z) ((1 2) (3))) '(((x 1) (x 2)) ((y 3))))
+        \\       (equal? (ragged (x y) ((1 2) (3) (4))) '(((x 1) (x 2)) ((y 3))))
+        \\       (equal? (ragged (x y) ((1 2 3) (4))) '(((x 1) (x 2) (x 3)) ((y 4))))))
+    );
+}
+
+test "syntax-rules: same-depth count mismatch still errors (#78 control)" {
+    // The depth-aware count rule must NOT relax the R7RS 4.3.2
+    // requirement that pattern variables matched at the same depth and
+    // used under the same ellipsis have equal counts. This is the
+    // kaappi#78 shape (previously read uninitialized memory).
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define-syntax zip (syntax-rules ()
+        \\  ((_ (a ...) (b ...)) '((a b) ...))))
+    );
+    const result = vm.eval("(zip (1 2 3) (4 5))");
+    try std.testing.expectError(error.CompileError, result);
+}

--- a/src/tests_ellipsis.zig
+++ b/src/tests_ellipsis.zig
@@ -209,3 +209,57 @@ test "syntax-rules: same-depth count mismatch still errors (#78 control)" {
     const result = vm.eval("(zip (1 2 3) (4 5))");
     try std.testing.expectError(error.CompileError, result);
 }
+
+test "syntax-rules: same-depth mismatch is not masked by a leading shallow variable (#78 review)" {
+    // A depth-1 variable referenced before two same-depth drivers must not
+    // hide a genuine R7RS count mismatch between those drivers: the count
+    // check is per-depth, so b (2 groups) and c (3 groups) error whether or
+    // not a shallower `a` is present (previously order-dependent).
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define-syntax m (syntax-rules ()
+        \\  ((_ (a ...) ((b ...) ...) ((c ...) ...)) '((a (b ...) (c ...)) ...))))
+    );
+    const result = vm.eval("(m (p q r s t) ((1)(2)) ((7)(8)(9)))");
+    try std.testing.expectError(error.CompileError, result);
+}
+
+test "syntax-rules: empty-match under-use fires even when no repetition runs (#682 review)" {
+    // The under-use check must be structural, not gated on the consuming
+    // run being instantiated: b is matched at depth 3 but the template
+    // `((b ...) ...)` uses it at depth 2, so the input matching ZERO outer
+    // repetitions must still error instead of silently expanding to () —
+    // both the pure-list and the vector spelling.
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax c1 (syntax-rules () ((_ ((b ...) ...)) '((b ...) ...))))
+        \\  (equal? (c1 ()) '()))  ;; correct depth, empty match -> ()
+    );
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define-syntax l2 (syntax-rules () ((_ (((b ...) ...) ...)) '((b ...) ...))))
+    );
+    try std.testing.expectError(error.CompileError, vm.eval("(l2 ())"));
+
+    _ = try vm.eval(
+        \\(define-syntax v2 (syntax-rules () ((_ (#((b ...) ...) ...)) '((b ...) ...))))
+    );
+    try std.testing.expectError(error.CompileError, vm.eval("(v2 ())"));
+
+    // A depth-2 variable inside a vector ellipsis used at depth 1: the
+    // vector's own ellipsis level must be counted when seeding the
+    // empty-match binding depth (vector patterns match through list
+    // semantics).
+    _ = try vm.eval(
+        \\(define-syntax v4 (syntax-rules () ((_ (#(b ...) ...)) '(b ...))))
+    );
+    try std.testing.expectError(error.CompileError, vm.eval("(v4 ())"));
+}

--- a/tests/scheme/errors/error-format.sh
+++ b/tests/scheme/errors/error-format.sh
@@ -421,6 +421,13 @@ assert_output_contains "mismatched ellipsis lengths rejected cleanly" \
     '(define-syntax zip (syntax-rules () ((zip (a ...) (b ...)) (quote ((a b) ...))))) (zip (1 2 3) (4 5))' \
     "compile error"
 
+# The same-depth mismatch must be detected regardless of binding iteration
+# order: a depth-1 variable referenced before two mismatched depth-2 drivers
+# must not mask the error (previously order-dependent).
+assert_output_contains "same-depth mismatch not masked by a leading shallow variable" \
+    '(define-syntax m (syntax-rules () ((_ (a ...) ((b ...) ...) ((c ...) ...)) (quote ((a (b ...) (c ...)) ...))))) (m (p q r s t) ((1)(2)) ((7)(8)(9)))' \
+    "compile error"
+
 # --- Issue #1046: apply-position type errors must include procedure name ---
 echo
 echo "-- Apply-position error detail (issue #1046) --"

--- a/tests/scheme/smoke/ellipsis-depth-mismatch.scm
+++ b/tests/scheme/smoke/ellipsis-depth-mismatch.scm
@@ -57,6 +57,26 @@
            (m ((1 2) (3 4))))
         (environment '(scheme base))))
 
+;; Invalid: the under-use check is STRUCTURAL, not gated on the consuming
+;; run being instantiated. A depth-3 variable used at depth 2, with the
+;; input matching ZERO outer repetitions, must still error rather than
+;; silently expand to (); ditto the vector spelling.
+(test-error "depth 3->2 under-use fires even with an empty outer match"
+  (eval '(let-syntax ((m (syntax-rules () ((_ (((b ...) ...) ...)) '((b ...) ...)))))
+           (m ()))
+        (environment '(scheme base))))
+(test-error "depth 3->2 under-use via a vector pattern fires with an empty match"
+  (eval '(let-syntax ((m (syntax-rules () ((_ (#((b ...) ...) ...)) '((b ...) ...)))))
+           (m ()))
+        (environment '(scheme base))))
+
+;; The control: the same shapes at their CORRECT template depth, with an
+;; empty match, expand to the empty list (not an error).
+(define-syntax ok-empty-outer
+  (syntax-rules () ((_ ((b ...) ...)) '((b ...) ...))))
+(test-equal "empty outer match at the correct depth expands to the empty list"
+  '() (ok-empty-outer ()))
+
 (let ((runner (test-runner-current)))
   (test-end "ellipsis-depth-mismatch")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi149.scm
+++ b/tests/scheme/srfi/srfi149.scm
@@ -61,6 +61,32 @@
   '(((x 1) (x 2) (x 3)) ((y 4)))
   (ragged (x y) ((1 2 3) (4))))
 
+;;; the depth-1 sibling zipped against a SHORTER driver: SRFI 149 rule 2
+;;; repeats the depth-1 variable's elements for the innermost excess
+;;; ellipsis, so the outer run iterates min(counts) times and the surplus
+;;; element is dropped.  chibi-scheme (the SRFI's reference implementation)
+;;; agrees; guile 3.0 rejects unequal outer counts, which this expander
+;;; deliberately does not (kaappi#682).
+(test-equal "excess replication zips a longer depth-1 variable"
+  '(((x 1) (x 2)) ((y 3)))
+  (ragged (x y z) ((1 2) (3))))
+
+;;; and the reverse: a SHORTER depth-1 variable truncates the driver.
+(test-equal "excess replication zips a shorter depth-1 variable"
+  '(((x 1) (x 2)) ((y 3)))
+  (ragged (x y) ((1 2) (3) (4))))
+
+;;; an EMPTY driver: the outer run repeats zero times, so the depth-1
+;;; variable's elements are never consumed.  Both chibi and guile return
+;;; the empty list; kaappi rejected the shape with EllipsisCountMismatch
+;;; until the count check became depth-aware (kaappi#682).
+(test-equal "excess replication with an empty driver yields the empty list"
+  '()
+  (ragged (x y) ()))
+(test-equal "excess replication with an empty variable and empty driver"
+  '()
+  (ragged () ()))
+
 ;;; a depth-0 variable carried through two excess ellipsis levels
 (define-syntax broadcast2
   (syntax-rules ()


### PR DESCRIPTION
Fixes #682, Fixes #2082

## Summary

Both issues were already fixed on `main` by #2256 (`ed37a085`) — the under-use depth check (#682) and the one-ellipsis-per-pattern grammar check (#2082) — but the issues were never closed (the PR's `closingIssuesReferences` is empty). I verified both fixes against a 40-case battery cross-checked with chibi-scheme 0.12 and guile 3.0, and confirmed the regression tests are now meaningful (they fail against a pre-fix build).

That verification surfaced one **remaining defect in the same area**: SRFI 149's excess-ellipsis semantics reject a class of legal input. This PR fixes it, adds the missing regression coverage, and closes both issues.

## The remaining defect

A depth-1 variable used at a depth-2 template position is zipped against the depth-2 driver (SRFI 149 rule 2; the SRFI's reference implementation is chibi). Kaappi compared ellipsis **counts across depths** and raised `EllipsisCountMismatch`, so this legal macro errored on an empty or shorter driver where chibi and guile both expand correctly:

```scheme
(define-syntax ragged
  (syntax-rules () ((_ (a ...) ((b ...) ...)) '(((a b) ...) ...))))
(ragged (x y) ())   ;; chibi: ()   guile: ()   kaappi: compile error
(ragged (x y z) ((1 2) (3)))   ;; chibi: (((x 1) (x 2)) ((y 3)))   kaappi: error
```

Two root causes:

1. **The count check was not depth-aware** (`src/expander_instantiate.zig`). R7RS 4.3.2 requires equal counts only among variables matched at the *same* depth; SRFI 149's excess case zips shallower variables (min counts). New `joinRepeatCount` enforces equality only within a depth and otherwise takes the min — the kaappi#78 same-depth error (previously read uninitialized memory) is preserved, verified via `error-format.sh`.

2. **Empty matches under-reported binding depth** (`src/expander.zig`). `matchEllipsis` seeded every ellipsis binding with depth 1 and only corrected it per repetition, so a nested variable matching zero repetitions — `((b ...) ...)` against `()` — kept depth 1, never qualified as a driver, and the run died with `EllipsisNoPatternVariable`. Bindings are now seeded from the pattern structure (`patternVarNesting` + 1), which agrees with the per-repetition formula whenever a repetition runs.

## Oracle matrix (kaappi → chibi → guile after this PR)

| Case | kaappi | chibi | guile |
|---|---|---|---|
| empty driver `(ragged (x y) ())` | `()` | `()` | `()` |
| both empty `(ragged () ())` | `()` | `()` | `()` |
| longer depth-1 var `(x y z) / ((1 2) (3))` | `(((x 1) (x 2)) ((y 3)))` | same | errors¹ |
| shorter depth-1 var `(x y) / ((1 2) (3) (4))` | `(((x 1) (x 2)) ((y 3)))` | same | errors¹ |
| ragged equal counts (control) | `(((x 1) (x 2) (x 3)) ((y 4)))` | same | same |
| empty inner group | `(() ((y 1) (y 2)))` | same | errors² |
| same-depth count mismatch (#78) | error | zip-shortest³ | error |

¹ guile's strict `map` rejects unequal outer counts — noted as an intentional divergence (we follow the SRFI's reference implementation).
² guile rejects ragged inner groups entirely.
³ chibi is lenient beyond R7RS here; kaappi keeps the R7RS error (kaappi#78).

## Tests

- `tests/scheme/srfi/srfi149.scm` — 4 new assertions (empty driver ×2, unequal counts ×2); suite grew 21 → 25, all verified to **fail against the pre-fix build** (exit 1) and pass with it (exit 0).
- `src/tests_ellipsis.zig` — 2 new Zig unit tests (the zip cases, plus the same-depth #78 control).
- `zig build test` ✓ (also under `-Dgc-stress=true`)
- `bash tests/scheme/run-all.sh` ✓ — 2090 pass, 0 fail (R7RS suite 1395 pass)
- `tests/scheme/errors/error-format.sh` ✓ — 143 pass (includes the #78 mismatched-length case)
- `zig fmt --check` ✓

## Checklist

- [x] `zig build test` passes (also under `-Dgc-stress=true`)
- [x] `zig fmt --check src/` passes
- [x] Scheme test suites pass (`bash tests/scheme/run-all.sh` — 2090 pass, 0 fail)
- [x] New tests shown to fail against a build with the fix reverted
- [x] CHANGELOG updated
