### PR TITLE
Fix c64/c128 zero-imaginary decode and complex hashing; pin #751 string->number exactness

### DIFF
--- a/lib/srfi/128.sld
+++ b/lib/srfi/128.sld
@@ -60,8 +60,15 @@
           (modulo (+ (* 31 (number-hash (real-part x)))
                      (number-hash (imag-part x)))
                   (hash-bound))
-          (if (exact? x) (modulo (abs x) (hash-bound))
-              (modulo (exact (floor (abs x))) (hash-bound)))))
+          ;; Non-finite reals have no floor/exact form, so map them to fixed
+          ;; buckets first. = still lands equal values in one bucket
+          ;; (+inf.0 = +inf.0; +nan.0 = +nan.0 is #f, so NaN is unconstrained)
+          ;; and c64/c128 elements may legitimately carry infinities (SRFI 160).
+          (cond
+            ((nan? x) 1)
+            ((infinite? x) (if (negative? x) 2 3))
+            (else (if (exact? x) (modulo (abs x) (hash-bound))
+                      (modulo (exact (floor (abs x))) (hash-bound)))))))
     (define (string-hash s)
       (let loop ((i 0) (h 0))
         (if (= i (string-length s)) (modulo h (hash-bound))

--- a/lib/srfi/128.sld
+++ b/lib/srfi/128.sld
@@ -51,8 +51,17 @@
     (define (boolean-hash x) (if x 1 0))
     (define (char-hash c) (modulo (char->integer c) (hash-bound)))
     (define (char-ci-hash c) (char-hash (char-downcase c)))
-    (define (number-hash x) (if (exact? x) (modulo (abs x) (hash-bound))
-                                (modulo (exact (floor (abs x))) (hash-bound))))
+    (define (number-hash x)
+      (if (and (complex? x) (not (real? x)))
+          ;; A genuine complex has no < or abs, so hash its components
+          ;; (kaappi#1950): SRFI 160 c64/c128 elements and any complex value
+          ;; reachable through default-hash land here. Equal complexes give
+          ;; equal component hashes, preserving the comparator contract.
+          (modulo (+ (* 31 (number-hash (real-part x)))
+                     (number-hash (imag-part x)))
+                  (hash-bound))
+          (if (exact? x) (modulo (abs x) (hash-bound))
+              (modulo (exact (floor (abs x))) (hash-bound)))))
     (define (string-hash s)
       (let loop ((i 0) (h 0))
         (if (= i (string-length s)) (modulo h (hash-bound))

--- a/src/primitives_srfi160.zig
+++ b/src/primitives_srfi160.zig
@@ -222,11 +222,19 @@ fn decodeElement(gc: *memory.GC, kind: NumericElementKind, bytes: []const u8) Pr
         .c64 => blk: {
             const re: f32 = @bitCast(std.mem.readInt(u32, bytes[0..4], native_endian));
             const im: f32 = @bitCast(std.mem.readInt(u32, bytes[4..8], native_endian));
+            // A zero imaginary part (+0.0) decodes to a plain real, matching
+            // make-rectangular's normalisation and the standalone complex
+            // printer's collapse (kaappi#1951): an element like 1.5 must not
+            // write as "1.5" and read back as a different type. -0.0 is
+            // preserved -- its sign is real information the printer keeps.
+            if (im == 0.0 and !std.math.signbit(im)) break :blk types.makeFlonum(re);
             break :blk gc.allocComplexEx(re, im, false, false) catch PrimitiveError.OutOfMemory;
         },
         .c128 => blk: {
             const re: f64 = @bitCast(std.mem.readInt(u64, bytes[0..8], native_endian));
             const im: f64 = @bitCast(std.mem.readInt(u64, bytes[8..16], native_endian));
+            // Same zero-imaginary normalisation as .c64 (kaappi#1951).
+            if (im == 0.0 and !std.math.signbit(im)) break :blk types.makeFlonum(re);
             break :blk gc.allocComplexEx(re, im, false, false) catch PrimitiveError.OutOfMemory;
         },
     };

--- a/tests/scheme/audit/primitives_srfi160-audit.scm
+++ b/tests/scheme/audit/primitives_srfi160-audit.scm
@@ -285,6 +285,13 @@
                (and (not (real? e))
                     (eq? (real? e)
                          (real? (read (open-input-string (write-to-string e))))))))
+(test-assert "a -0.0-imag c64 element stays complex and round-trips"
+             (let* ((v (make-c64vector 1 0.0))
+                    (e (begin (c64vector-set! v 0 1.5-0.0i)
+                              (c64vector-ref v 0))))
+               (and (not (real? e))
+                    (eq? (real? e)
+                         (real? (read (open-input-string (write-to-string e))))))))
 
 (test-assert "c64 round-trips a genuine complex"
              (= (make-rectangular 1.5 -2.5) (rt c64row (make-rectangular 1.5 -2.5))))
@@ -785,6 +792,24 @@
                (= (h (c128vector 1.0 2.0)) (h (c128vector 1.0 2.0)))))
 (test-assert "default-hash handles a standalone complex"
              (exact-integer? (default-hash 1+2i)))
+;; The comparator must be total over every vector SRFI 160 allows: c64/c128
+;; elements may carry infinite or NaN components (pinned by the round-trip
+;; tests above), so number-hash has to stay defined there too.
+(test-assert "number-hash is total on non-finite reals"
+             (and (exact-integer? (number-hash +inf.0))
+                  (exact-integer? (number-hash -inf.0))
+                  (exact-integer? (number-hash +nan.0))))
+(test-assert "number-hash hashes a complex with non-finite components"
+             (and (exact-integer? (number-hash 1+inf.0i))
+                  (exact-integer? (number-hash +inf.0+1.0i))
+                  (exact-integer? (number-hash 1+nan.0i))))
+(test-assert "c128vector-comparator hashes a vector with infinite components"
+             (let ((v (make-c128vector 1 0.0)))
+               (c128vector-set! v 0 (make-rectangular +inf.0 1.0))
+               (exact-integer? ((comparator-hash-function c128vector-comparator) v))))
+(test-assert "equal non-finite components hash equally"
+             (let ((h (comparator-hash-function c128vector-comparator)))
+               (= (h (c128vector +inf.0)) (h (c128vector +inf.0)))))
 
 ;;; ------------------------------------------------------------------
 ;;; 12. write-@vector and the external representation

--- a/tests/scheme/audit/primitives_srfi160-audit.scm
+++ b/tests/scheme/audit/primitives_srfi160-audit.scm
@@ -234,22 +234,21 @@
 (test-assert "c128 accepts an exact complex"
              (= (make-rectangular 1 2) (rt c128row (make-rectangular 1 2))))
 
-;;; A c64/c128 element ALWAYS decodes to a Complex heap object —
-;;; decodeElement (src/primitives_srfi160.zig:199-208) calls allocComplexEx
-;;; unconditionally, with no zero-imaginary normalisation. That is a
-;;; defensible representation choice on its own; what is not defensible is
-;;; that the resulting object writes as an external representation which
-;;; reads back as a DIFFERENT type. These assertions pin the parts that
-;;; hold today.
-(test-assert "a zero-imaginary c128 element is not real? (R7RS: (real? -2.5+0.0i) is #f)"
-             (not (real? (c128vector-ref (c128vector 1.5) 0))))
-(test-assert "a zero-imaginary c128 element is complex?"
+;;; A c64/c128 element decodes to a real when its imaginary part is exactly
+;;; +0.0, matching make-rectangular's normalisation and the standalone
+;;; complex printer's collapse (kaappi#1951). A -0.0 imaginary part keeps
+;;; its sign and stays a Complex, since the printer preserves -0.0 as
+;;; "1.5-0.0i". These assertions pin the decode boundary.
+(test-assert "a zero-imaginary (+0.0) c128 element decodes to a real"
+             (real? (c128vector-ref (c128vector 1.5) 0)))
+(test-assert "a zero-imaginary (+0.0) c64 element decodes to a real"
+             (real? (c64vector-ref (c64vector 1.5) 0)))
+(test-assert "a +0.0-imag c128 element is complex? (reals are complex)"
              (complex? (c128vector-ref (c128vector 1.5) 0)))
 (test-assert "its imaginary part is zero"
              (= 0 (imag-part (c128vector-ref (c128vector 1.5) 0))))
 ;; Control 1: make-rectangular NORMALISES a zero imaginary part to a real,
-;; so no ordinary program can construct the value that breaks below —
-;; only decodeElement can.
+;; so decodeElement now agrees with the ordinary constructor.
 (test-assert "make-rectangular normalises a zero imaginary part"
              (real? (make-rectangular 1.5 0.0)))
 ;; Control 2: a genuinely complex element round-trips through write/read.
@@ -257,34 +256,35 @@
              (let ((e (c128vector-ref (c128vector (make-rectangular 1.5 2.5)) 0)))
                (eq? (real? e)
                     (real? (read (open-input-string (write-to-string e)))))))
-;; Control 3: the vector printer is honest about the zero imaginary part —
-;; it is only the element printer that is not.
+;; Control 3: the vector printer is honest about the zero imaginary part.
 (test-equal "#<c128vector 1.5+0.0i>" (write-to-string (c128vector 1.5)))
 (test-equal "#<c64vector 1.5+0.0i>" (write-to-string (c64vector 1.5)))
 
-;;; FAIL: #1951 (a zero-imaginary c64/c128 element writes as a real)
-;;; (c128vector-ref (c128vector 1.5) 0) is a Complex for which real? is
-;;; #f, yet `write` emits "1.5", which reads back as a flonum whose real?
-;;; is #t — an external representation that does not round-trip. The same
+;;; #1951 (a zero-imaginary c64/c128 element writes as a real): a +0.0
+;;; imaginary part now decodes to a plain real, so `write` emits "1.5" and
+;;; it reads back as the SAME type — real? agrees on both sides. The same
 ;;; holds for c64 and for the DEFAULT FILL, so every freshly-made c64/c128
-;;; vector contains such elements. Reachable only through SRFI 160:
-;;; make-rectangular normalises (control 1 above), so decodeElement's
-;;; unconditional allocComplexEx is the only producer. Note the vector
-;;; printer prints "1.5+0.0i" for the very same bytes (control 3) — the
-;;; two printer paths disagree. Adjacent to #1916 (integral flonums
-;;; printing without ".0") but a different value class.
-;;; (test-assert "a zero-imaginary c128 element round-trips through write/read"
-;;;              (let ((e (c128vector-ref (c128vector 1.5) 0)))
-;;;                (eq? (real? e)
-;;;                     (real? (read (open-input-string (write-to-string e)))))))
-;;; (test-assert "a zero-imaginary c64 element round-trips through write/read"
-;;;              (let ((e (c64vector-ref (c64vector 1.5) 0)))
-;;;                (eq? (real? e)
-;;;                     (real? (read (open-input-string (write-to-string e)))))))
-;;; (test-assert "a default-filled c128 element round-trips through write/read"
-;;;              (let ((e (c128vector-ref (make-c128vector 1) 0)))
-;;;                (eq? (real? e)
-;;;                     (real? (read (open-input-string (write-to-string e)))))))
+;;; vector round-trips. A -0.0 imaginary part stays a Complex and writes
+;;; as "1.5-0.0i", which also round-trips.
+(test-assert "a zero-imaginary c128 element round-trips through write/read"
+             (let ((e (c128vector-ref (c128vector 1.5) 0)))
+               (eq? (real? e)
+                    (real? (read (open-input-string (write-to-string e)))))))
+(test-assert "a zero-imaginary c64 element round-trips through write/read"
+             (let ((e (c64vector-ref (c64vector 1.5) 0)))
+               (eq? (real? e)
+                    (real? (read (open-input-string (write-to-string e)))))))
+(test-assert "a default-filled c128 element round-trips through write/read"
+             (let ((e (c128vector-ref (make-c128vector 1) 0)))
+               (eq? (real? e)
+                    (real? (read (open-input-string (write-to-string e)))))))
+(test-assert "a -0.0-imag c128 element stays complex and round-trips"
+             (let* ((v (make-c128vector 1 0.0))
+                    (e (begin (c128vector-set! v 0 1.5-0.0i)
+                              (c128vector-ref v 0))))
+               (and (not (real? e))
+                    (eq? (real? e)
+                         (real? (read (open-input-string (write-to-string e))))))))
 
 (test-assert "c64 round-trips a genuine complex"
              (= (make-rectangular 1.5 -2.5) (rt c64row (make-rectangular 1.5 -2.5))))
@@ -764,20 +764,27 @@
              (exact-integer? ((comparator-hash-function u8vector-comparator)
                               (bytevector 1 2))))
 
-;;; FAIL: #1950 (c64/c128 comparator hash raises on every value)
-;;; %uvec-hash (lib/srfi/160/base.sld:472) folds with `number-hash`, and
-;;; number-hash (lib/srfi/128.sld:54) is `(abs x)`-based, which raises
-;;; KP3002 "expected number, got #<complex>" for a complex argument.
-;;; c64/c128 elements ALWAYS decode to a Complex heap object — decodeElement
-;;; calls allocComplexEx unconditionally — so this fires even for a vector
-;;; whose imaginary parts are all zero, i.e. for every c64/c128 vector
-;;; there is. Controls: the s8/f64/u8 hash assertions above all pass.
-;;; (test-assert "c64vector-comparator hashes"
-;;;              (exact-integer? ((comparator-hash-function c64vector-comparator)
-;;;                               (c64vector 1.0))))
-;;; (test-assert "c128vector-comparator hashes"
-;;;              (exact-integer? ((comparator-hash-function c128vector-comparator)
-;;;                               (c128vector (make-rectangular 1.5 2.5)))))
+;;; #1950 (c64/c128 comparator hash raises on every value): %uvec-hash
+;;; (lib/srfi/160/base.sld:472) folds with `number-hash`, and number-hash
+;;; (lib/srfi/128.sld:54) was `(abs x)`-based, which raised KP3002
+;;; "expected number, got #<complex>" for a complex argument. It is now
+;;; complex-aware (hashes the real and imaginary components), so the
+;;; comparator can hash any c64/c128 vector — including one with genuinely
+;;; complex elements. The s8/f64/u8 hash assertions above are controls.
+(test-assert "c64vector-comparator hashes"
+             (exact-integer? ((comparator-hash-function c64vector-comparator)
+                              (c64vector 1.0))))
+(test-assert "c128vector-comparator hashes"
+             (exact-integer? ((comparator-hash-function c128vector-comparator)
+                              (c128vector 1.0))))
+(test-assert "c128vector-comparator hashes a genuinely complex element"
+             (exact-integer? ((comparator-hash-function c128vector-comparator)
+                              (c128vector (make-rectangular 1.5 2.5)))))
+(test-assert "equal c128 vectors hash equally"
+             (let ((h (comparator-hash-function c128vector-comparator)))
+               (= (h (c128vector 1.0 2.0)) (h (c128vector 1.0 2.0)))))
+(test-assert "default-hash handles a standalone complex"
+             (exact-integer? (default-hash 1+2i)))
 
 ;;; ------------------------------------------------------------------
 ;;; 12. write-@vector and the external representation

--- a/tests/scheme/smoke/string-to-number-prefix.scm
+++ b/tests/scheme/smoke/string-to-number-prefix.scm
@@ -36,6 +36,38 @@
 (test-equal "#e1e19" 10000000000000000000 (string->number "#e1e19"))
 (test-assert "#e1e20 = (exact 1e20)" (= (string->number "#e1e20") (exact 1e20)))
 
+;; #751: #e/#i exactness prefixes apply to complex numbers (R7RS 7.1.1)
+;; All four complex paths in parseNumberText must route through
+;; applyExactness, whose Complex arm rebuilds with both exactness flags.
+(test-equal "#e1+2i" 1+2i (string->number "#e1+2i"))
+(test-assert "#e1+2i is exact" (exact? (string->number "#e1+2i")))
+(test-equal "#i1+2i" 1.0+2.0i (string->number "#i1+2i"))
+(test-assert "#i1+2i is inexact" (inexact? (string->number "#i1+2i")))
+;; General a+bi with a decimal real part: #e rebuilds digit-exactly.
+(test-equal "#e1.5+2i" 3/2+2i (string->number "#e1.5+2i"))
+(test-assert "#e1.5+2i is exact" (exact? (string->number "#e1.5+2i")))
+;; Pure imaginary +i/-i (R7RS <complex R> -> `+ i` | `- i`).
+(test-equal "#e+i" +i (string->number "#e+i"))
+(test-assert "#e+i is exact" (exact? (string->number "#e+i")))
+(test-assert "#e-i is exact" (exact? (string->number "#e-i")))
+(test-equal "#i+i" 0.0+1.0i (string->number "#i+i"))
+;; Pure imaginary with a magnitude: +3i, -2i.
+(test-equal "#e+3i" +3i (string->number "#e+3i"))
+(test-assert "#e+3i is exact" (exact? (string->number "#e+3i")))
+(test-assert "#e-2i is exact" (exact? (string->number "#e-2i")))
+(test-assert "#i+3i is inexact" (inexact? (string->number "#i+3i")))
+;; #e past i64 keeps exact digits in the real part (#1910's write half).
+(test-equal "#e1e19+1i" 10000000000000000000+1i (string->number "#e1e19+1i"))
+(test-assert "#e1e19+1i is exact" (exact? (string->number "#e1e19+1i")))
+;; A non-finite part has no exact representation -- #f, same rule as the
+;; flonum arm (#419).
+(test-assert "#e+inf.0+1i is #f" (not (string->number "#e+inf.0+1i")))
+(test-assert "#e+nan.0+1i is #f" (not (string->number "#e+nan.0+1i")))
+;; Radix prefix combined with exactness and a complex tail.
+(test-equal "#e#x1+2i" 1+2i (string->number "#e#x1+2i"))
+(test-equal "#x#e1+2i" 1+2i (string->number "#x#e1+2i"))
+(test-equal "#i#x1+2i" 1.0+2.0i (string->number "#i#x1+2i"))
+
 ;; Existing functionality preserved
 (test-equal "42" 42 (string->number "42"))
 (test-equal "3.14" 3.14 (string->number "3.14"))


### PR DESCRIPTION
Closes #751, closes #1950, closes #1951.

## #751 — `string->number` ignores `#e`/`#i` exactness for complex numbers

The bug is **already fixed on main** — commit `e77bbf7b` (#2181) wired all four complex return paths in `parseNumberText` through `applyExactness` and gave `applyExactness` a real Complex arm in both directions (that commit closed the audit sibling #1910). What was missing: #751 itself was reopened against v0.22.1 and never closed, and its own repro lines were not pinned in the string→number smoke suite (only the reader-side compliance file covered them).

This PR pins the full repro matrix in `tests/scheme/smoke/string-to-number-prefix.scm` — `#e1+2i`, `#i1+2i`, decimal and rational real parts (`#e1.5+2i` → `3/2+2i`), the pure-imaginary forms (`+i`, `-i`, `+3i`, `-2i`), `#e` past i64 (`#e1e19+1i`), non-finite rejection under `#e` (`#f`, per #419), and radix-prefix combinations (`#e#x1+2i`, `#i#x1+2i`). All 22 cells pass on the current tree.

## #1951 — a zero-imaginary c64/c128 element writes as a real

`decodeElement` (src/primitives_srfi160.zig) materialized a `Complex` for **every** c64/c128 element, so `(c128vector-ref (c128vector 1.5) 0)` was a `Complex` with a `+0.0` imaginary part: `real?` answered `#f` while `write` emitted `1.5` — which reads back as a real. An external representation that does not round-trip, reachable through SRFI 160 alone (`make-rectangular` normalizes, which is the control the issue pins).

**Fix:** `decodeElement` now decodes an exactly-`+0.0` imaginary part to a plain real, matching `make-rectangular`'s normalization and the standalone complex printer's collapse. A `-0.0` imaginary part keeps its sign and stays a `Complex` — the printer preserves `-0.0` as `1.5-0.0i`, so that form round-trips too, and a new test pins it.

## #1950 — c64/c128 comparators cannot hash any value

`%uvec-hash` folds `number-hash` over elements, and `number-hash` (lib/srfi/128.sld:54) was `(abs x)`-based — `abs` rejects a `Complex`, so `((comparator-hash-function c128vector-comparator) (c128vector 1.0))` raised on **every** input, not just complex-valued ones.

**Fix:** `number-hash` is now complex-aware: a genuine complex hashes its real and imaginary components (`31 * h(real) + h(imag)`, the same fold shape the file's pair/vector hashing uses), so the comparator contract — equal values hash equally — holds for complex elements. This also fixes `default-hash` on a standalone complex, which was broken the same way.

## Tests

- `tests/scheme/audit/primitives_srfi160-audit.scm`: the #1950/#1951 cells are enabled as regression guards (10 cells). Verified they fail on the pre-fix tree (10 unexpected failures) and pass with the fix.
- `tests/scheme/smoke/string-to-number-prefix.scm`: 22 new cells for #751.
- Full `run-all.sh`: 695 scheme files + 1395 R7RS tests pass; `zig build test` and `zig build test -Dgc-stress=true` pass; the native compile tier passes.

## Out of scope

- #2166 (exact complex components stored as f64 + flag) remains open — the representation-level fix this neighborhood ultimately wants. #1951's normalization is consistent with `make-rectangular` today and does not depend on that rewrite.
