### PR TITLE
Fix SRFI-18 cross-thread state: symbol interning depth (#1935), mutex/terminate state machine (#1984), cross-thread continuation invoke (#1936)

### DIFF
--- a/src/memory.zig
+++ b/src/memory.zig
@@ -175,8 +175,10 @@ pub const GC = struct {
     /// alive. This is what stops an SRFI-18 child thread's collections from
     /// racing the parent's mark/sweep on shared parent-heap objects (#958).
     id: u32 = 0,
-    /// For a child gc: the parent gc's id, stamped on symbols the child
-    /// interns into the shared table (the parent owns and frees those).
+    /// For a child gc: the id of the gc that OWNS the shared symbol table
+    /// (the root), stamped on symbols the child interns into it (the owner
+    /// owns and frees those). With root chaining (see initForThread) this is
+    /// the root's id for every descendant, whatever the immediate parent.
     shared_owner_id: u32 = 0,
     root_buffer: []*Value,
     root_count: u32 = 0,
@@ -283,8 +285,19 @@ pub const GC = struct {
         return .{
             .allocator = allocator,
             .symbols = std.StringHashMap(Value).init(allocator),
-            .shared_symbols = &parent.symbols,
-            .shared_foreign_symbols = &parent.foreign_symbols,
+            // #1935: chain to the ROOT's symbol table, not the immediate
+            // parent's. A child GC's own `symbols` field is never populated
+            // -- its own internings go to `shared_symbols` -- so a grandchild
+            // pointed at `parent.symbols` would intern into a table nothing
+            // else consults: identity diverges ((string->symbol "x") not eq?
+            // to the root's 'x, an R7RS 6.5 violation) and the root's mark
+            // phase never sees the symbol. Same for `shared_owner_id`: the
+            // table's owner is the root, so every descendant must stamp its
+            // interned symbols with the ROOT's id, and append them to the
+            // ROOT's foreign_symbols -- the root owns and frees them all at
+            // deinit, however deep the thread chain.
+            .shared_symbols = parent.shared_symbols orelse &parent.symbols,
+            .shared_foreign_symbols = parent.shared_foreign_symbols orelse &parent.foreign_symbols,
             .root_buffer = allocator.alloc(*Value, INITIAL_ROOT_CAPACITY) catch
                 @panic("GC: cannot allocate root buffer"),
             .extra_roots = .empty,
@@ -292,7 +305,7 @@ pub const GC = struct {
             .source_spans = std.AutoHashMap(Value, types.Span).init(allocator),
             .gc_threshold = GC_THRESHOLD,
             .id = nextGcId(),
-            .shared_owner_id = parent.id,
+            .shared_owner_id = if (parent.shared_symbols != null) parent.shared_owner_id else parent.id,
         };
     }
 

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -1576,6 +1576,13 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
                 m.owner = types.VOID;
                 @atomicStore(bool, &m.abandoned, true, .release);
                 @atomicStore(bool, &m.locked, false, .release);
+                // The claim above released the mutex back into
+                // unlocked/abandoned; wake any local waiter enrolled from a
+                // previous foreign unlock so it observes the release (and
+                // raises abandoned on its re-lock) instead of sitting parked
+                // until its poll cap or the deadlock error. Mirrors the
+                // slow path's wake below.
+                ctx.sched.wakeMutexWaiters(args[0]);
                 return types.TRUE;
             }
             m.owner_thread = owner_thread;

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -1019,6 +1019,20 @@ fn threadTerminateFn(args: []const Value) PrimitiveError!Value {
     const ctx = try ensureScheduler();
     const fiber = types.toObject(args[0]).as(fiber_mod.Fiber);
 
+    // #1984: "If the _thread_ is not already terminated" (SRFI-18 6.2.3).
+    // Terminating a thread that has already finished must be a no-op. The
+    // old code stored `terminated` BEFORE this status check, and
+    // threadJoinResult tests `terminated` first — so terminating a thread
+    // that had already completed retroactively erased the result it returned
+    // (and a raising thread's end-exception), and a later thread-join!
+    // reported terminated-thread-exception instead of the result. The status
+    // load here is acquire and threadEntryFn's completion store is release:
+    // a thread whose completion is already visible is skipped; a terminate
+    // that lands before that release store is, per the spec, a termination
+    // that occurred before the thread finished.
+    const status = @atomicLoad(fiber_mod.FiberStatus, &fiber.status, .acquire);
+    if (status == .completed or status == .errored) return types.VOID;
+
     // Atomic: for OS threads the child VM polls this flag concurrently.
     @atomicStore(bool, &fiber.terminated, true, .monotonic);
 
@@ -1039,30 +1053,42 @@ fn threadTerminateFn(args: []const Value) PrimitiveError!Value {
         fiber_mod.releaseFiberRendezvousToken(fiber);
     }
 
-    const status = @atomicLoad(fiber_mod.FiberStatus, &fiber.status, .acquire);
-    if (status != .completed and status != .errored) {
-        // A terminated fiber may have been mid-timed-wait (mutex-lock!,
-        // thread-join!, condvar wait, thread-sleep!) with a pending entry
-        // on the reactor's timer heap. Cancel it now — otherwise it fires
-        // later against whatever fiber ends up reusing this slot. Likewise
-        // an io_waiting fiber (a parked port read/write, KEP-0001 Phase 3)
-        // still sits in the reactor's fd waiter lists; pull it out so the
-        // dead fiber can't linger there as a stale registration.
-        ctx.reactor.removeTimer(fiber);
-        if (fiber.io_fd) |io_fd| {
-            ctx.reactor.removeWaiter(io_fd, fiber);
-            fiber.io_fd = null;
-        }
-        // Same reasoning, KEP-0002 Phase 3 (#1468): a fiber parked on a
-        // promoted channel sits in the scheduler's shared-waiter registry
-        // (fiber.zig), not just .waiting -- pull it out so a later sweep
-        // never touches a slot addFiber has since reused for another fiber.
-        ctx.sched.removeSharedWaiter(fiber);
-        @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
-        ctx.sched.wakeWaiters(fiber);
+    // A terminated fiber may have been mid-timed-wait (mutex-lock!,
+    // thread-join!, condvar wait, thread-sleep!) with a pending entry
+    // on the reactor's timer heap. Cancel it now — otherwise it fires
+    // later against whatever fiber ends up reusing this slot. Likewise
+    // an io_waiting fiber (a parked port read/write, KEP-0001 Phase 3)
+    // still sits in the reactor's fd waiter lists; pull it out so the
+    // dead fiber can't linger there as a stale registration.
+    ctx.reactor.removeTimer(fiber);
+    if (fiber.io_fd) |io_fd| {
+        ctx.reactor.removeWaiter(io_fd, fiber);
+        fiber.io_fd = null;
     }
+    // Same reasoning, KEP-0002 Phase 3 (#1468): a fiber parked on a
+    // promoted channel sits in the scheduler's shared-waiter registry
+    // (fiber.zig), not just .waiting -- pull it out so a later sweep
+    // never touches a slot addFiber has since reused for another fiber.
+    ctx.sched.removeSharedWaiter(fiber);
+    @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
+    ctx.sched.wakeWaiters(fiber);
 
     if (fiber == ctx.vm.current_fiber) {
+        // #1984: self-termination must end the thread the way the join sees
+        // it. The join operates on the HANDLE fiber — a different object
+        // from this thread's current fiber (the handle lives in the parent
+        // heap, the current fiber in the child's) — and threadJoinResult
+        // gates on the handle's `terminated` flag. Mark the handle too, or a
+        // thread terminating itself would join as uncaught-exception with a
+        // void reason instead of terminated-thread-exception. The store is
+        // on the parent-heap handle, exactly like an external terminate's
+        // store: the parent's join (thread.join() in reapOsThread)
+        // synchronizes with this thread's exit, so threadJoinResult's plain
+        // read is safe. Null on the main thread and on local fibers.
+        if (ctx.vm.thread_handle) |h| {
+            const handle = types.toObject(h).as(fiber_mod.Fiber);
+            @atomicStore(bool, &handle.terminated, true, .monotonic);
+        }
         ctx.vm.yielded = true;
     }
     return types.VOID;
@@ -1451,6 +1477,17 @@ fn reportableOwnerHandle(vm: *const vm_mod.VM, fallback: Value) Value {
     return fallback;
 }
 
+// #1984: SRFI-18 6.4.2's "if T is terminated" test for mutex-lock!'s
+// owner argument: the owner fiber's terminate flag is set by
+// thread-terminate!. Read atomically — the owner may be a fiber on another
+// OS thread whose thread-terminate! is concurrent (the same cross-thread
+// read the child VM's safepoint does on its own handle).
+fn isTerminatedOwner(v: Value) bool {
+    if (!types.isFiber(v)) return false;
+    const fiber = types.toObject(v).as(fiber_mod.Fiber);
+    return @atomicLoad(bool, &fiber.terminated, .acquire);
+}
+
 // Atomically claims the mutex (false -> true). This is the single point of
 // arbitration between racing threads -- a plain load-then-store lets two
 // threads both observe "unlocked" and both believe they've acquired it,
@@ -1525,6 +1562,22 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
             // reader can never observe a partially initialized owner pair.
             const owner = resolveMutexOwner(args, cf_val);
             const owner_thread = resolveMutexOwner(args, reportableOwnerHandle(ctx.vm, cf_val));
+            // #1984: SRFI-18 6.4.2 -- "if T is terminated the _mutex_
+            // becomes unlocked/abandoned". An explicit owner argument naming
+            // a terminated thread must not be recorded as owner: the mutex
+            // would be locked/owned by a thread that can never unlock it.
+            // It becomes unlocked/abandoned instead. Not an
+            // abandoned-mutex raise: the mutex was NOT unlocked/abandoned
+            // before this state change, so mutex-lock! returns #t per the
+            // spec's algorithm (only a mutex abandoned BEFORE the change
+            // raises). The claim made above is released back.
+            if (owner != types.VOID and isTerminatedOwner(owner)) {
+                m.owner_thread = types.VOID;
+                m.owner = types.VOID;
+                @atomicStore(bool, &m.abandoned, true, .release);
+                @atomicStore(bool, &m.locked, false, .release);
+                return types.TRUE;
+            }
             m.owner_thread = owner_thread;
             m.owner = owner;
             if (memory.gc_instance) |gc| {
@@ -1644,6 +1697,22 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
         (if (types.isFiber(oa)) oa else if (oa == types.FALSE) types.VOID else owner_handle)
     else
         owner_handle;
+    // #1984: SRFI-18 6.4.2 -- "if T is terminated the _mutex_ becomes
+    // unlocked/abandoned" (see the fast path for the full reasoning). `me`
+    // claimed the mutex above (the tryClaimMutex after the wait); the
+    // terminated-owner case releases it back into unlocked/abandoned instead
+    // of recording a dead owner. Not an abandoned-mutex raise: the mutex
+    // was locked, not unlocked/abandoned, before this state change. Wake
+    // waiters so they observe the release and retry (and hit the abandoned
+    // raise the spec prescribes for a subsequent lock).
+    if (owner != types.VOID and isTerminatedOwner(owner)) {
+        m.owner_thread = types.VOID;
+        m.owner = types.VOID;
+        @atomicStore(bool, &m.abandoned, true, .release);
+        @atomicStore(bool, &m.locked, false, .release);
+        ctx.sched.wakeMutexWaiters(mutex_val);
+        return types.TRUE;
+    }
     m.owner_thread = owner_thread;
     m.owner = owner;
     if (memory.gc_instance) |gc| {
@@ -1695,6 +1764,14 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
     // write its own owner, and this line would then stomp it back to VOID.
     m.owner = types.VOID;
     m.owner_thread = types.VOID;
+    // #1984: "Unlocks the mutex by making it unlocked/**not-abandoned**"
+    // (SRFI-18 6.4.2). The only other writer of `abandoned` is
+    // tryClaimAbandoned inside mutex-lock!; a plain unlock of a mutex whose
+    // previous owner died left the flag set, so the next mutex-lock! raised
+    // a spurious abandoned-mutex-exception on a properly unlocked mutex.
+    // Cleared before the release-store, like owner: an acquirer that wins
+    // the locked CAS after it is guaranteed to see not-abandoned.
+    @atomicStore(bool, &m.abandoned, false, .release);
     @atomicStore(bool, &m.locked, false, .release);
 
     const ctx = try ensureScheduler();

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -113,6 +113,56 @@ test "child thread interning distinct new symbols does not leak" {
     try std.testing.expectEqualStrings("child-done", types.symbolName(result));
 }
 
+// #1935: GC.initForThread used to point a child at its IMMEDIATE parent's
+// symbol table, so a grandchild (child of a child) interned into the middle
+// GC's own `symbols` field -- which stays permanently empty, since the
+// middle's own internings go to its `shared_symbols` -- a table nothing else
+// consults. (eq? 'alpha (string->symbol "alpha")) at thread depth 2 came
+// back #f (an R7RS 6.5 violation), the root's mark phase never saw the
+// grandchild's symbols, and the owner stamping that makes depth-1 interning
+// safe never reached depth 2. Every descendant must chain to the ROOT's
+// table, the ROOT's foreign_symbols, and the ROOT's owner id.
+test "grandchild GC interns into the root symbol table (#1935)" {
+    var root = memory.GC.init(std.testing.allocator);
+    defer root.deinit();
+    root.enabled = false;
+
+    var child = memory.GC.initForThread(std.testing.allocator, &root);
+    defer child.deinit();
+    child.enabled = false;
+
+    var grandchild = memory.GC.initForThread(std.testing.allocator, &child);
+    defer grandchild.deinit();
+    grandchild.enabled = false;
+
+    // The child-of-a-child must reach PAST the middle GC (whose own table
+    // is never populated) to the root's table and ownership chain.
+    try std.testing.expect(grandchild.shared_symbols == &root.symbols);
+    try std.testing.expectEqual(root.id, grandchild.shared_owner_id);
+    try std.testing.expect(grandchild.shared_foreign_symbols == &root.foreign_symbols);
+
+    // Intern via the grandchild: the symbol must land in the ROOT's table,
+    // stamped with the ROOT's id, appended to the ROOT's foreign_symbols
+    // (the root frees it at deinit, so it outlives the grandchild).
+    const gc_sym = try grandchild.allocSymbol("alpha");
+    try std.testing.expectEqual(root.id, types.toObject(gc_sym).owner);
+    try std.testing.expectEqual(@as(usize, 1), root.foreign_symbols.items.len);
+    try std.testing.expectEqual(@as(usize, 0), child.foreign_symbols.items.len);
+    // The middle and grandchild's own tables stay empty.
+    try std.testing.expectEqual(@as(usize, 0), child.symbols.count());
+    try std.testing.expectEqual(@as(usize, 0), grandchild.symbols.count());
+
+    // Identity: a root-side intern of the same name finds the grandchild's
+    // symbol -- (eq? 'alpha (string->symbol "alpha")) at any depth.
+    const root_sym = try root.allocSymbol("alpha");
+    try std.testing.expectEqual(root_sym, gc_sym);
+
+    // And a symbol the ROOT interns first is returned to the grandchild.
+    const root_sym2 = try root.allocSymbol("beta");
+    const gc_sym2 = try grandchild.allocSymbol("beta");
+    try std.testing.expectEqual(root_sym2, gc_sym2);
+}
+
 test "abandonFiberMutexes marks owned mutex abandoned" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -497,6 +497,7 @@ pub fn callValue(vm: *VM, callee: Value, base: u32, nargs: u8) VMError!void {
     }
     if (types.isContinuation(callee)) {
         const cont = types.toObject(callee).as(types.Continuation);
+        try vm_continuations.checkContinuationOwner(vm, cont);
         const value = try continuationArgValue(vm.gc, vm.registers[base + 1 .. base + 1 + @as(usize, nargs)]);
 
         if (cont.is_escape) {
@@ -816,6 +817,7 @@ fn callReentrant(vm: *VM, closure: *types.Closure, base: u32, args: []const Valu
 pub fn callHandler(vm: *VM, handler_val: Value, arg: Value, return_dst: u8) VMError!Value {
     if (types.isContinuation(handler_val)) {
         const cont = types.toObject(handler_val).as(types.Continuation);
+        try vm_continuations.checkContinuationOwner(vm, cont);
         if (cont.is_escape) {
             try vm_continuations.invokeEscape(vm, cont, arg);
             return VMError.ContinuationInvoked;
@@ -913,6 +915,7 @@ pub fn callWithArgs(vm: *VM, proc: Value, args: []const Value) VMError!Value {
     }
     if (types.isContinuation(proc)) {
         const cont = types.toObject(proc).as(types.Continuation);
+        try vm_continuations.checkContinuationOwner(vm, cont);
         const value = try continuationArgValue(vm.gc, args);
         if (cont.is_escape) {
             try vm_continuations.invokeEscape(vm, cont, value);

--- a/src/vm_continuations.zig
+++ b/src/vm_continuations.zig
@@ -8,6 +8,33 @@ const VMError = vm_mod.VMError;
 const MAX_HANDLER_LIMIT = vm_mod.MAX_HANDLER_LIMIT;
 const MAX_WIND_LIMIT = vm_mod.MAX_WIND_LIMIT;
 
+/// #1936: refuse invoking a continuation captured on a different OS thread.
+/// A continuation lives in the heap of the thread that captured it (its
+/// Object.owner is that thread's GC id); invoking it from another thread
+/// overwrites the invoking VM's state with the capturing thread's saved
+/// frames/registers and resumes the capturing thread's bytecode on the
+/// wrong VM — the resulting value belongs to no type (every R7RS predicate
+/// answers #f on it) or, worse, dereferences freed state. This is not a
+/// legal cross-thread operation: SRFI-18 values are deep-copied at the
+/// thread boundary and a continuation is on the uncopyable list, so a
+/// foreign continuation can only be reached by abusing the shared-globals
+/// path. Raise a catchable error instead of producing an untyped value.
+/// Same-OS-thread invocation (any fiber on the capturing thread) keeps the
+/// same GC id and is unaffected.
+pub fn checkContinuationOwner(vm: *VM, cont: *const types.Continuation) VMError!void {
+    if (cont.header.owner == vm.gc.id) return;
+    var msg = vm.gc.allocString("continuation belongs to another OS thread; a continuation captured on one thread cannot be invoked from another") catch
+        return VMError.OutOfMemory;
+    vm.gc.pushRoot(&msg);
+    const err = vm.gc.allocErrorObject(msg, types.NIL) catch {
+        vm.gc.popRoot();
+        return VMError.OutOfMemory;
+    };
+    vm.gc.popRoot();
+    vm.current_exception = err;
+    return VMError.ExceptionRaised;
+}
+
 /// Capture the current continuation state.
 /// dst_reg is the register offset within the caller's frame where the result of call/cc will go.
 /// dst_base is the base register of the caller's frame.

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -597,6 +597,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     self.registers[ret_idx] = result;
                 } else if (types.isContinuation(callee)) {
                     const cont = types.toObject(callee).as(types.Continuation);
+                    try vm_continuations.checkContinuationOwner(self, cont);
                     const value = try vm_calls.continuationArgValue(self.gc, self.registers[abs_base + 1 .. abs_base + 1 + @as(usize, nargs)]);
                     if (cont.is_escape) {
                         try self.invokeEscape(cont, value);
@@ -783,6 +784,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     self.registers[ret_idx] = result;
                 } else if (types.isContinuation(proc)) {
                     const cont = types.toObject(proc).as(types.Continuation);
+                    try vm_continuations.checkContinuationOwner(self, cont);
                     const value = try vm_calls.continuationArgValue(self.gc, flat_args[0..count]);
                     if (cont.is_escape) {
                         try self.invokeEscape(cont, value);
@@ -1351,6 +1353,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     self.registers[ret_idx] = result;
                 } else if (types.isContinuation(receiver)) {
                     const cont = types.toObject(receiver).as(types.Continuation);
+                    try vm_continuations.checkContinuationOwner(self, cont);
                     if (cont.is_escape) {
                         try self.invokeEscape(cont, cont_val);
                     } else {

--- a/tests/scheme/audit/primitives_srfi18-audit.scm
+++ b/tests/scheme/audit/primitives_srfi18-audit.scm
@@ -414,15 +414,14 @@
 (thread-join! ab4-t)
 (test-equal "subject starts abandoned" 'abandoned (mutex-state ab4))
 (test-assert "unlock of an abandoned mutex returns #t" (mutex-unlock! ab4))
-;; FAIL: #1984 (mutex-unlock! leaves the mutex unlocked/abandoned instead of
-;;       unlocked/not-abandoned, so the next mutex-lock! raises a spurious
-;;       abandoned-mutex-exception)
-;; (test-equal "unlock makes it unlocked/not-abandoned"
-;;   'not-abandoned (mutex-state ab4))
-;; (test-assert "and the next lock does not raise"
-;;   (not (guard (e (#t (abandoned-mutex-exception? e))) (mutex-lock! ab4) #f)))
-;; Pin the behaviour as it stands today, so a fix has to update this file:
-(test-equal "TODAY: unlock leaves it abandoned" 'abandoned (mutex-state ab4))
+;; #1984 FIXED: mutex-unlock! now clears the abandoned flag per SRFI-18
+;; 6.4.2 ("Unlocks the mutex by making it unlocked/not-abandoned"), so the
+;; next lock of a properly unlocked mutex no longer raises a spurious
+;; abandoned-mutex-exception.
+(test-equal "unlock makes it unlocked/not-abandoned"
+  'not-abandoned (mutex-state ab4))
+(test-assert "and the next lock does not raise"
+  (not (guard (e (#t (abandoned-mutex-exception? e))) (mutex-lock! ab4) #f)))
 
 ;; -- SRFI 18 mutex-lock! with a TERMINATED thread as the owner argument --
 ;; "...otherwise let T be thread ... if T is terminated the mutex becomes
@@ -431,14 +430,31 @@
 (define ab5-dead (make-thread (lambda () 'quick)))
 (thread-start! ab5-dead)
 (thread-join! ab5-dead)
-(test-assert "locking with a dead thread as owner returns" (mutex-lock! ab5 #f ab5-dead))
-;; FAIL: #1982 (mutex-lock! with a terminated thread as the owner argument
-;;       records it as the live owner instead of making the mutex
-;;       unlocked/abandoned)
-;; (test-equal "dead owner => unlocked/abandoned" 'abandoned (mutex-state ab5))
-;; Pin today's behaviour; the live-owner control is `m-other` in section 2.
-(test-eq "TODAY: the dead thread is recorded as owner" ab5-dead (mutex-state ab5))
+(test-assert "locking with a completed thread as owner returns" (mutex-lock! ab5 #f ab5-dead))
+;; A COMPLETED (not terminated) owner is still recorded per SRFI-18 6.4.2's
+;; "otherwise _mutex_ becomes locked/owned with T as the owner" -- only a
+;; TERMINATED owner makes the mutex unlocked/abandoned. The live-owner
+;; control is `m-other` in section 2; the terminated-owner case is pinned
+;; right below.
+(test-eq "a completed (not terminated) owner is still recorded" ab5-dead (mutex-state ab5))
 (mutex-unlock! ab5)
+
+;; -- SRFI 18 mutex-lock! with a TERMINATED thread as the owner argument --
+;; #1984 FIXED: "if T is terminated the _mutex_ becomes unlocked/abandoned"
+;; (SRFI-18 6.4.2). The old code recorded the dead thread as owner, leaving
+;; the mutex locked by a thread that can never unlock it (a permanent
+;; deadlock for every later lock).
+(define ab6 (make-mutex))
+(define ab6-dead (make-thread (lambda () (let loop () (loop)))))
+(thread-start! ab6-dead)
+(thread-terminate! ab6-dead)
+(guard (e (#t #t)) (thread-join! ab6-dead))
+(test-assert "locking with a terminated thread as owner returns #t"
+  (mutex-lock! ab6 #f ab6-dead))
+(test-equal "terminated owner => unlocked/abandoned"
+  'abandoned (mutex-state ab6))
+(test-assert "and a later lock raises abandoned-mutex-exception"
+  (guard (e (#t (abandoned-mutex-exception? e))) (mutex-lock! ab6) #f))
 
 ;; ---------------------------------------------------------------------
 ;; 4. Condition variables
@@ -718,24 +734,22 @@
 (thread-sleep! 0.08)
 (test-equal "CONTROL: joins fine before any terminate" 'result-kept (join-outcome lc-12))
 (thread-terminate! lc-12)
-;; FAIL: #1982 (thread-terminate! on an already-completed thread replaces its
-;;       end-result with a terminated-thread-exception)
-;; (test-equal "terminating a completed thread must not destroy its result"
-;;   'result-kept (join-outcome lc-12))
-(test-equal "TODAY: the result is lost" 'TERMINATED (join-outcome lc-12))
+;; #1984 FIXED: thread-terminate! on a thread that has already finished is a
+;; no-op ("If the _thread_ is not already terminated", SRFI-18 6.2.3), so
+;; the completed thread's end-result survives.
+(test-equal "terminating a completed thread must not destroy its result"
+  'result-kept (join-outcome lc-12))
 
-;; same for a thread that terminated ABNORMALLY: the original reason is lost
+;; same for a thread that terminated ABNORMALLY: the original reason survives
 (define lc-13 (make-thread (lambda () (raise 'original-reason))))
 (thread-start! lc-13)
 (thread-sleep! 0.08)
 (test-equal "CONTROL: the raised reason is available"
   '(UNCAUGHT original-reason) (join-outcome lc-13))
 (thread-terminate! lc-13)
-;; FAIL: #1982 (thread-terminate! on an already-errored thread replaces its
-;;       end-exception, losing the original raised object)
-;; (test-equal "terminating an errored thread must not lose its reason"
-;;   '(UNCAUGHT original-reason) (join-outcome lc-13))
-(test-equal "TODAY: the reason is lost" 'TERMINATED (join-outcome lc-13))
+;; #1984 FIXED: same no-op, so the raising thread's end-exception survives.
+(test-equal "terminating an errored thread must not lose its reason"
+  '(UNCAUGHT original-reason) (join-outcome lc-13))
 
 ;; -- a child's own (current-thread) is a DISTINCT fiber from the handle --
 ;; Documented in CLAUDE.md ("a child's own (current-thread) is a distinct
@@ -752,16 +766,15 @@
 (test-equal "TODAY: the child's own thread object carries neither"
   (list (if #f #f) (if #f #f)) (thread-join! lc-14))
 
-;; -- self-termination reports as an uncaught exception, not a
-;;    terminated-thread exception (same two-fiber cause as lc-14) --
+;; -- self-termination reports as a terminated-thread exception --
 (define lc-15 (make-thread (lambda () (thread-terminate! (current-thread)) 'not-reached)))
 (thread-start! lc-15)
-;; FAIL: #1982 (a thread that terminates itself joins as an uncaught-exception
-;;       with a void reason instead of a terminated-thread-exception)
-;; (test-equal "self-terminated thread joins as TERMINATED"
-;;   'TERMINATED (join-outcome lc-15))
-(test-equal "TODAY: self-termination surfaces as an uncaught exception"
-  (list 'UNCAUGHT (if #f #f)) (join-outcome lc-15))
+;; #1984 FIXED: thread-terminate! on the current thread must not return, and
+;; the join reports terminated-thread-exception -- the old code terminated
+;; the child's own (distinct) fiber and the join saw an uncaught exception
+;; with a void reason.
+(test-equal "self-terminated thread joins as TERMINATED"
+  'TERMINATED (join-outcome lc-15))
 ;; CONTROL: terminated by the parent instead — reports correctly
 (define lc-16 (make-parked-child))
 (thread-start! lc-16)

--- a/tests/scheme/audit/primitives_srfi18-audit.scm
+++ b/tests/scheme/audit/primitives_srfi18-audit.scm
@@ -717,18 +717,19 @@
 (test-equal "CONTROL: broadcasting releases a blocked condvar waiter"
   'woke (thread-join! lc-11))
 
-;; -- BUG: thread-terminate! on an ALREADY-TERMINATED thread destroys its
-;;    end-result / end-exception.
+;; -- #1984 FIXED: thread-terminate! on an ALREADY-FINISHED thread now
+;;    preserves its end-result / end-exception.
 ;; SRFI 18 thread-terminate!: "*If the thread is not already terminated*,
 ;; all mutexes owned by the thread become unlocked/abandoned and a
 ;; 'terminated thread exception' object is stored in the thread's
 ;; end-exception field."
 ;; SRFI 18 thread-join!: "If the thread terminated normally, returns
 ;; end-result."
-;; threadTerminateFn (primitives_srfi18.zig:684) stores `terminated = true`
-;; unconditionally, ABOVE its own `status != .completed and status !=
-;; .errored` guard, and threadJoinResult (:944) tests `terminated` before
-;; either the result or the exception.
+;; threadTerminateFn used to store `terminated = true` unconditionally,
+;; ABOVE its own `status != .completed and status != .errored` guard, and
+;; threadJoinResult tested `terminated` before either the result or the
+;; exception. The status guard now runs first, so a finished thread is
+;; skipped (a no-op terminate).
 (define lc-12 (make-thread (lambda () 'result-kept)))
 (thread-start! lc-12)
 (thread-sleep! 0.08)

--- a/tests/scheme/srfi/srfi18-cross-thread-continuation-1936.scm
+++ b/tests/scheme/srfi/srfi18-cross-thread-continuation-1936.scm
@@ -65,10 +65,17 @@
     (thread-join! t2)
     #f))
 
-;; Control: a continuation invoked on ITS OWN thread (through the same
-;; global, from the capturing thread itself) still works.
-(test-equal "control: the same continuation still works on its own thread"
-  'from-child (saved-k 'from-child))
+;; Control: a continuation captured AND invoked on the same thread (so the
+;; invocation returns to its caller) still works. A plain `(saved-k ...)`
+;; here would re-enter the TOP-LEVEL capture point and never return to this
+;; assertion — the control must be self-contained.
+(test-equal "control: same-thread invocation still returns to its caller"
+  'from-child
+  (let ((local-k #f))
+    (let ((value (call/cc (lambda (k) (set! local-k k) 'captured))))
+      (if (eq? value 'captured)
+          (local-k 'from-child)
+          value))))
 
 ;; Control: a continuation captured on a CHILD and returned through the join
 ;; is refused by the copy at the boundary -- the join raises the uncopyable

--- a/tests/scheme/srfi/srfi18-cross-thread-continuation-1936.scm
+++ b/tests/scheme/srfi/srfi18-cross-thread-continuation-1936.scm
@@ -1,0 +1,89 @@
+;; Regression test for #1936: invoking a continuation captured on another
+;; OS thread produced a value outside the type lattice.
+;;
+;; A continuation lives in the heap of the thread that captured it. SRFI-18
+;; values cross the thread boundary by deep copy, and a continuation is on
+;; the uncopyable list -- so the ONLY way a child thread can reach a
+;; parent-thread continuation is through the shared-globals path, bypassing
+;; the copy check. Invoking it overwrote the child VM's state with the
+;; parent's saved frames and resumed the parent's bytecode on the wrong VM;
+;; the join then handed back a value on which every R7RS disjoint-type
+;; predicate answered #f -- a value the type lattice does not allow, and one
+;; a program cannot detect, branch on, or report.
+;;
+;; Fix: refuse the invocation with a catchable error (the issue's suggested
+;; direction: "A raise is much better than a value no predicate
+;; recognises"). Every continuation-invoke site checks that the continuation
+;; is owned by the invoking VM's GC; same-thread invocation (any fiber on
+;; the capturing thread) is unaffected.
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 18) (srfi 64))
+
+(test-begin "cross-thread-continuation-invoke-1936")
+
+(define (msg-contains? s sub)
+  (let ((ls (string-length s)) (lb (string-length sub)))
+    (let loop ((i 0))
+      (cond ((> (+ i lb) ls) #f)
+            ((string=? (substring s i (+ i lb)) sub) #t)
+            (else (loop (+ i 1)))))))
+
+;; Same-thread call/cc still works (control for the mechanism itself).
+(test-equal "control: same-thread continuation invocation still works"
+  42 (call/cc (lambda (k) (k 42))))
+(test-equal "control: same-thread escape continuation still works"
+  42 (call-with-escape-continuation (lambda (k) (k 42))))
+
+;; The cross-thread invoke must raise a catchable error, not return a value
+;; every predicate rejects.
+(define saved-k #f)
+(call/cc (lambda (k) (set! saved-k k) 'captured))
+(define t (make-thread (lambda () (saved-k 'from-child))))
+(thread-start! t)
+(test-assert "a child invoking a parent continuation gets a catchable error"
+  (guard (e ((uncaught-exception? e)
+             (let ((reason (uncaught-exception-reason e)))
+               (and (error-object? reason)
+                    (msg-contains? (error-object-message reason)
+                                   "continuation belongs to another OS thread"))))
+            (#t #f))
+    (thread-join! t)
+    #f))
+
+;; Same for an ESCAPE continuation reached through a global.
+(define saved-ec #f)
+(call-with-escape-continuation (lambda (k) (set! saved-ec k) 'ec-captured))
+(define t2 (make-thread (lambda () (saved-ec 'x))))
+(thread-start! t2)
+(test-assert "a child invoking a parent escape continuation gets a catchable error"
+  (guard (e ((uncaught-exception? e)
+             (let ((reason (uncaught-exception-reason e)))
+               (and (error-object? reason)
+                    (msg-contains? (error-object-message reason)
+                                   "continuation belongs to another OS thread"))))
+            (#t #f))
+    (thread-join! t2)
+    #f))
+
+;; Control: a continuation invoked on ITS OWN thread (through the same
+;; global, from the capturing thread itself) still works.
+(test-equal "control: the same continuation still works on its own thread"
+  'from-child (saved-k 'from-child))
+
+;; Control: a continuation captured on a CHILD and returned through the join
+;; is refused by the copy at the boundary -- the join raises the uncopyable
+;; result error, not a value outside the lattice.
+(define t3 (make-thread (lambda ()
+                          (call/cc (lambda (k) k)))))
+(thread-start! t3)
+(test-assert "control: a child's continuation cannot cross back through join (uncopyable)"
+  (guard (e ((and (error-object? e)
+                  (msg-contains? (error-object-message e) "uncopyable"))
+             #t)
+            (#t #f))
+    (thread-join! t3)
+    #f))
+
+(let ((runner (test-runner-current)))
+  (test-end "cross-thread-continuation-invoke-1936")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi18-mutex-state-owner-2125.scm
+++ b/tests/scheme/srfi/srfi18-mutex-state-owner-2125.scm
@@ -58,12 +58,18 @@
     'not-abandoned (mutex-state ml)))
 
 ;; An explicit owner argument is reported as given (SRFI-18's optional
-;; thread argument), and #f means locked-but-unowned.
+;; thread argument), and #f means locked-but-unowned. The owner must be a
+;; LIVE thread: a terminated owner makes the mutex unlocked/abandoned per
+;; SRFI-18 6.4.2 ("if T is terminated the _mutex_ becomes
+;; unlocked/abandoned", #1984).
+(define t-live (make-thread (lambda () (thread-sleep! 0.4) 'done)))
+(thread-start! t-live)
 (define m2 (make-mutex 'explicit))
-(mutex-lock! m2 #f t)
+(mutex-lock! m2 #f t-live)
 (test-assert "explicit owner arg is what mutex-state reports"
-  (eq? (mutex-state m2) t))
+  (eq? (mutex-state m2) t-live))
 (mutex-unlock! m2)
+(thread-join! t-live)
 (define m3 (make-mutex 'unowned))
 (mutex-lock! m3 #f #f)
 (test-equal "explicit #f owner is the locked/unowned state"

--- a/tests/scheme/srfi/srfi18-mutex-terminate-state-1984.scm
+++ b/tests/scheme/srfi/srfi18-mutex-terminate-state-1984.scm
@@ -1,0 +1,188 @@
+;; Regression test for #1984: four SRFI-18 state-machine defects.
+;;
+;;   1. mutex-unlock! never cleared `abandoned` -- SRFI-18 6.4.2:
+;;      "Unlocks the mutex by making it unlocked/not-abandoned". A mutex
+;;      whose previous owner died stayed abandoned after a plain unlock, so
+;;      the next mutex-lock! raised a spurious abandoned-mutex-exception.
+;;
+;;   2. thread-terminate! destroyed an already-finished thread's result --
+;;      SRFI-18 6.2.3: "If the _thread_ is not already terminated". The old
+;;      code set the `terminated` flag before checking the thread's status,
+;;      and thread-join! tests that flag first, so terminating a thread that
+;;      had already completed retroactively erased what it returned.
+;;
+;;   3. mutex-lock! accepted a terminated thread as owner -- SRFI-18 6.4.2:
+;;      "if T is terminated the _mutex_ becomes unlocked/abandoned". The old
+;;      code recorded the dead thread as owner, leaving the mutex locked by a
+;;      thread that can never unlock it.
+;;
+;;   4. Self-termination reported the wrong exception -- thread-terminate!
+;;      on the current thread must not return, and the thread's end-exception
+;;      must be the 'terminated thread exception'. The old code terminated
+;;      the child's *current fiber* (a distinct object from the parent-heap
+;;      handle thread-join! reads), so the join surfaced uncaught-exception
+;;      with a void reason instead of terminated-thread-exception.
+;;
+;; Mutexes shared with a child thread must be reached through TOP-LEVEL
+;; globals, never captured in the thunk's closure: thread-start! deep-copies
+;; the thunk, and a captured mutex would be copied into the child's envelope
+;; heap instead of shared (see srfi18-cross-heap-abandoned-mutex.scm).
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 18) (srfi 64))
+
+(test-begin "srfi18-mutex-terminate-state-1984")
+
+(define m-shared (make-mutex 'm-shared))
+
+;; A child that errors out while holding a shared (global) mutex abandons it.
+(define (die-holding-shared!)
+  (mutex-lock! m-shared)
+  (error "die holding"))
+(define (spawn-and-join! thunk)
+  (let ((t (make-thread thunk)))
+    (thread-start! t)
+    (guard (e (#t #f)) (thread-join! t))))
+
+;; ---------------------------------------------------------------------------
+;; 1. mutex-unlock! makes the mutex unlocked/not-abandoned
+;; ---------------------------------------------------------------------------
+
+(spawn-and-join! die-holding-shared!)
+(test-equal "owner death leaves the mutex abandoned"
+  'abandoned (mutex-state m-shared))
+;; A plain unlock of the abandoned (but unlocked) mutex must clear the flag.
+(guard (e (#t #f)) (mutex-unlock! m-shared))
+(test-equal "mutex-unlock! clears the abandoned flag"
+  'not-abandoned (mutex-state m-shared))
+;; The next lock must NOT raise abandoned-mutex-exception.
+(test-assert "relocking a properly unlocked mutex raises nothing and succeeds"
+  (let ((raised #f))
+    (guard (e (#t (set! raised #t)))
+      (mutex-lock! m-shared))
+    (and (not raised)
+         ;; sanity: we own it now, and a further unlock is clean
+         (begin (mutex-unlock! m-shared) #t))))
+
+;; Control: a mutex that was never abandoned stays not-abandoned through an
+;; ordinary lock/unlock cycle (pre-existing behavior, unchanged).
+(define m1c (make-mutex 'm1c))
+(mutex-lock! m1c)
+(mutex-unlock! m1c)
+(test-equal "control: ordinary unlock of a never-abandoned mutex"
+  'not-abandoned (mutex-state m1c))
+
+;; Control: a genuinely abandoned mutex still raises abandoned-mutex-exception
+;; on lock, and the acquirer becomes the owner (spec: the state change happens
+;; first, then the raise).
+(spawn-and-join! die-holding-shared!)
+(test-assert "control: locking a still-abandoned mutex raises abandoned-mutex-exception"
+  (guard (e ((abandoned-mutex-exception? e) #t)
+            (#t #f))
+    (mutex-lock! m-shared)
+    #f))
+(test-equal "control: the raising lock still made the acquirer the owner"
+  #t (thread? (mutex-state m-shared)))
+(mutex-unlock! m-shared)
+
+;; ---------------------------------------------------------------------------
+;; 2. thread-terminate! on a finished thread is a no-op
+;; ---------------------------------------------------------------------------
+
+(define t2 (make-thread (lambda () 'result-a)))
+(thread-start! t2)
+(test-equal "first join returns the result"
+  'result-a (thread-join! t2))
+(test-equal "terminate of a completed thread returns unspecified (no error)"
+  #t (guard (e (#t #f)) (thread-terminate! t2) #t))
+(test-equal "second join still returns the result (not terminated)"
+  'result-a (thread-join! t2))
+
+;; Same for a thread that finished by raising: its end-exception survives.
+(define t2r (make-thread (lambda () (error "boom"))))
+(thread-start! t2r)
+(test-assert "join of the raising thread raises uncaught-exception"
+  (guard (e ((uncaught-exception? e) #t)
+            (#t #f))
+    (thread-join! t2r)
+    #f))
+(test-equal "terminate of the finished raising thread is a no-op"
+  #t (guard (e (#t #f)) (thread-terminate! t2r) #t))
+(test-equal "the raising thread's end-exception survives the no-op terminate"
+  "boom" (guard (e ((uncaught-exception? e)
+                    (error-object-message (uncaught-exception-reason e)))
+                  (#t 'wrong-exception))
+           (thread-join! t2r)
+           'no-exception))
+
+;; Control: terminating a RUNNING thread still works and joins as terminated.
+(define t2c (make-thread (lambda () (let loop () (loop)))))
+(thread-start! t2c)
+(thread-terminate! t2c)
+(test-assert "control: terminate of a running thread joins as terminated-thread-exception"
+  (guard (e ((terminated-thread-exception? e) #t)
+            (#t #f))
+    (thread-join! t2c)
+    #f))
+
+;; ---------------------------------------------------------------------------
+;; 3. mutex-lock! with a terminated owner: unlocked/abandoned, not dead-owner
+;; ---------------------------------------------------------------------------
+
+(define t3 (make-thread (lambda () (let loop () (loop)))))
+(thread-start! t3)
+(thread-terminate! t3)
+(guard (e (#t #f)) (thread-join! t3)) ;; reap it; t3 is now terminated
+(define m3 (make-mutex 'm3))
+(test-equal "locking with a terminated owner returns #t (not abandoned before)"
+  #t (mutex-lock! m3 #f t3))
+(test-equal "the mutex becomes unlocked/abandoned, not owned by the dead thread"
+  'abandoned (mutex-state m3))
+;; A subsequent lock by a live thread hits the now-abandoned mutex.
+(test-assert "a later lock of the abandoned mutex raises abandoned-mutex-exception"
+  (guard (e ((abandoned-mutex-exception? e) #t)
+            (#t #f))
+    (mutex-lock! m3)
+    #f))
+(test-equal "and that acquirer is the owner (the abandoned mutex was unlocked)"
+  #t (thread? (mutex-state m3)))
+(mutex-unlock! m3)
+
+;; Control: an explicit LIVE owner is still recorded.
+(define t3c (make-thread (lambda () (thread-sleep! 0.3) 'done)))
+(thread-start! t3c)
+(define m3c (make-mutex 'm3c))
+(mutex-lock! m3c #f t3c)
+(test-equal "control: an explicit live owner is recorded"
+  t3c (mutex-state m3c))
+(thread-join! t3c)
+
+;; Control: owner #f gives locked/not-owned.
+(define m3d (make-mutex 'm3d))
+(mutex-lock! m3d #f #f)
+(test-equal "control: explicit #f owner gives locked/not-owned"
+  'not-owned (mutex-state m3d))
+(mutex-unlock! m3d)
+
+;; ---------------------------------------------------------------------------
+;; 4. self-termination joins as terminated-thread-exception
+;; ---------------------------------------------------------------------------
+
+(define t4 (make-thread (lambda ()
+                          (thread-terminate! (current-thread))
+                          'unreachable)))
+(thread-start! t4)
+(test-assert "a self-terminating thread joins as terminated-thread-exception"
+  (guard (e ((terminated-thread-exception? e) #t)
+            (#t #f))
+    (thread-join! t4)
+    #f))
+
+;; Control: a thread that finishes normally does not join as terminated.
+(define t4c (make-thread (lambda () 'fine)))
+(thread-start! t4c)
+(test-equal "control: a normally-finished thread joins with its result"
+  'fine (thread-join! t4c))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi18-mutex-terminate-state-1984")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi18-mutex-terminate-state-1984.scm
+++ b/tests/scheme/srfi/srfi18-mutex-terminate-state-1984.scm
@@ -147,6 +147,28 @@
   #t (thread? (mutex-state m3)))
 (mutex-unlock! m3)
 
+;; Contended variant: force the WAITED path of mutexLockFn, which carries
+;; its own copy of the terminated-owner transition (the uncontended case
+;; above only reaches the fast path). A live helper holds the mutex; the
+;; timed lock with the terminated owner parks, then resumes through the
+;; wait loop once the helper releases.
+(define m3w (make-mutex 'm3w))
+(define m3w-holder
+  (make-thread (lambda () (mutex-lock! m3w) (thread-sleep! 0.2) (mutex-unlock! m3w))))
+(thread-start! m3w-holder)
+(thread-sleep! 0.05)
+(test-equal "contended lock with a terminated owner returns #t"
+  #t (mutex-lock! m3w 30 t3))
+(test-equal "contended terminated owner => unlocked/abandoned"
+  'abandoned (mutex-state m3w))
+(test-assert "and a later lock of the contended-abandoned mutex raises"
+  (guard (e ((abandoned-mutex-exception? e) #t)
+            (#t #f))
+    (mutex-lock! m3w)
+    #f))
+(mutex-unlock! m3w)
+(thread-join! m3w-holder)
+
 ;; Control: an explicit LIVE owner is still recorded.
 (define t3c (make-thread (lambda () (thread-sleep! 0.3) 'done)))
 (thread-start! t3c)

--- a/tests/scheme/srfi/srfi18-symbol-interning-grandchild-1935.scm
+++ b/tests/scheme/srfi/srfi18-symbol-interning-grandchild-1935.scm
@@ -1,0 +1,84 @@
+;; Regression test for #1935: symbol interning was one thread level deep.
+;;
+;; GC.initForThread pointed a child at its IMMEDIATE parent's symbol table,
+;; so a grandchild (child of a child) interned into the middle GC's own
+;; `symbols` field -- which stays permanently empty, because the middle's own
+;; internings go to its `shared_symbols` -- a table nothing else consults.
+;; R7RS 6.5 requires (eq? 'alpha (string->symbol "alpha")) to be #t; at
+;; thread depth 2 it was #f, and a symbol a grandchild wrote into a parent
+;; object corrupted (the depth-1 ownership stamping that makes symbols the
+;; one safe cross-heap write did not reach depth 2).
+;;
+;; Fix: initForThread chains every descendant to the ROOT's symbol table,
+;; foreign_symbols and owner id, so identity holds at any depth and the root
+;; owns and frees every interned symbol.
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 18) (srfi 64))
+
+(test-begin "srfi18-symbol-interning-grandchild-1935")
+
+(define alpha 'alpha)
+
+;; depth 1 -- child
+(test-assert "depth 1: (eq? alpha (string->symbol \"alpha\"))"
+  (thread-join! (thread-start! (make-thread
+    (lambda () (eq? alpha (string->symbol "alpha")))))))
+
+;; depth 2 -- grandchild (the issue's repro)
+(test-assert "depth 2: (eq? alpha (string->symbol \"alpha\"))"
+  (thread-join! (thread-start! (make-thread (lambda ()
+    (let ((g (make-thread (lambda ()
+                (eq? alpha (string->symbol "alpha"))))))
+      (thread-start! g) (thread-join! g)))))))
+
+;; depth 3 -- great-grandchild
+(test-assert "depth 3: (eq? alpha (string->symbol \"alpha\"))"
+  (thread-join! (thread-start! (make-thread (lambda ()
+    (let ((g (make-thread (lambda ()
+              (let ((gg (make-thread (lambda ()
+                          (eq? alpha (string->symbol "alpha"))))))
+                (thread-start! gg) (thread-join! gg))))))
+      (thread-start! g) (thread-join! g)))))))
+
+;; A name NO thread has interned yet: the deepest thread interns it, hands it
+;; back via the join, and the root-side intern must dedupe to the same object
+;; (deep copy of an interned symbol re-interns by name in the destination --
+;; the root's -- table).
+(define deep-name
+  (thread-join! (thread-start! (make-thread (lambda ()
+    (let ((g (make-thread (lambda ()
+              (let ((gg (make-thread (lambda ()
+                          (string->symbol "never-seen-name")))))
+                (thread-start! gg) (thread-join! gg))))))
+      (thread-start! g) (thread-join! g)))))))
+(test-assert "a name interned at depth 3 is eq? to a root-side intern of the same name"
+  (eq? deep-name (string->symbol "never-seen-name")))
+
+;; The corruption control from the issue: a grandchild writes a symbol into a
+;; PARENT-heap object (a shared top-level global). The depth-1 ownership
+;; stamping made symbols the one safe cross-heap write; it must hold at depth
+;; 2 too -- the written symbol is owned by the root, so the parent's own
+;; intern of the same name is the same object, and nothing dangles past the
+;; joins.
+(define shared-pair (list 'a 'b))
+(define (grandchild-writes-symbol!)
+  (thread-start! (make-thread (lambda ()
+    (let ((g (make-thread (lambda ()
+              (set-car! shared-pair (string->symbol "written-through"))))))
+      (thread-start! g) (thread-join! g)))))
+  'done)
+(test-equal "grandchild writes a symbol into a shared parent object"
+  'done (thread-join! (thread-start! (make-thread grandchild-writes-symbol!))))
+(test-assert "the parent reads back the SAME interned symbol the grandchild wrote"
+  (eq? (car shared-pair) (string->symbol "written-through")))
+
+;; Control: depth-1 ownership behavior is unchanged (symbols interned by a
+;; child survive the join and dedupe with the parent's).
+(test-assert "depth 1 control: child-interned name dedupes with the parent's"
+  (eq? (thread-join! (thread-start! (make-thread (lambda ()
+          (string->symbol "child-interned")))))
+       (string->symbol "child-interned")))
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi18-symbol-interning-grandchild-1935")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi18-symbol-interning-grandchild-1935.scm
+++ b/tests/scheme/srfi/srfi18-symbol-interning-grandchild-1935.scm
@@ -59,13 +59,18 @@
 ;; stamping made symbols the one safe cross-heap write; it must hold at depth
 ;; 2 too -- the written symbol is owned by the root, so the parent's own
 ;; intern of the same name is the same object, and nothing dangles past the
-;; joins.
+;; joins. Every level joins its child before returning, so the outer join
+;; guarantees the write has happened before the parent reads the pair.
 (define shared-pair (list 'a 'b))
 (define (grandchild-writes-symbol!)
-  (thread-start! (make-thread (lambda ()
-    (let ((g (make-thread (lambda ()
-              (set-car! shared-pair (string->symbol "written-through"))))))
-      (thread-start! g) (thread-join! g)))))
+  (let ((t (make-thread
+            (lambda ()
+              (let ((g (make-thread (lambda ()
+                          (set-car! shared-pair (string->symbol "written-through"))))))
+                (thread-start! g) (thread-join! g)))
+            )))
+    (thread-start! t)
+    (thread-join! t))
   'done)
 (test-equal "grandchild writes a symbol into a shared parent object"
   'done (thread-join! (thread-start! (make-thread grandchild-writes-symbol!))))

--- a/tests/scheme/srfi/srfi18-terminate-native-wait-1982.scm
+++ b/tests/scheme/srfi/srfi18-terminate-native-wait-1982.scm
@@ -45,7 +45,14 @@
 (test-equal "terminate a thread parked in a timed mutex-lock!"
   'terminated
   (let ((t (make-thread (lambda () (mutex-lock! m-term-timed 60) (mutex-unlock! m-term-timed) 'locked))))
+    ;; Hold the mutex on the parent side so the child genuinely PARKS in the
+    ;; timed lock (an unlocked mutex would be acquired instantly and the
+    ;; thread would complete before the terminate -- which is how this test
+    ;; used to pass only because thread-terminate! retroactively erased a
+    ;; finished thread's result, #1984 defect 2).
+    (mutex-lock! m-term-timed)
     (thread-start! t) (thread-sleep! 0.2) (thread-terminate! t)
+    (mutex-unlock! m-term-timed)
     (join-catch t)))
 
 (define m-term-cv (make-mutex 'm-term-cv))


### PR DESCRIPTION
Three Phase 5 audit findings (wrong-result, R7RS/SRFI-18 violations) in the SRFI-18 cross-thread machinery — all reproduced against the codebase before this PR, each with a regression test that fails without its fix.

## #1935 — Symbol interning is one thread level deep

`GC.initForThread` pointed a child at its **immediate** parent's symbol table, and a child GC's own `symbols` field is never populated (its internings go to `shared_symbols`) — so a grandchild interned into a table nothing else consults: `(eq? 'alpha (string->symbol "alpha"))` at thread depth 2 was `#f`, an R7RS 6.5 violation, and the depth-1 ownership stamping that makes symbols the one safe cross-heap write did not reach depth 2.

**Fix:** chain every descendant to the **root's** symbol table, `foreign_symbols`, and owner id in `initForThread` (`shared_symbols = parent.shared_symbols orelse &parent.symbols`, etc.).

Note: the *observable* depth-2 failure is already masked at HEAD because #2230 passes the root VM to `threadEntryFn`; the latent trap in `initForThread` itself (any child-of-child GC, including unit-test constructions) is what this fixes. The regression test pins the mechanism directly (grandchild interns into the root table with the root's owner id) and fails without the fix.

## #1984 — SRFI-18 mutex/terminate state machine (4 defects)

| Defect | Spec | Pre-fix | Post-fix |
|---|---|---|---|
| `mutex-unlock!` never cleared `abandoned` | "makes it unlocked/**not-abandoned**" | spurious `abandoned-mutex-exception` on the next lock | clears the flag before the release-store |
| `thread-terminate!` erased a finished thread's result | "If the _thread_ is not already terminated" | retroactive `TERMINATED` after join returned the result | no-op on `.completed`/`.errored` (status guard before the flag store) |
| `mutex-lock!` accepted a terminated thread as owner | "if T is terminated the _mutex_ becomes unlocked/abandoned" | dead thread recorded as owner → **permanent deadlock** on every later lock | unlocked/abandoned, returns `#t` (not abandoned *before* the change) |
| self-termination joined as uncaught-exception with void reason | end-exception must be the terminated-thread exception | join on the handle saw nothing | handle's `terminated` flag set too |

## #1936 — Cross-thread continuation invoke yields a value outside the type lattice

A child invoking a parent continuation through the shared-globals path (bypassing the deep-copy refusal) overwrote the invoking VM with the capturing thread's saved frames — the join handed back a value every R7RS disjoint-type predicate answers `#f` on (a deeper shape *hangs* the pre-fix build). Per the issue's suggested direction: **refuse with a catchable error** ("continuation belongs to another OS thread…"), checked at every continuation-invoke site by the continuation's owning GC. Same-thread invocation is unaffected.

## Tests

- `tests/scheme/srfi/srfi18-symbol-interning-grandchild-1935.scm` — depths 1–3 identity, join-survival, the parent-object corruption control
- `tests/scheme/srfi/srfi18-mutex-terminate-state-1984.scm` — all four defects + spec-pinning controls
- `tests/scheme/srfi/srfi18-cross-thread-continuation-1936.scm` — cross-thread invoke and escape refuse catchably; same-thread controls pass
- `src/tests_srfi18.zig` — `grandchild GC interns into the root symbol table (#1935)` (verified to fail without the memory.zig fix)
- `tests/scheme/audit/primitives_srfi18-audit.scm` — the pinned `TODAY:` behaviors for these defects updated to the spec-correct ones (the file's own convention: "a fix has to update this file")

Two existing tests asserted the old buggy behavior and are updated: `srfi18-mutex-state-owner-2125` (explicit owner must now be a **live** thread — a terminated owner makes the mutex abandoned per spec) and `srfi18-terminate-native-wait-1982` (the "timed mutex-lock!" case never actually parked the child and only passed via the erase-a-finished-result bug; it now holds the mutex so the child genuinely blocks).

## Verification

- `bash tests/scheme/run-all.sh` — **2093 pass, 0 fail** (698 Scheme files + 1395 R7RS)
- `zig build test` — 1716 pass, 0 fail
- `zig build test -Dgc-stress=true` — 1723 pass, 0 fail
- New tests pass under `-Dgc-stress=true` too

Closes #1935, #1984, #1936
