### PR TITLE
Honor top-level redefinitions of the five tail fast-path names (Fixes #2033)

### DIFF
--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -635,21 +635,24 @@ expression in the body (~19x on kaappi#1803's arithmetic-loop reproducer). So
 `emitApplyForm` (`llvm_emit.zig`), which mirrors the interpreter's own dispatch
 (`compiler.zig`) case for case:
 
-- **tail + unshadowed + ≥2 operands** — structural apply with built-in
-  semantics: the callee and fixed arguments are emitted like `emitCallNode`'s,
-  and the final operand is passed as a Value to `@kaappi_apply`
+- **tail + unshadowed + unrebound + ≥2 operands** — structural apply with
+  built-in semantics: the callee and fixed arguments are emitted like
+  `emitCallNode`'s, and the final operand is passed as a Value to `@kaappi_apply`
   (`runtime_exports.zig`), which splices it with `primitives.applyFn`'s exact
   semantics — same `isProcedure` validation, same tortoise-and-hare
   proper-list check (a circular list raises rather than hangs), same
-  `typeError` texts. The interpreter's `tail_apply` opcode ignores a top-level
-  rebinding of `apply`, so this path deliberately does too.
+  `typeError` texts. Since #2033 the interpreter's `tail_apply` opcode honours
+  a top-level rebinding of `apply` (R7RS 5.3.1), gated on the compile-time
+  global binding — so this path is gated the same way: a define/set! of
+  `apply` in the module marks it rebound and routes the form through an
+  ordinary indirect call instead.
 - **tail + unshadowed + <2 operands** — the interpreter raises InvalidSyntax
   at compile time; abandoning native compilation of the enclosing scope
   (`error.UnsupportedNodeType`) routes the form to that exact error.
-- **everything else resolvable** — a lexically shadowed `apply`, or a non-tail
-  form that is rebound or has too few operands — is an ordinary indirect call
-  through whatever `apply` resolves to in scope, matching the interpreter's
-  plain `call_global`/local call.
+- **everything else resolvable** — a lexically shadowed `apply`, a rebound
+  `apply` (tail or non-tail), or a non-tail form with too few operands — is an
+  ordinary indirect call through whatever `apply` resolves to in scope,
+  matching the interpreter's plain `call_global`/local call.
 
 Two consequences worth knowing. First, the free-variable analyses
 (`nodeHasFreeVars`/`collectNodeFreeVars` in `llvm_emit_freevars.zig`) walk an

--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -646,9 +646,13 @@ expression in the body (~19x on kaappi#1803's arithmetic-loop reproducer). So
   global binding — so this path is gated the same way: a define/set! of
   `apply` in the module marks it rebound and routes the form through an
   ordinary indirect call instead.
-- **tail + unshadowed + <2 operands** — the interpreter raises InvalidSyntax
-  at compile time; abandoning native compilation of the enclosing scope
-  (`error.UnsupportedNodeType`) routes the form to that exact error.
+- **tail + unshadowed + unrebound + <2 operands** — the interpreter raises
+  InvalidSyntax at compile time; abandoning native compilation of the enclosing
+  scope (`error.UnsupportedNodeType`) routes the form to that exact error. A
+  **rebound** `apply` with too few operands is not this case — the interpreter
+  routes it through the ordinary call path (its #2033 gate), and so does the
+  generic indirect call here, raising whatever the user's procedure (or the
+  built-in arity check) raises at run time.
 - **everything else resolvable** — a lexically shadowed `apply`, a rebound
   `apply` (tail or non-tail), or a non-tail form with too few operands — is an
   ordinary indirect call through whatever `apply` resolves to in scope,

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -390,6 +390,55 @@ pub const Compiler = struct {
         return false;
     }
 
+    /// Answers whether a free global reference spelled `sym_name` (a bare
+    /// name like `apply`, or a hygiene-renamed `__hyg_N_apply`) would still
+    /// resolve to the genuine `(scheme base)` primitive `base_name` at run
+    /// time — the gate the tail-position superinstructions
+    /// (apply/eval/call/cc/call-with-values) need so a top-level
+    /// redefinition of one of those names routes to the user's procedure
+    /// instead of the baked-in builtin (kaappi#2033). Mirrors
+    /// IR.isRedefined's fold gate and the resolution order of
+    /// vm_dispatch_helpers.lookupGlobalLocked so the compile-time decision
+    /// cannot disagree with what get_global would fetch.
+    fn globalBindingStillGenuine(self: *const Compiler, sym_name: []const u8, base_name: []const u8) bool {
+        // A `set!` target in the enclosing top-level form (or a truncated
+        // pre-scan) means the global may hold a different value by the time
+        // the call executes — the same conservative bias as IR.isRedefined.
+        if (self.set_targets_all) return false;
+        if (self.set_targets) |st| {
+            if (st.contains(sym_name) or st.contains(base_name)) return false;
+        }
+
+        // No environment info (standalone/unit-test paths): keep the legacy
+        // optimistic behavior, mirroring IR.isRedefined's `orelse return false`.
+        const g = self.globals orelse return true;
+        const glk = globals_mod.acquireGlobalsRead(g);
+        defer globals_mod.releaseGlobalsRead(glk);
+
+        // Mirror lookupGlobalLocked's resolution: the name as spelled, then
+        // the hygienic-prefix fallback to the bare name.
+        var val: ?Value = g.get(sym_name);
+        if (val == null and !std.mem.eql(u8, sym_name, base_name)) {
+            val = g.get(base_name);
+        }
+        const v = val orelse {
+            // Not bound in the compile-time env. Inside a library (partial
+            // lib_env) or restricted environment the runtime may still find
+            // it elsewhere — the vm.globals fallback for a library body,
+            // nowhere at all for a restricted env — so decline the fast path
+            // rather than silently run the builtin for a name the program
+            // never bound (mirrors IR.isRedefined's restricted_env arm). At
+            // top level the name being absent is the legacy unbound case,
+            // which keeps the fast path exactly as before.
+            return !self.restricted_env;
+        };
+        if (!types.isPointer(v)) return false;
+        const obj = types.toObject(v);
+        if (obj.tag != .native_fn) return false;
+        const nfn = obj.as(types.NativeFn);
+        return std.mem.eql(u8, nfn.name, base_name);
+    }
+
     pub fn isLocalBoxed(self: *Compiler, name: []const u8) bool {
         var i: usize = self.locals.items.len;
         while (i > 0) {
@@ -873,7 +922,14 @@ pub const Compiler = struct {
 
         if (is_tail and types.isSymbol(head)) {
             const sym_name = types.symbolName(head);
-            // The four tail fast paths (apply / call-with-values / call/cc /
+            // A compiler-synthesized reference carries base_binding_prefix
+            // (#1715) — the let-values/let*-values/define-values/case-lambda
+            // desugarings mint __kaappi_base__apply / _call-with-values —
+            // and is immune to redefinition BY CONSTRUCTION: it resolves
+            // through the (scheme base) registry at run time, so the fast
+            // path is always sound for it and the gate below does not apply.
+            const is_synth = globals_mod.stripBaseBindingPrefix(sym_name) != null;
+            // The five tail fast paths (apply / call-with-values / call/cc /
             // eval) recognize their operator by spelling. Since #2003 a
             // macro template's free reference to one of these globals is
             // hygiene-renamed (__hyg_N_<name>), so compare the stripped name
@@ -884,35 +940,37 @@ pub const Compiler = struct {
             // path. The fast paths themselves resolve the true (scheme base)
             // primitive, which is what a renamed free reference to one of
             // these means under the hygienic-prefix fallback.
-            const eff_name = types.stripHygienicPrefix(sym_name);
-            if (std.mem.eql(u8, eff_name, "apply")) {
-                if (self.resolveLocal(sym_name) == null and
-                    (try self.resolveUpvalue(sym_name)) == null)
-                {
-                    return passthrough.compileApplyTail(self, expr, dst);
-                }
-            }
-            if (std.mem.eql(u8, eff_name, "call-with-values")) {
-                if (self.resolveLocal(sym_name) == null and
-                    (try self.resolveUpvalue(sym_name)) == null)
-                {
-                    return passthrough.compileCallWithValuesTail(self, expr, dst);
-                }
-            }
-            if (std.mem.eql(u8, eff_name, "call-with-current-continuation") or
-                std.mem.eql(u8, eff_name, "call/cc"))
+            const eff_name = if (is_synth)
+                globals_mod.stripBaseBindingPrefix(sym_name).?
+            else
+                types.stripHygienicPrefix(sym_name);
+
+            if (std.mem.eql(u8, eff_name, "apply") or
+                std.mem.eql(u8, eff_name, "call-with-values") or
+                std.mem.eql(u8, eff_name, "call-with-current-continuation") or
+                std.mem.eql(u8, eff_name, "call/cc") or
+                std.mem.eql(u8, eff_name, "eval"))
             {
-                if (self.resolveLocal(sym_name) == null and
-                    (try self.resolveUpvalue(sym_name)) == null)
-                {
-                    return passthrough.compileCallCCTail(self, expr, dst);
-                }
-            }
-            if (std.mem.eql(u8, eff_name, "eval")) {
-                if (self.resolveLocal(sym_name) == null and
-                    (try self.resolveUpvalue(sym_name)) == null)
-                {
-                    return passthrough.compileEvalTail(self, expr, dst);
+                // #2033: a *user-text* reference must resolve like any other
+                // global — R7RS 5.3.1 makes a top-level redefinition
+                // essentially an assignment, so the builtin's superinstruction
+                // is only sound while the global binding is still the genuine
+                // primitive. Local/upvalue shadowing and the compile-time
+                // global binding (plus the form's own set! pre-scan) gate the
+                // fast path; synthesized references skip the gate entirely.
+                const fast_ok = is_synth or
+                    (self.resolveLocal(sym_name) == null and
+                        (try self.resolveUpvalue(sym_name)) == null and
+                        self.globalBindingStillGenuine(sym_name, eff_name));
+                if (fast_ok) {
+                    if (std.mem.eql(u8, eff_name, "apply")) return passthrough.compileApplyTail(self, expr, dst);
+                    if (std.mem.eql(u8, eff_name, "call-with-values")) return passthrough.compileCallWithValuesTail(self, expr, dst);
+                    if (std.mem.eql(u8, eff_name, "call-with-current-continuation") or
+                        std.mem.eql(u8, eff_name, "call/cc"))
+                    {
+                        return passthrough.compileCallCCTail(self, expr, dst);
+                    }
+                    if (std.mem.eql(u8, eff_name, "eval")) return passthrough.compileEvalTail(self, expr, dst);
                 }
             }
         }

--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -944,7 +944,7 @@ pub fn compileCaseLambda(self: *Compiler, args: Value, dst: u16) CompileError!vo
         const eq_sym = try gc.allocSymbol("=");
         const ge_sym = try gc.allocSymbol(">=");
         const length_sym = try Compiler.trueBuiltinRefOrSymbol(gc, "length");
-        const apply_sym = try gc.allocSymbol("apply");
+        const apply_sym = try Compiler.trueBuiltinRefOrSymbol(gc, "apply");
         const else_sym = try gc.allocSymbol("else");
         const error_sym = try gc.allocSymbol("error");
         const args_sym = try gc.allocSymbol("%cl-args");

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -636,21 +636,15 @@ pub fn compileLetValues(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
         var j = count;
         while (j > 0) {
             j -= 1;
-            // Every inner apply (j > 0) sits in the tail position of its
-            // enclosing consumer lambda, so it always compiles through
-            // compileApplyTail's structural bytecode fast path (matched on
-            // a literal `apply` symbol, checked only against local/upvalue
-            // shadowing) regardless of this form's own is_tail — that path
-            // never looks `apply` up by name, so a bare symbol is already
-            // safe there. Only the outermost (j == 0) apply's tail-ness
-            // follows this let-values's own is_tail; when that's false, it
-            // falls through to ordinary call compilation, which resolves
-            // `apply` like any other identifier and can be shadowed by a
-            // top-level redefinition (#1715).
-            const apply_sym = if (j == 0 and !is_tail)
-                try compiler_mod.Compiler.trueBuiltinRefOrSymbol(gc, "apply")
-            else
-                gc.allocSymbol("apply") catch return CompileError.OutOfMemory;
+            // Every apply here is a compiler-synthesized reference and must
+            // mean the (scheme base) apply regardless of any top-level
+            // redefinition (#1715, #2033): the tail-position superinstruction
+            // recognizes the base-binding-prefixed spelling and skips its
+            // redefinition gate, and the prefixed name resolves through the
+            // base registry if the fast path is unavailable (non-tail). A
+            // bare symbol would be indistinguishable from user text and get
+            // routed to the user's redefined `apply` under #2033's gate.
+            const apply_sym = try compiler_mod.Compiler.trueBuiltinRefOrSymbol(gc, "apply");
             const inner_body = gc.allocPair(inner, types.NIL) catch return CompileError.OutOfMemory;
             const consumer = gc.allocPair(lambda_sym, gc.allocPair(formals_arr[j], inner_body) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
             const temp_sym = temp_syms[j];
@@ -671,7 +665,7 @@ pub fn compileLetStarValues(self: *Compiler, args: Value, dst: u16, is_tail: boo
     const body = types.cdr(args);
     if (body == types.NIL) return CompileError.InvalidSyntax;
 
-    const desugared = buildLetValues(self, bindings, body, is_tail) catch |err| return switch (err) {
+    const desugared = buildLetValues(self, bindings, body) catch |err| return switch (err) {
         error.InvalidSyntax => CompileError.InvalidSyntax,
         else => CompileError.OutOfMemory,
     };
@@ -697,7 +691,7 @@ pub fn compileLetStarValues(self: *Compiler, args: Value, dst: u16, is_tail: boo
 /// identifier resolution can be shadowed by a top-level redefinition of
 /// `call-with-values` (#1715) — so it takes the same true-binding reference
 /// unconditionally rather than relying on which path the compiler picks.
-pub fn buildLetValues(self: *Compiler, bindings: Value, body: Value, is_tail: bool) !Value {
+pub fn buildLetValues(self: *Compiler, bindings: Value, body: Value) !Value {
     const gc = self.gc;
     gc.no_collect += 1;
     defer gc.no_collect -= 1;
@@ -718,7 +712,7 @@ pub fn buildLetValues(self: *Compiler, bindings: Value, body: Value, is_tail: bo
     if (!types.isPair(expr_rest)) return error.InvalidSyntax;
     const expr = types.car(expr_rest);
 
-    const inner = try buildLetValues(self, rest_bindings, body, true);
+    const inner = try buildLetValues(self, rest_bindings, body);
 
     // (lambda () expr)
     const producer_body = try gc.allocPair(expr, types.NIL);
@@ -729,9 +723,9 @@ pub fn buildLetValues(self: *Compiler, bindings: Value, body: Value, is_tail: bo
     const consumer_lambda = try gc.allocPair(lambda_sym, try gc.allocPair(formals, consumer_body));
 
     // (call-with-values producer consumer)
-    const cwv_sym = if (is_tail)
-        try gc.allocSymbol("call-with-values")
-    else
-        try compiler_mod.Compiler.trueBuiltinRefOrSymbol(gc, "call-with-values");
+    // A compiler-synthesized reference: always the pristine (scheme base)
+    // binding, so no top-level redefinition of `call-with-values` can change
+    // the desugaring's meaning (#1715, #2033).
+    const cwv_sym = try compiler_mod.Compiler.trueBuiltinRefOrSymbol(gc, "call-with-values");
     return try gc.allocPair(cwv_sym, try gc.allocPair(producer_lambda, try gc.allocPair(consumer_lambda, types.NIL)));
 }

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -679,18 +679,14 @@ pub fn compileLetStarValues(self: *Compiler, args: Value, dst: u16, is_tail: boo
 ///   (lambda (a b)
 ///     (call-with-values (lambda () e2) (lambda (c) (begin body)))))
 ///
-/// Each *nested* call-with-values (built by the recursive call below) is
-/// the sole body of its enclosing consumer lambda, so it is always in tail
-/// position, hence always compiled through compileCallWithValuesTail's
-/// bytecode fast path — which avoids both native re-entrancy and (since
-/// #1715) shadowing, as it now loads the true `(scheme base)` binding
-/// directly instead of resolving `call-with-values` by name. Only the
-/// OUTERMOST call-with-values (returned to the original, non-recursive
-/// caller) has tail-ness that depends on this let*-values's own is_tail;
-/// when that's false, it falls through to ordinary call compilation, whose
-/// identifier resolution can be shadowed by a top-level redefinition of
-/// `call-with-values` (#1715) — so it takes the same true-binding reference
-/// unconditionally rather than relying on which path the compiler picks.
+/// Every call-with-values built here is a compiler-synthesized reference to
+/// the true `(scheme base)` binding (base-binding-prefixed, #1715): the
+/// nested ones sit in tail position and compile through
+/// compileCallWithValuesTail's bytecode fast path — which avoids both
+/// native re-entrancy and (since #2033) the redefinition gate, as the
+/// dispatch recognizes the prefixed spelling as immune — and any that fall
+/// through to ordinary call compilation resolve the pristine binding
+/// regardless of how the program rebinds `call-with-values`.
 pub fn buildLetValues(self: *Compiler, bindings: Value, body: Value) !Value {
     const gc = self.gc;
     gc.no_collect += 1;

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -799,14 +799,14 @@ fn buildDefineValuesAssignForm(gc: *memory.GC, names: []const []const u8, rest_n
     if (is_single) {
         // (define-values x expr) → (set! x (call-with-values (lambda () expr) list))
         const rn_sym = gc.allocSymbol(rest_name.?) catch return CompileError.OutOfMemory;
-        const list_sym = gc.allocSymbol("list") catch return CompileError.OutOfMemory;
+        const list_sym = try compiler_mod.Compiler.trueBuiltinRefOrSymbol(gc, "list");
 
         const producer_body = gc.allocPair(expr, types.NIL) catch return CompileError.OutOfMemory;
         const producer_lambda = gc.allocPair(types.NIL, producer_body) catch return CompileError.OutOfMemory;
         const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;
         const producer = gc.allocPair(lambda_sym, producer_lambda) catch return CompileError.OutOfMemory;
 
-        const cwv_sym = gc.allocSymbol("call-with-values") catch return CompileError.OutOfMemory;
+        const cwv_sym = try compiler_mod.Compiler.trueBuiltinRefOrSymbol(gc, "call-with-values");
         const cwv_3 = gc.allocPair(list_sym, types.NIL) catch return CompileError.OutOfMemory;
         const cwv_2 = gc.allocPair(producer, cwv_3) catch return CompileError.OutOfMemory;
         const cwv_form = gc.allocPair(cwv_sym, cwv_2) catch return CompileError.OutOfMemory;
@@ -879,7 +879,10 @@ fn buildDefineValuesAssignForm(gc: *memory.GC, names: []const []const u8, rest_n
     const producer = gc.allocPair(lambda_sym, producer_lambda) catch return CompileError.OutOfMemory;
 
     // Build (call-with-values producer consumer)
-    const cwv_sym = gc.allocSymbol("call-with-values") catch return CompileError.OutOfMemory;
+    // A compiler-synthesized reference: must mean the pristine (scheme base)
+    // call-with-values even if the program rebinds the name at top level
+    // (#1715, #2033).
+    const cwv_sym = try compiler_mod.Compiler.trueBuiltinRefOrSymbol(gc, "call-with-values");
     const cwv_3 = gc.allocPair(consumer, types.NIL) catch return CompileError.OutOfMemory;
     const cwv_2 = gc.allocPair(producer, cwv_3) catch return CompileError.OutOfMemory;
     return gc.allocPair(cwv_sym, cwv_2) catch return CompileError.OutOfMemory;

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -702,6 +702,18 @@ fn lowerFormWithMacros(ir: *IR, expr: Value, macros: ?*std.StringHashMap(Value))
             if (sexpr_form_map.get(effective_name)) |form|
                 return ir.makeSexprNode(form, types.cdr(expr));
 
+            // A compiler-synthesized reference to a special form — the
+            // let-values/let*-values/define-values/case-lambda desugarings
+            // mint __kaappi_base__apply / _call-with-values (#1715) — must
+            // be dispatched exactly like its bare spelling: the tail-position
+            // superinstructions in compileForm recognize it there, and the
+            // base-binding prefix marks it immune to redefinition so the
+            // #2033 gate skips it. Lowered as a plain call node it would
+            // bypass compileForm entirely and lose the fast path.
+            if (globals_mod.stripBaseBindingPrefix(effective_name)) |base_name| {
+                if (isSpecialForm(base_name)) return ir.makePassthrough(expr);
+            }
+
             if (isSpecialForm(effective_name)) return ir.makePassthrough(expr);
         }
 

--- a/src/llvm_emit_forms.zig
+++ b/src/llvm_emit_forms.zig
@@ -1015,9 +1015,14 @@ pub fn emitPassthrough(self: *LLVMEmitter, expr: Value, is_tail: bool) EmitError
 //     `apply` since #2033, so the fast path must be gated the same way: a
 //     define/set! of `apply` in this module marks it rebound and routes the
 //     form through an ordinary indirect call instead.
-//   - tail + unshadowed + <2 operands → the interpreter's compileApplyTail
-//     raises InvalidSyntax at compile time; abandoning native compilation
-//     routes the enclosing form to that exact error.
+//   - tail + unshadowed + unrebound + <2 operands → the interpreter's
+//     compileApplyTail raises InvalidSyntax at compile time; abandoning
+//     native compilation routes the enclosing form to that exact error. A
+//     REBOUND `apply` with too few operands is not this case: the
+//     interpreter routes it through the ordinary call path (its #2033
+//     gate), so the generic indirect call below is the matching behavior,
+//     and the user's own procedure (or the built-in arity check) raises at
+//     run time.
 //   - everything else — lexically shadowed `apply` (any shape), a rebound
 //     `apply` (tail or non-tail), or a non-tail form with <2 operands — is
 //     an ordinary indirect call through whatever `apply` resolves to in
@@ -1043,7 +1048,13 @@ pub fn emitApplyForm(self: *LLVMEmitter, expr: Value, is_tail: bool) EmitError![
     const rebound = self.rebound_globals.contains("apply") or
         self.native_fns.contains("apply");
 
-    if (!shadowed and is_tail and operands.items.len < 2)
+    // Abandon to the interpreter only for the genuinely builtin shape: a
+    // rebound `apply` with too few operands is a runtime arity/behavior
+    // question for the user's procedure, exactly as in the interpreter
+    // (whose #2033 gate routes it through the ordinary call path), so it
+    // falls through to the generic indirect call below, not this compile
+    // error.
+    if (!shadowed and !rebound and is_tail and operands.items.len < 2)
         return error.UnsupportedNodeType;
 
     const is_builtin_apply = !shadowed and !rebound;

--- a/src/llvm_emit_forms.zig
+++ b/src/llvm_emit_forms.zig
@@ -1009,17 +1009,19 @@ pub fn emitPassthrough(self: *LLVMEmitter, expr: Value, is_tail: bool) EmitError
 // scope (kaappi#1803), mirroring the interpreter's own dispatch
 // (compiler.zig / compileApplyTail) case for case:
 //
-//   - tail + unshadowed + ≥2 operands → structural apply with built-in
-//     semantics (the interpreter's tail_apply opcode ignores a top-level
-//     rebinding of `apply`, so the fast path must too): @kaappi_apply
-//     splices the final operand at run time.
+//   - tail + unshadowed + unrebound + ≥2 operands → structural apply with
+//     built-in semantics (@kaappi_apply splices the final operand at run
+//     time). The interpreter's tail_apply honours a top-level rebinding of
+//     `apply` since #2033, so the fast path must be gated the same way: a
+//     define/set! of `apply` in this module marks it rebound and routes the
+//     form through an ordinary indirect call instead.
 //   - tail + unshadowed + <2 operands → the interpreter's compileApplyTail
 //     raises InvalidSyntax at compile time; abandoning native compilation
 //     routes the enclosing form to that exact error.
-//   - everything else — lexically shadowed `apply` (any shape), or a
-//     non-tail form that is rebound/natively redefined or has <2 operands
-//     — is an ordinary indirect call through whatever `apply` resolves to
-//     in scope (emitGlobalRef's lexical order), matching the interpreter's
+//   - everything else — lexically shadowed `apply` (any shape), a rebound
+//     `apply` (tail or non-tail), or a non-tail form with <2 operands — is
+//     an ordinary indirect call through whatever `apply` resolves to in
+//     scope (emitGlobalRef's lexical order), matching the interpreter's
 //     plain call: a shadowed binding IS the callee, and the built-in's own
 //     arity check raises the interpreter's exact runtime error for the
 //     too-few-operands shapes.
@@ -1044,7 +1046,7 @@ pub fn emitApplyForm(self: *LLVMEmitter, expr: Value, is_tail: bool) EmitError![
     if (!shadowed and is_tail and operands.items.len < 2)
         return error.UnsupportedNodeType;
 
-    const is_builtin_apply = !shadowed and (is_tail or !rebound);
+    const is_builtin_apply = !shadowed and !rebound;
 
     if (is_builtin_apply and operands.items.len >= 2) {
         const n_fixed = operands.items.len - 2;

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -467,7 +467,38 @@ test "eval tail position runs in constant frame depth (#1253)" {
 // Regression for #1253: null-environment must not leak VM globals in tail position.
 // guard desugars its body into a lambda, putting eval in tail position and
 // routing through get_global (not call_global). Without restricted_globals,
-// get_global falls back to vm.globals, letting car resolve.
+
+// #2033: R7RS 5.3.1 makes a top-level redefinition essentially an assignment,
+// so the tail-position superinstructions for apply / call-with-values /
+// call/cc / call-with-current-continuation / eval must not fire when the
+// global binding is no longer the genuine primitive — the user's procedure
+// wins in tail position exactly as it always did in non-tail position.
+test "top-level redefinition honoured in tail position (#2033)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(define (call/cc f) 'user-callcc)");
+    _ = try ctx.vm.eval("(define (tail-use) (call/cc 42))");
+    try std.testing.expectEqualStrings("user-callcc", types.symbolName(try ctx.vm.eval("(tail-use)")));
+
+    _ = try ctx.vm.eval("(define (apply . r) 'user-apply)");
+    _ = try ctx.vm.eval("(define (apply-tail) (apply + (list 1 2)))");
+    try std.testing.expectEqualStrings("user-apply", types.symbolName(try ctx.vm.eval("(apply-tail)")));
+
+    _ = try ctx.vm.eval("(define (call-with-values p c) 'user-cwv)");
+    _ = try ctx.vm.eval("(define (cwv-tail) (call-with-values (lambda () 1) list))");
+    try std.testing.expectEqualStrings("user-cwv", types.symbolName(try ctx.vm.eval("(cwv-tail)")));
+
+    _ = try ctx.vm.eval("(define (eval x . env) 'user-eval)");
+    _ = try ctx.vm.eval("(define (eval-tail) (eval '(+ 1 2)))");
+    try std.testing.expectEqualStrings("user-eval", types.symbolName(try ctx.vm.eval("(eval-tail)")));
+
+    _ = try ctx.vm.eval("(define (call-with-current-continuation f) 'user-ccc)");
+    _ = try ctx.vm.eval("(define (ccc-tail) (call-with-current-continuation (lambda (k) 1)))");
+    try std.testing.expectEqualStrings("user-ccc", types.symbolName(try ctx.vm.eval("(ccc-tail)")));
+}
+
 test "environment accepts import-set modifiers (#1189)" {
     var ctx: th.TestContext = undefined;
     try ctx.init();

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -670,7 +670,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
             if (spec.protocol_expr) |protocol_expr| {
                 // (protocol (lambda n-args (let ((__parent-inst (apply parent-ctor n-args))) (lambda own-args (apply %make-record __rt (append (list ...parent fields...) own-args))))))
                 const own_args_sym = gc.allocSymbol(" __own-args") catch return VMError.OutOfMemory;
-                const apply_sym = gc.allocSymbol("apply") catch return VMError.OutOfMemory;
+                const apply_sym = globals_mod.baseBindingSymbol(gc, "apply") catch return VMError.OutOfMemory;
                 const append_sym = gc.allocSymbol("append") catch return VMError.OutOfMemory;
                 const mr_sym = globals_mod.baseBindingSymbol(gc, "%make-record") catch return VMError.OutOfMemory;
                 const rt_local = gc.allocSymbol(" __rt") catch return VMError.OutOfMemory;
@@ -706,7 +706,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
 
                 const parent_ctor_internal = internCtorName(gc, spec.parent_name.?) catch return VMError.OutOfMemory;
                 const parent_ctor_sym = gc.allocSymbol(parent_ctor_internal) catch return VMError.OutOfMemory;
-                const apply_sym = gc.allocSymbol("apply") catch return VMError.OutOfMemory;
+                const apply_sym = globals_mod.baseBindingSymbol(gc, "apply") catch return VMError.OutOfMemory;
                 const apply_parent = gc.makeList(&[_]Value{ apply_sym, parent_ctor_sym, parent_args_expr }) catch return VMError.OutOfMemory;
 
                 const append_sym = gc.allocSymbol("append") catch return VMError.OutOfMemory;

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -659,7 +659,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
             const parent_internal = internRecordTypeName(gc, spec.parent_name.?) catch return VMError.OutOfMemory;
             const parent_rt_ref = gc.allocSymbol(parent_internal) catch return VMError.OutOfMemory;
             var extract_elems: [257]Value = undefined;
-            extract_elems[0] = gc.allocSymbol("list") catch return VMError.OutOfMemory;
+            extract_elems[0] = globals_mod.baseBindingSymbol(gc, "list") catch return VMError.OutOfMemory;
             const parent_inst_sym = gc.allocSymbol(" __parent-inst") catch return VMError.OutOfMemory;
             for (0..parent_total_fields) |fi| {
                 const rr_sym = globals_mod.baseBindingSymbol(gc, "%record-ref") catch return VMError.OutOfMemory;
@@ -671,7 +671,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
                 // (protocol (lambda n-args (let ((__parent-inst (apply parent-ctor n-args))) (lambda own-args (apply %make-record __rt (append (list ...parent fields...) own-args))))))
                 const own_args_sym = gc.allocSymbol(" __own-args") catch return VMError.OutOfMemory;
                 const apply_sym = globals_mod.baseBindingSymbol(gc, "apply") catch return VMError.OutOfMemory;
-                const append_sym = gc.allocSymbol("append") catch return VMError.OutOfMemory;
+                const append_sym = globals_mod.baseBindingSymbol(gc, "append") catch return VMError.OutOfMemory;
                 const mr_sym = globals_mod.baseBindingSymbol(gc, "%make-record") catch return VMError.OutOfMemory;
                 const rt_local = gc.allocSymbol(" __rt") catch return VMError.OutOfMemory;
                 const appended = gc.makeList(&[_]Value{ append_sym, parent_fields_list, own_args_sym }) catch return VMError.OutOfMemory;
@@ -699,8 +699,8 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
                 const own_count_val = types.makeFixnum(@intCast(spec.field_count));
                 const split_call = gc.makeList(&[_]Value{ rss_sym, call_args_sym, own_count_val }) catch return VMError.OutOfMemory;
 
-                const car_sym = gc.allocSymbol("car") catch return VMError.OutOfMemory;
-                const cdr_sym = gc.allocSymbol("cdr") catch return VMError.OutOfMemory;
+                const car_sym = globals_mod.baseBindingSymbol(gc, "car") catch return VMError.OutOfMemory;
+                const cdr_sym = globals_mod.baseBindingSymbol(gc, "cdr") catch return VMError.OutOfMemory;
                 const parent_args_expr = gc.makeList(&[_]Value{ car_sym, split_sym }) catch return VMError.OutOfMemory;
                 const own_args_expr = gc.makeList(&[_]Value{ cdr_sym, split_sym }) catch return VMError.OutOfMemory;
 
@@ -709,7 +709,7 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
                 const apply_sym = globals_mod.baseBindingSymbol(gc, "apply") catch return VMError.OutOfMemory;
                 const apply_parent = gc.makeList(&[_]Value{ apply_sym, parent_ctor_sym, parent_args_expr }) catch return VMError.OutOfMemory;
 
-                const append_sym = gc.allocSymbol("append") catch return VMError.OutOfMemory;
+                const append_sym = globals_mod.baseBindingSymbol(gc, "append") catch return VMError.OutOfMemory;
                 const appended = gc.makeList(&[_]Value{ append_sym, parent_fields_list, own_args_expr }) catch return VMError.OutOfMemory;
                 const mr_sym = globals_mod.baseBindingSymbol(gc, "%make-record") catch return VMError.OutOfMemory;
                 const rt_local = gc.allocSymbol(" __rt") catch return VMError.OutOfMemory;

--- a/tests/scheme/audit/primitives_control-audit.scm
+++ b/tests/scheme/audit/primitives_control-audit.scm
@@ -882,13 +882,27 @@
             'local ((lambda () (let ((apply (lambda a 'local)))
                                  ((lambda () (apply + '(1 2))))))))
 
-;; FAIL: #2033 (a top-level redefinition of these five names is ignored in tail
-;; position; the same call in non-tail position honours it)
-;; (define (audit-user-call/cc f) 'user)
-;; (test-equal "shadowing: a top-level redefinition of call/cc wins in tail position"
-;;             'user (let ()
-;;                     (define (call/cc f) 'user)
-;;                     ((lambda () (call/cc (lambda (k) 1))))))
+;; #2033: a top-level redefinition of these names is honoured in tail position
+;; (R7RS 5.3.1: "At the top level of a program, a definition ... has essentially
+;; the same effect as the assignment expression"). The same call one position
+;; away (non-tail) always honoured it; tail position must too. Each name is
+;; saved, rebound, tested, then restored so the rest of the file keeps the
+;; genuine binding.
+(define saved-audit-call/cc call/cc)
+(define (call/cc f) 'user)
+(test-equal "shadowing: a top-level redefinition of call/cc wins in tail position"
+            'user ((lambda () (call/cc (lambda (k) 1)))))
+(define call/cc saved-audit-call/cc)
+(test-equal "shadowing: the genuine call/cc works in tail position after restore"
+            42 ((lambda () (call/cc (lambda (k) 42)))))
+
+(define saved-audit-call-with-values call-with-values)
+(define (call-with-values p c) 'user)
+(test-equal "shadowing: a top-level redefinition of call-with-values wins in tail position"
+            'user ((lambda () (call-with-values (lambda () 1) list))))
+(define call-with-values saved-audit-call-with-values)
+(test-equal "shadowing: the genuine call-with-values works in tail position after restore"
+            '(1 2) ((lambda () (call-with-values (lambda () (values 1 2)) list))))
 
 ;;; ------------------------------------------------------------------
 ;;; Deeply nested dynamic-wind

--- a/tests/scheme/compile/native-apply-lowering-1803.sh
+++ b/tests/scheme/compile/native-apply-lowering-1803.sh
@@ -8,9 +8,10 @@
 # emitApplyForm now emits the callee and fixed arguments natively and hands the
 # final operand to @kaappi_apply (runtime_exports.zig), which splices it with
 # primitives.applyFn's exact semantics. The dispatch mirrors the interpreter's
-# (compiler.zig): tail + unshadowed = structural built-in apply (tail_apply
-# ignores a top-level rebinding, so the fast path must too); everything else
-# resolvable is an ordinary call through whatever `apply` denotes in scope.
+# (compiler.zig): tail + unshadowed + unrebound = structural built-in apply
+# (tail_apply honours a top-level rebinding since #2033, so the fast path is
+# gated the same way); everything else resolvable is an ordinary call through
+# whatever `apply` denotes in scope.
 #
 # Every functional case asserts the compiled binary agrees with the
 # interpreter; error cases assert both fail and the native diagnostic carries
@@ -195,10 +196,11 @@ cat > "$DIR/shadowed.scm" << 'SCHEME'
 SCHEME
 check_both "shadowed" "30"
 
-# 5. A top-level rebinding of `apply`: the interpreter honors it for a
-#    NON-tail apply (an ordinary call through the current global) but ignores
-#    it in TAIL position (the tail_apply opcode is structural). The native
-#    dispatch mirrors both halves.
+# 5. A top-level rebinding of `apply`: the interpreter honors it in BOTH
+#    positions since #2033 (R7RS 5.3.1: a top-level definition is essentially
+#    an assignment). A non-tail apply is an ordinary call through the current
+#    global; a tail apply must also resolve the user's binding instead of
+#    firing the structural tail_apply opcode. The native dispatch mirrors both.
 cat > "$DIR/rebound.scm" << 'SCHEME'
 (define (myapply f lst) 99)
 (define apply myapply)
@@ -209,7 +211,7 @@ cat > "$DIR/rebound.scm" << 'SCHEME'
 (display (tail (list 1 2 3)))
 (newline)
 SCHEME
-check_both "rebound" "$(printf '99\n6')"
+check_both "rebound" "$(printf '99\n99')"
 
 # 6. `apply` as a VALUE rather than a call head: resolves to the built-in
 #    procedure object and flows through map like any other argument.

--- a/tests/scheme/compliance/top-level-redefinition-2033.scm
+++ b/tests/scheme/compliance/top-level-redefinition-2033.scm
@@ -159,14 +159,30 @@
             3 ((case-lambda ((a b) (+ a b)) (a a)) 1 2))
 (test-equal "case-lambda desugaring keeps pristine apply (rest-arg arm)"
             '(5) ((case-lambda ((a b) (+ a b)) (a a)) 5))
-(test-equal "define-record-type desugaring keeps pristine apply"
-            3 (let ()
-                (define-record-type <t2033-pt> (make-t2033-pt x y) t2033-pt?
-                  (x t2033-pt-x) (y t2033-pt-y))
-                (define-record-type <t2033-pt3> (make-t2033-pt3 x y z) t2033-pt3?
-                  (x t2033-pt3-x) (y t2033-pt3-y) (z t2033-pt3-z)
-                  (parent <t2033-pt>))
-                (t2033-pt3-z (make-t2033-pt3 1 2 3))))
+
+;; R6RS clause-syntax define-record-type with a parent — exercises the two
+;; inherited-constructor paths in vm_records whose synthesized `apply`
+;; (and list/append/car/cdr) references must stay pristine under the
+;; rebinding: the protocol-less split-args path and the protocol path.
+;; R6RS clause syntax is only supported at top level (vm_records.zig), so
+;; the definitions live here, inside the redefinition window.
+(define-record-type (t2033-r6 make-t2033-r6 t2033-r6?)
+  (fields (immutable x t2033-r6-x) (immutable y t2033-r6-y)))
+(define-record-type (t2033-r63 make-t2033-r63 t2033-r63?)
+  (parent t2033-r6)
+  (fields (immutable z t2033-r63-z)))
+(define-record-type (t2033-r6p make-t2033-r6p t2033-r6p?)
+  (parent t2033-r6)
+  (fields (immutable w t2033-r6p-w))
+  (protocol (lambda (new) (lambda (x y w) (let ((p (new x y))) (p w))))))
+(test-equal "define-record-type (R6RS, protocol-less parent): keeps pristine apply"
+            '(1 2 3) (list (t2033-r6-x (make-t2033-r63 1 2 3))
+                           (t2033-r6-y (make-t2033-r63 1 2 3))
+                           (t2033-r63-z (make-t2033-r63 1 2 3))))
+(test-equal "define-record-type (R6RS, protocol parent): keeps pristine apply"
+            '(1 2 9) (list (t2033-r6-x (make-t2033-r6p 1 2 9))
+                           (t2033-r6-y (make-t2033-r6p 1 2 9))
+                           (t2033-r6p-w (make-t2033-r6p 1 2 9))))
 
 ;; The define-values single case also synthesizes a `list` consumer; that
 ;; immunity needs a `list` redefinition, which would corrupt SRFI-64's own

--- a/tests/scheme/compliance/top-level-redefinition-2033.scm
+++ b/tests/scheme/compliance/top-level-redefinition-2033.scm
@@ -1,0 +1,192 @@
+;;; Regression tests for #2033: a top-level redefinition of call/cc, apply,
+;;; eval or call-with-values (plus call-with-current-continuation) was
+;;; ignored in tail position.
+;;;
+;;; R7RS 5.3.1, "Top level definitions": "At the top level of a program, a
+;;; definition ... has essentially the same effect as the assignment
+;;; expression ... if ⟨variable⟩ is bound to a non-syntax value."
+;;;
+;;; compiler.zig's tail-position dispatch sent these five names to
+;;; hand-written superinstructions guarded only by resolveLocal /
+;;; resolveUpvalue — a *global* rebinding of the name was not consulted, so a
+;;; program that redefined one of them got its own definition everywhere
+;;; except in tail position, where the builtin ran instead and the user's
+;;; procedure was silently discarded. The fix gates each fast path on the
+;;; compile-time global binding (mirroring IR.isRedefined), so the same
+;;; resolution rules apply in both positions.
+;;;
+;;; Also covered here: the compiler-synthesized references the
+;;; let-values/let*-values/define-values/case-lambda/define-record-type
+;;; desugarings mint for apply / call-with-values / list stay bound to the
+;;; pristine (scheme base) procedures under a redefinition (#1715), and a
+;;; hygiene-renamed macro-template reference agrees between tail and
+;;; non-tail position.
+;;;
+;;; The originals are saved first because the file intentionally rebinds each
+;;; name several times; every section restores from these saved values so the
+;;; framework's own machinery (and the later sections) keep the genuine
+;;; bindings.
+
+(import (scheme base) (scheme write) (scheme eval) (scheme process-context) (srfi 64))
+
+(test-begin "top-level-redefinition-2033")
+
+(define saved-2033-orig-apply apply)
+(define saved-2033-orig-eval eval)
+(define saved-2033-orig-call/cc call/cc)
+(define saved-2033-orig-cwv call-with-values)
+(define saved-2033-orig-ccc call-with-current-continuation)
+
+;;; ------------------------------------------------------------------
+;;; The five names, redefined BEFORE the caller is defined: tail position
+;;; must resolve the user's binding, exactly like the non-tail position
+;;; that was always correct.
+;;; ------------------------------------------------------------------
+
+(define (user-apply f . rest) 'user-apply)
+(define (apply f . rest) 'user-apply)
+(define (apply-tail) (apply + (list 1 2)))
+(define (apply-nontail) (list (apply + (list 1 2))))
+(test-equal "apply: top-level redefinition wins in tail position"
+            'user-apply (apply-tail))
+(test-equal "apply: top-level redefinition wins in non-tail position (control)"
+            '(user-apply) (apply-nontail))
+(define apply saved-2033-orig-apply)
+
+(define (user-eval x . env) 'user-eval)
+(define (eval x . env) 'user-eval)
+(define (eval-tail) (eval '(+ 1 2) (interaction-environment)))
+(define (eval-nontail) (list (eval '(+ 1 2) (interaction-environment))))
+(test-equal "eval: top-level redefinition wins in tail position"
+            'user-eval (eval-tail))
+(test-equal "eval: top-level redefinition wins in non-tail position (control)"
+            '(user-eval) (eval-nontail))
+(define eval saved-2033-orig-eval)
+
+(define (user-call/cc f) 'user-call/cc)
+(define (call/cc f) 'user-call/cc)
+(define (call/cc-tail) (call/cc (lambda (k) 1)))
+(define (call/cc-nontail) (list (call/cc (lambda (k) 1))))
+(test-equal "call/cc: top-level redefinition wins in tail position"
+            'user-call/cc (call/cc-tail))
+(test-equal "call/cc: top-level redefinition wins in non-tail position (control)"
+            '(user-call/cc) (call/cc-nontail))
+(define call/cc saved-2033-orig-call/cc)
+
+(define (user-cwv p c) 'user-cwv)
+(define (call-with-values p c) 'user-cwv)
+(define (cwv-tail) (call-with-values (lambda () 1) list))
+(define (cwv-nontail) (list (call-with-values (lambda () 1) list)))
+(test-equal "call-with-values: top-level redefinition wins in tail position"
+            'user-cwv (cwv-tail))
+(test-equal "call-with-values: top-level redefinition wins in non-tail position (control)"
+            '(user-cwv) (cwv-nontail))
+(define call-with-values saved-2033-orig-cwv)
+
+(define (user-ccc f) 'user-ccc)
+(define (call-with-current-continuation f) 'user-ccc)
+(define (ccc-tail) (call-with-current-continuation (lambda (k) 1)))
+(define (ccc-nontail) (list (call-with-current-continuation (lambda (k) 1))))
+(test-equal "call-with-current-continuation: top-level redefinition wins in tail position"
+            'user-ccc (ccc-tail))
+(test-equal "call-with-current-continuation: redefinition wins in non-tail position (control)"
+            '(user-ccc) (ccc-nontail))
+(define call-with-current-continuation saved-2033-orig-ccc)
+
+;;; ------------------------------------------------------------------
+;;; A redefinition to a non-procedure value: the builtin must not run —
+;;; the ordinary call path reports the type error.
+;;; ------------------------------------------------------------------
+
+(define call/cc 42)
+(test-assert "call/cc: redefined to a non-procedure raises in tail position"
+             (guard (e (#t (error-object? e))) ((lambda () (call/cc (lambda (k) 1))))))
+(define call/cc saved-2033-orig-call/cc)
+(test-equal "call/cc: genuine binding restored, tail position works again"
+            42 ((lambda () (call/cc (lambda (k) 42)))))
+
+;;; ------------------------------------------------------------------
+;;; A hygiene-renamed free reference from a macro template agrees between
+;;; tail and non-tail position under a top-level redefinition.
+;;; ------------------------------------------------------------------
+
+(define (call-with-current-continuation f) 'template-user)
+(define-syntax tpl-2033-ref
+  (syntax-rules () ((_ x) (call-with-current-continuation x))))
+(define (tpl-tail x) (tpl-2033-ref x))
+(define (tpl-nontail x) (list (tpl-2033-ref x)))
+(test-equal "macro template free reference: tail position honours the redefinition"
+            'template-user (tpl-tail 42))
+(test-equal "macro template free reference: non-tail position agrees"
+            '(template-user) (tpl-nontail 42))
+(define call-with-current-continuation saved-2033-orig-ccc)
+
+;;; ------------------------------------------------------------------
+;;; A set! target inside the same top-level form suppresses the fast path
+;;; (the compile-time global binding is still pristine, so only the set!
+;;; pre-scan can see the hazard).
+;;; ------------------------------------------------------------------
+
+(test-equal "call/cc: a set! target in the enclosing form suppresses the fast path"
+            'set-user (let ((f (lambda () (set! call/cc (lambda (x) 'set-user)) (call/cc 1))))
+                        (f)))
+(define call/cc saved-2033-orig-call/cc)
+(test-equal "call/cc: restored after the set! test"
+            42 ((lambda () (call/cc (lambda (k) 42)))))
+
+;;; ------------------------------------------------------------------
+;;; The compiler-synthesized references in derived-form desugarings stay
+;;; bound to the pristine (scheme base) procedures even while the names are
+;;; redefined at top level (#1715): let-values / let*-values / define-values
+;;; / case-lambda / define-record-type must not pick up the user's
+;;; redefinitions.
+;;; ------------------------------------------------------------------
+
+(define (apply f . r) 'user-apply)
+(define (call-with-values p c) 'user-cwv)
+
+(test-equal "let-values desugaring keeps pristine apply/call-with-values"
+            7 (let-values (((a b) (values 3 4))) (+ a b)))
+(test-equal "let*-values desugaring keeps pristine apply/call-with-values"
+            30 (let*-values (((a) (values 10)) ((b) (values 20))) (+ a b)))
+(test-equal "define-values (single) desugaring keeps pristine call-with-values"
+            5 (let ((x 'unset)) (define-values (x) (values 5)) x))
+(test-equal "define-values (multi) desugaring keeps pristine call-with-values"
+            '(6 7) (let ((a 'unset) (b 'unset))
+                     (define-values (a b) (values 6 7))
+                     (list a b)))
+(test-equal "case-lambda desugaring keeps pristine apply"
+            3 ((case-lambda ((a b) (+ a b)) (a a)) 1 2))
+(test-equal "case-lambda desugaring keeps pristine apply (rest-arg arm)"
+            '(5) ((case-lambda ((a b) (+ a b)) (a a)) 5))
+(test-equal "define-record-type desugaring keeps pristine apply"
+            3 (let ()
+                (define-record-type <t2033-pt> (make-t2033-pt x y) t2033-pt?
+                  (x t2033-pt-x) (y t2033-pt-y))
+                (define-record-type <t2033-pt3> (make-t2033-pt3 x y z) t2033-pt3?
+                  (x t2033-pt3-x) (y t2033-pt3-y) (z t2033-pt3-z)
+                  (parent <t2033-pt>))
+                (t2033-pt3-z (make-t2033-pt3 1 2 3))))
+
+;; The define-values single case also synthesizes a `list` consumer; that
+;; immunity needs a `list` redefinition, which would corrupt SRFI-64's own
+;; runner state (the runner calls the global `list`), so it is asserted
+;; without the framework instead.
+(define saved-2033-list list)
+(define (list . r) 'user-list)
+(if (equal? (let ((x 'unset)) (define-values (x) (values 5)) x) 5)
+    (write 'list-consumer-immunity-ok)
+    (begin (write 'list-consumer-immunity-FAIL) (exit 1)))
+(newline)
+(define list saved-2033-list)
+
+(define apply saved-2033-orig-apply)
+(define call-with-values saved-2033-orig-cwv)
+(test-equal "genuine apply restored"
+            3 (apply + (list 1 2)))
+(test-equal "genuine call-with-values restored"
+            '(1 2) (call-with-values (lambda () (values 1 2)) list))
+
+(define %test-fail-count (test-runner-fail-count (test-runner-current)))
+(test-end "top-level-redefinition-2033")
+(if (> %test-fail-count 0) (exit 1))


### PR DESCRIPTION
Fixes #2033 — [R7RS 5.3.1] A top-level redefinition of `call/cc`, `apply`, `eval` or `call-with-values` was ignored in tail position.

## The bug

`compiler.zig`'s tail-position dispatch sent `(apply …)`, `(eval …)`, `(call/cc …)`, `(call-with-current-continuation …)` and `(call-with-values …)` to hand-written superinstructions guarded only by `resolveLocal`/`resolveUpvalue` — a **global** rebinding of the name was not consulted. A program that redefined one of these five names at top level got its own definition everywhere except in tail position, where the builtin ran instead and the user's procedure was silently discarded. R7RS 5.3.1: *"At the top level of a program, a definition … has essentially the same effect as the assignment expression."*

```scheme
(define (call/cc f) 'user-callcc)
(define (tail-use)    (call/cc 42))        ; tail position — ran the builtin (ERR)
(define (nontail-use) (list (call/cc 42))) ; not tail — correct
```

## The fix

Each fast path is now gated on the compile-time global binding, mirroring `IR.isRedefined` and `vm_dispatch_helpers.lookupGlobalLocked`'s resolution order (raw name, then the hygienic-prefix fallback to the bare name):

- a `set!` target in the enclosing form, or a truncated pre-scan (`set_targets_all`), declines the fast path;
- a name unbound in a library/restricted environment declines it (the builtin no longer silently runs for a name the program never bound);
- everything else (the 99.9% case) keeps the structural superinstruction — **zero runtime cost**, the gate only decides which bytecode the compiler emits.

## Adjacent fixes the gate forced

- **Synthesized references stay pristine (#1715):** the let-values / let*-values / define-values / case-lambda / define-record-type desugarings minted bare `apply`/`call-with-values` symbols that were indistinguishable from user text. They now carry the `base_binding_prefix` so they remain bound to the `(scheme base)` procedures under a redefinition; `ir.zig` lowers a base-prefixed special-form head as a passthrough so it still reaches `compileForm`'s dispatch instead of bypassing it as a plain call (fast path preserved). The define-values single-name `list` consumer is base-prefixed too.
- **Native backend parity (#1803):** `emitApplyForm` mirrored the interpreter's old "tail ignores rebinding" behavior; it now gates on the module's rebound/native redefinitions the same way.
- **Docs:** `docs/dev/llvm-backend.md` updated.

## Tests

- New `tests/scheme/compliance/top-level-redefinition-2033.scm` — all five names (tail + non-tail controls), non-procedure redefinitions, hygiene-renamed macro-template references, `set!`-in-form suppression, and desugaring immunity under redefinition.
- The previously disabled audit assertions in `primitives_control-audit.scm` are re-enabled with real top-level redefinitions (the old proxy used an internal `let` define, which shadows lexically and never exercised the bug).
- New Zig unit test in `src/tests_core_eval.zig`.
- `native-apply-lowering-1803.sh`'s "rebound" case updated to the corrected expectation (it documented the bug as expected behavior).
- Verified: both new test files fail on `main` and pass here; full suite is green — **700 Scheme files, 1395 R7RS assertions, unit tests (incl. `-Dgc-stress=true`)**, WASM build, and the native tier matches the interpreter on the repro.

## Known limitation (unchanged, out of scope)

A redefinition compiled **after** the caller is baked in stays stale in tail position — the same compile-time-baking trade-off the constant folder already makes for `(+ 1 2)` (only ordinary calls re-resolve globals at run time). No new divergence was introduced.

---

## Review follow-ups (commit `8e09371e`)

- **CodeRabbit:** the original `define-record-type` test used R7RS constructor-first syntax, where `(parent …)` parses as a *field spec* — it never exercised the changed R6RS inherited-constructor paths in `vm_records.zig`. Replaced with top-level R6RS clause-syntax records covering **both** inherited-ctor variants (protocol-less split-args path and protocol path); both fail on `main` and pass here. While in those paths, the remaining bare synthesized refs (`list`/`append`/`car`/`cdr`) got the same base-binding-prefix treatment as `apply`.
- **baijum:** `emitApplyForm`'s `<2 operands` early return fired before the rebound check, needlessly abandoning native compilation for a *rebound* tail `apply` with one operand. Gated on `!rebound` so that shape takes the generic indirect call (matching the interpreter's #2033-gated ordinary call path); docs updated.
- **baijum:** trimmed the stale `buildLetValues` doc comment that described the removed `is_tail`-dependent reasoning.
