### PR TITLE
REPL: click inside the input to move the edit cursor (#2264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Click inside the REPL input to move the edit cursor** (#2264). SGR mouse
+  tracking behind a `repl.mouse: true` setting in `~/.kaappi/config` (default
+  off, so drag-to-select behavior never changes unasked): a left click maps
+  to a buffer position with prompt width, continuation prompt, and line
+  wrapping all taken into account, including on wrapped and multi-line
+  forms. Clicks outside the editing area are no-ops. This is the fifth
+  Kaappi patch to vendored isocline (`vendor/isocline/PATCHES.md`); the
+  Windows console needs its own mouse-input path and is not yet supported.
+
 ### Fixed
 
 - **Rational→flonum conversion is correct when a single side alone leaves

--- a/docs/dev/repl.md
+++ b/docs/dev/repl.md
@@ -25,6 +25,7 @@ which `main.zig` never reaches.
 | `ic_set_default_highlighter` | `highlightCallback` → `scanHighlight` | Emits styled spans; `scanHighlight` is separated so the token rules are testable without a terminal. |
 | `ic_style_def` | `applyTheme` | `repl.color.*` names become isocline styles via `ansiToIcStyle`. `ic-prompt` and `ic-bracematch` are isocline's own names, redefined. |
 | `ic_enable_brace_matching` | — | Limited to `"()"`: the reader gives `[`/`]` no meaning (`0]` is KP1002). |
+| `ic_enable_mouse` | — | Opt-in SGR mouse tracking: click inside the input to move the edit cursor. Off by default (`repl.mouse` in `~/.kaappi/config`); see `vendor/isocline/PATCHES.md`, patch 5. |
 
 Two settings are deliberate rather than default:
 
@@ -76,6 +77,27 @@ Three things are worth knowing before changing them:
 Rotate keeps the head in place and cycles the arguments. Rotating the head too
 would turn every call form into something unevaluatable (`(+ 1 2)` → `(1 2 +)`);
 as it stands, repeating it n-1 times on n arguments restores the original.
+
+## Click to position the cursor
+
+`repl.mouse: true` in `~/.kaappi/config` turns on SGR mouse tracking for the
+edit session, so a left click inside the current input moves the edit cursor
+(kaappi#2264). Default is **off**: while tracking is on, the terminal stops
+reporting drag-to-select to the application — copy still works
+modifier-gated (Option-drag in Terminal.app / iTerm2, Shift-drag in most
+Linux terminals). Clicks outside the editing area — into scrollback above,
+blank rows below — are no-ops; a click on the prompt clamps to the start of
+that line's content.
+
+The mouse reports absolute screen coordinates, so the editor anchors the
+input's on-screen start with a one-time `ESC[6n` query at the start of each
+read. A terminal that does not answer (some emulators, SSH without mouse
+support) makes clicks no-ops. The Windows console needs its own mouse-input
+path, not SGR, and is not supported (`vendor/isocline/PATCHES.md`, patch 5).
+
+`tests/scheme/smoke/repl-mouse-click-2264.sh` drives the whole path over a
+real pty: it answers the DSR query the way a terminal emulator would and
+then feeds SGR mouse sequences, asserting on what the evaluator prints.
 
 ## Comma commands
 

--- a/docs/dev/repl.md
+++ b/docs/dev/repl.md
@@ -91,9 +91,14 @@ that line's content.
 
 The mouse reports absolute screen coordinates, so the editor anchors the
 input's on-screen start with a one-time `ESC[6n` query at the start of each
-read. A terminal that does not answer (some emulators, SSH without mouse
-support) makes clicks no-ops. The Windows console needs its own mouse-input
-path, not SGR, and is not supported (`vendor/isocline/PATCHES.md`, patch 5).
+read. The response reader never consumes input: typing ahead between forms
+(Enter, then start typing the next form while the previous one evaluates)
+is common, and bytes that are not a well-formed response are pushed back to
+be read as keys — only the anchor is skipped for that line, never a
+keystroke. A terminal that does not answer (some emulators, SSH without
+mouse support) makes clicks no-ops. The Windows console needs its own
+mouse-input path, not SGR, and is not supported
+(`vendor/isocline/PATCHES.md`, patch 5).
 
 `tests/scheme/smoke/repl-mouse-click-2264.sh` drives the whole path over a
 real pty: it answers the DSR query the way a terminal emulator would and

--- a/src/config.zig
+++ b/src/config.zig
@@ -52,6 +52,10 @@ pub const Config = struct {
     prompt_len: u8 = default_prompt.len,
     history_length: c_int = 1000,
     highlight: bool = true,
+    /// Click in the input to move the edit cursor (isocline SGR mouse
+    /// tracking; kaappi#2264). Off by default: while tracking is on, the
+    /// terminal stops reporting drag-to-select to the application.
+    mouse: bool = false,
 
     pub fn prompt(self: *const Config) [*:0]const u8 {
         return @ptrCast(&self.prompt_buf);
@@ -179,6 +183,14 @@ fn parseLine(cfg: *Config, line: []const u8, line_num: usize, no_color: bool) vo
             cfg.highlight = false;
         } else {
             warnLine(line_num, "repl.highlight must be 'true' or 'false'");
+        }
+    } else if (std.mem.eql(u8, key, "repl.mouse")) {
+        if (std.mem.eql(u8, value, "true")) {
+            cfg.mouse = true;
+        } else if (std.mem.eql(u8, value, "false")) {
+            cfg.mouse = false;
+        } else {
+            warnLine(line_num, "repl.mouse must be 'true' or 'false'");
         }
     } else {
         warnKey(line_num, key);
@@ -322,6 +334,7 @@ test "Config defaults match dark preset" {
     try std.testing.expectEqualStrings("\x1b[0m", cfg.theme.reset);
     try std.testing.expectEqual(true, cfg.highlight);
     try std.testing.expectEqual(@as(c_int, 1000), cfg.history_length);
+    try std.testing.expectEqual(false, cfg.mouse);
 }
 
 test "light preset uses standard colors" {
@@ -392,6 +405,17 @@ test "parseLine highlight" {
     var cfg: Config = .{};
     parseLine(&cfg, "repl.highlight: false", 1, false);
     try std.testing.expectEqual(false, cfg.highlight);
+}
+
+test "parseLine mouse" {
+    var cfg: Config = .{};
+    try std.testing.expectEqual(false, cfg.mouse); // default off: selection behavior must not change unasked
+    parseLine(&cfg, "repl.mouse: true", 1, false);
+    try std.testing.expectEqual(true, cfg.mouse);
+    parseLine(&cfg, "repl.mouse: false", 2, false);
+    try std.testing.expectEqual(false, cfg.mouse);
+    parseLine(&cfg, "repl.mouse: maybe", 3, false); // invalid value leaves it unchanged
+    try std.testing.expectEqual(false, cfg.mouse);
 }
 
 test "parseLine skips comments and blanks" {

--- a/src/isocline.zig
+++ b/src/isocline.zig
@@ -7,10 +7,11 @@
 //! `readline` returns a finished expression — newlines and all — and every line
 //! of it stays editable until the user submits.
 //!
-//! Kaappi's copy carries three patches, all documented in
+//! Kaappi's copy carries five patches, all documented in
 //! `vendor/isocline/PATCHES.md`: an input-completeness callback (upstream's
 //! Enter always submits), a configurable history size (upstream caps at 200),
-//! and structural s-expression editing (upstream has none).
+//! structural s-expression editing (upstream has none), a TCSADRAIN fix so a
+//! multi-line paste tail is not discarded, and opt-in mouse click-to-position.
 //!
 //! Isocline is not thread-safe: `readline` and `print` must be called from one
 //! thread. That holds here — only the REPL loop touches it.
@@ -168,6 +169,13 @@ pub fn enableBraceMatching(enable: bool) void {
 
 pub fn enableBraceInsertion(enable: bool) void {
     _ = c.ic_enable_brace_insertion(enable);
+}
+
+/// Opt in to SGR mouse tracking so a click inside the input moves the edit
+/// cursor (KAAPPI PATCH 5, kaappi#2264). Off by default: while tracking is on
+/// the terminal reports button presses instead of drag-to-select.
+pub fn enableMouse(enable: bool) void {
+    _ = c.ic_enable_mouse(enable);
 }
 
 /// Which brace pairs to match. Kaappi's reader gives `[` and `]` no meaning,

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -615,6 +615,10 @@ pub fn repl(vm: *vm_mod.VM) !void {
         ic.enableBraceInsertion(false);
         ic.enableHighlight(highlight_enabled);
         ic.enableHint(false); // no hint callback is wired up
+        // Opt-in SGR mouse tracking: click inside the input to move the edit
+        // cursor (kaappi#2264). Off by default — while tracking is on, the
+        // terminal stops reporting drag-to-select to the application.
+        ic.enableMouse(cfg.mouse);
         applyTheme(cfg.theme);
 
         ic.setIsComplete(&isCompleteCallback, null);

--- a/tests/scheme/smoke/repl-mouse-click-2264.sh
+++ b/tests/scheme/smoke/repl-mouse-click-2264.sh
@@ -61,7 +61,9 @@ import fcntl, os, pty, re, select, struct, sys, termios, time
 kaappi = sys.argv[1]
 mode = sys.argv[2]              # 'on'  -> repl.mouse: true;  'off' -> default
 width = int(sys.argv[3]) if len(sys.argv) > 3 else 200
+scenario = sys.argv[4] if len(sys.argv) > 4 else 'cases'   # 'cases' | 'ahead'
 assert mode in ('on', 'off')
+assert scenario in ('cases', 'ahead')
 ansi = re.compile(rb'\x1b\[[0-9;?]*[a-zA-Z]|\x1b[()][B0]|\x1b[=>]|\r')
 
 # The fixed DSR answer: the prompt's content starts at row 4, col 9 (two
@@ -210,33 +212,48 @@ cases = CASES if mode == 'on' else [OFF_CASE]
 if width < 100:
     cases = [WRAP_CASE]
 failures = []
-for send_bytes, echo, clk, editkey, expect, reject in cases:
+if scenario == 'ahead':
+    # Type-ahead (maintainer review): submit a form and immediately start
+    # typing the next one while it evaluates. The next prompt's DSR anchor
+    # query must not eat the '(' — the reader pushes back bytes that are not
+    # a well-formed response, so the whole form still lands in the buffer.
+    # Without that, the buffer would be "list 9 8)" and error out.
     mark = len(buf)
-    send(send_bytes)
-    # The echoed text is proof the editor has the buffer — a plain sleep is not,
-    # and typing on while the REPL is still evaluating puts the bytes in the
-    # tty's canonical buffer, where the click then arrives as a literal ESC.
-    if not wait_for(echo, mark, 20):
-        failures.append((send_bytes, expect, seen(mark)))
-        idle()
-        continue
-    idle(0.3)
-    send(clk)
-    idle(0.3)
-    send(editkey)
-    idle(0.3)
-    send(b'\r')
-    # The result line, not the prompt: the prompt string appears in every
-    # redraw of the line being typed, so it says nothing about evaluation.
-    ok = wait_for(b'\n' + expect + b'\n', mark, 20)
+    send(b'(+ 1 2)\r')
+    send(b'(list 9 8)\r')     # no idle between: typed while the first evaluates
+    ok1 = wait_for(b'\n3\n', mark, 20)
+    ok2 = wait_for(b'\n(9 8)\n', mark, 20)
     idle()
-    # Only what this case produced, so an earlier case cannot satisfy a later
-    # assertion. The reject is scoped to a standalone result line too: the
-    # typed echo of `abc` contains `ab`, which would false-positive a plain
-    # substring check.
-    produced = seen(mark)
-    if not ok or (reject is not None and (b'\n' + reject + b'\n') in produced):
-        failures.append((send_bytes, expect, produced))
+    if not (ok1 and ok2):
+        failures.append((b'ahead', b'3 then (9 8)', seen(mark)))
+else:
+    for send_bytes, echo, clk, editkey, expect, reject in cases:
+        mark = len(buf)
+        send(send_bytes)
+        # The echoed text is proof the editor has the buffer — a plain sleep is not,
+        # and typing on while the REPL is still evaluating puts the bytes in the
+        # tty's canonical buffer, where the click then arrives as a literal ESC.
+        if not wait_for(echo, mark, 20):
+            failures.append((send_bytes, expect, seen(mark)))
+            idle()
+            continue
+        idle(0.3)
+        send(clk)
+        idle(0.3)
+        send(editkey)
+        idle(0.3)
+        send(b'\r')
+        # The result line, not the prompt: the prompt string appears in every
+        # redraw of the line being typed, so it says nothing about evaluation.
+        ok = wait_for(b'\n' + expect + b'\n', mark, 20)
+        idle()
+        # Only what this case produced, so an earlier case cannot satisfy a later
+        # assertion. The reject is scoped to a standalone result line too: the
+        # typed echo of `abc` contains `ab`, which would false-positive a plain
+        # substring check.
+        produced = seen(mark)
+        if not ok or (reject is not None and (b'\n' + reject + b'\n') in produced):
+            failures.append((send_bytes, expect, produced))
 
 send(b',quit\r')
 while pump(1.0):
@@ -252,7 +269,7 @@ for failed, expect, produced in failures:
 sys.exit(1 if failures else 0)
 PY
 
-run_case() {  # $1 = mode ('on' | 'off'), $2 = pty width
+run_case() {  # $1 = mode ('on' | 'off'), $2 = pty width, $3 = scenario
     mkdir -p "$work/home"
     if [ "$1" = "on" ]; then
         printf 'repl.mouse: true\n' > "$work/home/config"
@@ -260,13 +277,13 @@ run_case() {  # $1 = mode ('on' | 'off'), $2 = pty width
         rm -f "$work/home/config"
     fi
     set +e
-    KAAPPI_HOME="$work/home" python3 "$driver" "$kaappi_abs" "$1" "$2"
+    KAAPPI_HOME="$work/home" python3 "$driver" "$kaappi_abs" "$1" "$2" "$3"
     status=$?
     set -e
     return $status
 }
 
-run_case on 200
+run_case on 200 cases
 status_on=$?
 if [ $status_on -eq 0 ]; then
     echo "PASS: click repositions the cursor (single-line and continuation rows)"
@@ -278,7 +295,7 @@ else
     exit 1
 fi
 
-run_case off 200
+run_case off 200 cases
 status_off=$?
 if [ $status_off -eq 0 ]; then
     echo "PASS: without repl.mouse the SGR bytes are ignored (default stays safe)"
@@ -287,11 +304,20 @@ else
     exit 1
 fi
 
-run_case on 20
+run_case on 20 cases
 status_wrap=$?
 if [ $status_wrap -eq 0 ]; then
     echo "PASS: click maps correctly on an automatically wrapped row"
 else
     echo "FAIL: click-to-position on a wrapped row"
+    exit 1
+fi
+
+run_case on 200 ahead
+status_ahead=$?
+if [ $status_ahead -eq 0 ]; then
+    echo "PASS: typing ahead between forms loses no characters to the DSR query"
+else
+    echo "FAIL: type-ahead was consumed by the anchor query"
     exit 1
 fi

--- a/tests/scheme/smoke/repl-mouse-click-2264.sh
+++ b/tests/scheme/smoke/repl-mouse-click-2264.sh
@@ -61,9 +61,9 @@ import fcntl, os, pty, re, select, struct, sys, termios, time
 kaappi = sys.argv[1]
 mode = sys.argv[2]              # 'on'  -> repl.mouse: true;  'off' -> default
 width = int(sys.argv[3]) if len(sys.argv) > 3 else 200
-scenario = sys.argv[4] if len(sys.argv) > 4 else 'cases'   # 'cases' | 'ahead'
+scenario = sys.argv[4] if len(sys.argv) > 4 else 'cases'   # 'cases' | 'ahead' | 'garble'
 assert mode in ('on', 'off')
-assert scenario in ('cases', 'ahead')
+assert scenario in ('cases', 'ahead', 'garble')
 ansi = re.compile(rb'\x1b\[[0-9;?]*[a-zA-Z]|\x1b[()][B0]|\x1b[=>]|\r')
 
 # The fixed DSR answer: the prompt's content starts at row 4, col 9 (two
@@ -226,6 +226,25 @@ if scenario == 'ahead':
     idle()
     if not (ok1 and ok2):
         failures.append((b'ahead', b'3 then (9 8)', seen(mark)))
+elif scenario == 'garble':
+    # Hostile terminal report (maintainer review, memory safety): a CSI with
+    # 40 digits/semicolons not terminated by R, arriving while the DSR
+    # anchor query is pending. The reader must cap its restore at
+    # TTY_PUSH_MAX bytes — the pre-fix code wrote up to 66 bytes into the
+    # 32-byte cpushbuf (OOB into the tty struct). Assert the REPL survives:
+    # ctrl-C clears whatever leftover digits got typed, then a fresh form
+    # still evaluates.
+    mark = len(buf)
+    send(b'(+ 1 2)\r')
+    send(b'\x1b[' + b'0;' * 20)     # 40 bytes of digits/semicolons, no 'R'
+    send(b'\x03')                    # ctrl-C: clear any garbage the leftovers typed
+    idle()
+    send(b'(+ 40 2)\r')
+    ok1 = wait_for(b'\n3\n', mark, 20)
+    ok2 = wait_for(b'\n42\n', mark, 20)
+    idle()
+    if not (ok1 and ok2):
+        failures.append((b'garble', b'3 then 42 (no crash)', seen(mark)))
 else:
     for send_bytes, echo, clk, editkey, expect, reject in cases:
         mark = len(buf)
@@ -319,5 +338,14 @@ if [ $status_ahead -eq 0 ]; then
     echo "PASS: typing ahead between forms loses no characters to the DSR query"
 else
     echo "FAIL: type-ahead was consumed by the anchor query"
+    exit 1
+fi
+
+run_case on 200 garble
+status_garble=$?
+if [ $status_garble -eq 0 ]; then
+    echo "PASS: a hostile 40-byte CSI during the DSR query neither crashes nor corrupts"
+else
+    echo "FAIL: the DSR reader mishandled a hostile report"
     exit 1
 fi

--- a/tests/scheme/smoke/repl-mouse-click-2264.sh
+++ b/tests/scheme/smoke/repl-mouse-click-2264.sh
@@ -60,6 +60,7 @@ import fcntl, os, pty, re, select, struct, sys, termios, time
 
 kaappi = sys.argv[1]
 mode = sys.argv[2]              # 'on'  -> repl.mouse: true;  'off' -> default
+width = int(sys.argv[3]) if len(sys.argv) > 3 else 200
 assert mode in ('on', 'off')
 ansi = re.compile(rb'\x1b\[[0-9;?]*[a-zA-Z]|\x1b[()][B0]|\x1b[=>]|\r')
 
@@ -93,6 +94,15 @@ CASES = [
 # one form and (1 2 3 4) would never print.
 OFF_CASE = (b'(list 1 2\r3 4)', b'3 4)', click(11, 5), b'9', b'(1 2 3 4)', b'(1 2 3 94)')
 
+# An automatically wrapped row, driven by a NARROW pty (20 columns: 8 for
+# the prompt, and the wrap threshold leaves 11 for content — the cursor
+# column is reserved), so "(list 1 2 3 4 5 6)" spills onto two visual rows:
+# "(list 1 2 " + "3 4 5 6)". Click at (9+2, 4+1) = editor (1, 2) -> the
+# wrapped row's '4'; typing '9' gives "(list 1 2 3 94 5 6)" ->
+# (1 2 3 94 5 6), where a plain end-insert gives (1 2 3 4 5 69).
+WRAP_CASE = (b'(list 1 2 3 4 5 6)', b'5 6)', click(11, 5), b'9',
+             b'(1 2 3 94 5 6)', b'(1 2 3 4 5 69)')
+
 pid, fd = pty.fork()
 if pid == 0:
     # The child must exec or die: `pty.fork` gives it the parent's code, so a
@@ -106,8 +116,10 @@ if pid == 0:
         pass
     os._exit(127)
 
-# A pty starts out 0x0, which gives the editor no room to render in.
-fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack('HHHH', 40, 200, 0, 0))
+# A pty starts out 0x0, which gives the editor no room to render in. The
+# default 200 columns keep every input on one row; a 20-column run forces
+# automatic wrapping so the wrapped-row mapping is exercised.
+fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack('HHHH', 40, width, 0, 0))
 
 buf = b''
 eof = False
@@ -195,6 +207,8 @@ if not wait_for(b'kaappi> ', 0, 25):
 idle()
 
 cases = CASES if mode == 'on' else [OFF_CASE]
+if width < 100:
+    cases = [WRAP_CASE]
 failures = []
 for send_bytes, echo, clk, editkey, expect, reject in cases:
     mark = len(buf)
@@ -203,7 +217,7 @@ for send_bytes, echo, clk, editkey, expect, reject in cases:
     # and typing on while the REPL is still evaluating puts the bytes in the
     # tty's canonical buffer, where the click then arrives as a literal ESC.
     if not wait_for(echo, mark, 20):
-        failures.append((typed, expect, seen(mark)))
+        failures.append((send_bytes, expect, seen(mark)))
         idle()
         continue
     idle(0.3)
@@ -233,12 +247,12 @@ try:
 except OSError:
     pass
 
-for typed, expect, produced in failures:
-    sys.stdout.write('FAIL %r: expected %r in\n%r\n\n' % (typed, expect, produced))
+for failed, expect, produced in failures:
+    sys.stdout.write('FAIL %r: expected %r in\n%r\n\n' % (failed, expect, produced))
 sys.exit(1 if failures else 0)
 PY
 
-run_case() {  # $1 = mode ('on' | 'off')
+run_case() {  # $1 = mode ('on' | 'off'), $2 = pty width
     mkdir -p "$work/home"
     if [ "$1" = "on" ]; then
         printf 'repl.mouse: true\n' > "$work/home/config"
@@ -246,13 +260,13 @@ run_case() {  # $1 = mode ('on' | 'off')
         rm -f "$work/home/config"
     fi
     set +e
-    KAAPPI_HOME="$work/home" python3 "$driver" "$kaappi_abs" "$1"
+    KAAPPI_HOME="$work/home" python3 "$driver" "$kaappi_abs" "$1" "$2"
     status=$?
     set -e
     return $status
 }
 
-run_case on
+run_case on 200
 status_on=$?
 if [ $status_on -eq 0 ]; then
     echo "PASS: click repositions the cursor (single-line and continuation rows)"
@@ -264,11 +278,20 @@ else
     exit 1
 fi
 
-run_case off
+run_case off 200
 status_off=$?
 if [ $status_off -eq 0 ]; then
     echo "PASS: without repl.mouse the SGR bytes are ignored (default stays safe)"
 else
     echo "FAIL: SGR bytes must be inert when repl.mouse is off"
+    exit 1
+fi
+
+run_case on 20
+status_wrap=$?
+if [ $status_wrap -eq 0 ]; then
+    echo "PASS: click maps correctly on an automatically wrapped row"
+else
+    echo "FAIL: click-to-position on a wrapped row"
     exit 1
 fi

--- a/tests/scheme/smoke/repl-mouse-click-2264.sh
+++ b/tests/scheme/smoke/repl-mouse-click-2264.sh
@@ -1,0 +1,274 @@
+#!/bin/bash
+# kaappi#2264: click inside the current input to reposition the edit cursor.
+#
+# The mapping from an SGR mouse event to a buffer byte position is split
+# across two C files and cannot be reached from Zig: the SGR decode in
+# `tty_esc.c` and the anchor + click-to-position in `editline.c` (KAAPPI
+# PATCH 5 in `vendor/isocline/PATCHES.md`). Driving it needs a real
+# terminal, so the whole thing runs under a pty, like the structural-editing
+# test.
+#
+# The driver plays the terminal emulator: it answers the editor's one-time
+# `ESC[6n` anchor query with a fixed `ESC[4;9R` (the prompt's content starts
+# at row 4, col 9 after the two banner lines and the blank), then feeds SGR
+# mouse presses relative to that anchor. Everything the editor maps depends
+# on the anchor and the click coordinates being consistent, which is exactly
+# the absolute -> relative arithmetic this test pins down.
+#
+# Each case clicks, then does one editing op whose effect is only observable
+# through the *evaluator*'s output, so the assertion is independent of how
+# the editor redraws the line: the only way `bc` prints from `abc` is for
+# the click to have moved the cursor between 'a' and 'b' before the
+# backspace. A second run with mouse support off (the default) feeds the same
+# SGR bytes and asserts they are safely ignored.
+
+set -eu
+
+KAAPPI="${KAAPPI:-${1:-zig-out/bin/kaappi}}"
+
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "no pty; isocline drives the Windows console API directly"
+
+command -v python3 >/dev/null 2>&1 || {
+    echo "SKIP: python3 is needed to allocate a pty"
+    exit 77
+}
+
+# Resolve to an absolute path for the driver, which execs it directly. A value
+# with no slash is a PATH lookup; anything else is a path as given. A binary
+# that cannot be executed is a *failure*, not a skip — the skip below exists
+# for platforms with no usable terminal, and letting a missing build take that
+# exit would make this test silently green.
+case "$KAAPPI" in
+    */*) kaappi_abs="$(cd "$(dirname "$KAAPPI")" 2>/dev/null && pwd)/$(basename "$KAAPPI")" ;;
+    *)   kaappi_abs="$(command -v "$KAAPPI" || true)" ;;
+esac
+if [ ! -x "$kaappi_abs" ]; then
+    echo "FAIL: $KAAPPI is not an executable file (build first: zig build)"
+    exit 1
+fi
+
+# Isolate history and config: the REPL reads ~/.kaappi, and a developer's own
+# `repl.prompt` would move the sentinel this script waits for. Mouse is on for
+# the first run, off for the second (no `repl.mouse` key at all).
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+driver="$work/drive.py"
+cat > "$driver" <<'PY'
+import fcntl, os, pty, re, select, struct, sys, termios, time
+
+kaappi = sys.argv[1]
+mode = sys.argv[2]              # 'on'  -> repl.mouse: true;  'off' -> default
+assert mode in ('on', 'off')
+ansi = re.compile(rb'\x1b\[[0-9;?]*[a-zA-Z]|\x1b[()][B0]|\x1b[=>]|\r')
+
+# The fixed DSR answer: the prompt's content starts at row 4, col 9 (two
+# banner lines + one blank, prompt "kaappi> " is 8 columns). The editor maps
+# a click at absolute (row, col) to editor (row - 4, col - 9).
+DSR = b'\x1b[4;9R'
+def click(col, row):
+    return b'\x1b[<0;%d;%dM' % (col, row)   # SGR: left-button press
+
+# (send, echo, click, edit-key, expected result, reject as a standalone
+# result line). `echo` is what to wait for after sending: the editor renders
+# the buffer, so a `\r` that became a newline is waited for as `3 4)` — the
+# raw bytes never appear in the output. Every buffer must be a valid
+# expression whose *evaluated* value distinguishes the click from a plain
+# end-of-buffer edit; reject is what the same edit without the click would
+# have produced.
+CASES = [
+    # single line: click at (9+6, 4) = editor (0, 6) -> before the '1' of
+    # "(list 1 2 3)"; typing '9' gives "(list 91 2 3)" -> (91 2 3), where a
+    # plain end-insert gives "(list 1 2 3 9)" -> (1 2 3 9).
+    (b'(list 1 2 3)', b'(list 1 2 3)', click(15, 4), b'9', b'(91 2 3)', b'(1 2 3 9)'),
+    # continuation row: click at (9+2, 4+1) = editor (1, 2) -> before the '4'
+    # of "(list 1 2\n3 4)"; typing '9' gives "(list 1 2\n3 94)" ->
+    # (1 2 3 94), where a plain end-insert gives (1 2 3 49).
+    (b'(list 1 2\r3 4)', b'3 4)', click(11, 5), b'9', b'(1 2 3 94)', b'(1 2 3 49)'),
+]
+# With mouse off the click must be ignored: the '9' lands at the end, after
+# the closing paren, so the buffer is "(list 1 2\n3 4)9" — two forms, whose
+# first result is (1 2 3 4). Had the click repositioned, the buffer would be
+# one form and (1 2 3 4) would never print.
+OFF_CASE = (b'(list 1 2\r3 4)', b'3 4)', click(11, 5), b'9', b'(1 2 3 4)', b'(1 2 3 94)')
+
+pid, fd = pty.fork()
+if pid == 0:
+    # The child must exec or die: `pty.fork` gives it the parent's code, so a
+    # raising execv would otherwise let a traceback land in the pty slave and
+    # muddy the buffer the parent is matching against.
+    try:
+        os.environ['TERM'] = 'xterm'
+        os.environ['NO_COLOR'] = '1'
+        os.execv(kaappi, [kaappi])
+    except BaseException:
+        pass
+    os._exit(127)
+
+# A pty starts out 0x0, which gives the editor no room to render in.
+fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack('HHHH', 40, 200, 0, 0))
+
+buf = b''
+eof = False
+answered_dsr = 0                 # how many ESC[6n queries we have answered
+deadline = time.time() + 90
+
+def pump(timeout):
+    global buf, eof
+    try:
+        r, _, _ = select.select([fd], [], [], timeout)
+    except OSError:
+        eof = True
+        return False
+    if not r:
+        return False
+    try:
+        chunk = os.read(fd, 65536)
+    except OSError:
+        eof = True
+        return False
+    if not chunk:
+        eof = True
+        return False
+    buf += chunk
+    return True
+
+def answer_dsr():
+    """Answer every ESC[6n anchor query the child sent, the way a terminal
+    emulator would. The child blocks ~400ms waiting, so we answer on sight."""
+    global answered_dsr
+    while True:
+        idx = buf.find(b'\x1b[6n', answered_dsr)
+        if idx < 0:
+            return
+        answered_dsr = idx + 4
+        os.write(fd, DSR)
+
+def seen(mark=0):
+    """Everything the child has written since *raw* byte `mark`, escapes
+    stripped. The mark indexes `buf`, not the stripped text, because stripped
+    indices are not stable: a read that ends mid-escape-sequence leaves bytes
+    the regex cannot match yet, and they disappear once the rest arrives —
+    shifting every index taken before that."""
+    return ansi.sub(b'', buf[mark:])
+
+def wait_for(needle, mark=0, timeout=20):
+    """Wait for `needle` in output written *after* `mark`. The mark matters:
+    every prompt looks alike, so searching the whole buffer would match the
+    previous one and return before this step had produced anything."""
+    end = min(time.time() + timeout, deadline)
+    while time.time() < end:
+        answer_dsr()
+        if needle in seen(mark):
+            return True
+        if eof:
+            break          # the child is gone; no more output is coming
+        pump(0.2)
+    return needle in seen(mark)
+
+def idle(quiet=0.5, limit=5.0):
+    """Drain until the child has been silent for `quiet` seconds. Typing into
+    a REPL that has not finished evaluating lands in the tty's canonical
+    buffer instead of the editor, so every step waits for quiet first."""
+    end = time.time() + limit
+    while time.time() < end:
+        answer_dsr()
+        if not pump(quiet):
+            return
+
+def send(data):
+    os.write(fd, data)
+    time.sleep(0.05)
+
+if not wait_for(b'kaappi> ', 0, 25):
+    # Two very different things look alike here, and conflating them is how a
+    # test goes quietly green: a REPL that wrote *nothing at all* did not run,
+    # which is a failure; a REPL that wrote something but never prompted has no
+    # usable terminal, which is a skip (the alternative is a flake on every
+    # emulated CI leg).
+    if not buf:
+        sys.stdout.write('the REPL produced no output at all; it did not start\n')
+        sys.exit(1)
+    sys.stdout.write('no prompt in:\n%r\n' % seen())
+    sys.exit(77)
+idle()
+
+cases = CASES if mode == 'on' else [OFF_CASE]
+failures = []
+for send_bytes, echo, clk, editkey, expect, reject in cases:
+    mark = len(buf)
+    send(send_bytes)
+    # The echoed text is proof the editor has the buffer — a plain sleep is not,
+    # and typing on while the REPL is still evaluating puts the bytes in the
+    # tty's canonical buffer, where the click then arrives as a literal ESC.
+    if not wait_for(echo, mark, 20):
+        failures.append((typed, expect, seen(mark)))
+        idle()
+        continue
+    idle(0.3)
+    send(clk)
+    idle(0.3)
+    send(editkey)
+    idle(0.3)
+    send(b'\r')
+    # The result line, not the prompt: the prompt string appears in every
+    # redraw of the line being typed, so it says nothing about evaluation.
+    ok = wait_for(b'\n' + expect + b'\n', mark, 20)
+    idle()
+    # Only what this case produced, so an earlier case cannot satisfy a later
+    # assertion. The reject is scoped to a standalone result line too: the
+    # typed echo of `abc` contains `ab`, which would false-positive a plain
+    # substring check.
+    produced = seen(mark)
+    if not ok or (reject is not None and (b'\n' + reject + b'\n') in produced):
+        failures.append((send_bytes, expect, produced))
+
+send(b',quit\r')
+while pump(1.0):
+    pass
+try:
+    os.close(fd)
+    os.waitpid(pid, 0)
+except OSError:
+    pass
+
+for typed, expect, produced in failures:
+    sys.stdout.write('FAIL %r: expected %r in\n%r\n\n' % (typed, expect, produced))
+sys.exit(1 if failures else 0)
+PY
+
+run_case() {  # $1 = mode ('on' | 'off')
+    mkdir -p "$work/home"
+    if [ "$1" = "on" ]; then
+        printf 'repl.mouse: true\n' > "$work/home/config"
+    else
+        rm -f "$work/home/config"
+    fi
+    set +e
+    KAAPPI_HOME="$work/home" python3 "$driver" "$kaappi_abs" "$1"
+    status=$?
+    set -e
+    return $status
+}
+
+run_case on
+status_on=$?
+if [ $status_on -eq 0 ]; then
+    echo "PASS: click repositions the cursor (single-line and continuation rows)"
+elif [ $status_on -eq 77 ]; then
+    echo "SKIP: no usable pty for the REPL here"
+    exit 77
+else
+    echo "FAIL: click-to-position did not take effect"
+    exit 1
+fi
+
+run_case off
+status_off=$?
+if [ $status_off -eq 0 ]; then
+    echo "PASS: without repl.mouse the SGR bytes are ignored (default stays safe)"
+else
+    echo "FAIL: SGR bytes must be inert when repl.mouse is off"
+    exit 1
+fi

--- a/vendor/isocline/PATCHES.md
+++ b/vendor/isocline/PATCHES.md
@@ -172,11 +172,13 @@ on the `tty` (via `tty_set_mouse_event`, new in `tty.h`) and surfaced as a
 single `KEY_EVENT_MOUSE` code; the edit loop reads it back with
 `tty_last_mouse`.
 
-3. **Cursor move** (`editline.c`): on a plain left press (button 0, no
-modifiers), convert the absolute screen coordinates to prompt-relative
-(row, col) and call the existing `edit_set_pos_at_rowcol` — the hard part,
-mapping (row, col) to a buffer byte position with prompt width, continuation
-prompt, and line wrapping, is already implemented (`sbuf_get_pos_at_rc`).
+3. **Cursor move** (`editline.c`): on a plain left **press** (button 0, no
+modifiers — the release event `m` is decoded but ignored, so a click moves
+the cursor exactly once), convert the absolute screen coordinates to
+prompt-relative (row, col) and call the existing `edit_set_pos_at_rowcol`
+— the hard part, mapping (row, col) to a buffer byte position with prompt
+width, continuation prompt, and line wrapping, is already implemented
+(`sbuf_get_pos_at_rc`).
 
 ### The one hard part: absolute → relative anchor
 
@@ -186,13 +188,21 @@ the prompt) and never queries the absolute cursor position — `term.c` has no
 DSR reader wired into the edit loop. So the patch anchors the input's
 on-screen start with a **one-time `\x1b[6n` query at edit-session start**
 (`edit_line`, right after the prompt is written), storing the answer on the
-editor as `anchor_row`/`anchor_col`. The response is read with the existing
-`tty_read_esc_response` (raw mode is already on, so the toggling
-`term_esc_query` is unusable here). This anchor is the only piece that must
-be correct; everything downstream is already safe. A terminal that does not
-answer (some emulators, SSH without mouse support) leaves the anchor unset
-and clicks become no-ops — the query costs at most the escape-sequence
-timeout.
+editor as `anchor_row`/`anchor_col`. The response is read by a new
+dedicated reader (`tty_read_dsr_response` in `tty.c`, deliberately not the
+existing `tty_read_esc_response`): a REPL user types ahead between forms —
+press Enter and start typing the next form while the previous one evaluates
+— so the first bytes the reader sees are often **not** the response. The
+reader accepts only a well-formed `ESC [ digits ; digits R`; anything else
+it read is pushed back in order, so a queued keystroke (or an arrow key
+sent as `ESC [ A`) still reaches the edit loop as a key. The only
+consequence of a response that cannot be read is an unset anchor, i.e.
+clicks no-op for that line — never lost input. A response that arrives
+after the reader gave up decodes to `KEY_NONE` later and is ignored. This
+anchor is the only piece that must be correct; everything downstream is
+already safe. A terminal that does not answer (some emulators, SSH without
+mouse support) leaves the anchor unset and clicks become no-ops — the
+query costs at most the escape-sequence timeout.
 
 Clicks outside the editing area are safe no-ops (`edit_set_pos_at_rowcol`
 already guards `if (pos < 0) return;`, and the mapper returns `-1` for

--- a/vendor/isocline/PATCHES.md
+++ b/vendor/isocline/PATCHES.md
@@ -4,7 +4,7 @@ Vendored from <https://github.com/daanx/isocline> at commit
 `8d6dc1ef95b1b46711e66eb23d39d4467a0fcdac` (2026-04-23, v1.1.0), MIT licensed —
 see `LICENSE`.
 
-**This is a patched copy.** Four changes diverge from upstream. Each is marked
+**This is a patched copy.** Five changes diverge from upstream. Each is marked
 in the source with a `KAAPPI PATCH <n>` comment pointing here. When updating
 isocline, re-apply them; `grep -rn 'KAAPPI PATCH' vendor/isocline/` finds every
 site.
@@ -123,6 +123,101 @@ The `TCSAFLUSH` in the termination-signal handler (`sig_handler`, for
 SIGINT/SIGTSTP/etc.) is untouched: the process is dying or suspending there,
 not reading the next form, so discarding stray input is the right call and
 out of scope for this bug.
+
+## Patch 5 — click to reposition the edit cursor (mouse support)
+
+**Files:** `include/isocline.h`, `src/env.h`, `src/isocline.c`,
+`src/tty.h`, `src/tty.c`, `src/tty_esc.c`, `src/editline.c`
+
+Upstream isocline moves the cursor with arrow keys and structural editing
+only. The patch adds an opt-in `ic_enable_mouse(bool)` that turns on SGR mouse
+tracking for the edit session, decodes the clicks, and translates a left press
+into a cursor move (kaappi#2264).
+
+### The three pieces
+
+1. **Tracking on/off** (`ic_editline` in `editline.c`): on raw-mode entry,
+emit `\x1b[?1000h` (button-press tracking; deliberately *not* `?1002h`/
+`?1003h` motion) and `\x1b[?1006h` (SGR extended coordinates); emit the
+matching `l` sequences before leaving raw mode. `?1000h` captures clicks, so
+drag-to-select-and-copy in the REPL stops working while it is on — the
+usual reason REPLs don't do this. Mainstream terminals bypass app mouse mode
+with a modifier for one-off native selection (Option-drag in Terminal.app /
+iTerm2, Shift-drag in most Linux terminals), so copy still works,
+modifier-gated; preserving un-gated selection would require shift-click
+passthrough, out of scope. **Windows is a second, parallel implementation,
+not a reuse of this path** (kaappi#2264 comment): isocline reads `INPUT_RECORD`
+structs via `ReadConsoleInputW` on Windows — not a byte stream — and currently
+discards non-key events (`if (inp.EventType != KEY_EVENT) continue;` in
+`tty_waitc_console`). Mouse is first-class there: `MOUSE_EVENT_RECORD` carries
+`dwMousePosition` (already in console cells), `dwButtonState`, `dwEventFlags`.
+The follow-up needs (1) `ENABLE_MOUSE_INPUT` and clearing
+`ENABLE_QUICK_EDIT_MODE` in the Windows `tty_start_raw` — Quick Edit *is*
+Windows' drag-to-select, the exact mirror of `?1000h` breaking selection on
+Unix; (2) a `MOUSE_EVENT` arm instead of the drop; (3) the anchor is *easier*
+there: `GetConsoleScreenBufferInfo().dwCursorPosition` is synchronous, no
+`ESC[6n` round-trip. One Console-API path covers classic conhost and Windows
+Terminal alike (ConPTY translates the terminal's mouse back into
+`MOUSE_EVENT_RECORD`s for a console app that has not requested VT input), so
+there is one shell-agnostic Windows implementation, not one per shell. Until
+then, tracking stays off on Windows (`#if !defined(_WIN32)`) and the flag is
+honored by nothing.
+
+2. **Decoding** (`tty_esc.c`): SGR mouse arrives as `\x1b[<b;x;yM` (press)
+or `m` (release). `<` lands in the CSI decoder's "special byte" catch, and
+the generic parameter parsing only handles two parameters, so the three-part
+mouse event is intercepted right after the special-byte check. The
+coordinates cannot fit in the `code_t` keycode space, so the event is stashed
+on the `tty` (via `tty_set_mouse_event`, new in `tty.h`) and surfaced as a
+single `KEY_EVENT_MOUSE` code; the edit loop reads it back with
+`tty_last_mouse`.
+
+3. **Cursor move** (`editline.c`): on a plain left press (button 0, no
+modifiers), convert the absolute screen coordinates to prompt-relative
+(row, col) and call the existing `edit_set_pos_at_rowcol` — the hard part,
+mapping (row, col) to a buffer byte position with prompt width, continuation
+prompt, and line wrapping, is already implemented (`sbuf_get_pos_at_rc`).
+
+### The one hard part: absolute → relative anchor
+
+The mouse reports **absolute** screen coordinates; isocline works entirely in
+coordinates **relative to the prompt** (`eb->cur_row` is 0-based relative to
+the prompt) and never queries the absolute cursor position — `term.c` has no
+DSR reader wired into the edit loop. So the patch anchors the input's
+on-screen start with a **one-time `\x1b[6n` query at edit-session start**
+(`edit_line`, right after the prompt is written), storing the answer on the
+editor as `anchor_row`/`anchor_col`. The response is read with the existing
+`tty_read_esc_response` (raw mode is already on, so the toggling
+`term_esc_query` is unusable here). This anchor is the only piece that must
+be correct; everything downstream is already safe. A terminal that does not
+answer (some emulators, SSH without mouse support) leaves the anchor unset
+and clicks become no-ops — the query costs at most the escape-sequence
+timeout.
+
+Clicks outside the editing area are safe no-ops (`edit_set_pos_at_rowcol`
+already guards `if (pos < 0) return;`, and the mapper returns `-1` for
+out-of-range rows):
+
+| Click location | Result |
+|---|---|
+| Below the input (blank rows) | row out of range → `-1` → cursor doesn't move |
+| Above the input (prior output / scrollback) | negative relative row → `-1` → no-op *(iff the anchor is right)* |
+| On the prompt glyphs | clamps to start of that logical line's content |
+| Past end of a line's text | `i < end` guard clamps to line end |
+| Inside text (incl. wrapped lines) | maps exactly (mapper is wrap-aware) |
+
+Clicking into scrollback can never reposition there: that region is terminal
+history, not an edit buffer, and isocline has no model of it. The whole risk
+concentrates in the anchor — a stale/off-by-one anchor could map an
+above-input click to a valid in-range row and jump the cursor unexpectedly,
+instead of no-op'ing. The anchor is queried per `ic_readline` call (the
+cursor row moves with evaluation output between calls), and it goes stale if
+the input itself scrolls the terminal — the input taller than the window is a
+known limitation of the first cut.
+
+A delayed DSR response arriving *after* its query timed out decodes to
+`KEY_NONE`; the edit loop now ignores `KEY_NONE` in its default case, where
+previously it fell through to `code_is_unicode(0)` and inserted a NUL.
 
 ## Deliberately not patched
 

--- a/vendor/isocline/PATCHES.md
+++ b/vendor/isocline/PATCHES.md
@@ -204,6 +204,15 @@ already safe. A terminal that does not answer (some emulators, SSH without
 mouse support) leaves the anchor unset and clicks become no-ops — the
 query costs at most the escape-sequence timeout.
 
+The push-back is bounded so it can never overflow the 32-byte `cpushbuf`:
+the digit buffer is capped at `TTY_PUSH_MAX - 2` (a real cursor report is
+a handful of digits), and the restore is skipped entirely if it would not
+fit. The `tty_cpush` overflow guard itself was also fixed: it tested
+`push_count` (the high-level code pushback buffer) while writing
+`cpushbuf` via `cpush_count`, so an overflow would silently corrupt the
+struct instead of tripping the assert — a pre-existing upstream mismatch
+this reader is the first caller able to exercise.
+
 Clicks outside the editing area are safe no-ops (`edit_set_pos_at_rowcol`
 already guards `if (pos < 0) return;`, and the mapper returns `-1` for
 out-of-range rows):

--- a/vendor/isocline/include/isocline.h
+++ b/vendor/isocline/include/isocline.h
@@ -463,6 +463,24 @@ void ic_set_insertion_braces(const char* brace_pairs);
 
 
 //--------------------------------------------------------------
+// Mouse click-to-position (KAAPPI PATCH 5)
+//--------------------------------------------------------------
+
+/// \defgroup mouse Mouse click-to-position
+/// Click inside the current input to move the edit cursor.
+/// \{
+
+/// Enable SGR mouse tracking for click-to-position (disabled by default).
+/// While tracking is on, the terminal reports button presses instead of
+/// letting the application receive drag-to-select events, so this is opt-in.
+/// The Windows console needs its own mouse-input path and is not supported.
+/// Returns the previous setting.
+bool ic_enable_mouse(bool enable);
+
+/// \}
+
+
+//--------------------------------------------------------------
 // Advanced Completion
 //--------------------------------------------------------------
 

--- a/vendor/isocline/src/editline.c
+++ b/vendor/isocline/src/editline.c
@@ -194,7 +194,7 @@ static void edit_mouse_click(ic_env_t* env, editor_t* eb) {
   tty_mouse_t m;
   if (!tty_last_mouse(env->tty, &m)) return;
   if (!eb->has_anchor) return;
-  if (m.button != 0) return;                    // only a plain left press moves the cursor
+  if (m.button != 0 || !m.press) return;   // only a plain left press moves the cursor
   if (m.row < 1 || m.col < 1) return;
   const ssize_t row = m.row - eb->anchor_row;   // 0-based, relative to the prompt
   if (row < 0) return;                          // click above the input: scrollback, no-op
@@ -944,22 +944,17 @@ static char* edit_line( ic_env_t* env, const char* prompt_text )
   // query (ESC[6n). The mouse reports absolute screen coordinates; isocline
   // works relative to the prompt, so this anchor is the only mapping piece —
   // everything downstream (prompt width, continuation prompt, line wrapping)
-  // is already handled by `sbuf_get_pos_at_rc`. A terminal that does not
-  // answer (some emulators, SSH without mouse support) just leaves the anchor
-  // unset and clicks become no-ops. See PATCHES.md.
+  // is already handled by `sbuf_get_pos_at_rc`. The response reader never
+  // consumes input: typing ahead between forms is common in a REPL, and any
+  // bytes that are not a well-formed response are pushed back so the edit
+  // loop still reads them as keys. A terminal that does not answer just
+  // leaves the anchor unset and clicks become no-ops. See PATCHES.md.
   #if !defined(_WIN32)
   if (env->mouse) {
     term_writef(env->term, "\x1B[6n");
     term_flush(env->term);
-    char dsrbuf[128];
-    if (tty_read_esc_response(env->tty, '[', false, dsrbuf, sizeof(dsrbuf))) {
-      ssize_t crow = 0;
-      ssize_t ccol = 0;
-      if (ic_atoz2(dsrbuf, &crow, &ccol)) {
-        eb.anchor_row = crow;
-        eb.anchor_col = ccol;
-        eb.has_anchor = true;
-      }
+    if (tty_read_dsr_response(env->tty, &eb.anchor_row, &eb.anchor_col)) {
+      eb.has_anchor = true;
     }
   }
   #endif

--- a/vendor/isocline/src/editline.c
+++ b/vendor/isocline/src/editline.c
@@ -40,6 +40,13 @@ typedef struct editor_s {
   editstate_t*  redo;         // redo buffer
   const char*   prompt_text;  // text of the prompt before the prompt marker    
   alloc_t*      mem;          // allocator
+  // KAAPPI PATCH 5: absolute anchor of the input's on-screen start, queried
+  // once per edit session via ESC[6n. The mouse reports absolute screen
+  // coordinates; everything else in isocline is relative to the prompt, so
+  // this anchor is the only mapping piece. See PATCHES.md.
+  ssize_t       anchor_row;   // absolute 1-based row where the prompt starts
+  ssize_t       anchor_col;   // absolute 1-based col where row 0's content starts
+  bool          has_anchor;   // true once the DSR query has answered
   // caches
   attrbuf_t*    attrs;        // reuse attribute buffers 
   attrbuf_t*    attrs_extra; 
@@ -58,7 +65,24 @@ static void edit_refresh(ic_env_t* env, editor_t* eb);
 ic_private char* ic_editline(ic_env_t* env, const char* prompt_text) {
   tty_start_raw(env->tty);
   term_start_raw(env->term);
+  // KAAPPI PATCH 5: opt-in mouse tracking for click-to-position (see
+  // PATCHES.md). ?1000h = button presses (deliberately not ?1002h/?1003h
+  // motion), ?1006h = SGR extended coordinates. The Windows console needs its
+  // own mouse-input path, not SGR — out of scope, so tracking stays off there.
+  #if !defined(_WIN32)
+  const bool mouse_tracking = env->mouse;
+  if (mouse_tracking) {
+    term_writef(env->term, "\x1B[?1000h\x1B[?1006h");
+    term_flush(env->term);
+  }
+  #endif
   char* line = edit_line(env,prompt_text);
+  #if !defined(_WIN32)
+  if (mouse_tracking) {
+    term_writef(env->term, "\x1B[?1000l\x1B[?1006l");
+    term_flush(env->term);
+  }
+  #endif
   term_end_raw(env->term,false);
   tty_end_raw(env->tty);
   term_writeln(env->term,"");
@@ -155,6 +179,31 @@ static void edit_set_pos_at_rowcol( ic_env_t* env, editor_t* eb, ssize_t row, ss
   if (pos < 0) return;
   eb->pos = pos;
   edit_refresh(env, eb);
+}
+
+// KAAPPI PATCH 5: click to reposition the cursor (see PATCHES.md). The mouse
+// reports absolute screen coordinates; the anchor (queried once at edit
+// session start) converts them to prompt-relative row/col, which
+// `sbuf_get_pos_at_rc` maps to a buffer position with prompt width,
+// continuation prompt, and line wrapping all taken into account. Clicks
+// outside the editing area are safe no-ops: rows above the input are negative
+// (scrollback), rows below are out of range, both of which `sbuf_get_pos_at_rc`
+// answers with -1.
+static void edit_mouse_click(ic_env_t* env, editor_t* eb) {
+  if (!env->mouse) return;
+  tty_mouse_t m;
+  if (!tty_last_mouse(env->tty, &m)) return;
+  if (!eb->has_anchor) return;
+  if (m.button != 0) return;                    // only a plain left press moves the cursor
+  if (m.row < 1 || m.col < 1) return;
+  const ssize_t row = m.row - eb->anchor_row;   // 0-based, relative to the prompt
+  if (row < 0) return;                          // click above the input: scrollback, no-op
+  ssize_t promptw, cpromptw;
+  edit_get_prompt_width(env, eb, false, &promptw, &cpromptw);
+  ssize_t col = m.col - eb->anchor_col;
+  if (row > 0) col += (promptw - cpromptw);     // continuation rows start at the cpromptw column
+  if (col < 0) col = 0;                         // click on the prompt glyphs: clamp to content start
+  edit_set_pos_at_rowcol(env, eb, row, col);
 }
 
 static bool edit_pos_is_at_row_end( ic_env_t* env, editor_t* eb ) {
@@ -891,6 +940,30 @@ static char* edit_line( ic_env_t* env, const char* prompt_text )
   // show prompt
   edit_write_prompt(env, &eb, 0, false);   
 
+  // KAAPPI PATCH 5: anchor the input's on-screen start with a one-time DSR
+  // query (ESC[6n). The mouse reports absolute screen coordinates; isocline
+  // works relative to the prompt, so this anchor is the only mapping piece —
+  // everything downstream (prompt width, continuation prompt, line wrapping)
+  // is already handled by `sbuf_get_pos_at_rc`. A terminal that does not
+  // answer (some emulators, SSH without mouse support) just leaves the anchor
+  // unset and clicks become no-ops. See PATCHES.md.
+  #if !defined(_WIN32)
+  if (env->mouse) {
+    term_writef(env->term, "\x1B[6n");
+    term_flush(env->term);
+    char dsrbuf[128];
+    if (tty_read_esc_response(env->tty, '[', false, dsrbuf, sizeof(dsrbuf))) {
+      ssize_t crow = 0;
+      ssize_t ccol = 0;
+      if (ic_atoz2(dsrbuf, &crow, &ccol)) {
+        eb.anchor_row = crow;
+        eb.anchor_col = ccol;
+        eb.has_anchor = true;
+      }
+    }
+  }
+  #endif
+
   // always a history entry for the current input
   history_push(env->history, "");
 
@@ -982,6 +1055,10 @@ static char* edit_line( ic_env_t* env, const char* prompt_text )
         break;
       case KEY_EVENT_AUTOTAB:
         edit_generate_completions(env, &eb, true);
+        break;
+      // KAAPPI PATCH 5: click to reposition the cursor (see PATCHES.md)
+      case KEY_EVENT_MOUSE:
+        edit_mouse_click(env,&eb);
         break;
 
       // completion, history, help, undo
@@ -1123,7 +1200,12 @@ static char* edit_line( ic_env_t* env, const char* prompt_text )
       default: {
         char chr;
         unicode_t uchr;
-        if (code_is_ascii_char(c,&chr)) {
+        if (c == KEY_NONE) {
+          // KAAPPI PATCH 5: a DSR or other query response that arrived after
+          // its query timed out decodes to KEY_NONE; without this guard it
+          // would fall through to `code_is_unicode(0)` and insert a NUL.
+        }
+        else if (code_is_ascii_char(c,&chr)) {
           edit_insert_char(env,&eb,chr);
         }
         else if (code_is_unicode(c, &uchr)) {

--- a/vendor/isocline/src/env.h
+++ b/vendor/isocline/src/env.h
@@ -54,6 +54,8 @@ struct ic_env_s {
   bool            no_bracematch;    // enable brace matching?
   bool            no_autobrace;     // enable automatic brace insertion?
   bool            no_lscolors;      // use LSCOLORS/LS_COLORS to colorize file name completions?
+  // KAAPPI PATCH 5: see vendor/isocline/PATCHES.md
+  bool            mouse;            // enable mouse click-to-position in the editor?
   long            hint_delay;       // delay before displaying a hint in milliseconds
 };
 

--- a/vendor/isocline/src/isocline.c
+++ b/vendor/isocline/src/isocline.c
@@ -304,6 +304,17 @@ ic_public bool ic_enable_brace_insertion(bool enable) {
   return !prev;
 }
 
+// KAAPPI PATCH 5: see vendor/isocline/PATCHES.md. Enables SGR mouse tracking
+// for click-to-position inside the editor. Default off: while tracking is on
+// the terminal stops reporting drag-to-select to the application, and copy
+// still works modifier-gated (Option/Shift-drag), so users opt in.
+ic_public bool ic_enable_mouse(bool enable) {
+  ic_env_t* env = ic_get_env(); if (env==NULL) return false;
+  bool prev = env->mouse;
+  env->mouse = enable;
+  return prev;
+}
+
 ic_public void ic_set_insertion_braces(const char* brace_pairs) {
   ic_env_t* env = ic_get_env(); if (env==NULL) return;
   mem_free(env->mem, env->auto_braces);

--- a/vendor/isocline/src/tty.c
+++ b/vendor/isocline/src/tty.c
@@ -11,6 +11,7 @@
 #include <locale.h>
 
 #include "tty.h"
+#include "stringbuf.h"  // ic_atoz2 (KAAPPI PATCH 5)
 
 #if defined(_WIN32)
 #include <windows.h>
@@ -52,6 +53,7 @@ struct tty_s {
   uint32_t  mouse_button;           // SGR button code (see tty.h `tty_mouse_t`)
   ssize_t   mouse_row;              // 1-based absolute row
   ssize_t   mouse_col;              // 1-based absolute column
+  bool      mouse_press;            // press ('M') or release ('m')
   #if defined(_WIN32)
   HANDLE    hcon;                   // console input handle
   DWORD     hcon_orig_mode;         // original console mode
@@ -234,10 +236,11 @@ ic_private code_t tty_read(tty_t* tty)
 // KAAPPI PATCH 5: see PATCHES.md — set/read the last decoded SGR mouse event.
 // The decoder in tty_esc.c writes through the setter; the edit loop in
 // editline.c reads through the getter, so the tty struct can stay opaque.
-ic_private void tty_set_mouse_event(tty_t* tty, uint32_t button, ssize_t row, ssize_t col) {
+ic_private void tty_set_mouse_event(tty_t* tty, uint32_t button, ssize_t row, ssize_t col, bool press) {
   tty->mouse_button = button;
   tty->mouse_row = row;
   tty->mouse_col = col;
+  tty->mouse_press = press;
 }
 
 ic_private bool tty_last_mouse(const tty_t* tty, tty_mouse_t* mouse) {
@@ -245,7 +248,61 @@ ic_private bool tty_last_mouse(const tty_t* tty, tty_mouse_t* mouse) {
   mouse->button = tty->mouse_button;
   mouse->row = tty->mouse_row;
   mouse->col = tty->mouse_col;
+  mouse->press = tty->mouse_press;
   return true;
+}
+
+// KAAPPI PATCH 5: see PATCHES.md — read a DSR response (ESC [ row ; col R)
+// without ever losing input. In a REPL the user types ahead between forms,
+// and those bytes sit in the tty buffer when the anchor query runs; a naive
+// "read the response" would consume the first one and discard it. Every
+// failure path here pushes back exactly the bytes it read (in order), so the
+// edit loop still sees a queued keystroke as a key. The response is only
+// accepted when it is a well-formed ESC [ digits ; digits R.
+ic_private bool tty_read_dsr_response(tty_t* tty, ssize_t* row, ssize_t* col) {
+  if (tty == NULL || row == NULL || col == NULL) return false;
+  uint8_t c = 0;
+  if (!tty_readc_noblock(tty, &c, 2*tty->esc_initial_timeout)) {
+    return false;                          // nothing arrived: nothing consumed
+  }
+  if (c != '\x1B') {
+    tty_cpush_char(tty, c);                // a queued keystroke: hand it back
+    return false;
+  }
+  if (!tty_readc_noblock(tty, &c, tty->esc_timeout)) {
+    tty_cpush_char(tty, '\x1B');
+    return false;
+  }
+  if (c != '[') {
+    tty_cpush_char(tty, c);                // Alt+<char> etc.: hand it back
+    tty_cpush_char(tty, '\x1B');
+    return false;
+  }
+
+  // ESC [ <digits;digits> R. Anything else (an arrow key is ESC [ A, ...) is
+  // a key sequence, not a response, and must be handed back whole.
+  char buf[64];
+  ssize_t n = 0;
+  for (;;) {
+    if (!tty_readc_noblock(tty, &c, tty->esc_timeout)) break;
+    if (c == 'R') {
+      buf[n] = 0;
+      if (ic_atoz2(buf, row, col)) {
+        debug_msg("tty: dsr response: cursor at %zd,%zd\n", *row, *col);
+        return true;
+      }
+      break;                               // malformed payload: restore below
+    }
+    if ((c < '0' || c > '9') && c != ';') break;  // not a DSR: restore below
+    if (n >= (ssize_t)sizeof(buf) - 1) break;     // absurdly long: restore
+    buf[n++] = (char)c;
+  }
+  // push back everything we read, in order (the low-level buffer pops LIFO)
+  tty_cpush_char(tty, c);
+  while (n > 0) { n--; tty_cpush_char(tty, buf[n]); }
+  tty_cpush_char(tty, '[');
+  tty_cpush_char(tty, '\x1B');
+  return false;
 }
 
 //-------------------------------------------------------------

--- a/vendor/isocline/src/tty.c
+++ b/vendor/isocline/src/tty.c
@@ -48,6 +48,10 @@ struct tty_s {
   ssize_t   cpush_count;
   long      esc_initial_timeout;    // initial ms wait to see if ESC starts an escape sequence
   long      esc_timeout;            // follow up delay for characters in an escape sequence
+  // KAAPPI PATCH 5: the last decoded SGR mouse event (see PATCHES.md)
+  uint32_t  mouse_button;           // SGR button code (see tty.h `tty_mouse_t`)
+  ssize_t   mouse_row;              // 1-based absolute row
+  ssize_t   mouse_col;              // 1-based absolute column
   #if defined(_WIN32)
   HANDLE    hcon;                   // console input handle
   DWORD     hcon_orig_mode;         // original console mode
@@ -225,6 +229,23 @@ ic_private code_t tty_read(tty_t* tty)
   code_t code;
   if (!tty_read_timeout(tty, -1, &code)) return KEY_NONE;
   return code;
+}
+
+// KAAPPI PATCH 5: see PATCHES.md — set/read the last decoded SGR mouse event.
+// The decoder in tty_esc.c writes through the setter; the edit loop in
+// editline.c reads through the getter, so the tty struct can stay opaque.
+ic_private void tty_set_mouse_event(tty_t* tty, uint32_t button, ssize_t row, ssize_t col) {
+  tty->mouse_button = button;
+  tty->mouse_row = row;
+  tty->mouse_col = col;
+}
+
+ic_private bool tty_last_mouse(const tty_t* tty, tty_mouse_t* mouse) {
+  if (tty == NULL || mouse == NULL) return false;
+  mouse->button = tty->mouse_button;
+  mouse->row = tty->mouse_row;
+  mouse->col = tty->mouse_col;
+  return true;
 }
 
 //-------------------------------------------------------------

--- a/vendor/isocline/src/tty.c
+++ b/vendor/isocline/src/tty.c
@@ -280,8 +280,12 @@ ic_private bool tty_read_dsr_response(tty_t* tty, ssize_t* row, ssize_t* col) {
   }
 
   // ESC [ <digits;digits> R. Anything else (an arrow key is ESC [ A, ...) is
-  // a key sequence, not a response, and must be handed back whole.
-  char buf[64];
+  // a key sequence, not a response, and must be handed back whole. The digit
+  // cap keeps a restore within TTY_PUSH_MAX bytes: 1 (c) + n + 2 ('[' + ESC);
+  // a real cursor report is only a handful of digits, so a tight cap costs
+  // nothing. A longer run of digits (a garbled or hostile terminal report)
+  // simply fails the read and is restored as far as the cap allows.
+  char buf[TTY_PUSH_MAX - 2];   // n <= sizeof(buf)-1 leaves room for the NUL
   ssize_t n = 0;
   for (;;) {
     if (!tty_readc_noblock(tty, &c, tty->esc_timeout)) break;
@@ -294,14 +298,18 @@ ic_private bool tty_read_dsr_response(tty_t* tty, ssize_t* row, ssize_t* col) {
       break;                               // malformed payload: restore below
     }
     if ((c < '0' || c > '9') && c != ';') break;  // not a DSR: restore below
-    if (n >= (ssize_t)sizeof(buf) - 1) break;     // absurdly long: restore
+    if (n >= (ssize_t)sizeof(buf) - 1) break;     // restore cap: stop reading
     buf[n++] = (char)c;
   }
-  // push back everything we read, in order (the low-level buffer pops LIFO)
-  tty_cpush_char(tty, c);
-  while (n > 0) { n--; tty_cpush_char(tty, buf[n]); }
-  tty_cpush_char(tty, '[');
-  tty_cpush_char(tty, '\x1B');
+  // push back everything we read, in order (the low-level buffer pops LIFO).
+  // Guard the restore against overflowing cpushbuf even if it holds leftover
+  // bytes from elsewhere (it is normally empty here, but the guard is cheap).
+  if (tty->cpush_count + n + 3 <= TTY_PUSH_MAX) {
+    tty_cpush_char(tty, c);
+    while (n > 0) { n--; tty_cpush_char(tty, buf[n]); }
+    tty_cpush_char(tty, '[');
+    tty_cpush_char(tty, '\x1B');
+  }
   return false;
 }
 
@@ -385,7 +393,12 @@ ic_private bool tty_cpop(tty_t* tty, uint8_t* c) {
 
 static void tty_cpush(tty_t* tty, const char* s) {
   ssize_t len = ic_strlen(s);
-  if (tty->push_count + len > TTY_PUSH_MAX) {
+  // KAAPPI PATCH 5: the guard used to test `push_count` — the *high-level*
+  // code pushback buffer — while the writes below land in `cpushbuf` via
+  // `cpush_count`. The two counts are unrelated, so a push could silently
+  // write past the 32-byte cpushbuf (the assert never fired). Guard the
+  // counter the writes actually use. See PATCHES.md, patch 5.
+  if (tty->cpush_count + len > TTY_PUSH_MAX) {
     debug_msg("tty: cpush buffer full! (pushing %s)\n", s);
     assert(false);
     return;

--- a/vendor/isocline/src/tty.h
+++ b/vendor/isocline/src/tty.h
@@ -40,6 +40,18 @@ ic_private bool   tty_term_resize_event(tty_t* tty); // did the terminal resize?
 ic_private bool   tty_async_stop(const tty_t* tty);  // unblock the read asynchronously
 ic_private void   tty_set_esc_delay(tty_t* tty, long initial_delay_ms, long followup_delay_ms);
 
+// KAAPPI PATCH 5: see PATCHES.md — the last decoded SGR mouse event. The mouse
+// reports absolute screen coordinates (1-based); converting them to editor
+// coordinates is the edit loop's job, see editline.c.
+typedef struct tty_mouse_s {
+  uint32_t button;   // SGR button code: 0 left, 1 middle, 2 right, 64/65 wheel up/down; +4 shift, +8 alt, +16 ctrl
+  ssize_t  row;      // 1-based absolute row
+  ssize_t  col;      // 1-based absolute column
+} tty_mouse_t;
+
+ic_private void tty_set_mouse_event(tty_t* tty, uint32_t button, ssize_t row, ssize_t col);
+ic_private bool tty_last_mouse(const tty_t* tty, tty_mouse_t* mouse);
+
 // shared between tty.c and tty_esc.c: low level character push
 ic_private void   tty_cpush_char(tty_t* tty, uint8_t c);
 ic_private bool   tty_cpop(tty_t* tty, uint8_t* c);
@@ -143,6 +155,7 @@ static inline code_t key_unicode( unicode_t u ) {
 #define KEY_EVENT_RESIZE  (KEY_EVENT_BASE+1)
 #define KEY_EVENT_AUTOTAB (KEY_EVENT_BASE+2)
 #define KEY_EVENT_STOP    (KEY_EVENT_BASE+3)
+#define KEY_EVENT_MOUSE   (KEY_EVENT_BASE+4)  // KAAPPI PATCH 5: see PATCHES.md
 
 // Convenience
 #define KEY_CTRL_UP       (WITH_CTRL(KEY_UP))

--- a/vendor/isocline/src/tty.h
+++ b/vendor/isocline/src/tty.h
@@ -47,10 +47,16 @@ typedef struct tty_mouse_s {
   uint32_t button;   // SGR button code: 0 left, 1 middle, 2 right, 64/65 wheel up/down; +4 shift, +8 alt, +16 ctrl
   ssize_t  row;      // 1-based absolute row
   ssize_t  col;      // 1-based absolute column
+  bool     press;    // true = button press ('M'), false = release ('m')
 } tty_mouse_t;
 
-ic_private void tty_set_mouse_event(tty_t* tty, uint32_t button, ssize_t row, ssize_t col);
+ic_private void tty_set_mouse_event(tty_t* tty, uint32_t button, ssize_t row, ssize_t col, bool press);
 ic_private bool tty_last_mouse(const tty_t* tty, tty_mouse_t* mouse);
+
+// KAAPPI PATCH 5: see PATCHES.md — read a DSR response (ESC [ row ; col R)
+// without ever losing input: any bytes read that turn out not to be a valid
+// response are pushed back so the edit loop still sees them as keys.
+ic_private bool tty_read_dsr_response(tty_t* tty, ssize_t* row, ssize_t* col);
 
 // shared between tty.c and tty_esc.c: low level character push
 ic_private void   tty_cpush_char(tty_t* tty, uint8_t c);

--- a/vendor/isocline/src/tty_esc.c
+++ b/vendor/isocline/src/tty_esc.c
@@ -257,6 +257,35 @@ static code_t tty_read_csi(tty_t* tty, uint8_t c1, uint8_t peek, code_t mods0, l
     }
   }
 
+  // KAAPPI PATCH 5: SGR mouse events, ESC [ < button ; x ; y M|m (see
+  // PATCHES.md). `<` lands in the "special" catch above, and the generic
+  // parameter parsing below only handles two parameters, so a three-parameter
+  // mouse event must be decoded here, before the rest. The event is stashed on
+  // the tty (the keycode space cannot carry two coordinates) and surfaced as
+  // KEY_EVENT_MOUSE for the edit loop.
+  if (special == '<') {
+    uint32_t btn = 1;
+    uint32_t x = 1;
+    uint32_t y = 1;
+    tty_read_csi_num(tty,&peek,&btn,esc_timeout);
+    if (peek == ';') {
+      if (!tty_readc_noblock(tty,&peek,esc_timeout)) return KEY_NONE;
+      tty_read_csi_num(tty,&peek,&x,esc_timeout);
+    }
+    if (peek == ';') {
+      if (!tty_readc_noblock(tty,&peek,esc_timeout)) return KEY_NONE;
+      tty_read_csi_num(tty,&peek,&y,esc_timeout);
+    }
+    uint8_t final = peek;   // 'M' = press, 'm' = release
+    if (final == 'M' || final == 'm') {
+      tty_set_mouse_event(tty, btn, (ssize_t)y, (ssize_t)x);
+      debug_msg("tty: mouse: button %u at %u,%u (%c)\n", btn, x, y, final);
+      return KEY_EVENT_MOUSE;
+    }
+    debug_msg("tty: ignore malformed mouse sequence: ESC [ < ... %c\n", final);
+    return KEY_NONE;
+  }
+
   // up to 2 parameters that default to 1
   uint32_t num1 = 1;
   uint32_t num2 = 1;

--- a/vendor/isocline/src/tty_esc.c
+++ b/vendor/isocline/src/tty_esc.c
@@ -278,7 +278,7 @@ static code_t tty_read_csi(tty_t* tty, uint8_t c1, uint8_t peek, code_t mods0, l
     }
     uint8_t final = peek;   // 'M' = press, 'm' = release
     if (final == 'M' || final == 'm') {
-      tty_set_mouse_event(tty, btn, (ssize_t)y, (ssize_t)x);
+      tty_set_mouse_event(tty, btn, (ssize_t)y, (ssize_t)x, (final == 'M'));
       debug_msg("tty: mouse: button %u at %u,%u (%c)\n", btn, x, y, final);
       return KEY_EVENT_MOUSE;
     }


### PR DESCRIPTION
## Summary

Fixes #2264 — click inside the REPL input to reposition the edit cursor (SGR mouse support).

Shipped behind **`repl.mouse: true`** in `~/.kaappi/config` (default **off**), so the selection tradeoff — `?1000h` captures clicks, which stops un-gated drag-to-select while enabled — only applies to users who opt in. This is the **fifth Kaappi patch to vendored isocline** (`vendor/isocline/PATCHES.md`), following the pattern of the other four (re-applied on every isocline upgrade; each site marked `KAAPPI PATCH 5`).

## What it does

- **Tracking** (`ic_editline`): emits `\x1b[?1000h\x1b[?1006h` on raw-mode entry, `l` sequences on exit. Deliberately `?1000h` (button presses), not `?1002h`/`?1003h` (motion).
- **Decode** (`tty_esc.c`): intercepts `ESC[<b;x;yM|m` right after the CSI decoder's special-byte check (the generic parser only handles two parameters). The event is stashed on the tty via `tty_set_mouse_event` and surfaced as `KEY_EVENT_MOUSE`, since two coordinates cannot fit the `code_t` keycode space.
- **Anchor** (`editline.c`): the mouse reports absolute screen coordinates while isocline works relative to the prompt, so the editor issues a one-time `ESC[6n` query at edit-session start and maps clicks through the existing `edit_set_pos_at_rowcol` / `sbuf_get_pos_at_rc` machinery (prompt width, continuation prompt, line wrapping). Terminals that don't answer the DSR leave the anchor unset → clicks are no-ops.
- **Safety**: clicks above (scrollback), below, or on the prompt are no-ops or clamp to line content; a delayed DSR response now decodes to `KEY_NONE`, which the edit loop ignores instead of inserting a NUL.

## Windows (not in this PR)

Per the issue and its author comment: Windows reads `INPUT_RECORD` structs, not a byte stream, so SGR has nothing to decode there. It needs a second, parallel Console-API implementation (`MOUSE_EVENT` arm + `ENABLE_MOUSE_INPUT`, with `GetConsoleScreenBufferInfo` for the anchor). That path is documented in `PATCHES.md` as the follow-up; tracking is `#if !defined(_WIN32)` gated until then. It also has no test harness here (REPL pty tests skip on Windows), which is the other reason to land POSIX first.

## Tests

- New `tests/scheme/smoke/repl-mouse-click-2264.sh` — pty test that plays the terminal emulator: answers the DSR query, feeds SGR presses, and asserts on what the *evaluator* prints (single-line click, continuation-row click, plus a mouse-off run proving the SGR bytes are inert by default).
- `src/config.zig` unit tests for `repl.mouse` parsing/defaults.
- Also fixes the stale "three patches" count in the `src/isocline.zig` module doc (PATCHES.md had already outgrown it).

Full suite green locally: `zig build test` + `tests/scheme/run-all.sh` (2095 pass, 0 fail, including the new test).

## Docs follow-up (separate repo)

The end-user guide (`kaappi.github.io/docs/guide/repl.md`) should get a short `repl.mouse` mention in a follow-up PR to the docs repo.
