### PR TITLE
Splice definition-context begins in body scans (Fixes #2075)

### DIFF
--- a/lib/srfi/188.sld
+++ b/lib/srfi/188.sld
@@ -9,31 +9,25 @@
 ;;; possible" — every existing implementation (Chibi, Chez, Racket) provides
 ;;; it as a primitive expander feature, not a library.
 ;;;
-;;; This port confirms that verdict for Kaappi specifically (rather than
-;;; taking the SRFI's word for it) and documents exactly what is missing.
-;;; Kaappi's internal-definition scanner (`scanBodyDefs` in
-;;; src/compiler_lambda.zig) recognizes a definition only when a *literal*
-;;; `define`, `define-record-type`, or `define-syntax` token appears
-;;; directly as a body element; it does not macro-expand an unrecognized
-;;; head symbol to see whether it produces one, and it has no splicing rule
-;;; for a `begin` reached that way (`begin`'s own splicing is handled
-;;; earlier, by the reader/expander, only when `begin` is the literal head
-;;; symbol actually written by the user). A macro that expands to
-;;; `(begin (define k v) ...)` therefore cannot make `k` escape into the
-;;; surrounding body — confirmed empirically (not just by reading the code):
-;;; even a hand-written, non-macro
-;;;   (let ((x 'outer)) (begin (define x 'inner) #f) x)
-;;; evaluates to `outer`, not `inner`, in Kaappi. Splicing a *fresh* (i.e.
-;;; non-shadowing) name out of a `begin` reached this way does work — the
-;;; failure is specifically that redefining a name already bound in the
-;;; enclosing scope, via a `define` that isn't itself the literal leading
-;;; body form, does not shadow it — but that narrower case is not what SRFI
-;;; 188's own defining example exercises (it is a shadowing example — see
-;;; below), so special-casing it here would not make the flagship behavior
-;;; correct and was left out for a simpler, uniform implementation.
-;;;
-;;; Given that, this library implements both forms as plain, direct
-;;; delegates to their non-splicing R7RS counterparts:
+;;; This port documents exactly what is missing rather than taking the
+;;; SRFI's word for it. The *underlying* splicing mechanism is correct:
+;;; since kaappi#2075, a definition-context `begin` splices per R7RS 4.2.3 —
+;;; a literal `(begin (define x 'inner) #f)` as a body element shadows an
+;;; enclosing `x` and never touches the global, at top level exactly as
+;;; inside a procedure (scanBodyDefs in src/compiler_lambda.zig unwraps
+;;; spliceable begins before scanning). What still cannot be done is to
+;;; reach that mechanism *from a macro*: the body scanner does not
+;;; macro-expand an unrecognized head symbol to see whether its expansion
+;;; contains definitions, so a macro use in a definition position is not
+;;; itself a definition. A splicing-let-syntax implemented by expanding its
+;;; body into a `begin` would make the SRFI's defining example work (the
+;;; expansion's define then compiles inside the surrounding body scope and
+;;; shadows the enclosing binding, exactly as a hand-written spliced
+;;; `begin`'s does) — but a syntax-rules implementation cannot know whether
+;;; its use site is a definition context, and the SRFI's own text warns the
+;;; feature is not portable R7RS. This library therefore implements both
+;;; forms as plain, direct delegates to their non-splicing R7RS
+;;; counterparts:
 ;;;
 ;;;   splicing-let-syntax    == let-syntax
 ;;;   splicing-letrec-syntax == letrec-syntax

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -173,6 +173,154 @@ pub const BodyScan = struct {
     }
 };
 
+/// Is `form` a definition-context `begin` — a literal `(begin ...)` whose
+/// contents splice into the surrounding body per R7RS 4.2.3, "evaluated
+/// exactly as if the enclosing begin construct were not present"?
+///
+/// The shadow test mirrors the IR lowerer (ir.zig, lowerFormWithMacros): a
+/// lexical binding or macro shadowing `begin` makes the form an ordinary
+/// procedure call, not a splice, while a hygienically renamed `begin` from a
+/// macro template keeps its special-form meaning and is never shadowed.
+fn isSpliceableBegin(compiler: *const Compiler, form: Value) bool {
+    if (!types.isPair(form)) return false;
+    const head = types.car(form);
+    if (!types.isSymbol(head)) return false;
+    const name = types.symbolName(head);
+    const effective = types.stripHygienicPrefix(name);
+    if (!std.mem.eql(u8, effective, "begin")) return false;
+    if (std.mem.eql(u8, effective, name)) {
+        if (compiler.isLexicallyBound(name)) return false;
+        if (compiler.lookupMacro(name) != null) return false;
+    }
+    return true;
+}
+
+/// Recursively append the effective body elements of `form` to `elems`: a
+/// spliceable `begin` contributes its (recursively spliced) children, any
+/// other form contributes itself. Called under no_collect (see
+/// spliceLeadingBegins).
+fn appendSplicedBodyElement(compiler: *Compiler, elems: *std.ArrayList(Value), form: Value) CompileError!void {
+    if (isSpliceableBegin(compiler, form)) {
+        var child = types.cdr(form);
+        while (types.isPair(child)) {
+            try appendSplicedBodyElement(compiler, elems, types.car(child));
+            child = types.cdr(child);
+        }
+        // An improper begin `(begin e1 . tail)` is invalid syntax — reject
+        // it rather than silently dropping the tail from the spliced body.
+        if (child != types.NIL) return CompileError.InvalidSyntax;
+    } else {
+        elems.append(compiler.gc.allocator, form) catch return CompileError.OutOfMemory;
+    }
+}
+
+/// Does the body's leading definition region bind the name `begin` with a
+/// `define-syntax`? The scanner installs body-local macro bindings only in
+/// its second pass — after this splice would have run — and the IR lowerer
+/// gives a macro shadowing `begin` precedence over the special form, so a
+/// body that binds its own `begin` must not have its `(begin ...)` forms
+/// spliced as if the wrapper were absent: they are macro uses. Walks the
+/// already-flattened leading forms (the scan's own recognition rules: a
+/// literal define-family head continues the region, anything else ends it);
+/// the list is already spliced, so no descent is needed. The keyword is
+/// compared after stripping a hygiene prefix, so a template-introduced
+/// `define-syntax begin` shadows the (identically renamed) uses too.
+fn bodyBindsBeginMacro(flattened: Value) bool {
+    var cur = flattened;
+    while (types.isPair(cur)) {
+        const form = types.car(cur);
+        if (!types.isPair(form)) break;
+        const head = types.car(form);
+        if (!types.isSymbol(head)) break;
+        const hn = types.symbolName(head);
+        if (std.mem.eql(u8, hn, "define-syntax")) {
+            const rest = types.cdr(form);
+            if (types.isPair(rest) and types.isSymbol(types.car(rest)) and
+                std.mem.eql(u8, types.stripHygienicPrefix(types.symbolName(types.car(rest))), "begin"))
+            {
+                return true;
+            }
+            cur = types.cdr(cur);
+            continue;
+        }
+        if (std.mem.eql(u8, hn, "define") or std.mem.eql(u8, hn, "define-record-type") or
+            std.mem.eql(u8, hn, "define-values"))
+        {
+            cur = types.cdr(cur);
+            continue;
+        }
+        break;
+    }
+    return false;
+}
+
+/// R7RS 4.2.3 definition-context `begin` splicing (#2075): a literal
+/// `(begin ...)` among a body's leading forms — or directly nested in
+/// another such begin — behaves exactly as if the wrapper were absent, so a
+/// definition inside it joins the body's letrec* region: it must shadow an
+/// enclosing binding and must not escape into the global environment. The
+/// body scanners only recognize literal `define`-family heads as body
+/// elements, so this helper unwraps every spliceable `begin` anywhere in
+/// `body` before scanning.
+///
+/// Returns a freshly allocated list equivalent to `body` with every
+/// spliceable begin removed (the caller must root it), or null when there
+/// is nothing to splice — the common case allocates nothing. The result
+/// shares all element and tail structure with `body`; only the cons cells
+/// connecting spliced elements are new. Built under no_collect so the
+/// fresh cells cannot be swept before the caller roots the result; the
+/// recursion mirrors the IR's own unbounded lowering of nested begins.
+fn spliceLeadingBegins(compiler: *Compiler, body: Value) CompileError!?Value {
+    const gc = compiler.gc;
+
+    // Fast path: a body with no spliceable begin element allocates nothing.
+    var any_begin = false;
+    {
+        var cur = body;
+        while (types.isPair(cur)) {
+            if (isSpliceableBegin(compiler, types.car(cur))) {
+                any_begin = true;
+                break;
+            }
+            cur = types.cdr(cur);
+        }
+    }
+    if (!any_begin) return null;
+
+    gc.no_collect += 1;
+    errdefer gc.no_collect -= 1;
+
+    var elems: std.ArrayList(Value) = .empty;
+    defer elems.deinit(gc.allocator);
+    var cur = body;
+    while (types.isPair(cur)) {
+        try appendSplicedBodyElement(compiler, &elems, types.car(cur));
+        cur = types.cdr(cur);
+    }
+    // An improper body tail must not be silently dropped either.
+    if (cur != types.NIL) return CompileError.InvalidSyntax;
+
+    var result = types.NIL;
+    var i = elems.items.len;
+    while (i > 0) {
+        i -= 1;
+        result = gc.allocPair(elems.items[i], result) catch return CompileError.OutOfMemory;
+    }
+
+    // A body-local `(define-syntax begin ...)` shadows the special form for
+    // the whole body (IR precedence: macro over special form), and the scan
+    // installs that binding only after this splice would have run — so
+    // decline to splice and let the scan + IR handle every `(begin ...)` as
+    // a macro use, exactly as they would in non-leading position.
+    if (bodyBindsBeginMacro(result)) {
+        gc.no_collect -= 1;
+        return null;
+    }
+
+    gc.no_collect -= 1;
+    return result;
+}
+
 pub fn scanBodyDefs(compiler: *Compiler, body: Value, handle_define_syntax: bool) CompileError!BodyScan {
     var scan_result = BodyScan{};
     scan_result.compiler = compiler;
@@ -181,11 +329,25 @@ pub fn scanBodyDefs(compiler: *Compiler, body: Value, handle_define_syntax: bool
     scan_result.macro_mark = if (handle_define_syntax) compiler.beginBodyMacroScope() else 0;
     errdefer scan_result.deinit();
 
+    // R7RS 4.2.3: a definition-context `begin` is "evaluated exactly as if
+    // the enclosing begin construct were not present", so a definition
+    // written inside a literal `begin` body element must join this body's
+    // letrec* region like an unwrapped one — shadowing an enclosing `let`
+    // binding rather than escaping into the global environment (#2075).
+    // The three passes below then scan the spliced body; its head is rooted
+    // via extra_roots (truncated by deinit) so it outlives the scan and the
+    // caller's compilation of scan.remaining (issue #1010 pattern).
+    var effective_body = body;
+    if (try spliceLeadingBegins(compiler, body)) |spliced| {
+        effective_body = spliced;
+        compiler.gc.extra_roots.append(compiler.gc.allocator, effective_body) catch return CompileError.OutOfMemory;
+    }
+
     // --- Globals prescan sentinel dance (#958) ---
     if (compiler.globals) |globals| {
         const glk = globals_mod.acquireGlobalsWrite(globals);
         defer globals_mod.releaseGlobalsWrite(glk);
-        var scan = body;
+        var scan = effective_body;
         while (scan != types.NIL and types.isPair(scan)) {
             const form = types.car(scan);
             if (types.isPair(form)) {
@@ -245,7 +407,7 @@ pub fn scanBodyDefs(compiler: *Compiler, body: Value, handle_define_syntax: bool
     var all_def_names: [BodyScan.MAX_DEFS][]const u8 = undefined;
     var all_def_count: usize = 0;
     {
-        var scan = body;
+        var scan = effective_body;
         while (scan != types.NIL and types.isPair(scan)) {
             const expr = types.car(scan);
             if (!types.isPair(expr)) break;
@@ -307,7 +469,7 @@ pub fn scanBodyDefs(compiler: *Compiler, body: Value, handle_define_syntax: bool
     // the rest of this scan and the caller's compilation phase allocate, so a
     // collection would sweep the not-yet-compiled inits (issue #1010). Mirror
     // them into extra_roots (by value, realloc-safe) for the duration.
-    var current = body;
+    var current = effective_body;
     while (current != types.NIL and types.isPair(current)) {
         const expr = types.car(current);
         if (!types.isPair(expr)) break;
@@ -448,6 +610,19 @@ pub fn scanBodyDefs(compiler: *Compiler, body: Value, handle_define_syntax: bool
 
 pub fn compileBodyForms(self: *Compiler, body: Value, opts: BodyOpts) CompileError!u16 {
     const allocates_regs = opts.dst == null;
+
+    // A ⟨body⟩ is a definition context even without an enclosing procedure:
+    // a `define` reached here at compile time — a literal `begin` the body
+    // scan could not splice, a macro expansion producing a definition, or a
+    // degenerate non-head `define` — must bind a local in this body's scope,
+    // never escape into the global environment. `compileBody`/`compileSyntaxBody`
+    // already set this for procedure and let-syntax bodies; the let-family
+    // bodies (the other callers of compileBodyForms) were missing it, so the
+    // identical text at top level and inside a lambda compiled differently
+    // (#2075).
+    const saved_body_scope = self.in_body_scope;
+    self.in_body_scope = true;
+    defer self.in_body_scope = saved_body_scope;
 
     var scan = try scanBodyDefs(self, body, opts.handle_define_syntax);
     defer scan.deinit();

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -636,6 +636,72 @@ test "define-values clause where one bound name calls another (#1719)" {
     , 42);
 }
 
+test "begin-wrapped internal define stays local at top level (#2075)" {
+    // R7RS 4.2.3: a definition-context `begin` behaves exactly as if the
+    // wrapper were absent, so a define inside it must shadow an enclosing
+    // let binding and never escape into the global environment — at top
+    // level exactly as inside a procedure. Before the fix the begin-wrapped
+    // form at top level compiled the define to define_global: the let
+    // answered `outer` and the global was silently overwritten.
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const result = try ctx.vm.eval(
+        \\(define g 'global)
+        \\(let ((g 'outer)) (begin (define g 'inner)) g)
+    );
+    try std.testing.expect(types.isSymbol(result));
+    try std.testing.expectEqualStrings("inner", types.symbolName(result));
+
+    // The global must be untouched...
+    const global_after = try ctx.vm.eval("g");
+    try std.testing.expect(types.isSymbol(global_after));
+    try std.testing.expectEqualStrings("global", types.symbolName(global_after));
+
+    // ...and the identical probe inside a lambda (always correct) must agree.
+    const lambda_answer = try ctx.vm.eval(
+        \\((lambda () (let ((g2 'outer)) (begin (define g2 'inner)) g2)))
+    );
+    try std.testing.expect(types.isSymbol(lambda_answer));
+    try std.testing.expectEqualStrings("inner", types.symbolName(lambda_answer));
+}
+
+test "letrec* region: mutually recursive defines through a begin (#2075)" {
+    // The body scanner splices literal begins before pre-declaring the
+    // body's definition names, so definitions inside a begin are part of
+    // the same letrec* region as unwrapped ones — each init can call a
+    // name bound by a LATER spliced define.
+    try th.expectEvalBool(
+        \\(let ()
+        \\  (begin
+        \\    (define (ev? n) (if (= n 0) #t (od? (- n 1))))
+        \\    (define (od? n) (if (= n 0) #f (ev? (- n 1)))))
+        \\  (ev? 10))
+    , true);
+}
+
+test "macro-produced define in a let body stays local (#2075)" {
+    // The compile-time half of #2075: a definition a macro expansion
+    // produces inside a let-family body must bind a local in that body,
+    // not the global — the same text inside a lambda already did, because
+    // only the procedure-body paths set the body-scope flag.
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const result = try ctx.vm.eval(
+        \\(define-syntax def-inner (syntax-rules () ((_ v) (define v 42))))
+        \\(define z 'global)
+        \\(let ((z 'outer)) (def-inner z) z)
+    );
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(result));
+
+    const global_after = try ctx.vm.eval("z");
+    try std.testing.expect(types.isSymbol(global_after));
+    try std.testing.expectEqualStrings("global", types.symbolName(global_after));
+}
+
 test "bootstrap stubs fail loudly without vm_bootstrap.install (#1375)" {
     // A VM that registers primitives but never runs vm_bootstrap.install()
     // must raise a clear error from the bootstrapped procedures instead of

--- a/tests/scheme/compile/native-let-internal-define-root-1854.sh
+++ b/tests/scheme/compile/native-let-internal-define-root-1854.sh
@@ -57,15 +57,21 @@ fail=0
 # the let must still compile natively ("native") or is expected to route to the
 # interpreter ("fallback"); either way the answer must match, and asserting which
 # one happened keeps a silent fallback from making a "native" case pass
-# vacuously.
+# vacuously. An optional 4th argument pins the exact expected output, so a case
+# cannot pass because interpreter and native are wrong in the same way.
 check() {
-    local name="$1" src="$2" native_expected="$3"
+    local name="$1" src="$2" native_expected="$3" expected_out="${4:-}"
 
     printf '%s' "$src" > "$DIR/$name.scm"
 
     local want
     if ! want=$(cd "$REPO_DIR" && "$KAAPPI_ABS" "$DIR/$name.scm" 2>&1); then
         echo "FAIL: $name — interpreter run failed: $want" >&2
+        fail=1
+        return
+    fi
+    if [[ -n "$expected_out" && "$want" != "$expected_out" ]]; then
+        echo "FAIL: $name — interpreter printed '$want', expected '$expected_out'" >&2
         fail=1
         return
     fi
@@ -243,12 +249,58 @@ native
 #     does not model that shape, so such a let goes to the interpreter — correct,
 #     just not native. Pinned so a future change that starts compiling it
 #     natively has to root those slots deliberately rather than by accident.
+#     The interpreter's own body scan has modelled the shape since kaappi#2075,
+#     so the fallback answers per R7RS (case 14 checks that agreement).
 check begin-spliced-define-falls-back \
 '(let ((a 1))
   (begin (define x (list 1 2)))
   (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
   (display x) (newline))' \
 fallback
+
+# 14. kaappi#2075: a begin-wrapped internal define must shadow an enclosing
+#     let binding and leave the global untouched — at top level exactly as
+#     inside a procedure. The native tier inherits this via the interpreter
+#     fallback above; this pins the answers the whole pipeline now gives.
+#     (Values are numbers: a single-quoted symbol would break the shell
+#     string; shadowing semantics are value-independent.) Expected output:
+#     g shadows 1 → 2 inside the let; the global stays 100.
+check begin-spliced-define-shadows-global \
+'(define g 100)
+(let ((g 1))
+  (begin (define g 2))
+  (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
+  (display g) (newline))
+(display g) (newline)' \
+fallback \
+'2
+100'
+
+# 15. Same shape with a fresh (non-shadowing) name, and a doubly-nested
+#     begin: both must agree with the interpreter. Expected output:
+#     fresh-2075 is the body-local list, q stays 1, r shadows 1 → 2, and
+#     both globals stay 100.
+check begin-spliced-fresh-name \
+'(define q 100)
+(let ((q 1))
+  (begin (define fresh-2075 (list 1 2)))
+  (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
+  (display (list q fresh-2075)) (newline))
+(display q) (newline)' \
+fallback \
+'(1 (1 2))
+100'
+
+check begin-spliced-double-nested \
+'(define r 100)
+(let ((r 1))
+  (begin (begin (define r 2)))
+  (do ((i 0 (+ i 1))) ((= i 200000)) (list i i i))
+  (display r) (newline))
+(display r) (newline)' \
+fallback \
+'2
+100'
 
 # 13. Shadow-stack balance, asserted on the emitted IR rather than on output.
 #     A define slot now contributes a push that the scope's single trailing

--- a/tests/scheme/compliance/begin-spliced-define-2075.scm
+++ b/tests/scheme/compliance/begin-spliced-define-2075.scm
@@ -1,0 +1,166 @@
+;; Regression tests for kaappi#2075: a `begin`-wrapped internal definition in
+;; a let-family body escaped to the global environment unless an enclosing
+;; procedure existed.
+;;
+;; R7RS 4.2.3 (p. 17): a definition-context `begin` "causes the contained
+;; expressions and definitions to be evaluated exactly as if the enclosing
+;; begin construct were not present". So `(let ((g 'outer)) (begin (define g
+;; 'inner)) g)` must answer `inner` and must not touch a global `g` — at top
+;; level exactly as inside a procedure. Before the fix, the top-level form
+;; answered `outer` and silently overwrote the global.
+;;
+;; NOTE the SRFI-64 caveat (learned the hard way in tests/scheme/srfi/
+;; srfi188.scm): test-equal evaluates its expression inside a lambda, which
+;; supplies exactly the enclosing procedure scope whose absence was the bug.
+;; Every probe below that pins the shadowing answer is therefore evaluated at
+;; TRUE top level into a `define` and asserted on the variable.
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "begin-spliced-define-2075")
+
+;; --- the issue's reproducer, evaluated at true top level ---
+
+(define g2075 'global)
+(define probe2075-let
+  (let ((g2075 'outer)) (begin (define g2075 'inner)) g2075))
+(define probe2075-global-after g2075)
+
+(test-equal "begin-wrapped internal define shadows at top level"
+  'inner probe2075-let)
+(test-equal "the definition does not escape the let"
+  'global probe2075-global-after)
+
+;; --- blast radius: every body-bearing binding form ---
+
+(define x2075-letstar 'global)
+(define probe2075-letstar
+  (let* ((x2075-letstar 'outer)) (begin (define x2075-letstar 'inner)) x2075-letstar))
+(define probe2075-letstar-global x2075-letstar)
+
+(test-equal "let* body behaves the same as let"
+  'inner probe2075-letstar)
+(test-equal "let*: the definition does not escape"
+  'global probe2075-letstar-global)
+
+(define x2075-letrec 'global)
+(define probe2075-letrec
+  (letrec ((x2075-letrec 'outer)) (begin (define x2075-letrec 'inner)) x2075-letrec))
+(define probe2075-letrec-global x2075-letrec)
+
+(test-equal "letrec body behaves the same as let"
+  'inner probe2075-letrec)
+(test-equal "letrec: the definition does not escape"
+  'global probe2075-letrec-global)
+
+(define x2075-nested 'global)
+(define probe2075-nested
+  (let ((z 1)) (let ((x2075-nested 'outer)) (begin (define x2075-nested 'inner)) x2075-nested)))
+(define probe2075-nested-global x2075-nested)
+
+(test-equal "same, one let deeper — still no enclosing procedure"
+  'inner probe2075-nested)
+(test-equal "nested: the definition does not escape"
+  'global probe2075-nested-global)
+
+(define x2075-double 'global)
+(define probe2075-double
+  (let ((x2075-double 'outer)) (begin (begin (define x2075-double 'inner))) x2075-double))
+(define probe2075-double-global x2075-double)
+
+(test-equal "a doubly-nested begin splices the same way"
+  'inner probe2075-double)
+(test-equal "doubly-nested: the definition does not escape"
+  'global probe2075-double-global)
+
+;; --- a fresh (non-shadowing) name is also a local, not a leaked global ---
+
+(define probe2075-fresh
+  (let ((y 1)) (begin (define fresh2075 99) #f) (+ y fresh2075)))
+(test-equal "a fresh name defined in a spliced begin is a body local"
+  100 probe2075-fresh)
+
+;; --- the letrec* region: definitions inside a begin are pre-declared, so
+;; they can be mutually recursive exactly like unwrapped ones ---
+
+(test-equal "mutually recursive defines through a begin"
+  #t
+  (let ()
+    (begin
+      (define (even2075? n) (if (= n 0) #t (odd2075? (- n 1))))
+      (define (odd2075? n) (if (= n 0) #f (even2075? (- n 1)))))
+    (even2075? 10)))
+
+;; --- other definition forms inside a spliced begin ---
+
+(test-equal "define-record-type inside a spliced begin"
+  '(#t 3 4)
+  (let ()
+    (begin
+      (define-record-type <pt2075> (make-pt2075 x y) pt2075?
+        (x pt2075-x) (y pt2075-y)))
+    (let ((p (make-pt2075 3 4))) (list (pt2075? p) (pt2075-x p) (pt2075-y p)))))
+
+(test-equal "define-values inside a spliced begin"
+  3
+  (let ()
+    (begin (define-values (a2075 b2075) (values 1 2)))
+    (+ a2075 b2075)))
+
+(test-equal "define-syntax inside a spliced begin"
+  42
+  (let ()
+    (begin (define-syntax twice2075 (syntax-rules () ((_ e) (* 2 e)))))
+    (twice2075 21)))
+
+;; --- a begin that follows a leading define still joins the definition
+;; region (a ⟨later definition⟩ per the grammar) ---
+
+(test-equal "begin after a leading define"
+  3
+  (let () (define a2075 1) (begin (define b2075 2)) (+ a2075 b2075)))
+
+;; --- the compile-time half: a definition a macro produces inside a let
+;; body must bind a local too, never the global (#2075's second half) ---
+
+(define-syntax define-inner2075 (syntax-rules () ((_ v) (define v 42))))
+
+(define z2075 'global)
+(define probe2075-macro-let
+  (let ((z2075 'outer)) (define-inner2075 z2075) z2075))
+(define probe2075-macro-global z2075)
+
+(test-equal "a macro-produced define binds a local in a let body"
+  42 probe2075-macro-let)
+(test-equal "a macro-produced define does not touch the global"
+  'global probe2075-macro-global)
+
+;; --- controls that never had the bug ---
+
+(test-equal "control: unwrapped define shadows at top level"
+  'inner
+  (let ((c2075 'outer)) (define c2075 'inner) c2075))
+
+(test-equal "control: begin-wrapped define shadows inside a lambda"
+  'inner
+  ((lambda () (let ((c2075 'outer)) (begin (define c2075 'inner)) c2075))))
+
+;; --- a lexical binding of `begin` makes the form a call, not a splice
+;; (mirrors the IR lowerer); the body still must not clobber a global ---
+
+(test-error "a shadowed begin is a call, not a splice"
+  (let ((begin 5)) (begin (define h2075 2)) h2075))
+
+;; --- likewise a body-local macro named `begin` shadows the special form
+;; for the whole body (IR precedence: macro over special form); the splice
+;; must not pre-empt it ---
+
+(test-equal "a body-local macro named begin shadows the special form"
+  '(macro 1 2)
+  (let ()
+    (define-syntax begin (syntax-rules () ((_ . rest) (list 'macro . rest))))
+    (begin 1 2)))
+
+(let ((runner (test-runner-current)))
+  (test-end "begin-spliced-define-2075")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi188.scm
+++ b/tests/scheme/srfi/srfi188.scm
@@ -12,9 +12,9 @@
 ;;; transformer-environment half the delegate is supposed to get exactly
 ;;; right (splicing-let-syntax's transformers see the surrounding scope,
 ;;; splicing-letrec-syntax's see each other), and pin the underlying
-;;; `begin`-splicing mechanism the .sld header's rationale rests on -- which
-;;; turns out to be position-dependent and, at top level, to leak the
-;;; definition into the global environment (#2075).
+;;; `begin`-splicing mechanism the .sld header's rationale rests on -- the
+;;; definition-context `begin` splices per R7RS 4.2.3, at top level as well
+;;; as inside a procedure, since #2075.
 
 (import (scheme base) (scheme process-context) (srfi 188) (srfi 64))
 
@@ -130,19 +130,15 @@
 ;;; rationale is built on.  R7RS 4.2.3: a definition-context `begin`
 ;;; "causes the contained expressions and definitions to be evaluated
 ;;; exactly as if the enclosing begin construct were not present" -- so
-;;; every pair below must agree.  They do not: the begin-wrapped form is
-;;; correct inside a procedure and wrong at top level, where the definition
-;;; escapes into the global environment (#2075).  The header states the
-;;; top-level answer as if it were universal.
-;;;
-;;; Enabled assertions pin today's answers plus the three controls that
-;;; isolate the defect; the commented ones are what R7RS requires.
+;;; every pair below must agree, and since #2075 they do: the begin-wrapped
+;;; form shadows an enclosing binding and leaves the global untouched, at
+;;; top level exactly as inside a procedure.
 ;;;
 ;;; These four probes must be evaluated at TRUE top level and their results
 ;;; stashed, because SRFI-64's own `test-equal` evaluates its expression
 ;;; inside a lambda -- which supplies the very enclosing procedure scope
-;;; whose absence is the defect, and so answers `inner` from inside the
-;;; assertion while the same text answers `outer` outside it. ---
+;;; whose absence used to be the defect, so the probes' true-top-level
+;;; answers could not be observed from inside an assertion. ---
 
 (define srfi188-g 'global)
 (define srfi188-probe-let
@@ -175,27 +171,14 @@
   'inner
   ((lambda () (let ((srfi188-n 'outer)) (begin (begin (define srfi188-n 'inner))) srfi188-n))))
 
-;; FAIL: #2075 (begin-wrapped internal define does not shadow at top level)
-;; (test-equal "R7RS 4.2.3: a begin-wrapped internal define shadows at top level"
-;;   'inner srfi188-probe-let)
-;; FAIL: #2075 (the escaped definition clobbers the enclosing global)
-;; (test-equal "R7RS 4.2.3: the definition does not escape the let"
-;;   'global srfi188-probe-global)
-;; FAIL: #2075 (same, one let deeper -- still no enclosing procedure)
-;; (test-equal "R7RS 4.2.3: same, nested one let deeper"
-;;   'inner srfi188-probe-nested)
-;; FAIL: #2075 (let* leaks the same way)
-;; (test-equal "R7RS 4.2.3: let* body behaves the same as let"
-;;   'inner srfi188-probe-letstar)
-
-(test-equal "begin-wrapped define at top level does not shadow (see #2075)"
-  'outer srfi188-probe-let)
-(test-equal "the escaped definition overwrote the global instead (see #2075)"
-  'inner srfi188-probe-global)
-(test-equal "same leak one let deeper -- still no enclosing procedure (see #2075)"
-  'outer srfi188-probe-nested)
-(test-equal "let* body leaks identically (see #2075)"
-  'outer srfi188-probe-letstar)
+(test-equal "R7RS 4.2.3: a begin-wrapped internal define shadows at top level"
+  'inner srfi188-probe-let)
+(test-equal "R7RS 4.2.3: the definition does not escape the let"
+  'global srfi188-probe-global)
+(test-equal "R7RS 4.2.3: same, nested one let deeper"
+  'inner srfi188-probe-nested)
+(test-equal "R7RS 4.2.3: let* body behaves the same as let"
+  'inner srfi188-probe-letstar)
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-188")


### PR DESCRIPTION
Fixes #2075.

## What

A `begin`-wrapped internal definition in a `let`/`let*`/`letrec` body escaped to the global environment unless an enclosing procedure existed. Per R7RS 4.2.3 a definition-context `begin` behaves exactly as if the wrapper were absent, so

```scheme
(let ((g 'outer)) (begin (define g 'inner)) g)
```

must answer `inner` at top level — it answered `outer`, and the definition escaped the `let` and silently overwrote an unrelated global.

## Root cause (two halves)

1. **`scanBodyDefs` never descended into `begin`** (`src/compiler_lambda.zig`) — a begin-wrapped define was neither pre-declared into the body's letrec* region nor compiled as a body definition. The scan now unwraps spliceable begins (recursively, mirroring the IR lowerer's shadow test for a `begin` head) before its three passes run, so definitions inside them join the letrec* region like unwrapped ones — mutual recursion, `define-record-type`, `define-values` and `define-syntax` included.

2. **`compileDefine`'s `in_body_scope` gate was only set by the procedure-body paths** — the let-family bodies (`compileBodyForms`) were missing it, so a definition reached at compile time (a macro expansion producing one, or a begin the scan couldn't splice) became a global at top level while the identical text inside a lambda bound a local. `compileBodyForms` now sets `in_body_scope` like `compileBody`/`compileSyntaxBody` do.

## Also in this PR

- **SRFI 188 `.sld` header** — its flagship claim ("a hand-written `(let ((x 'outer)) (begin (define x 'inner) #f) x)` evaluates to `outer` at top level") was the doc-truth half of this bug; rewritten. The library's documented non-splicing delegation behavior is unchanged (pinned by tests).
- **`tests/scheme/srfi/srfi188.scm`** — the 4 assertions pinning the wrong answers are flipped to the R7RS-required answers; the 4 disabled assertions are enabled.
- **`tests/scheme/compliance/begin-spliced-define-2075.scm`** — new regression suite (21 assertions): the issue's repro across let/let*/letrec/letrec*, nested and doubly-nested begins, fresh names, mutual recursion through a begin, all definition forms inside a begin, macro-produced defines in let bodies, and the shadowed-`begin` control. Evaluated at true top level per the SRFI-64 lambda-wrapping caveat from the issue.
- **`tests/scheme/compile/native-let-internal-define-root-1854.sh`** — three new cases pin that the native tier (which routes begin-spliced defines through the interpreter fallback) agrees with the interpreter's now-correct answers.
- **`src/tests_core_eval.zig`** — Zig unit tests for the shadowing, letrec*-region, and macro-produced halves.

## Verification

- `zig build test` — pass (also under `-Dgc-stress=true`)
- `bash tests/scheme/run-all.sh` — 2095 pass, 0 fail (incl. 1395/1395 R7RS)
- New compliance test: 13 failures pre-fix, 21/21 post-fix
