### PR TITLE
Keep an inexact zero imaginary part complex in make-rectangular, write, and c64/c128 decode (Fixes #2269)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,14 +34,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   through the normal numeric printer, so `write` and `real-part` agree;
   and the reader and `string->number` build components digit-exactly at
   any size. Per R7RS 6.2.2 a stored complex is never mixed-exactness (an
-  inexact operand makes both components inexact), and a zero imaginary
-  part demotes to the real component — except that a literal's *inexact*
-  zero imag stays complex (`(real? -2.5+0.0i)` => #f) while an exact one
-  demotes (`(integer? 3+0i)` => #t). The `.sbc` constant encoding stores
+  inexact operand makes both components inexact), and an *exact* zero
+  imaginary part demotes to the real component (`(integer? 3+0i)` => #t)
+  while an *inexact* zero imag keeps the value complex (`(real?
+  -2.5+0.0i)` => #f). The `.sbc` constant encoding stores
   the two component constants instead of f64+flags. This dissolves the
   #2182/#2243 f64 round-trip gates in the reader and `string->number`:
   `9007199254740993+1i`, `#x20000000000001+2i`, and
   `10000000000000000000000000/3+1i` all read digit-exactly now.
+
+- **`make-rectangular` keeps an inexact zero imaginary part complex, and
+  `write`/`number->string` print it in full** (#2269). The reader already
+  kept `1.5+0.0i` complex (`(real? 1.5+0.0i)` => #f), but
+  `(make-rectangular 1.5 0.0)` demoted to the real `1.5` and the printer
+  collapsed an inexact-zero-imag complex to its bare real part, so
+  `(write 1.5+0.0i)` printed `1.5` — which reads back as a different
+  value, violating R7RS 6.2.7's `number->string` round-trip. Both
+  construction and printing now match the reader: only an exact zero imag
+  demotes, `(write 1.5+0.0i)` emits `"1.5+0.0i"`, and the decomposition
+  round-trip `(eqv? (make-rectangular (real-part z) (imag-part z)) z)`
+  holds for `z = 1.5+0.0i`. c64/c128 elements with a +0.0 imaginary part
+  likewise decode to a Complex instead of a plain real, so SRFI-160 refs
+  and the standalone constructor agree (Chez, Guile, chibi, and Gambit
+  all behave this way).
 
 - **Rational→flonum conversion is correct when a single side alone leaves
   f64 range** (#2183). `(inexact (/ 1 (expt 2 1074)))` was `0.0` instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,20 +43,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `9007199254740993+1i`, `#x20000000000001+2i`, and
   `10000000000000000000000000/3+1i` all read digit-exactly now.
 
-- **`make-rectangular` keeps an inexact zero imaginary part complex, and
+- **An inexact zero imaginary part stays complex everywhere, and
   `write`/`number->string` print it in full** (#2269). The reader already
   kept `1.5+0.0i` complex (`(real? 1.5+0.0i)` => #f), but
-  `(make-rectangular 1.5 0.0)` demoted to the real `1.5` and the printer
-  collapsed an inexact-zero-imag complex to its bare real part, so
-  `(write 1.5+0.0i)` printed `1.5` — which reads back as a different
-  value, violating R7RS 6.2.7's `number->string` round-trip. Both
-  construction and printing now match the reader: only an exact zero imag
-  demotes, `(write 1.5+0.0i)` emits `"1.5+0.0i"`, and the decomposition
+  `(make-rectangular 1.5 0.0)` demoted to the real `1.5`, the arithmetic
+  tower demoted any zero-imag result (`(+ 1.0+2.0i 1.0-2.0i)` => `2.0`),
+  and `(make-polar 1.5 0.0)` demoted too — while the printer collapsed an
+  inexact-zero-imag complex to its bare real part, so `(write 1.5+0.0i)`
+  printed `1.5`, which reads back as a different value, violating R7RS
+  6.2.7's `number->string` round-trip. Every construction site — the
+  reader, `string->number`, `make-rectangular`, `+ - * /`, `make-polar`,
+  and exact/inexact conversion — now shares one rule: only an EXACT zero
+  imaginary part demotes, an inexact zero keeps the value complex
+  (`(integer? 3+0i)` => #t, `(real? 1.5+0.0i)` => #f). The printer emits
+  the full form (`"1.5+0.0i"` / `"1.5-0.0i"`), and the decomposition
   round-trip `(eqv? (make-rectangular (real-part z) (imag-part z)) z)`
   holds for `z = 1.5+0.0i`. c64/c128 elements with a +0.0 imaginary part
-  likewise decode to a Complex instead of a plain real, so SRFI-160 refs
-  and the standalone constructor agree (Chez, Guile, chibi, and Gambit
-  all behave this way).
+  likewise decode to a Complex instead of a plain real. Chez, Guile,
+  chibi, and Gambit all behave this way. (The f64 transcendental and
+  power paths — `sin`/`cos`/`tan`, `sqrt`, `expt`, `exp`, `log`, `asin`
+  — are unchanged: they still demote an exactly-zero (or, for `exp`/
+  `log`/`asin`, below-1e-15-noise) imaginary result via the pre-existing
+  `makeComplexOrReal` and its epsilon guard. That noise-suppression design
+  is deliberate and orthogonal to the construction-site rule above.)
 
 - **Rational→flonum conversion is correct when a single side alone leaves
   f64 range** (#2183). `(inexact (/ 1 (expt 2 1074)))` was `0.0` instead of

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -1033,7 +1033,9 @@ pub fn isZeroValue(v: Value) bool {
 /// inexact, so a stored complex is never mixed-exactness (kaappi#2166) — and
 /// demoting to the real component when the imaginary part is zero, so every
 /// complex constructed here has a nonzero imaginary part. The construction
-/// site behind make-rectangular and exact/inexact conversions.
+/// site behind exact/inexact conversions and the arithmetic tower
+/// (kaappi#2269 moved make-rectangular to makeComplexOrRealLiteral so an
+/// inexact zero imag stays complex there).
 pub fn makeComplexOrRealV(gc: *memory.GC, real_in: Value, imag_in: Value) PrimitiveError!Value {
     var real = real_in;
     var imag = imag_in;
@@ -1592,10 +1594,13 @@ fn makeRectangular(args: []const Value) PrimitiveError!Value {
     for (args) |a| {
         if (!isComponentValue(a)) return primitives.typeError("make-rectangular", "real number", a);
     }
-    // The exactness rule (R7RS 6.2.2) and the zero-imag demotion live in
-    // makeComplexOrRealV, so make-rectangular never touches an f64:
-    // 2^53+1 and 10^25 survive digit-exactly (kaappi#2166).
-    return makeComplexOrRealV(gc, args[0], args[1]);
+    // Components are never forced through an f64: 2^53+1 and 10^25 survive
+    // digit-exactly (kaappi#2166). The exactness rule (R7RS 6.2.2) and the
+    // zero-imag demotion live in makeComplexOrRealLiteral — the same
+    // construction the reader uses, so an INEXACT zero imaginary part stays
+    // complex ((real? (make-rectangular 1.5 0.0)) => #f, kaappi#2269) and
+    // only an exact zero demotes, matching the literal 1.5+0.0i.
+    return makeComplexOrRealLiteral(gc, args[0], args[1]);
 }
 
 fn makePolar(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -364,10 +364,11 @@ pub fn inexactFn(args: []const Value) PrimitiveError!Value {
     }
     if (types.isComplex(args[0])) {
         const c = types.toComplex(args[0]);
-        // Already all-inexact: return unchanged. Rebuilding through
-        // makeComplexOrRealV would demote a stored inexact zero imag
-        // (-2.5+0.0i) to the real -2.5, losing the complexness the reader
-        // deliberately keeps ((real? -2.5+0.0i) => #f, kaappi#2166).
+        // Already all-inexact: return unchanged rather than rebuild. With
+        // makeComplexOrRealV's exact-zero-only demotion (kaappi#2269) a
+        // rebuild would preserve the stored inexact zero imag anyway
+        // ((real? -2.5+0.0i) => #f); this is a no-alloc shortcut, not a
+        // correctness guard.
         if (!types.isExactNumber(c.real)) return args[0];
         const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
         const real_i = try inexactFn(&[1]Value{c.real});
@@ -1031,31 +1032,20 @@ pub fn isZeroValue(v: Value) bool {
 /// Build a complex number from two real component Values, applying the
 /// R7RS 6.2.2 inexactness rule — if either component is inexact both become
 /// inexact, so a stored complex is never mixed-exactness (kaappi#2166) — and
-/// demoting to the real component when the imaginary part is zero, so every
-/// complex constructed here has a nonzero imaginary part. The construction
-/// site behind exact/inexact conversions and the arithmetic tower
-/// (kaappi#2269 moved make-rectangular to makeComplexOrRealLiteral so an
-/// inexact zero imag stays complex there).
+/// demoting to the real component only when the imaginary part is an EXACT
+/// zero. An inexact zero imag keeps the value complex ((real? -2.5+0.0i)
+/// => #f, kaappi#2269) at every construction site — the reader,
+/// string->number, make-rectangular, the arithmetic tower (+ - * /), and
+/// exact/inexact conversion — matching Chez, Guile, chibi, and Gambit.
+/// This single rule replaced makeComplexOrRealLiteral (kaappi#2269); an
+/// exact zero imag demotes ((integer? 3+0i) => #t).
 pub fn makeComplexOrRealV(gc: *memory.GC, real_in: Value, imag_in: Value) PrimitiveError!Value {
     var real = real_in;
     var imag = imag_in;
-    if (!types.isExactNumber(real) or !types.isExactNumber(imag)) {
-        real = try inexactFn(&[1]Value{real});
-        imag = try inexactFn(&[1]Value{imag});
-    }
-    if (isZeroValue(imag)) return real;
-    return gc.allocComplex(real, imag) catch return PrimitiveError.OutOfMemory;
-}
-
-/// Reader/string->number complex construction: like makeComplexOrRealV, but
-/// only an EXACT zero imaginary part demotes to the real component. The R7RS
-/// conformance suite pins both sides: (real? -2.5+0.0i) => #f (an inexact
-/// zero imag written in a literal stays a complex) and (integer? 3+0i) => #t
-/// (an exact zero imag demotes). Inexactness still propagates whole-number
-/// (R7RS 6.2.2), so the two parsers agree (R7RS 6.2.7, kaappi#2166).
-pub fn makeComplexOrRealLiteral(gc: *memory.GC, real_in: Value, imag_in: Value) PrimitiveError!Value {
-    var real = real_in;
-    var imag = imag_in;
+    // Exactness of the zero is read off the INPUT imag: an inexact 0.0
+    // must stay complex, while an exact 0 (fixnum/bignum/rational zero)
+    // demotes — after the whole-number inexactness propagation below the
+    // imag would be an indistinguishable 0.0 flonum.
     const imag_exact_zero = types.isExactNumber(imag) and isZeroValue(imag);
     if (!types.isExactNumber(real) or !types.isExactNumber(imag)) {
         real = try inexactFn(&[1]Value{real});
@@ -1513,7 +1503,7 @@ pub fn parseNumberText(gc: *@import("memory.zig").GC, text: []const u8, radix_in
             const imag_str = body[sp..];
             // Components are built digit-exactly; exactness is carried by
             // each component's own type (integer/rational parts are exact,
-            // decimals and exponents inexact), and makeComplexOrRealLiteral
+            // decimals and exponents inexact), and makeComplexOrRealV
             // normalizes the pair to a single exactness. `#e`/`#i` still
             // override everything via applyExactness below (#2243 review).
             const real_v = if (real_str.len == 0)
@@ -1528,7 +1518,7 @@ pub fn parseNumberText(gc: *@import("memory.zig").GC, text: []const u8, radix_in
                 types.makeFixnum(-1)
             else
                 parseComplexComponent(gc, imag_str, radix) orelse return types.FALSE;
-            const c = makeComplexOrRealLiteral(gc, slot.get(), imag_v) catch return PrimitiveError.OutOfMemory;
+            const c = makeComplexOrRealV(gc, slot.get(), imag_v) catch return PrimitiveError.OutOfMemory;
             return applyExactness(gc, c, exactness);
         } else {
             // No split found -- pure imaginary with a magnitude: +3i,
@@ -1577,7 +1567,7 @@ pub fn parseNumberText(gc: *@import("memory.zig").GC, text: []const u8, radix_in
                     imag_v = types.makeFlonum(f);
                 }
             }
-            const c = makeComplexOrRealLiteral(gc, types.makeFixnum(0), imag_v) catch return PrimitiveError.OutOfMemory;
+            const c = makeComplexOrRealV(gc, types.makeFixnum(0), imag_v) catch return PrimitiveError.OutOfMemory;
             return applyExactness(gc, c, exactness);
         }
     }
@@ -1596,19 +1586,27 @@ fn makeRectangular(args: []const Value) PrimitiveError!Value {
     }
     // Components are never forced through an f64: 2^53+1 and 10^25 survive
     // digit-exactly (kaappi#2166). The exactness rule (R7RS 6.2.2) and the
-    // zero-imag demotion live in makeComplexOrRealLiteral — the same
-    // construction the reader uses, so an INEXACT zero imaginary part stays
-    // complex ((real? (make-rectangular 1.5 0.0)) => #f, kaappi#2269) and
-    // only an exact zero demotes, matching the literal 1.5+0.0i.
-    return makeComplexOrRealLiteral(gc, args[0], args[1]);
+    // exact-zero-only demotion live in makeComplexOrRealV — the same
+    // construction the reader and arithmetic use, so an INEXACT zero
+    // imaginary part stays complex ((real? (make-rectangular 1.5 0.0))
+    // => #f, kaappi#2269) and only an exact zero demotes, matching the
+    // literal 1.5+0.0i.
+    return makeComplexOrRealV(gc, args[0], args[1]);
 }
 
 fn makePolar(args: []const Value) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const mag = try toF64(args[0]);
     const ang = try toF64(args[1]);
     const real = mag * @cos(ang);
     const imag = mag * @sin(ang);
-    return makeComplexOrReal(real, imag);
+    // An inexact zero imaginary part keeps the value complex
+    // ((make-polar 1.5 0.0) => 1.5+0.0i, kaappi#2269), matching the reader,
+    // make-rectangular, and arithmetic. Only an EXACT zero angle — which
+    // produces an exact zero imag — demotes ((make-polar 1.5 0) => 1.5).
+    // Verified against Chez, Guile, chibi, and Gambit.
+    if (imag == 0.0 and types.isExactNumber(args[1])) return types.makeFlonum(real);
+    return gc.allocComplex(types.makeFlonum(real), types.makeFlonum(imag)) catch return PrimitiveError.OutOfMemory;
 }
 
 fn realPart(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -1603,9 +1603,12 @@ fn makePolar(args: []const Value) PrimitiveError!Value {
     // An inexact zero imaginary part keeps the value complex
     // ((make-polar 1.5 0.0) => 1.5+0.0i, kaappi#2269), matching the reader,
     // make-rectangular, and arithmetic. Only an EXACT zero angle — which
-    // produces an exact zero imag — demotes ((make-polar 1.5 0) => 1.5).
+    // produces an exact zero imag — demotes ((make-polar 1.5 0) => 1.5);
+    // the angle must be numerically zero, not merely exact, so a tiny exact
+    // nonzero angle whose sin underflows to 0.0 stays complex
+    // ((make-polar 1.5 (/ 1 (expt 10 400))) => 1.5+0.0i).
     // Verified against Chez, Guile, chibi, and Gambit.
-    if (imag == 0.0 and types.isExactNumber(args[1])) return types.makeFlonum(real);
+    if (imag == 0.0 and types.isExactNumber(args[1]) and isZeroValue(args[1])) return types.makeFlonum(real);
     return gc.allocComplex(types.makeFlonum(real), types.makeFlonum(imag)) catch return PrimitiveError.OutOfMemory;
 }
 

--- a/src/primitives_srfi160.zig
+++ b/src/primitives_srfi160.zig
@@ -222,19 +222,17 @@ fn decodeElement(gc: *memory.GC, kind: NumericElementKind, bytes: []const u8) Pr
         .c64 => blk: {
             const re: f32 = @bitCast(std.mem.readInt(u32, bytes[0..4], native_endian));
             const im: f32 = @bitCast(std.mem.readInt(u32, bytes[4..8], native_endian));
-            // A zero imaginary part (+0.0) decodes to a plain real, matching
-            // make-rectangular's normalisation and the standalone complex
-            // printer's collapse (kaappi#1951): an element like 1.5 must not
-            // write as "1.5" and read back as a different type. -0.0 is
-            // preserved -- its sign is real information the printer keeps.
-            if (im == 0.0 and !std.math.signbit(im)) break :blk types.makeFlonum(re);
+            // Both components are preserved, including a +0.0 imaginary part:
+            // the element decodes to the complex 1.5+0.0i, matching the
+            // reader and make-rectangular, where an inexact zero imag keeps
+            // the value complex (R7RS 6.2.6, kaappi#2269). -0.0 keeps its
+            // sign -- real information the printer preserves as "1.5-0.0i".
             break :blk gc.allocComplex(types.makeFlonum(re), types.makeFlonum(im)) catch PrimitiveError.OutOfMemory;
         },
         .c128 => blk: {
             const re: f64 = @bitCast(std.mem.readInt(u64, bytes[0..8], native_endian));
             const im: f64 = @bitCast(std.mem.readInt(u64, bytes[8..16], native_endian));
-            // Same zero-imaginary normalisation as .c64 (kaappi#1951).
-            if (im == 0.0 and !std.math.signbit(im)) break :blk types.makeFlonum(re);
+            // Same component-preserving decode as .c64 (kaappi#2269).
             break :blk gc.allocComplex(types.makeFlonum(re), types.makeFlonum(im)) catch PrimitiveError.OutOfMemory;
         },
     };

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -587,17 +587,22 @@ fn printValueOnce(
                 // printer: exact components print digit-exactly (fixnum /
                 // bignum / num-den rational), inexact components as
                 // flonums — so `write` and `real-part` can no longer
-                // disagree about the same object (kaappi#2166). Zero
-                // imaginary parts are demoted at construction; only the
-                // srfi160 -0.0i decode reaches the sign branch.
+                // disagree about the same object (kaappi#2166). Exact zero
+                // imaginary parts demote at construction, so a stored
+                // complex's zero imag is an inexact ±0.0 (reader literal,
+                // make-rectangular, or srfi160 decode).
                 const real = c.real;
                 const imag = c.imag;
-                // A +0.0 imaginary part prints as just the real component
-                // (kaappi#637/#1951): the reader keeps an inexact zero-imag
-                // complex ((real? -2.5+0.0i) => #f), but its printed form is
-                // the bare real, matching make-rectangular's demotion. A
-                // -0.0 imag keeps its sign and prints the full form.
-                if (isZeroComponent(imag) and !componentNegative(imag)) {
+                // Only an EXACT zero imaginary part collapses to the bare
+                // real component — and exact zeros demote at construction,
+                // so in practice a stored complex's zero imag is always an
+                // inexact ±0.0, which must print in full ("1.5+0.0i" /
+                // "1.5-0.0i") so write and number->string round-trip through
+                // read. R7RS 6.2.7: an inexact-zero-imag complex is NOT real
+                // ((real? -2.5+0.0i) => #f, kaappi#2269), so collapsing it to
+                // the bare real is a conformance bug. A -0.0 imag keeps its
+                // sign and prints the full form either way.
+                if (isZeroComponent(imag) and types.isExactNumber(imag)) {
                     try writeComplexComponent(allocator, writer, real);
                 } else {
                     const has_real = !isZeroComponent(real) or componentNegative(real);

--- a/src/reader_datum.zig
+++ b/src/reader_datum.zig
@@ -84,9 +84,9 @@ fn tokenToValue(self: *Reader, tok: Token) ReadError!Value {
             // constructor applies the whole-number inexactness rule and
             // demotes only an exact zero imaginary part, so -2.5+0.0i stays
             // a complex ((real? -2.5+0.0i) => #f) while 3+0i is the real 3
-            // ((integer? 3+0i) => #t, kaappi#2166).
+            // ((integer? 3+0i) => #t, kaappi#2269).
             const numeric = @import("primitives_numeric.zig");
-            return numeric.makeComplexOrRealLiteral(self.gc, c.real, c.imag) catch return ReadError.OutOfMemory;
+            return numeric.makeComplexOrRealV(self.gc, c.real, c.imag) catch return ReadError.OutOfMemory;
         },
         .boolean => |b| return if (b) types.TRUE else types.FALSE,
         .character => |c| return types.makeChar(c),

--- a/src/tests_advanced.zig
+++ b/src/tests_advanced.zig
@@ -396,15 +396,23 @@ test "real-part and imag-part of real numbers" {
     try std.testing.expectEqual(@as(i64, 0), types.toFixnum(ip));
 }
 
-test "make-rectangular with zero imag returns flonum" {
+test "make-rectangular with zero imag keeps an inexact zero-imag complex" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
     defer vm.deinit();
 
+    // An INEXACT zero imaginary part keeps the value complex (R7RS 6.2.6
+    // worked examples: (real? -2.5+0.0i) => #f; kaappi#2269). Only an
+    // exact zero demotes.
     const result = try vm.eval("(make-rectangular 5.0 0.0)");
-    try std.testing.expect(types.isFlonum(result));
-    try std.testing.expectEqual(@as(f64, 5.0), types.toFlonum(result));
+    try std.testing.expect(types.isComplex(result));
+    const c = types.toComplex(result);
+    try std.testing.expectEqual(@as(f64, 5.0), types.toFlonum(c.real));
+    try std.testing.expectEqual(@as(f64, 0.0), types.toFlonum(c.imag));
+
+    const exact = try vm.eval("(make-rectangular 5 0)");
+    try std.testing.expect(types.isFixnum(exact));
 }
 
 test "complex? predicate" {

--- a/src/tests_advanced.zig
+++ b/src/tests_advanced.zig
@@ -397,21 +397,20 @@ test "real-part and imag-part of real numbers" {
 }
 
 test "make-rectangular with zero imag keeps an inexact zero-imag complex" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
 
     // An INEXACT zero imaginary part keeps the value complex (R7RS 6.2.6
     // worked examples: (real? -2.5+0.0i) => #f; kaappi#2269). Only an
     // exact zero demotes.
-    const result = try vm.eval("(make-rectangular 5.0 0.0)");
+    const result = try ctx.vm.eval("(make-rectangular 5.0 0.0)");
     try std.testing.expect(types.isComplex(result));
     const c = types.toComplex(result);
     try std.testing.expectEqual(@as(f64, 5.0), types.toFlonum(c.real));
     try std.testing.expectEqual(@as(f64, 0.0), types.toFlonum(c.imag));
 
-    const exact = try vm.eval("(make-rectangular 5 0)");
+    const exact = try ctx.vm.eval("(make-rectangular 5 0)");
     try std.testing.expect(types.isFixnum(exact));
 }
 

--- a/tests/scheme/audit/primitives_srfi160-audit.scm
+++ b/tests/scheme/audit/primitives_srfi160-audit.scm
@@ -234,23 +234,24 @@
 (test-assert "c128 accepts an exact complex"
              (= (make-rectangular 1 2) (rt c128row (make-rectangular 1 2))))
 
-;;; A c64/c128 element decodes to a real when its imaginary part is exactly
-;;; +0.0, matching make-rectangular's normalisation and the standalone
-;;; complex printer's collapse (kaappi#1951). A -0.0 imaginary part keeps
-;;; its sign and stays a Complex, since the printer preserves -0.0 as
-;;; "1.5-0.0i". These assertions pin the decode boundary.
-(test-assert "a zero-imaginary (+0.0) c128 element decodes to a real"
-             (real? (c128vector-ref (c128vector 1.5) 0)))
-(test-assert "a zero-imaginary (+0.0) c64 element decodes to a real"
-             (real? (c64vector-ref (c64vector 1.5) 0)))
+;;; A c64/c128 element decodes to a Complex with BOTH components preserved
+;;; — an element stored as (1.5, +0.0) decodes to 1.5+0.0i, matching the
+;;; reader and make-rectangular, where an inexact zero imaginary part keeps
+;;; the value complex (R7RS 6.2.6; kaappi#2269). A -0.0 imaginary part keeps
+;;; its sign too, since the printer preserves it as "1.5-0.0i". These
+;;; assertions pin the decode boundary.
+(test-assert "a zero-imaginary (+0.0) c128 element stays complex"
+             (not (real? (c128vector-ref (c128vector 1.5) 0))))
+(test-assert "a zero-imaginary (+0.0) c64 element stays complex"
+             (not (real? (c64vector-ref (c64vector 1.5) 0))))
 (test-assert "a +0.0-imag c128 element is complex? (reals are complex)"
              (complex? (c128vector-ref (c128vector 1.5) 0)))
 (test-assert "its imaginary part is zero"
              (= 0 (imag-part (c128vector-ref (c128vector 1.5) 0))))
-;; Control 1: make-rectangular NORMALISES a zero imaginary part to a real,
-;; so decodeElement now agrees with the ordinary constructor.
-(test-assert "make-rectangular normalises a zero imaginary part"
-             (real? (make-rectangular 1.5 0.0)))
+;; Control 1: make-rectangular KEEPS an inexact zero imaginary part complex,
+;; so decodeElement agrees with the ordinary constructor.
+(test-assert "make-rectangular keeps an inexact zero imaginary part complex"
+             (not (real? (make-rectangular 1.5 0.0))))
 ;; Control 2: a genuinely complex element round-trips through write/read.
 (test-assert "a genuine complex writes and reads back as a complex"
              (let ((e (c128vector-ref (c128vector (make-rectangular 1.5 2.5)) 0)))
@@ -260,12 +261,12 @@
 (test-equal "#<c128vector 1.5+0.0i>" (write-to-string (c128vector 1.5)))
 (test-equal "#<c64vector 1.5+0.0i>" (write-to-string (c64vector 1.5)))
 
-;;; #1951 (a zero-imaginary c64/c128 element writes as a real): a +0.0
-;;; imaginary part now decodes to a plain real, so `write` emits "1.5" and
-;;; it reads back as the SAME type — real? agrees on both sides. The same
-;;; holds for c64 and for the DEFAULT FILL, so every freshly-made c64/c128
-;;; vector round-trips. A -0.0 imaginary part stays a Complex and writes
-;;; as "1.5-0.0i", which also round-trips.
+;;; #1951/#2269 (a zero-imaginary c64/c128 element writes as a real): a
+;;; +0.0 imaginary part now decodes to the complex 1.5+0.0i and `write`
+;;; emits "1.5+0.0i", so it reads back as the SAME type — real? agrees on
+;;; both sides. The same holds for c64 and for the DEFAULT FILL, so every
+;;; freshly-made c64/c128 vector round-trips. A -0.0 imaginary part stays a
+;;; Complex and writes as "1.5-0.0i", which also round-trips.
 (test-assert "a zero-imaginary c128 element round-trips through write/read"
              (let ((e (c128vector-ref (c128vector 1.5) 0)))
                (eq? (real? e)

--- a/tests/scheme/compliance/complex-exactness-2166-2167.scm
+++ b/tests/scheme/compliance/complex-exactness-2166-2167.scm
@@ -12,9 +12,10 @@
 ;; flonum) instead of f64+exactness-flags, so exact complexes are computed,
 ;; stored, printed, and read back digit-exactly. A stored complex is never
 ;; mixed-exactness: if either component is inexact both are (R7RS 6.2.2's
-;; inexactness rule), and a zero imaginary part demotes to the real
-;; component. These tests pin the full behavior, including the exact
-;; arithmetic the interim slice deliberately left inexact.
+;; inexactness rule), and an EXACT zero imaginary part demotes to the real
+;; component while an INEXACT zero keeps the value complex (kaappi#2269).
+;; These tests pin the full behavior, including the exact arithmetic the
+;; interim slice deliberately left inexact.
 
 (import (scheme base) (scheme complex) (scheme write) (scheme process-context) (srfi 64) (srfi 69))
 
@@ -133,13 +134,41 @@
   (finite? (make-rectangular (expt 10 400) 1)))
 (test-equal "make-rectangular 3/2 0 demotes to exact rational" 3/2
   (make-rectangular 3/2 0))
-(test-equal "make-rectangular 3/2 0.0 demotes to inexact" 1.5
+(test-equal "make-rectangular 3/2 0.0 keeps an inexact zero imag complex" 1.5+0.0i
   (make-rectangular 3/2 0.0))
 (test-assert "make-rectangular 3/2 0.0 result is inexact"
   (inexact? (make-rectangular 3/2 0.0)))
-(test-equal "make-rectangular 1 0.0 demotes to inexact 1.0" 1.0
+(test-equal "make-rectangular 1 0.0 keeps an inexact zero imag complex" 1.0+0.0i
   (make-rectangular 1 0.0))
-(test-assert "make-rectangular 1.5 0.0 is real" (real? (make-rectangular 1.5 0.0)))
+(test-assert "make-rectangular 1.5 0.0 is not real (inexact zero imag)"
+  (not (real? (make-rectangular 1.5 0.0))))
+
+;; --- #2269: an inexact zero imag stays complex and round-trips -----------
+;; make-rectangular now constructs through the same exact-zero-only demotion
+;; the reader uses, so the constructor and the literal 1.5+0.0i agree: the
+;; value is NOT real (R7RS 6.2.6's worked examples pin (real? -2.5+0.0i)
+;; => #f), and write/number->string emit the full form so it round-trips
+;; through read/string->number (R7RS 6.2.7). The decomposition probe starts
+;; from the READER value (not make-rectangular), because that is the only
+;; starting point that fails under the old demotion — the discriminating
+;; case per the cross-implementation check on the issue.
+(define z2269 (read (open-input-string "1.5+0.0i")))
+(test-assert "make-rectangular 1.5 0.0 agrees with the reader literal"
+  (eqv? (make-rectangular 1.5 0.0) z2269))
+(test-assert "decomposition round-trip: (make-rectangular (real-part z) (imag-part z)) == z"
+  (eqv? (make-rectangular (real-part z2269) (imag-part z2269)) z2269))
+(test-assert "write/read round-trip of 1.5+0.0i"
+  (let ((p (open-output-string)))
+    (write z2269 p)
+    (eqv? z2269 (read (open-input-string (get-output-string p))))))
+(test-equal "write of 1.5+0.0i is honest" "1.5+0.0i"
+  (let ((p (open-output-string)))
+    (write z2269 p)
+    (get-output-string p)))
+(test-assert "number->string/string->number round-trip (R7RS 6.2.7)"
+  (eqv? z2269 (string->number (number->string z2269))))
+(test-equal "number->string of 1.5+0.0i is honest" "1.5+0.0i"
+  (number->string z2269))
 
 ;; --- #2166 (full): write and real-part agree -------------------------------
 

--- a/tests/scheme/compliance/complex-exactness-2166-2167.scm
+++ b/tests/scheme/compliance/complex-exactness-2166-2167.scm
@@ -170,6 +170,52 @@
 (test-equal "number->string of 1.5+0.0i is honest" "1.5+0.0i"
   (number->string z2269))
 
+;; --- #2269 (review): the arithmetic tower and make-polar use the same ---
+;; exact-zero-only rule. The issue's cross-implementation check showed the
+;; constructor/reader split was only half the bug: (+ 1.0+2.0i 1.0-2.0i),
+;; (* 1.5+0.0i 2.0), (- 1.5+2.0i 0.0+2.0i), (+ 1.5+0.0i 0), and
+;; (make-polar 1.5 0.0) all stay complex in Chez/Guile/chibi/Gambit; only
+;; an exact zero imag demotes. These pin the arithmetic tower and polar on
+;; the same rule. (Exactness of the zero is read off the input components,
+;; so an exact zero still demotes: (- z z) => 0, (make-polar 1.5 0) => 1.5.)
+(define zadd (read (open-input-string "1.0+2.0i")))
+(test-assert "(+ 1.0+2.0i 1.0-2.0i) keeps an inexact zero imag complex"
+  (not (real? (+ zadd (make-rectangular 1.0 -2.0)))))
+(test-equal "(+ 1.0+2.0i 1.0-2.0i) writes 2.0+0.0i" "2.0+0.0i"
+  (number->string (+ zadd (make-rectangular 1.0 -2.0))))
+(test-assert "(+ 1.0+2.0i 1.0-2.0i) round-trips through number->string"
+  (eqv? (+ zadd (make-rectangular 1.0 -2.0))
+        (string->number (number->string (+ zadd (make-rectangular 1.0 -2.0))))))
+(test-assert "(* 1.5+0.0i 2.0) keeps an inexact zero imag complex"
+  (not (real? (* (make-rectangular 1.5 0.0) 2.0))))
+(test-assert "(- 1.5+2.0i 0.0+2.0i) keeps an inexact zero imag complex"
+  (not (real? (- (make-rectangular 1.5 2.0) (make-rectangular 0.0 2.0)))))
+(test-assert "(+ 1.5+0.0i 0) keeps an inexact zero imag complex"
+  (not (real? (+ (make-rectangular 1.5 0.0) 0))))
+(test-assert "(- 1.5+0.0i 1.5+0.0i) stays complex but is zero"
+  (and (not (real? (- z2269 z2269))) (zero? (- z2269 z2269))))
+(test-assert "make-polar 1.5 0.0 keeps an inexact zero imag complex"
+  (not (real? (make-polar 1.5 0.0))))
+(test-equal "make-polar 1.5 0.0 writes 1.5+0.0i" "1.5+0.0i"
+  (number->string (make-polar 1.5 0.0)))
+(test-assert "make-polar 1.5 0.0 round-trips through number->string"
+  (eqv? (make-polar 1.5 0.0) (string->number (number->string (make-polar 1.5 0.0)))))
+(test-equal "make-polar 1.5 -0.0 preserves the negative zero imag" "1.5-0.0i"
+  (number->string (make-polar 1.5 -0.0)))
+(test-equal "make-polar 1.5 0 (exact angle) demotes to a real" 1.5
+  (make-polar 1.5 0))
+;; (make-polar 0.0 1.0) has a +0.0 real part; kaappi's printer omits a
+;; zero real in the full form ("+0.0i", a valid R7RS literal) while the
+;; references print "0.0+0.0i" — same value, same round-trip.
+(test-assert "make-polar 0.0 1.0 keeps a zero imag complex"
+  (let ((z (make-polar 0.0 1.0)))
+    (and (not (real? z)) (zero? z)
+         (eqv? z (string->number (number->string z))))))
+;; The exact-zero demotions must survive the change.
+(test-equal "(- z z) still demotes to exact 0" 0 (- (make-rectangular 3/2 1) (make-rectangular 3/2 1)))
+(test-equal "(exact 1.5+0.0i) still demotes to an exact real" 3/2
+  (exact 1.5+0.0i))
+
 ;; --- #2166 (full): write and real-part agree -------------------------------
 
 (define w2166 (make-rectangular 3/2 1))

--- a/tests/scheme/compliance/complex-exactness-2166-2167.scm
+++ b/tests/scheme/compliance/complex-exactness-2166-2167.scm
@@ -204,6 +204,13 @@
   (number->string (make-polar 1.5 -0.0)))
 (test-equal "make-polar 1.5 0 (exact angle) demotes to a real" 1.5
   (make-polar 1.5 0))
+;; A tiny EXACT NONZERO angle whose sin underflows to 0.0 must NOT demote:
+;; the guard tests the angle is numerically zero, not merely exact
+;; (kaappi#2269, review). All four references keep this complex.
+(test-assert "make-polar with a tiny exact nonzero angle stays complex"
+  (let ((z (make-polar 1.5 (/ 1 (expt 10 400)))))
+    (and (not (real? z))
+         (eqv? z (string->number (number->string z))))))
 ;; (make-polar 0.0 1.0) has a +0.0 real part; kaappi's printer omits a
 ;; zero real in the full form ("+0.0i", a valid R7RS literal) while the
 ;; references print "0.0+0.0i" — same value, same round-trip.

--- a/tests/scheme/smoke/complex-neg-zero.scm
+++ b/tests/scheme/smoke/complex-neg-zero.scm
@@ -1,7 +1,7 @@
 ;;; Regression test for issue #637: Complex number printing must not drop
 ;;; real/imaginary part when it equals negative zero.
 
-(import (scheme base) (scheme write) (scheme inexact))
+(import (scheme base) (scheme write) (scheme inexact) (scheme process-context))
 
 ;; 1.0-0.0i: imaginary part is -0.0, must not be dropped
 (let* ((x (read (open-input-string "1.0-0.0i")))

--- a/tests/scheme/smoke/complex-neg-zero.scm
+++ b/tests/scheme/smoke/complex-neg-zero.scm
@@ -30,13 +30,15 @@
     (display "FAIL: expected 3.0+4.0i, got ") (display s) (newline)
     (exit 1)))
 
-;; Positive zero imaginary should collapse to real
+;; Positive zero imaginary must NOT collapse: 5.0+0.0i is complex (an
+;; inexact zero imaginary part keeps the value complex, R7RS 6.2.6,
+;; kaappi#2269), so write emits the full form and the value round-trips.
 (let* ((w (read (open-input-string "5.0+0.0i")))
        (s (let ((p (open-output-string)))
             (write w p)
             (get-output-string p))))
-  (unless (string=? s "5.0")
-    (display "FAIL: expected 5.0, got ") (display s) (newline)
+  (unless (string=? s "5.0+0.0i")
+    (display "FAIL: expected 5.0+0.0i, got ") (display s) (newline)
     (exit 1)))
 
 (display "OK")

--- a/tests/scheme/srfi/srfi231-storage-classes.scm
+++ b/tests/scheme/srfi/srfi231-storage-classes.scm
@@ -16,13 +16,13 @@
 ;;; --- a generic helper exercising the full 9-field contract on a
 ;;; storage class, used across every one of the 14 real classes below.
 ;;; Complex values read back from a c64/c128 body are always genuinely
-;;; complex-tagged even with a zero imaginary part (unlike a bare
-;;; make-rectangular call at the Scheme level, which collapses eagerly),
-;;; so numeric equality (=) is used for the value-carrying checks when
-;;; both sides are numbers, since equal? would otherwise spuriously fail
-;;; despite both sides being the same number. bad-value has no meaningful
-;;; "checker rejects this" case for generic-storage-class (its checker
-;;; always returns #t), so that assertion is a separate, optional check. ---
+;;; complex-tagged, including a zero imaginary part (an inexact zero imag
+;;; stays complex, kaappi#2269), so numeric equality (=) is used for the
+;;; value-carrying checks when both sides are numbers, since equal? would
+;;; otherwise spuriously fail despite both sides being the same number.
+;;; bad-value has no meaningful "checker rejects this" case for
+;;; generic-storage-class (its checker always returns #t), so that
+;;; assertion is a separate, optional check. ---
 (define (%same? a b) (if (and (number? a) (number? b)) (= a b) (equal? a b)))
 
 (define (check-storage-class sc value bad-value expected-default . rejects-bad?)


### PR DESCRIPTION
## Summary

Fixes #2269. Since #2166 stored complex components as `Value`s, construction
sites disagreed about an **inexact zero imaginary part**: `make-rectangular`
demoted `(make-rectangular 1.5 0.0)` to the real `1.5`, while the reader kept
`1.5+0.0i` complex; the arithmetic tower and `make-polar` demoted too, and the
printer collapsed `(write 1.5+0.0i)` to `"1.5"` — which reads back as a
different value, violating R7RS §6.2.7's `number->string` round-trip.

Per R7RS §6.2.6's worked examples, an explicitly **inexact** zero imaginary
part keeps the value complex (`(real? -2.5+0.0i)` => `#f`); only an **exact**
zero demotes (`(real? -2.5+0i)` => `#t`). I verified against Chez 10.4, Guile
3.0, chibi 0.12, and Gambit 4.9 — all four keep the complex everywhere
(construction, arithmetic, `make-polar`, and the transcendentals); kaappi was
the lone outlier.

## Changes

1. **One exact-zero-only construction rule.** `makeComplexOrRealV` and
   `makeComplexOrRealLiteral` differed only in their demotion condition and are
   now collapsed into a single `makeComplexOrRealV` (`src/primitives_numeric.zig`)
   — the one Value-component complex builder used by the reader,
   `string->number`, `make-rectangular`, the arithmetic tower (`+ - * /`), and
   `exact`/`inexact` conversion. An inexact zero imag stays complex; only an
   exact zero demotes.
2. **`make-polar`** (`src/primitives_numeric.zig`) — demotes only an exact
   zero angle (`(make-polar 1.5 0)` => `1.5`); an inexact zero imag stays
   complex (`(make-polar 1.5 0.0)` => `1.5+0.0i`), `-0.0` preserved
   (`(make-polar 1.5 -0.0)` => `1.5-0.0i`), and `(make-polar 0.0 1.0)` stays
   `0.0+0.0i` — all matching the references.
3. **Printer** (`src/printer.zig`) — the `.complex` arm collapses only an
   *exact* zero imag; an inexact ±0.0 prints in full (`"1.5+0.0i"` /
   `"1.5-0.0i"`), so `write` and `number->string` round-trip through
   `read`/`string->number`.
4. **SRFI-160 decode** (`src/primitives_srfi160.zig`) — c64/c128
   `decodeElement` preserves a `+0.0` imaginary part instead of demoting to a
   plain real, so vector refs agree with the standalone constructor.

## Tests

- Regressions in `tests/scheme/compliance/complex-exactness-2166-2167.scm`
  for the decomposition round-trip and `write`/`read` +
  `number->string`/`string->number` round-trips (starting from the reader
  value, the discriminating probe), plus the arithmetic (`+ - * /`) and
  `make-polar` cases from the review.
- Re-pinned the srfi160 audit control/decode assertions, `complex-neg-zero.scm`,
  and the Zig unit test for the new constructor/printer behavior.
- Exact-zero survival pins: `(- z z)` => `0`, `(exact 1.5+0.0i)` => `3/2`,
  `(make-polar 1.5 0)` => `1.5`, `(integer? 3+0i)` => `#t` — all still demote.
- `(real? -2.5+0.0i)` => `#f` stays green in `r7rs-tests.scm:760`.

## Known remaining divergence (unchanged, deliberate)

The f64 transcendental and power paths — `sin`/`cos`/`tan`, `sqrt`, `expt`,
`exp`, `log`, `asin` — still demote an exactly-zero (or, for `exp`/`log`/`asin`,
below-1e-15-noise) imaginary result via the pre-existing `makeComplexOrReal`
and its epsilon guard. That noise-suppression design is orthogonal to the
construction-site rule this PR fixes, the references themselves disagree about
noise (e.g. Guile zeroes `(expt 1.0+2.0i 2)` to `-3.0+4.0i` where Chez keeps
`-2.9999999999999987+4.0i`), and the reviewer's recommendation scoped to
construction + arithmetic + `make-polar`. Flagging it here so it is not shipped
silently; a follow-up could revisit it.

## Checklist

- [x] `zig build test` passes (also under `-Dgc-stress=true`)
- [x] `zig fmt --check src/` passes
- [x] Scheme test suites pass (`bash tests/scheme/run-all.sh`): 701 scheme
  files + 1395 R7RS tests, 0 failures
- [x] New tests added for new behavior
- [x] Documentation updated (CHANGELOG.md)
