### PR TITLE
,load: build the form as Values so paths with quotes or backslashes load (Fixes #2273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`,load` no longer mangles paths containing `"` or `\`** (#2273). The
+  command spliced the path into a `(load "...")` string literal, so the
+  reader's escapes broke or changed it: a quote ended the string (reader
+  error), a backslash started an escape (`\s` was an invalid escape and
+  `\t` decoded to a TAB, loading a different file — on Windows, whose
+  paths all use backslashes, `,load` was effectively broken). It now builds
+  the form as Values and hands the raw path bytes to `load`, so every path
+  works and the old 1024-byte path limit is gone.
+
 - **Exact complex numbers are stored, computed, printed, and read back
   digit-exactly** (#2166). A `Complex` held its components as two f64s
   plus exactness flags, so every consumer had to choose between

--- a/src/repl_commands.zig
+++ b/src/repl_commands.zig
@@ -185,12 +185,38 @@ pub fn handleCommand(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []cons
         if (load_path.len == 0) {
             writeStderr(",load requires a file path\n");
         } else {
-            var load_buf: [1024]u8 = undefined;
-            const load_expr = std.fmt.bufPrint(&load_buf, "(load \"{s}\")", .{load_path}) catch {
-                writeStderr("path too long\n");
+            // Build `(load "path")` as Values instead of splicing the path
+            // into a string literal: the reader's escapes (`\"`, `\\`,
+            // `\t`, ...) would mangle a path containing a quote or a
+            // backslash — on Windows every path does (kaappi#2273).
+            // evalInputValue evaluates the form with the same driver as the
+            // text path, errors included.
+            var path_val: types.Value = undefined;
+            vm.gc.pushRoot(&path_val);
+            defer vm.gc.popRoot();
+            path_val = vm.gc.allocString(load_path) catch {
+                writeStderr("out of memory\n");
                 return .handled;
             };
-            repl_eval.evalInput(vm, allocator, load_expr);
+            var sym_val: types.Value = undefined;
+            vm.gc.pushRoot(&sym_val);
+            defer vm.gc.popRoot();
+            sym_val = vm.gc.allocSymbol("load") catch {
+                writeStderr("out of memory\n");
+                return .handled;
+            };
+            // allocPair roots its Value arguments internally, so only the
+            // two locals above need explicit roots across the calls below
+            // (see .claude/rules/gc-safety.md).
+            const args = vm.gc.allocPair(path_val, types.NIL) catch {
+                writeStderr("out of memory\n");
+                return .handled;
+            };
+            const form = vm.gc.allocPair(sym_val, args) catch {
+                writeStderr("out of memory\n");
+                return .handled;
+            };
+            repl_eval.evalInputValue(vm, allocator, form, .normal);
         }
         return .handled;
     }

--- a/src/repl_commands.zig
+++ b/src/repl_commands.zig
@@ -191,23 +191,28 @@ pub fn handleCommand(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []cons
             // backslash — on Windows every path does (kaappi#2273).
             // evalInputValue evaluates the form with the same driver as the
             // text path, errors included.
-            var path_val: types.Value = undefined;
+            //
+            // Assign before rooting (matching `,expand`/`,import` below): the
+            // slot must hold a valid value before any later call can collect
+            // — allocString/allocSymbol copy their bytes, then maybeCollect()
+            // *before* returning, and markRoots dereferences every rooted
+            // slot, so rooting an undefined slot would let garbage bits that
+            // happen to look like a pointer corrupt the heap (kaappi#2274
+            // review). path_val is rooted before allocSymbol (the next
+            // allocation) and sym_val before the allocPair calls; allocPair
+            // roots its Value arguments internally.
+            var path_val = vm.gc.allocString(load_path) catch {
+                writeStderr("out of memory\n");
+                return .handled;
+            };
             vm.gc.pushRoot(&path_val);
             defer vm.gc.popRoot();
-            path_val = vm.gc.allocString(load_path) catch {
+            var sym_val = vm.gc.allocSymbol("load") catch {
                 writeStderr("out of memory\n");
                 return .handled;
             };
-            var sym_val: types.Value = undefined;
             vm.gc.pushRoot(&sym_val);
             defer vm.gc.popRoot();
-            sym_val = vm.gc.allocSymbol("load") catch {
-                writeStderr("out of memory\n");
-                return .handled;
-            };
-            // allocPair roots its Value arguments internally, so only the
-            // two locals above need explicit roots across the calls below
-            // (see .claude/rules/gc-safety.md).
             const args = vm.gc.allocPair(path_val, types.NIL) catch {
                 writeStderr("out of memory\n");
                 return .handled;

--- a/src/repl_eval.zig
+++ b/src/repl_eval.zig
@@ -58,6 +58,21 @@ pub fn evalInput(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u8
     evalInputInner(vm, allocator, input, .normal);
 }
 
+/// Evaluate one already-read top-level expression with the same driver the
+/// text path uses, skipping only the reader. `,load` builds `(load "path")`
+/// as Values this way so a path is never round-tripped through the reader's
+/// string escapes, which would mangle a path containing `"` or `\`
+/// (kaappi#2273). The caller may pass an unrooted value; it is rooted here
+/// across the compile and execute below.
+pub fn evalInputValue(vm: *vm_mod.VM, allocator: std.mem.Allocator, expr: types.Value, mode: EvalMode) void {
+    var expr_root = expr;
+    vm.gc.pushRoot(&expr_root);
+    defer vm.gc.popRoot();
+    crash.note(.executing, "<repl>");
+    defer crash.reset();
+    _ = evalExpr(vm, allocator, expr_root, mode, 0, 0);
+}
+
 fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u8, mode: EvalMode) void {
     // Crash breadcrumb (kaappi#1514); reset on return so a crash at the idle
     // prompt is not mislabeled as this input's last stage.
@@ -85,88 +100,79 @@ fn evalInputInner(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []const u
         vm.gc.pushRoot(&expr);
         defer vm.gc.popRoot();
 
-        crash.noteStage(.executing);
-        if (vm.handleTopLevelForm(expr)) |top_result| {
-            const result = top_result catch |err| {
-                toplevel_driver.reportRuntimeError(vm, err, null);
-                break;
-            };
-            var dr = result;
-            if (types.isMultipleValues(dr)) {
-                const mv = types.toObject(dr).as(types.MultipleValues);
-                dr = if (mv.values.len > 0) mv.values[0] else types.VOID;
-                if (mode != .show_type) {
-                    printValuesLines(allocator, mv.values);
-                    if (mode == .store_last and dr != types.VOID) {
-                        vm.globalsPut("_", dr) catch {};
-                    }
-                    continue;
-                }
-            }
-            if (dr != types.VOID) {
-                if (mode == .show_type) {
-                    writeStdout("; ");
-                    writeStdout(types.typeName(dr));
-                    writeStdout("\n");
-                } else {
-                    const s = printer.prettyPrint(allocator, dr, terminal_width) catch
-                        (printer.valueToString(allocator, dr, .write) catch continue);
-                    defer allocator.free(s);
-                    writeStdout(s);
-                    writeStdout("\n");
-                }
-                if (mode == .store_last) {
-                    vm.globalsPut("_", dr) catch {};
-                }
-            }
-            continue;
-        }
+        // The reader loop stops at the first form that errors (a pasted
+        // batch fails loud rather than limping on), so a false return from
+        // evalExpr breaks out here.
+        if (!evalExpr(vm, allocator, expr, mode, datum_lc.line, datum_lc.col)) break;
+    }
+}
 
-        crash.noteStage(.compiling);
-        const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, datum_lc.line, "<repl>", false) catch |err| {
-            toplevel_driver.reportCompileError("<repl>", datum_lc.line, datum_lc.col, err);
-            break;
-        };
-
-        var func_val = types.makePointer(&func.header);
-        vm.gc.pushRoot(&func_val);
-
-        crash.noteStage(.executing);
-        const result = vm.execute(func) catch |err| {
-            vm.gc.popRoot();
+/// The read-independent half of the REPL driver: classify, compile, execute
+/// and print one top-level expression. Returns false when evaluation errored
+/// (the reader loop treats that as fatal to the batch). Errors report exactly
+/// as the reader-driven path does, including the stack trace for runtime
+/// errors.
+fn evalExpr(vm: *vm_mod.VM, allocator: std.mem.Allocator, expr: types.Value, mode: EvalMode, line: u32, col: u32) bool {
+    crash.noteStage(.executing);
+    if (vm.handleTopLevelForm(expr)) |top_result| {
+        const result = top_result catch |err| {
             toplevel_driver.reportRuntimeError(vm, err, null);
-            toplevel_driver.printStackTrace(vm);
-            break;
+            return false;
         };
-        vm.gc.popRoot();
+        printResult(allocator, result, mode, vm);
+        return true;
+    }
 
-        var display_result = result;
-        if (types.isMultipleValues(display_result)) {
-            const mv = types.toObject(display_result).as(types.MultipleValues);
-            display_result = if (mv.values.len > 0) mv.values[0] else types.VOID;
-            if (mode != .show_type) {
-                printValuesLines(allocator, mv.values);
-                if (mode == .store_last and display_result != types.VOID) {
-                    vm.globalsPut("_", display_result) catch {};
-                }
-                continue;
+    crash.noteStage(.compiling);
+    const func = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, line, "<repl>", false) catch |err| {
+        toplevel_driver.reportCompileError("<repl>", line, col, err);
+        return false;
+    };
+
+    var func_val = types.makePointer(&func.header);
+    vm.gc.pushRoot(&func_val);
+
+    crash.noteStage(.executing);
+    const result = vm.execute(func) catch |err| {
+        vm.gc.popRoot();
+        toplevel_driver.reportRuntimeError(vm, err, null);
+        toplevel_driver.printStackTrace(vm);
+        return false;
+    };
+    vm.gc.popRoot();
+
+    printResult(allocator, result, mode, vm);
+    return true;
+}
+
+/// Print one evaluation result (or the first of a multiple-values result) the
+/// way the interactive loop does, and record it into `_` in store-last mode.
+fn printResult(allocator: std.mem.Allocator, result: types.Value, mode: EvalMode, vm: *vm_mod.VM) void {
+    var dr = result;
+    if (types.isMultipleValues(dr)) {
+        const mv = types.toObject(dr).as(types.MultipleValues);
+        dr = if (mv.values.len > 0) mv.values[0] else types.VOID;
+        if (mode != .show_type) {
+            printValuesLines(allocator, mv.values);
+            if (mode == .store_last and dr != types.VOID) {
+                vm.globalsPut("_", dr) catch {};
             }
+            return;
         }
-        if (display_result != types.VOID) {
-            if (mode == .show_type) {
-                writeStdout("; ");
-                writeStdout(types.typeName(display_result));
-                writeStdout("\n");
-            } else {
-                const s = printer.prettyPrint(allocator, display_result, terminal_width) catch
-                    (printer.valueToString(allocator, display_result, .write) catch continue);
-                defer allocator.free(s);
-                writeStdout(s);
-                writeStdout("\n");
-            }
-            if (mode == .store_last) {
-                vm.globalsPut("_", display_result) catch {};
-            }
-        }
+    }
+    if (dr == types.VOID) return;
+    if (mode == .show_type) {
+        writeStdout("; ");
+        writeStdout(types.typeName(dr));
+        writeStdout("\n");
+    } else {
+        const s = printer.prettyPrint(allocator, dr, terminal_width) catch
+            (printer.valueToString(allocator, dr, .write) catch return);
+        defer allocator.free(s);
+        writeStdout(s);
+        writeStdout("\n");
+    }
+    if (mode == .store_last) {
+        vm.globalsPut("_", dr) catch {};
     }
 }

--- a/tests/scheme/smoke/repl-load-path-2273.sh
+++ b/tests/scheme/smoke/repl-load-path-2273.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# kaappi#2273: `,load` must not round-trip the path through the reader's
+# string escapes.
+#
+# The command used to splice the path into a `(load "...")` string literal,
+# so a path containing `"` or `\` broke: a quote ended the string (reader
+# syntax error), a backslash started an escape (`\s` is an invalid escape;
+# `\t` decodes to a TAB and loads a *different* file). It now builds the
+# form as Values and hands the raw path bytes to `load`, which is also why
+# the regression is a pty test: `,load` only exists in the interactive REPL,
+# and only a pty can drive it (like the other repl-*.sh tests).
+
+set -eu
+
+KAAPPI="${KAAPPI:-${1:-zig-out/bin/kaappi}}"
+
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "no pty; isocline drives the Windows console API directly"
+
+command -v python3 >/dev/null 2>&1 || {
+    echo "SKIP: python3 is needed to allocate a pty"
+    exit 77
+}
+
+# Resolve to an absolute path for the driver, which execs it directly. A value
+# with no slash is a PATH lookup; anything else is a path as given. A binary
+# that cannot be executed is a *failure*, not a skip.
+case "$KAAPPI" in
+    */*) kaappi_abs="$(cd "$(dirname "$KAAPPI")" 2>/dev/null && pwd)/$(basename "$KAAPPI")" ;;
+    *)   kaappi_abs="$(command -v "$KAAPPI" || true)" ;;
+esac
+if [ ! -x "$kaappi_abs" ]; then
+    echo "FAIL: $KAAPPI is not an executable file (build first: zig build)"
+    exit 1
+fi
+
+# Isolate history and config: the REPL reads ~/.kaappi, and a developer's own
+# `repl.prompt` would move the sentinel this script waits for.
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Files whose names trip the reader escapes `,load` used to splice into a
+# string literal: a double quote ends the literal, a backslash starts an
+# escape. Backslashes and quotes are legal filename characters on POSIX.
+printf '(display "NORMAL")(newline)\n' > "$work/normal.scm"
+printf '(display "QUOTE")(newline)\n' > "$work/a\"b.scm"
+printf '(display "BACKSLASH")(newline)\n' > "$work/back\\slash.scm"
+printf '(display "TAB")(newline)\n' > "$work/tab\\tfile.scm"
+
+driver="$work/drive.py"
+cat > "$driver" <<'PY'
+import fcntl, os, pty, re, select, struct, sys, termios, time
+
+kaappi = sys.argv[1]
+# argv[2..] are path/marker pairs: the file at `path` displays `marker` when
+# loaded, so the marker's presence proves the file was opened at exactly the
+# path that was typed (a mangled path loads nothing, or a *different* file).
+cases = []
+i = 2
+while i + 1 < len(sys.argv):
+    cases.append((sys.argv[i].encode(), sys.argv[i + 1].encode()))
+    i += 2
+
+ansi = re.compile(rb'\x1b\[[0-9;?]*[a-zA-Z]|\x1b[()][B0]|\x1b[=>]|\r')
+
+pid, fd = pty.fork()
+if pid == 0:
+    # The child must exec or die: `pty.fork` gives it the parent's code, so a
+    # raising execv would otherwise let a traceback land in the pty slave and
+    # muddy the buffer the parent is matching against.
+    try:
+        os.environ['TERM'] = 'xterm'
+        os.environ['NO_COLOR'] = '1'
+        os.execv(kaappi, [kaappi])
+    except BaseException:
+        pass
+    os._exit(127)
+
+# A pty starts out 0x0, which gives the editor no room to render in.
+fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack('HHHH', 40, 200, 0, 0))
+
+buf = b''
+eof = False
+deadline = time.time() + 90
+
+def pump(timeout):
+    global buf, eof
+    try:
+        r, _, _ = select.select([fd], [], [], timeout)
+    except OSError:
+        eof = True
+        return False
+    if not r:
+        return False
+    try:
+        chunk = os.read(fd, 65536)
+    except OSError:
+        eof = True
+        return False
+    if not chunk:
+        eof = True
+        return False
+    buf += chunk
+    return True
+
+def seen(mark=0):
+    """Everything the child has written since *raw* byte `mark`, escapes
+    stripped. The mark indexes `buf`, not the stripped text, because stripped
+    indices are not stable: a read that ends mid-escape-sequence leaves bytes
+    the regex cannot match yet, and they disappear once the rest arrives."""
+    return ansi.sub(b'', buf[mark:])
+
+def wait_for(needle, mark=0, timeout=20):
+    """Wait for `needle` in output written *after* `mark`."""
+    end = min(time.time() + timeout, deadline)
+    while time.time() < end:
+        if needle in seen(mark):
+            return True
+        if eof:
+            break          # the child is gone; no more output is coming
+        pump(0.2)
+    return needle in seen(mark)
+
+def idle(quiet=0.5, limit=5.0):
+    """Drain until the child has been silent for `quiet` seconds. Typing into
+    a REPL that has not finished evaluating lands in the tty's canonical
+    buffer instead of the editor, so every step waits for quiet first."""
+    end = time.time() + limit
+    while time.time() < end:
+        if not pump(quiet):
+            return
+
+def send(data):
+    os.write(fd, data)
+    time.sleep(0.05)
+
+if not wait_for(b'kaappi> ', 0, 25):
+    # Two very different things look alike here, and conflating them is how a
+    # test goes quietly green: a REPL that wrote *nothing at all* did not run,
+    # which is a failure; a REPL that wrote something but never prompted has no
+    # usable terminal, which is a skip.
+    if not buf:
+        sys.stdout.write('the REPL produced no output at all; it did not start\n')
+        sys.exit(1)
+    sys.stdout.write('no prompt in:\n%r\n' % seen())
+    sys.exit(77)
+idle()
+
+failures = []
+for path, marker in cases:
+    mark = len(buf)
+    send(b',load ' + path + b'\r')
+    # The marker is printed by the loaded file itself, scoped to after this
+    # send; nothing else prints it. An "error[" line means the load failed
+    # or the path was mangled into a different file.
+    ok = wait_for(marker + b'\n', mark, 20)
+    idle()
+    produced = seen(mark)
+    if not ok or b'error[' in produced:
+        failures.append((path, marker, produced))
+
+send(b',quit\r')
+while pump(1.0):
+    pass
+try:
+    os.close(fd)
+    os.waitpid(pid, 0)
+except OSError:
+    pass
+
+for path, marker, produced in failures:
+    sys.stdout.write('FAIL %r: expected marker %r in\n%r\n\n' % (path, marker, produced))
+sys.exit(1 if failures else 0)
+PY
+
+set +e
+KAAPPI_HOME="$work/home" python3 "$driver" "$kaappi_abs" \
+    "$work/normal.scm" NORMAL \
+    "$work/a\"b.scm" QUOTE \
+    "$work/back\\slash.scm" BACKSLASH \
+    "$work/tab\\tfile.scm" TAB
+status=$?
+set -e
+
+case $status in
+    0)  echo "PASS: ,load opens paths containing quotes and backslashes"; exit 0 ;;
+    77) echo "SKIP: no usable pty for the REPL here"; exit 77 ;;
+    *)  echo "FAIL: ,load mangled a path with a quote or backslash"; exit 1 ;;
+esac


### PR DESCRIPTION
Fixes #2273 — `,load <path>` spliced the path into a `(load "...")` string literal, so the reader's string escapes broke or changed it:

- `,load /tmp/a"b.scm` → `(load "/tmp/a"b.scm")` → `read error[KP1006]: unterminated string literal`
- `,load C:\tmp\file.scm` → `\t` decodes to a TAB → `error[KP3000]: cannot open file ...` (a *different* file); `\s` in `back\slash.scm` → `read error[KP1007]: invalid escape sequence`

On Windows every path uses backslashes, so `,load` was effectively broken there for normal use.

## Fix

Build `(load "path")` as Values instead of text: a `load` symbol, a Scheme string holding the **raw path bytes**, and the two pairs — no escaping to get wrong, and the old 1024-byte path limit is gone. Evaluation goes through a new `repl_eval.evalInputValue`, which shares the compile/execute/print driver with the text path: the loop body of `evalInputInner` was extracted into `evalExpr` (returning whether the batch should continue, preserving the stop-at-first-error behavior) and the duplicated print/store logic into `printResult`, so error reporting, the runtime stack trace, multiple-values printing, and the `_` binding are unchanged.

GC-safety: the two fresh values (`path_val`, `sym_val`) are explicitly rooted across the pair allocations; `allocPair` roots its Value arguments internally per `.claude/rules/gc-safety.md`. Verified under `-Dgc-stress=true`.

## Regression test

`tests/scheme/smoke/repl-load-path-2273.sh` (pty-driven, like the other `repl-*.sh` tests) creates files whose names contain a double quote, a backslash, and the literal `\t` sequence, plus a normal-path control, and asserts each loads (its marker prints, no `error[` line). All three tricky cases fail on the old code with exactly the errors above.

## Verification

- `zig build` ✓, `zig fmt --check` ✓
- `zig build test` ✓, also green under `-Dgc-stress=true`
- `bash tests/scheme/run-all.sh`: 2097 pass, 0 fail (R7RS 1395/1395)
- New smoke test passes with the fix, fails without it
