### PR TITLE
Remove syntax-rules rule/literal caps; fix define-property in templates (Fixes #2184, #2089)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   the list and vector spellings, custom ellipsis identifiers, and the
   ellipsis-as-literal carve-out (`(syntax-rules ... (...))`).
 
+- **`syntax-rules` accepts any number of rules and literals** (#2184).
+  `parseSyntaxRules` parsed into fixed 32-slot stack buffers and rejected
+  the 33rd rule or literal with a bare KP2001 InvalidSyntax — a legal,
+  well-formed macro failed as if it were malformed, with no mention of the
+  cap (a qualifier- or opcode-style dispatcher reaches 33+ rules
+  naturally; `(srfi 42)`'s qualifier processor had been split into two
+  chained macros as a workaround). The buffers are now growable, so the
+  limit is gone and `(srfi 42)` is back to a single 34-rule `%do-ec`.
+
+- **A `syntax-rules` template may emit `define-property`** (#2089). The
+  keyword was missing from the expander's reserved template forms, so a
+  template-introduced `define-property` was hygiene-renamed to
+  `__hyg_N_define-property` — and even left bare, the legacy compileForm
+  path (which compiles macro expansions) had no dispatch for it — so any
+  macro wrapping SRFI 213's definition form failed with "undefined
+  variable 'define-property'". It now stays bare like `define-values` and
+  compiles through both the IR and legacy paths.
+
 ## [0.22.3] - 2026-08-07
 
 ### Fixed

--- a/lib/srfi/42.sld
+++ b/lib/srfi/42.sld
@@ -319,13 +319,16 @@
     ;; the loop's step test; the :do rule's inner
     ;; (when (and ne2? (not s)) ...) has always been the model, and the
     ;; typed-generator steps below follow it.
-    ;; The engine caps one syntax-rules form at 32 rules, so the
-    ;; qualifier rules are split across two macros: %do-ec holds the
-    ;; generators and forwards any other qualifier to %do-ec-more, which
-    ;; holds the grouping, command, control, and guard qualifiers.
+    ;; All qualifier rules live in one syntax-rules: the engine used to
+    ;; cap one form at 32 rules, so %do-ec held only the generators and
+    ;; forwarded grouping/command/control/guard qualifiers to a second
+    ;; macro %do-ec-more (kaappi#2184). That cap is gone — the merged
+    ;; form below is 34 rules — so the split workaround was removed.
     (define-syntax %do-ec
       (syntax-rules (:range :real-range :char-range :list :string :vector
-                     :integers :port :let :do :parallel : :dispatched let)
+                     :integers :port :let :do :parallel : :dispatched let
+                     nested begin :while :until %while-xlate %until-xlate
+                     if not and or)
         ;; --- generators ---
         ((_ s (:range var n) rest1 rest2 ...)
          (let ((%n n))
@@ -454,19 +457,6 @@
         ;; --- parallel (lockstep) iteration ---
         ((_ s (:parallel gen1 gen2 ...) rest1 rest2 ...)
          (%parallel s () (gen1 gen2 ...) rest1 rest2 ...))
-        ;; --- anything else: grouping/command/control/guard qualifiers ---
-        ((_ s q rest1 rest2 ...)
-         (%do-ec-more s q rest1 rest2 ...))
-        ;; --- base case ---
-        ((_ s body)
-         body)))
-
-    ;; Second half of the qualifier processor (see the %do-ec comment):
-    ;; grouping, command, control, and guard qualifiers.  Every recursion
-    ;; goes back through %do-ec, the single entry point.
-    (define-syntax %do-ec-more
-      (syntax-rules (nested begin :while :until %while-xlate %until-xlate
-                     if not and or)
         ;; --- qualifier grouping and command qualifiers ---
         ((_ s (nested q ...) rest1 rest2 ...)
          (%do-ec s q ... rest1 rest2 ...))
@@ -516,7 +506,10 @@
         ((_ s (and test ...) rest1 rest2 ...)
          (when (and test ...) (%do-ec s rest1 rest2 ...)))
         ((_ s (or test ...) rest1 rest2 ...)
-         (when (or test ...) (%do-ec s rest1 rest2 ...)))))
+         (when (or test ...) (%do-ec s rest1 rest2 ...)))
+        ;; --- base case ---
+        ((_ s body)
+         body)))
 
     ;; :parallel expansion helper: peel one (gen var arg ...) sub-form
     ;; per recursion step, converting it to a generator procedure (one

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -877,6 +877,11 @@ pub const Compiler = struct {
                 if (std.mem.eql(u8, effective_name, "define")) return self.compileDefine(args, dst);
                 if (std.mem.eql(u8, effective_name, "define-record-type")) return self.compileDefineRecordType(args, dst);
                 if (std.mem.eql(u8, effective_name, "define-values")) return self.compileDefineValues(args, dst);
+                // #2089: the legacy path (macro expansions compile through
+                // compileExpr, not the IR pipeline) must dispatch
+                // define-property like the IR path does, or a template-
+                // introduced one compiles as a call to an undefined name.
+                if (std.mem.eql(u8, effective_name, "define-property")) return macro.compileDefineProperty(self, args, dst);
                 if (std.mem.eql(u8, effective_name, "set!")) return self.compileSet(args, dst);
                 if (std.mem.eql(u8, effective_name, "begin")) return self.compileBegin(args, dst, is_tail);
 

--- a/src/compiler_define_syntax.zig
+++ b/src/compiler_define_syntax.zig
@@ -719,29 +719,35 @@ pub fn parseSyntaxRules(self: *Compiler, spec: Value, extra_bound: []const []con
     const literals_list = types.car(after_ellipsis);
     const rules = types.cdr(after_ellipsis);
 
-    var literals_buf: [32]Value = undefined;
-    var lit_count: usize = 0;
+    // R7RS places no bound on a syntax-rules' literal or rule count, so
+    // these grow past the old fixed 32-slot stack buffers (kaappi#2184): a
+    // 33-rule dispatcher macro is legal and must compile, not fail with a
+    // bare KP2001 that reads as "malformed macro". The ArrayList backing
+    // stores use the raw allocator (never GC-triggering), and every Value
+    // they hold is a subpart of `spec`, which resolveTransformerSpecRec
+    // roots for the duration of this call — safe against collection at
+    // any point.
+    var literals: std.ArrayList(Value) = .empty;
+    defer literals.deinit(self.gc.allocator);
     var lit = literals_list;
     while (lit != types.NIL) {
         if (!types.isPair(lit)) return CompileError.InvalidSyntax;
-        if (lit_count >= 32) return CompileError.InvalidSyntax;
         // A generating macro may splice a user identifier into this spec's
         // literal list (SRFI 257's if-new-var) — unwrap the provenance
         // marker so the literal is the bare identifier.
-        literals_buf[lit_count] = expander.unwrapUsertext(types.car(lit));
-        lit_count += 1;
+        literals.append(self.gc.allocator, expander.unwrapUsertext(types.car(lit))) catch return CompileError.OutOfMemory;
         lit = types.cdr(lit);
     }
 
-    var patterns_buf: [32]Value = undefined;
-    var templates_buf: [32]Value = undefined;
-    var rule_count: usize = 0;
+    var patterns: std.ArrayList(Value) = .empty;
+    defer patterns.deinit(self.gc.allocator);
+    var templates: std.ArrayList(Value) = .empty;
+    defer templates.deinit(self.gc.allocator);
     var rule = rules;
     while (rule != types.NIL) {
         if (!types.isPair(rule)) return CompileError.InvalidSyntax;
         const r = types.car(rule);
         if (!types.isPair(r)) return CompileError.InvalidSyntax;
-        if (rule_count >= 32) return CompileError.InvalidSyntax;
         const rule_pattern = types.car(r);
         // R7RS 4.3.2 (kaappi#2082): the <pattern> grammar admits at
         // most one <ellipsis> per list or vector pattern. A second one
@@ -749,22 +755,28 @@ pub fn parseSyntaxRules(self: *Compiler, spec: Value, extra_bound: []const []con
         // what may FOLLOW the single ellipsis); accepting it previously
         // split the input arbitrarily because the surplus ellipsis
         // tokens were counted as fixed tail elements by the matcher.
-        if (!validPatternGrammar(rule_pattern, custom_ellipsis orelse "...", literals_buf[0..lit_count]))
+        if (!validPatternGrammar(rule_pattern, custom_ellipsis orelse "...", literals.items))
             return CompileError.InvalidSyntax;
-        patterns_buf[rule_count] = rule_pattern;
+        patterns.append(self.gc.allocator, rule_pattern) catch return CompileError.OutOfMemory;
         const r_rest = types.cdr(r);
         if (r_rest == types.NIL) return CompileError.InvalidSyntax;
-        templates_buf[rule_count] = types.car(r_rest);
-        rule_count += 1;
+        templates.append(self.gc.allocator, types.car(r_rest)) catch return CompileError.OutOfMemory;
         rule = types.cdr(rule);
     }
 
-    if (rule_count == 0) return CompileError.InvalidSyntax;
+    if (patterns.items.len == 0) return CompileError.InvalidSyntax;
+
+    // Transformer.num_rules is a u16; the old 32-slot cap made an overflow
+    // unreachable, so guard the new unbounded path explicitly rather than
+    // let allocTransformer's @intCast trap (ReleaseSafe panic) on a
+    // 65k+-rule macro. No real program reaches this; it exists only to
+    // keep the now-unbounded rule count from becoming a crash.
+    if (patterns.items.len > std.math.maxInt(u16)) return CompileError.InvalidSyntax;
 
     const tx_val = self.gc.allocTransformer(
-        literals_buf[0..lit_count],
-        patterns_buf[0..rule_count],
-        templates_buf[0..rule_count],
+        literals.items,
+        patterns.items,
+        templates.items,
     ) catch return CompileError.OutOfMemory;
     const tx = types.toObject(tx_val).as(types.Transformer);
     if (custom_ellipsis) |ce| {
@@ -773,9 +785,9 @@ pub fn parseSyntaxRules(self: *Compiler, spec: Value, extra_bound: []const []con
     // R7RS 4.3.2: record each literal's def-site binding slot (0xFFFF = unbound).
     // Binding identity — not just bound/unbound — is needed so that two
     // different bindings with the same name don't falsely match.
-    if (lit_count > 0) {
-        const slots = self.gc.allocator.alloc(u32, lit_count) catch return CompileError.OutOfMemory;
-        for (literals_buf[0..lit_count], 0..) |lv, li| {
+    if (literals.items.len > 0) {
+        const slots = self.gc.allocator.alloc(u32, literals.items.len) catch return CompileError.OutOfMemory;
+        for (literals.items, 0..) |lv, li| {
             slots[li] = if (types.isSymbol(lv)) blk: {
                 const lname = types.symbolName(lv);
                 // Resolve through the full lexical chain with the SAME rules

--- a/src/compiler_define_syntax.zig
+++ b/src/compiler_define_syntax.zig
@@ -722,11 +722,16 @@ pub fn parseSyntaxRules(self: *Compiler, spec: Value, extra_bound: []const []con
     // R7RS places no bound on a syntax-rules' literal or rule count, so
     // these grow past the old fixed 32-slot stack buffers (kaappi#2184): a
     // 33-rule dispatcher macro is legal and must compile, not fail with a
-    // bare KP2001 that reads as "malformed macro". The ArrayList backing
-    // stores use the raw allocator (never GC-triggering), and every Value
-    // they hold is a subpart of `spec`, which resolveTransformerSpecRec
-    // roots for the duration of this call — safe against collection at
-    // any point.
+    // bare KP2001 that reads as "malformed macro". GC safety: the backing
+    // stores use the raw allocator (never GC-triggering), nothing between
+    // here and allocTransformer triggers a collection (unwrapUsertext /
+    // validPatternGrammar / append allocate nothing on the GC heap), and
+    // allocTransformer dupes all three slices with the raw allocator
+    // before it can collect — so the element Values only need to survive
+    // as subparts of the form being parsed. resolveTransformerSpecRec
+    // additionally roots `spec`, but the body-scan caller in
+    // compiler_lambda.zig does not, so do not add a GC-triggering call to
+    // these loops without rooting the spec first.
     var literals: std.ArrayList(Value) = .empty;
     defer literals.deinit(self.gc.allocator);
     var lit = literals_list;

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -45,17 +45,17 @@ pub fn isEllipsis(name: []const u8) bool {
 /// variables. The compiler recognizes hygienic renames via
 /// effective_name stripping.
 const well_known_forms = [_][]const u8{
-    "begin",         "define",        "set!",             "lambda",
-    "let*",          "letrec",        "letrec*",          "quote",
-    "quasiquote",    "unquote",       "unquote-splicing", "define-syntax",
-    "let-syntax",    "letrec-syntax", "syntax-rules",     "define-record-type",
-    "define-values", "let-values",    "let*-values",      "case-lambda",
-    "cond-expand",   "cond",          "case",             "and",
-    "or",            "when",          "unless",           "do",
-    "guard",         "delay",         "delay-force",      "parameterize",
-    "syntax-error",  "include",       "include-ci",       "define-library",
-    "import",        "export",        "else",             "=>",
-    "...",           "_",
+    "begin",          "define",          "set!",             "lambda",
+    "let*",           "letrec",          "letrec*",          "quote",
+    "quasiquote",     "unquote",         "unquote-splicing", "define-syntax",
+    "let-syntax",     "letrec-syntax",   "syntax-rules",     "define-record-type",
+    "define-values",  "define-property", "let-values",       "let*-values",
+    "case-lambda",    "cond-expand",     "cond",             "case",
+    "and",            "or",              "when",             "unless",
+    "do",             "guard",           "delay",            "delay-force",
+    "parameterize",   "syntax-error",    "include",          "include-ci",
+    "define-library", "import",          "export",           "else",
+    "=>",             "...",             "_",
 };
 
 pub fn isWellKnown(name: []const u8) bool {
@@ -86,11 +86,11 @@ pub fn isWellKnown(name: []const u8) bool {
 ///    / `(quasiquote ...)` FORM heads are renamed separately by the form
 ///    branches in instantiateTemplate.
 const reserved_template_forms = [_][]const u8{
-    "define",         "define-syntax", "define-values",    "define-record-type",
-    "let-syntax",     "letrec-syntax", "syntax-rules",     "quote",
-    "quasiquote",     "unquote",       "unquote-splicing", "else",
-    "...",            "_",             "import",           "export",
-    "define-library", "include",       "include-ci",
+    "define",          "define-syntax",  "define-values", "define-record-type",
+    "define-property", "let-syntax",     "letrec-syntax", "syntax-rules",
+    "quote",           "quasiquote",     "unquote",       "unquote-splicing",
+    "else",            "...",            "_",             "import",
+    "export",          "define-library", "include",       "include-ci",
 };
 
 /// True when a template-introduced identifier must keep its exact spelling

--- a/tests/scheme/hygiene/syntax-rules-unbounded-2184.scm
+++ b/tests/scheme/hygiene/syntax-rules-unbounded-2184.scm
@@ -1,0 +1,104 @@
+;; Regression test for #2184: syntax-rules silently capped at 32 rules
+;; (and 32 literals) with a bare KP2001 InvalidSyntax and no hint. R7RS
+;; places no bound on either, and a 33+ rule dispatcher macro is a normal
+;; shape (srfi 42's qualifier processor reached 35 before being split).
+;;
+;; parseSyntaxRules used fixed [32]Value stack buffers and rejected the
+;; 33rd rule/literal outright, making a structurally valid macro fail as
+;; if malformed. The buffers are now growable, so a 40-rule / 40-literal
+;; macro must compile and expand correctly.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "syntax-rules-unbounded")
+
+;;; --- 40 rules: dispatch table that the old 32-cap rejected ---
+(define-syntax dispatch
+  (syntax-rules ()
+    ((_ a) 'a)
+    ((_ b) 'b)
+    ((_ c) 'c)
+    ((_ d) 'd)
+    ((_ e) 'e)
+    ((_ f) 'f)
+    ((_ g) 'g)
+    ((_ h) 'h)
+    ((_ i) 'i)
+    ((_ j) 'j)
+    ((_ k) 'k)
+    ((_ l) 'l)
+    ((_ m) 'm)
+    ((_ n) 'n)
+    ((_ o) 'o)
+    ((_ p) 'p)
+    ((_ q) 'q)
+    ((_ r) 'r)
+    ((_ s) 's)
+    ((_ t) 't)
+    ((_ u) 'u)
+    ((_ v) 'v)
+    ((_ w) 'w)
+    ((_ x) 'x)
+    ((_ y) 'y)
+    ((_ z) 'z)
+    ((_ aa) 'aa)
+    ((_ ab) 'ab)
+    ((_ ac) 'ac)
+    ((_ ad) 'ad)
+    ((_ ae) 'ae)
+    ((_ af) 'af)
+    ((_ ag) 'ag)
+    ((_ ah) 'ah)
+    ((_ ai) 'ai)
+    ((_ aj) 'aj)
+    ((_ ak) 'ak)
+    ((_ al) 'al)
+    ((_ am) 'am)
+    ((_ an) 'an)
+    ((_ ao) 'ao)))
+
+(test-equal 'a (dispatch a))
+(test-equal 'z (dispatch z))
+(test-equal 'ao (dispatch ao))
+(test-equal 'an (dispatch an))
+(test-equal 'ak (dispatch ak))
+(test-equal 'b (dispatch b))
+
+;;; --- 40 literals: the old 32-cap rejected the 33rd literal ---
+(define-syntax litmac
+  (syntax-rules (l0 l1 l2 l3 l4 l5 l6 l7 l8 l9 l10 l11 l12 l13 l14 l15
+                  l16 l17 l18 l19 l20 l21 l22 l23 l24 l25 l26 l27 l28 l29
+                  l30 l31 l32 l33 l34 l35 l36 l37 l38 l39)
+    ((_ l0) 0) ((_ l1) 1) ((_ l2) 2) ((_ l3) 3) ((_ l4) 4) ((_ l5) 5)
+    ((_ l6) 6) ((_ l7) 7) ((_ l8) 8) ((_ l9) 9) ((_ l10) 10) ((_ l11) 11)
+    ((_ l12) 12) ((_ l13) 13) ((_ l14) 14) ((_ l15) 15) ((_ l16) 16) ((_ l17) 17)
+    ((_ l18) 18) ((_ l19) 19) ((_ l20) 20) ((_ l21) 21) ((_ l22) 22) ((_ l23) 23)
+    ((_ l24) 24) ((_ l25) 25) ((_ l26) 26) ((_ l27) 27) ((_ l28) 28) ((_ l29) 29)
+    ((_ l30) 30) ((_ l31) 31) ((_ l32) 32) ((_ l33) 33) ((_ l34) 34) ((_ l35) 35)
+    ((_ l36) 36) ((_ l37) 37) ((_ l38) 38) ((_ l39) 39)))
+
+(test-equal 0 (litmac l0))
+(test-equal 32 (litmac l32))
+(test-equal 33 (litmac l33))
+(test-equal 39 (litmac l39))
+(test-equal 17 (litmac l17))
+
+;;; --- 33 rules inside a define-library (the shape srfi 42 needed) ---
+(define-library (t2184 lib)
+  (import (scheme base))
+  (export op)
+  (begin
+    (define-syntax op
+      (syntax-rules ()
+        ((_ 1) 1) ((_ 2) 2) ((_ 3) 3) ((_ 4) 4) ((_ 5) 5) ((_ 6) 6)
+        ((_ 7) 7) ((_ 8) 8) ((_ 9) 9) ((_ 10) 10) ((_ 11) 11) ((_ 12) 12)
+        ((_ 13) 13) ((_ 14) 14) ((_ 15) 15) ((_ 16) 16) ((_ 17) 17) ((_ 18) 18)
+        ((_ 19) 19) ((_ 20) 20) ((_ 21) 21) ((_ 22) 22) ((_ 23) 23) ((_ 24) 24)
+        ((_ 25) 25) ((_ 26) 26) ((_ 27) 27) ((_ 28) 28) ((_ 29) 29) ((_ 30) 30)
+        ((_ 31) 31) ((_ 32) 32) ((_ 33) 33)))))
+(import (t2184 lib))
+(test-equal 33 (op 33))
+(test-equal 1 (op 1))
+
+(let ((runner (test-runner-current)))
+  (test-end "syntax-rules-unbounded")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi213.scm
+++ b/tests/scheme/srfi/srfi213.scm
@@ -84,6 +84,47 @@
 (import (t213 proplib))
 (test-equal 42 (lib-prop lib-id lib-key))
 
+;;; --- define-property through a syntax-rules template (#2089) ---
+;;; A template-introduced define-property used to be hygiene-renamed to
+;;; __hyg_N_define-property (it was missing from the expander's reserved
+;;; template forms), and even when left bare the legacy compileForm path
+;;; had no dispatch for it — so the whole define-library or program failed
+;;; with "undefined variable 'define-property'". It must behave exactly
+;;; like the direct form.
+(define mp-color 'mp-red)
+(define mp-hue 'mp-hue)
+(define-syntax defprop
+  (syntax-rules () ((_ id key val) (define-property id key val))))
+(defprop mp-color mp-hue '(via-template BRIGHT))
+
+(define-syntax prop-of
+  (er-macro-transformer
+   (lambda (form rename compare)
+     (capture-lookup
+      (lambda (lookup)
+        (list (rename 'quote) (lookup (cadr form) (car (cddr form)))))))))
+(test-equal '(via-template BRIGHT) (prop-of mp-color mp-hue))
+
+;;; same, inside a library: define-library bodies also compile macro
+;;; expansions through the legacy path
+(define-library (t213 templib)
+  (import (scheme base) (srfi 211 explicit-renaming) (srfi 213))
+  (export lib-color lib-hue lib-prop)
+  (begin
+    (define lib-color 'lib-c)
+    (define lib-hue 'lib-h)
+    (define-syntax defprop2
+      (syntax-rules () ((_ id key val) (define-property id key val))))
+    (defprop2 lib-color lib-hue 'lib-v)
+    (define-syntax lib-prop
+      (er-macro-transformer
+       (lambda (form rename compare)
+         (capture-lookup
+          (lambda (lookup)
+            (list (rename 'quote) (lookup (cadr form) (car (cddr form)))))))))))
+(import (t213 templib))
+(test-equal 'lib-v (lib-prop lib-color lib-hue))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-213")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Closes #2184, closes #2089.

## #2184 — `syntax-rules` silently capped at 32 rules (and 32 literals)

`parseSyntaxRules` (`src/compiler_define_syntax.zig`) parsed into fixed `[32]Value` stack buffers and rejected the 33rd rule or literal with a bare `KP2001 InvalidSyntax` — a legal, well-formed macro failed as if it were malformed, with no mention of the cap and no pointer to the tripping rule. R7RS places no bound on either count, and a 33+ rule dispatcher macro is a normal shape (`(srfi 42)`'s qualifier processor reached 35 and was split into two chained macros as a workaround).

**Fix:** the buffers are now growable `std.ArrayList`s (raw allocator, never GC-triggering; every held `Value` is a subpart of the rooted spec). The limit is gone. A `u16` guard replaces the old cap where `Transformer.num_rules`'s width would otherwise make `allocTransformer`'s `@intCast` trap on a 65k+-rule macro (previously unreachable).

**Bonus — the workaround is gone:** `lib/srfi/42.sld`'s `%do-ec`/`%do-ec-more` split is merged back into a single 34-rule `%do-ec`, exactly the shape that exposed the bug. All 119 srfi-42 assertions pass.

## #2089 — `define-property` unusable from a `syntax-rules` template

Two independent gaps, both fixed:

1. The keyword was missing from the expander's `reserved_template_forms`, so a template-introduced `define-property` was hygiene-renamed to `__hyg_N_define-property`. (`well_known_forms` alone — the issue's suggested fix — does not stop the rename: `instantiateTemplate` consults `isTemplateReserved`.)
2. Even left bare, the legacy `compileForm` path (which compiles macro expansions, via `compileExpr`) had no `define-property` dispatch — only the IR path did — so the expanded form compiled as a call to an undefined name.

`define-property` now sits in both `reserved_template_forms` and `well_known_forms` (mirroring `define-values`), and `compileForm` dispatches it like the IR path.

## Verification

- New regression tests (both fail on `main` with the exact issue symptoms, pass here):
  - `tests/scheme/hygiene/syntax-rules-unbounded-2184.scm` — 40-rule, 40-literal, and 33-rule-in-library macros
  - `tests/scheme/srfi/srfi213.scm` — template-emitted `define-property` at top level and inside a `define-library`
- `bash tests/scheme/run-all.sh`: **702 scheme files + 1395 R7RS tests, 0 failures**
- `zig build test` and `zig build test -Dgc-stress=true`: pass

Note: #2252 (FORMAL_FLAG comments) appears already resolved — the merged #2251 commit's comments now say "lambda formal… deliberately NOT extended to… case-lambda formals (#2252)", matching the code.
