### PR TITLE
Fix all eight SRFI-146 audit findings (2045, 2046, 2047, 2048, 2049, 2050, 2052, 2053)

### DIFF
--- a/lib/srfi/146.sld
+++ b/lib/srfi/146.sld
@@ -428,26 +428,31 @@
 
     (define mapping=?
       (case-lambda
+        ((vcmp m1) #t)               ; one mapping: vacuously true (#2052)
         ((vcmp m1 m2) (%mapping=? vcmp m1 m2))
         ((vcmp m1 m2 . rest) (and (%mapping=? vcmp m1 m2) (apply mapping=? vcmp m2 rest)))))
 
     (define mapping<?
       (case-lambda
+        ((vcmp m1) #t)
         ((vcmp m1 m2) (and (%mapping<=? vcmp m1 m2) (not (%mapping=? vcmp m1 m2))))
         ((vcmp m1 m2 . rest) (and (mapping<? vcmp m1 m2) (apply mapping<? vcmp m2 rest)))))
 
     (define mapping>?
       (case-lambda
+        ((vcmp m1) #t)
         ((vcmp m1 m2) (mapping<? vcmp m2 m1))
         ((vcmp m1 m2 . rest) (and (mapping>? vcmp m1 m2) (apply mapping>? vcmp m2 rest)))))
 
     (define mapping<=?
       (case-lambda
+        ((vcmp m1) #t)
         ((vcmp m1 m2) (%mapping<=? vcmp m1 m2))
         ((vcmp m1 m2 . rest) (and (%mapping<=? vcmp m1 m2) (apply mapping<=? vcmp m2 rest)))))
 
     (define mapping>=?
       (case-lambda
+        ((vcmp m1) #t)
         ((vcmp m1 m2) (%mapping<=? vcmp m2 m1))
         ((vcmp m1 m2 . rest) (and (mapping>=? vcmp m1 m2) (apply mapping>=? vcmp m2 rest)))))
 

--- a/lib/srfi/146.sld
+++ b/lib/srfi/146.sld
@@ -430,7 +430,16 @@
     (define mapping<?
       (case-lambda
         ((vcmp m1) #t)
-        ((vcmp m1 m2) (and (%mapping<=? vcmp m1 m2) (not (%mapping=? vcmp m1 m2))))
+        ((vcmp m1 m2)
+         ;; The strict predicates must not inherit #2047's identity guard
+         ;; through =? only: %mapping<=? is structural, so with different
+         ;; (but structurally identical) comparator objects both m1<m2 and
+         ;; m2<m1 would hold.  Guard the strict comparison on identity too,
+         ;; keeping the mixed-comparator path antisymmetric like the
+         ;; reference (whose <? is defined without consulting =?).
+         (and (eq? (%mapping-comparator m1) (%mapping-comparator m2))
+              (%mapping<=? vcmp m1 m2)
+              (not (%mapping=? vcmp m1 m2))))
         ((vcmp m1 m2 . rest) (and (mapping<? vcmp m1 m2) (apply mapping<? vcmp m2 rest)))))
 
     (define mapping>?

--- a/lib/srfi/146.sld
+++ b/lib/srfi/146.sld
@@ -594,8 +594,30 @@
 
     ;;; Comparator
 
+    ;; The spec's ordering for mapping-comparator: "the lexicographic ordering
+    ;; with respect to the keys (and, in case a tiebreak is necessary, with
+    ;; respect to the ordering of the values)", for pairs of mappings sharing
+    ;; the same key comparator.  The reference implements it by walking two
+    ;; tree generators in parallel; the sorted alists are the same walk (#2048).
+    (define (mapping-ordering vcmp)
+      (let ((veq (comparator-equality-predicate vcmp))
+            (vlt (comparator-ordering-predicate vcmp)))
+        (lambda (m1 m2)
+          (let ((eq (%cmp= m1))
+                (lt (%cmp< m1)))
+            (let loop ((a1 (mapping->alist m1)) (a2 (mapping->alist m2)))
+              (cond
+                ((null? a1) (not (null? a2)))
+                ((null? a2) #f)
+                ((eq (caar a1) (caar a2))
+                 (if (veq (cdar a1) (cdar a2))
+                     (loop (cdr a1) (cdr a2))
+                     (vlt (cdar a1) (cdar a2))))
+                (else (lt (caar a1) (caar a2)))))))))
+
     (define (make-mapping-comparator vcmp)
-      (make-comparator mapping? (lambda (m1 m2) (%mapping=? vcmp m1 m2)) #f #f))
+      (make-comparator mapping? (lambda (m1 m2) (%mapping=? vcmp m1 m2))
+                       (mapping-ordering vcmp) #f))
 
     (define mapping-comparator (make-mapping-comparator (make-default-comparator)))
 

--- a/lib/srfi/146.sld
+++ b/lib/srfi/146.sld
@@ -397,14 +397,18 @@
     ;;; Comparisons
 
     (define (%mapping=? vcmp m1 m2)
-      (let ((veq (comparator-equality-predicate vcmp))
-            (a1 (mapping->alist m1)) (a2 (mapping->alist m2)))
-        (and (= (length a1) (length a2))
-             (let loop ((a a1) (b a2))
-               (or (null? a)
-                   (and ((%cmp= m1) (caar a) (caar b))
-                        (veq (cdar a) (cdar b))
-                        (loop (cdr a) (cdr b))))))))
+      ;; The spec: it is "explicitly not an error" to compare mappings with
+      ;; different key comparators -- in that case #f is returned.  "Share the
+      ;; same comparator" means object identity, so this is eq? (#2047).
+      (and (eq? (%mapping-comparator m1) (%mapping-comparator m2))
+           (let ((veq (comparator-equality-predicate vcmp))
+                 (a1 (mapping->alist m1)) (a2 (mapping->alist m2)))
+             (and (= (length a1) (length a2))
+                  (let loop ((a a1) (b a2))
+                    (or (null? a)
+                        (and ((%cmp= m1) (caar a) (caar b))
+                             (veq (cdar a) (cdar b))
+                             (loop (cdr a) (cdr b)))))))))
 
     (define (%mapping<=? vcmp m1 m2)
       (let ((veq (comparator-equality-predicate vcmp))

--- a/lib/srfi/146.sld
+++ b/lib/srfi/146.sld
@@ -307,11 +307,6 @@
     (define (mapping-size m) (%rbt-size (%mapping-tree m)))
 
     (define (mapping-find pred m failure)
-      (%rbt-fold (lambda (k v acc)
-                   (if (eq? acc 'not-found)
-                       (if (pred k v) (cons k v) acc)
-                       acc))
-                 'not-found (%mapping-tree m))
       (let ((result (%rbt-fold (lambda (k v acc)
                                  (if (pair? acc) acc
                                      (if (pred k v) (cons k v) acc)))
@@ -342,12 +337,12 @@
     ;;; Mapping and folding
 
     (define (mapping-map proc comparator m)
+      ;; The spec deliberately gives mapping-map no "no guarantees how many
+      ;; times proc is invoked" licence, unlike its neighbours -- the first
+      ;; copy of this fold was dead work, and applying a side-effecting proc
+      ;; twice per association is observable (#2053).
       (let ((lt (comparator-ordering-predicate comparator))
             (eq (comparator-equality-predicate comparator)))
-        (%rbt-fold (lambda (k v acc)
-                     (let-values (((nk nv) (proc k v)))
-                       (%rbt-insert acc nk nv lt eq)))
-                   %empty (%mapping-tree m))
         (%make-mapping comparator
           (%rbt-fold (lambda (k v acc)
                        (let-values (((nk nv) (proc k v)))

--- a/lib/srfi/146.sld
+++ b/lib/srfi/146.sld
@@ -322,10 +322,17 @@
       (%rbt-fold (lambda (k v acc) (if (pred k v) (+ acc 1) acc)) 0 (%mapping-tree m)))
 
     (define (mapping-any? pred m)
-      (%rbt-fold (lambda (k v acc) (or acc (pred k v))) #f (%mapping-tree m)))
+      ;; The spec returns #t/#f, not the predicate's own value; a predicate
+      ;; that returns a truthy non-#t leaks it out of the accumulating fold
+      ;; (#2050).  The hashmap twins accumulate into a boolean flag.
+      (let ((result (%rbt-fold (lambda (k v acc) (or acc (pred k v))) #f
+                               (%mapping-tree m))))
+        (if result #t #f)))
 
     (define (mapping-every? pred m)
-      (%rbt-fold (lambda (k v acc) (and acc (pred k v))) #t (%mapping-tree m)))
+      (let ((result (%rbt-fold (lambda (k v acc) (and acc (pred k v))) #t
+                               (%mapping-tree m))))
+        (if result #t #f)))
 
     (define (mapping-keys m) (%rbt-fold-right (lambda (k v acc) (cons k acc)) '() (%mapping-tree m)))
     (define (mapping-values m) (%rbt-fold-right (lambda (k v acc) (cons v acc)) '() (%mapping-tree m)))

--- a/lib/srfi/146.sld
+++ b/lib/srfi/146.sld
@@ -172,21 +172,26 @@
     ;;; Constructors
 
     (define (mapping comparator . args)
+      ;; The spec: "Earlier associations with equal keys take precedence over
+      ;; later arguments" -- the same first-wins semantics as mapping-adjoin,
+      ;; deliberately different from mapping-set (#2045).
       (let ((lt (comparator-ordering-predicate comparator))
             (eq (comparator-equality-predicate comparator)))
         (let loop ((args args) (t %empty))
           (if (null? args) (%make-mapping comparator t)
-              (loop (cddr args) (%rbt-insert t (car args) (cadr args) lt eq))))))
+              (loop (cddr args) (%rbt-adjoin t (car args) (cadr args) lt eq))))))
 
     (define mapping/ordered mapping)
 
     (define (mapping-unfold stop? mapper successor seed comparator)
+      ;; The spec: "Associations earlier in the list take precedence over those
+      ;; that come later" -- first-wins, matching mapping (#2045).
       (let ((lt (comparator-ordering-predicate comparator))
             (eq (comparator-equality-predicate comparator)))
         (let loop ((seed seed) (t %empty))
           (if (stop? seed) (%make-mapping comparator t)
               (let-values (((key val) (mapper seed)))
-                (loop (successor seed) (%rbt-insert t key val lt eq)))))))
+                (loop (successor seed) (%rbt-adjoin t key val lt eq)))))))
 
     (define mapping-unfold/ordered mapping-unfold)
 

--- a/lib/srfi/146.sld
+++ b/lib/srfi/146.sld
@@ -509,16 +509,22 @@
           (let ((e (%rbt-max (%mapping-tree m)))) (values (car e) (cdr e)))))
 
     (define (mapping-key-predecessor m obj failure)
+      ;; The spec tail-calls `failure` only when no preceding key is contained
+      ;; in the mapping.  It is not a fold seed, so it must not run when the
+      ;; answer exists (#2046).
       (let ((lt (%cmp< m)))
-        (%rbt-fold (lambda (k v acc)
-                     (if (lt k obj) k acc))
-                   (failure) (%mapping-tree m))))
+        (let ((result (%rbt-fold (lambda (k v acc)
+                                   (if (lt k obj) (cons #t k) acc))
+                                 (cons #f #f) (%mapping-tree m))))
+          (if (car result) (cdr result) (failure)))))
 
     (define (mapping-key-successor m obj failure)
+      ;; Same discipline as mapping-key-predecessor (#2046).
       (let ((lt (%cmp< m)))
-        (%rbt-fold-right (lambda (k v acc)
-                           (if (lt obj k) k acc))
-                         (failure) (%mapping-tree m))))
+        (let ((result (%rbt-fold-right (lambda (k v acc)
+                                         (if (lt obj k) (cons #t k) acc))
+                                       (cons #f #f) (%mapping-tree m))))
+          (if (car result) (cdr result) (failure)))))
 
     (define (mapping-range= m obj)
       (let ((eq (%cmp= m)) (lt (%cmp< m)))

--- a/lib/srfi/146/hash.sld
+++ b/lib/srfi/146/hash.sld
@@ -359,7 +359,13 @@
     (define hashmap-xor! hashmap-xor)
 
     (define (make-hashmap-comparator vcmp)
-      (make-comparator hashmap? (lambda (m1 m2) (%hm=? vcmp m1 m2)) #f #f))
+      ;; The hash function is what the reference implementation ships: a
+      ;; constant.  The spec only requires an implementation-dependent hash
+      ;; consistent with the equality, and the reference leaves a real hash
+      ;; as a TODO (srfi/146/hash.scm:689).  A constant keeps every
+      ;; hashmap-keyed table a linear scan but is always consistent (#2048).
+      (make-comparator hashmap? (lambda (m1 m2) (%hm=? vcmp m1 m2)) #f
+                       (lambda (hashmap) 0)))
 
     (define hashmap-comparator
       (make-hashmap-comparator (make-default-comparator)))

--- a/lib/srfi/146/hash.sld
+++ b/lib/srfi/146/hash.sld
@@ -80,7 +80,12 @@
              (success (hash-table-ref (%hm-ht m) key)) (failure)))))
 
     (define (hashmap-ref/default m key default)
-      (hash-table-ref (%hm-ht m) key default))
+      ;; hash-table-ref's third argument is a failure THUNK, so forwarding the
+      ;; plain default there would invoke a procedural default and return its
+      ;; result in place of the procedure the caller asked for.  The spec
+      ;; means "may be more efficient than (hashmap-ref m key (lambda ()
+      ;; default))", exactly like mapping-ref/default (#2049).
+      (hash-table-ref/default (%hm-ht m) key default))
 
     (define (hashmap-key-comparator m) (%hm-comparator m))
 

--- a/lib/srfi/146/hash.sld
+++ b/lib/srfi/146/hash.sld
@@ -39,18 +39,25 @@
       ;; The table must be keyed by the comparator's equality/hash pair, not
       ;; the native equal? default, or 1 and 1.0 stay distinct keys under a
       ;; comparator whose equality is = (#2044).
+      ;; The spec: "Earlier associations with equal keys take precedence over
+      ;; later arguments" -- first-wins, matching hashmap-adjoin (#2045).
       (let ((ht (make-hash-table comparator)))
         (let loop ((args args))
           (if (null? args) (%make-hashmap comparator ht)
-              (begin (hash-table-set! ht (car args) (cadr args))
-                     (loop (cddr args)))))))
+              (begin
+                (if (not (hash-table-exists? ht (car args)))
+                    (hash-table-set! ht (car args) (cadr args)))
+                (loop (cddr args)))))))
 
     (define (hashmap-unfold stop? mapper successor seed comparator)
+      ;; The spec: "Associations earlier in the list take precedence over those
+      ;; that come later" -- first-wins, matching hashmap (#2045).
       (let ((ht (make-hash-table comparator)))
         (let loop ((seed seed))
           (if (stop? seed) (%make-hashmap comparator ht)
               (let-values (((key val) (mapper seed)))
-                (hash-table-set! ht key val)
+                (if (not (hash-table-exists? ht key))
+                    (hash-table-set! ht key val))
                 (loop (successor seed)))))))
 
     (define (hashmap-contains? m key) (hash-table-exists? (%hm-ht m) key))

--- a/lib/srfi/146/hash.sld
+++ b/lib/srfi/146/hash.sld
@@ -265,15 +265,19 @@
                 (loop (cdr al)))))))
 
     (define (%hm=? vcmp m1 m2)
-      (let ((veq (comparator-equality-predicate vcmp)))
-        (and (= (hashmap-size m1) (hashmap-size m2))
-             (let ((all #t))
-               (hash-table-walk (%hm-ht m1)
-                 (lambda (k v1)
-                   (if (not (and (hash-table-exists? (%hm-ht m2) k)
-                                 (veq v1 (hash-table-ref (%hm-ht m2) k))))
-                       (set! all #f))))
-               all))))
+      ;; The spec: it is "explicitly not an error" to compare hashmaps with
+      ;; different key comparators -- in that case #f is returned.  "Share the
+      ;; same comparator" means object identity, so this is eq? (#2047).
+      (and (eq? (%hm-comparator m1) (%hm-comparator m2))
+           (let ((veq (comparator-equality-predicate vcmp)))
+             (and (= (hashmap-size m1) (hashmap-size m2))
+                  (let ((all #t))
+                    (hash-table-walk (%hm-ht m1)
+                      (lambda (k v1)
+                        (if (not (and (hash-table-exists? (%hm-ht m2) k)
+                                      (veq v1 (hash-table-ref (%hm-ht m2) k))))
+                            (set! all #f))))
+                    all)))))
 
     (define (%hm<=? vcmp m1 m2)
       (let ((veq (comparator-equality-predicate vcmp)))

--- a/lib/srfi/146/hash.sld
+++ b/lib/srfi/146/hash.sld
@@ -296,22 +296,27 @@
 
     (define hashmap=?
       (case-lambda
+        ((vcmp m1) #t)               ; one hashmap: vacuously true (#2052)
         ((vcmp m1 m2) (%hm=? vcmp m1 m2))
         ((vcmp m1 m2 . rest) (and (%hm=? vcmp m1 m2) (apply hashmap=? vcmp m2 rest)))))
     (define hashmap<?
       (case-lambda
+        ((vcmp m1) #t)
         ((vcmp m1 m2) (and (%hm<=? vcmp m1 m2) (not (%hm=? vcmp m1 m2))))
         ((vcmp m1 m2 . rest) (and (hashmap<? vcmp m1 m2) (apply hashmap<? vcmp m2 rest)))))
     (define hashmap>?
       (case-lambda
+        ((vcmp m1) #t)
         ((vcmp m1 m2) (hashmap<? vcmp m2 m1))
         ((vcmp m1 m2 . rest) (and (hashmap>? vcmp m1 m2) (apply hashmap>? vcmp m2 rest)))))
     (define hashmap<=?
       (case-lambda
+        ((vcmp m1) #t)
         ((vcmp m1 m2) (%hm<=? vcmp m1 m2))
         ((vcmp m1 m2 . rest) (and (%hm<=? vcmp m1 m2) (apply hashmap<=? vcmp m2 rest)))))
     (define hashmap>=?
       (case-lambda
+        ((vcmp m1) #t)
         ((vcmp m1 m2) (%hm<=? vcmp m2 m1))
         ((vcmp m1 m2 . rest) (and (hashmap>=? vcmp m1 m2) (apply hashmap>=? vcmp m2 rest)))))
 

--- a/lib/srfi/146/hash.sld
+++ b/lib/srfi/146/hash.sld
@@ -302,7 +302,13 @@
     (define hashmap<?
       (case-lambda
         ((vcmp m1) #t)
-        ((vcmp m1 m2) (and (%hm<=? vcmp m1 m2) (not (%hm=? vcmp m1 m2))))
+        ((vcmp m1 m2)
+         ;; Mirror of the ordered side: %hm<=? is structural, so without this
+         ;; guard two same-content hashmaps with different comparator objects
+         ;; would compare < in both directions (see mapping<?).
+         (and (eq? (%hm-comparator m1) (%hm-comparator m2))
+              (%hm<=? vcmp m1 m2)
+              (not (%hm=? vcmp m1 m2))))
         ((vcmp m1 m2 . rest) (and (hashmap<? vcmp m1 m2) (apply hashmap<? vcmp m2 rest)))))
     (define hashmap>?
       (case-lambda

--- a/tests/scheme/srfi/srfi146-differential.scm
+++ b/tests/scheme/srfi/srfi146-differential.scm
@@ -541,13 +541,10 @@
   ;; The two libraries currently disagree here.  Each disagreement is a filed
   ;; defect; the fix PR re-enables the assertion.
 
-  ;; FAIL: #2050 (mapping-any?/mapping-every? return the predicate's value
-  ;;              rather than #t/#f; the hashmap twins return a boolean)
-  ;; (agree "any? returns a boolean"
-  ;;        (lambda (op) ((op 'any?) (lambda (k v) v) ((op 'make) c 1 'a 2 'b))))
-  ;; FAIL: #2050
-  ;; (agree "every? returns a boolean"
-  ;;        (lambda (op) ((op 'every?) (lambda (k v) v) ((op 'make) c 1 'a 2 'b))))
+  (agree "any? returns a boolean"
+         (lambda (op) ((op 'any?) (lambda (k v) v) ((op 'make) c 1 'a 2 'b))))
+  (agree "every? returns a boolean"
+         (lambda (op) ((op 'every?) (lambda (k v) v) ((op 'make) c 1 'a 2 'b))))
 
   (agree "ref/default returns a procedural default unchanged"
          (lambda (op) (procedure? ((op 'ref/default) ((op 'make) c 1 'a) 99

--- a/tests/scheme/srfi/srfi146-differential.scm
+++ b/tests/scheme/srfi/srfi146-differential.scm
@@ -558,19 +558,12 @@
   ;;                       ((op 'make) c 1 'a 2 'b 3 'c 4 'd 5 'e))
   ;;            n)))
 
-  ;; FAIL: #2052 (the comparison predicates reject the single-mapping form
-  ;;              the signature allows; guard keeps a re-enabled run reporting
-  ;;              a failed assertion rather than aborting on the raise)
-  ;; (test-assert "mapping=? accepts a single mapping"
-  ;;   (guard (e (#t #f)) (mapping=? c (mapping c 1 'a))))
-  ;; FAIL: #2052
-  ;; (test-assert "mapping<=? accepts a single mapping"
-  ;;   (guard (e (#t #f)) (mapping<=? c (mapping c 1 'a))))
-  ;; FAIL: #2052
-  ;; (test-assert "hashmap=? accepts a single hashmap"
-  ;;   (guard (e (#t #f)) (hashmap=? c (hashmap c 1 'a))))
-  (test-assert "pins #2052: the single-mapping comparison form still raises"
-    (guard (e (#t #t)) (mapping=? c (mapping c 1 'a)) #f)))
+  (test-assert "mapping=? accepts a single mapping"
+    (guard (e (#t #f)) (mapping=? c (mapping c 1 'a))))
+  (test-assert "mapping<=? accepts a single mapping"
+    (guard (e (#t #f)) (mapping<=? c (mapping c 1 'a))))
+  (test-assert "hashmap=? accepts a single hashmap"
+    (guard (e (#t #f)) (hashmap=? c (hashmap c 1 'a)))))
 
 ;;; ------------------------------------------------- duplicate-key precedence
 

--- a/tests/scheme/srfi/srfi146-differential.scm
+++ b/tests/scheme/srfi/srfi146-differential.scm
@@ -812,23 +812,16 @@
     (mapping-key-predecessor m 5/2 (lambda () 'NONE)))
   (test-equal "mapping-key-successor works for an absent obj" 3
     (mapping-key-successor m 5/2 (lambda () 'NONE)))
-  ;; FAIL: #2046 (the failure thunk is the fold's seed, so it runs unconditionally)
-  ;; (test-equal "mapping-key-predecessor does not run failure when a key exists"
-  ;;   '(2 0) (let ((n 0))
-  ;;            (let ((r (mapping-key-predecessor m 3 (lambda () (set! n (+ n 1)) 'NONE))))
-  ;;              (list r n))))
-  ;; FAIL: #2046
-  ;; (test-equal "mapping-key-successor does not run failure when a key exists"
-  ;;   '(4 0) (let ((n 0))
-  ;;            (let ((r (mapping-key-successor m 3 (lambda () (set! n (+ n 1)) 'NONE))))
-  ;;              (list r n))))
-  ;; FAIL: #2046
-  ;; (test-equal "mapping-key-predecessor tolerates a raising failure thunk"
-  ;;   2 (mapping-key-predecessor m 3 (lambda () (error "no predecessor"))))
-  (test-equal "pins #2046: failure runs once even on the success path" '(2 1)
-    (let ((n 0))
-      (let ((r (mapping-key-predecessor m 3 (lambda () (set! n (+ n 1)) 'NONE))))
-        (list r n))))
+  (test-equal "mapping-key-predecessor does not run failure when a key exists"
+    '(2 0) (let ((n 0))
+             (let ((r (mapping-key-predecessor m 3 (lambda () (set! n (+ n 1)) 'NONE))))
+               (list r n))))
+  (test-equal "mapping-key-successor does not run failure when a key exists"
+    '(4 0) (let ((n 0))
+             (let ((r (mapping-key-successor m 3 (lambda () (set! n (+ n 1)) 'NONE))))
+               (list r n))))
+  (test-equal "mapping-key-predecessor tolerates a raising failure thunk"
+    2 (mapping-key-predecessor m 3 (lambda () (error "no predecessor"))))
   (test-equal "control: failure runs exactly once when there is no answer" '(NONE 1)
     (let ((n 0))
       (let ((r (mapping-key-predecessor m 1 (lambda () (set! n (+ n 1)) 'NONE))))

--- a/tests/scheme/srfi/srfi146-differential.scm
+++ b/tests/scheme/srfi/srfi146-differential.scm
@@ -549,10 +549,9 @@
   ;; (agree "every? returns a boolean"
   ;;        (lambda (op) ((op 'every?) (lambda (k v) v) ((op 'make) c 1 'a 2 'b))))
 
-  ;; FAIL: #2049 (hashmap-ref/default calls a procedural default as a thunk)
-  ;; (agree "ref/default returns a procedural default unchanged"
-  ;;        (lambda (op) (procedure? ((op 'ref/default) ((op 'make) c 1 'a) 99
-  ;;                                                    (lambda () 'called)))))
+  (agree "ref/default returns a procedural default unchanged"
+         (lambda (op) (procedure? ((op 'ref/default) ((op 'make) c 1 'a) 99
+                                                     (lambda () 'called)))))
 
   ;; FAIL: #2053 (mapping-map runs its whole fold twice; hashmap-map does not)
   ;; (agree "map applies proc once per association"

--- a/tests/scheme/srfi/srfi146-differential.scm
+++ b/tests/scheme/srfi/srfi146-differential.scm
@@ -557,12 +557,41 @@
                         ((op 'make) c 1 'a 2 'b 3 'c 4 'd 5 'e))
              n)))
 
+  ;; The agree() checks above use the sibling library as the oracle; these
+  ;; direct assertions pin the spec value on the side that carried each
+  ;; defect, so they fail even if both libraries were to regress together.
+  (test-assert "mapping-any? returns exactly #t for a truthy predicate value"
+    (eq? #t (mapping-any? (lambda (k v) v) (mapping c 1 'a 2 'b))))
+  (test-assert "mapping-every? returns exactly #t for a truthy predicate value"
+    (eq? #t (mapping-every? (lambda (k v) v) (mapping c 1 'a 2 'b))))
+  (test-assert "hashmap-ref/default returns a procedural default unchanged"
+    (procedure? (hashmap-ref/default (hashmap c 1 'a) 99 (lambda () 'called))))
+  (test-equal "mapping-map applies proc exactly once per association" 5
+    (let ((n 0))
+      (mapping-map (lambda (k v) (set! n (+ n 1)) (values k v)) c
+                   (mapping c 1 'a 2 'b 3 'c 4 'd 5 'e))
+      n))
+
   (test-assert "mapping=? accepts a single mapping"
     (guard (e (#t #f)) (mapping=? c (mapping c 1 'a))))
+  (test-assert "mapping<? accepts a single mapping"
+    (guard (e (#t #f)) (mapping<? c (mapping c 1 'a))))
+  (test-assert "mapping>? accepts a single mapping"
+    (guard (e (#t #f)) (mapping>? c (mapping c 1 'a))))
   (test-assert "mapping<=? accepts a single mapping"
     (guard (e (#t #f)) (mapping<=? c (mapping c 1 'a))))
+  (test-assert "mapping>=? accepts a single mapping"
+    (guard (e (#t #f)) (mapping>=? c (mapping c 1 'a))))
   (test-assert "hashmap=? accepts a single hashmap"
-    (guard (e (#t #f)) (hashmap=? c (hashmap c 1 'a)))))
+    (guard (e (#t #f)) (hashmap=? c (hashmap c 1 'a))))
+  (test-assert "hashmap<? accepts a single hashmap"
+    (guard (e (#t #f)) (hashmap<? c (hashmap c 1 'a))))
+  (test-assert "hashmap>? accepts a single hashmap"
+    (guard (e (#t #f)) (hashmap>? c (hashmap c 1 'a))))
+  (test-assert "hashmap<=? accepts a single hashmap"
+    (guard (e (#t #f)) (hashmap<=? c (hashmap c 1 'a))))
+  (test-assert "hashmap>=? accepts a single hashmap"
+    (guard (e (#t #f)) (hashmap>=? c (hashmap c 1 'a)))))
 
 ;;; ------------------------------------------------- duplicate-key precedence
 
@@ -707,6 +736,21 @@
   (test-assert "hashmap=? separates hashmaps with different comparators"
     (not (hashmap=? c (hashmap (make-default-comparator) 1 'a)
                       (hashmap (make-default-comparator) 1 'a))))
+  ;; #2047's identity guard must not leak into the strict predicates through
+  ;; =? only: with different (but structurally identical) comparator objects,
+  ;; %mapping<=? is structural while %mapping=? is #f, which would make both
+  ;; m1<m2 and m2<m1 hold.  The strict predicates carry their own guard.
+  (test-assert "mapping<? is antisymmetric across different comparators"
+    (let ((m1 (mapping (make-default-comparator) 1 'a))
+          (m2 (mapping (make-default-comparator) 1 'a)))
+      (and (not (mapping<? c m1 m2)) (not (mapping<? c m2 m1)))))
+  (test-assert "hashmap<? is antisymmetric across different comparators"
+    (let ((h1 (hashmap (make-default-comparator) 1 'a))
+          (h2 (hashmap (make-default-comparator) 1 'a)))
+      (and (not (hashmap<? c h1 h2)) (not (hashmap<? c h2 h1)))))
+  (test-assert "control: mapping<? stays a proper subset on a shared comparator"
+    (and (mapping<? c (mapping c 1 'a) (mapping c 1 'a 2 'b))
+         (not (mapping<? c (mapping c 1 'a 2 'b) (mapping c 1 'a)))))
   (test-assert "control: mapping=? on a shared comparator is #t"
     (mapping=? c (mapping c 1 'a) (mapping c 1 'a)))
   (test-assert "control: hashmap=? on a shared comparator is #t"

--- a/tests/scheme/srfi/srfi146-differential.scm
+++ b/tests/scheme/srfi/srfi146-differential.scm
@@ -719,14 +719,12 @@
   (test-assert "pins #2048: hashmap-comparator has no hash yet"
     (not (comparator-hashable? hashmap-comparator)))
 
-  ;; FAIL: #2047 (=? omits the key-comparator identity check)
-  ;; (test-assert "mapping=? separates mappings with different comparators"
-  ;;   (not (mapping=? c (mapping (make-default-comparator) 1 'a)
-  ;;                     (mapping (make-default-comparator) 1 'a))))
-  ;; FAIL: #2047
-  ;; (test-assert "hashmap=? separates hashmaps with different comparators"
-  ;;   (not (hashmap=? c (hashmap (make-default-comparator) 1 'a)
-  ;;                     (hashmap (make-default-comparator) 1 'a))))
+  (test-assert "mapping=? separates mappings with different comparators"
+    (not (mapping=? c (mapping (make-default-comparator) 1 'a)
+                      (mapping (make-default-comparator) 1 'a))))
+  (test-assert "hashmap=? separates hashmaps with different comparators"
+    (not (hashmap=? c (hashmap (make-default-comparator) 1 'a)
+                      (hashmap (make-default-comparator) 1 'a))))
   (test-assert "control: mapping=? on a shared comparator is #t"
     (mapping=? c (mapping c 1 'a) (mapping c 1 'a)))
   (test-assert "control: hashmap=? on a shared comparator is #t"

--- a/tests/scheme/srfi/srfi146-differential.scm
+++ b/tests/scheme/srfi/srfi146-differential.scm
@@ -550,13 +550,12 @@
          (lambda (op) (procedure? ((op 'ref/default) ((op 'make) c 1 'a) 99
                                                      (lambda () 'called)))))
 
-  ;; FAIL: #2053 (mapping-map runs its whole fold twice; hashmap-map does not)
-  ;; (agree "map applies proc once per association"
-  ;;        (lambda (op)
-  ;;          (let ((n 0))
-  ;;            ((op 'map) (lambda (k v) (set! n (+ n 1)) (values k v)) c
-  ;;                       ((op 'make) c 1 'a 2 'b 3 'c 4 'd 5 'e))
-  ;;            n)))
+  (agree "map applies proc once per association"
+         (lambda (op)
+           (let ((n 0))
+             ((op 'map) (lambda (k v) (set! n (+ n 1)) (values k v)) c
+                        ((op 'make) c 1 'a 2 'b 3 'c 4 'd 5 'e))
+             n)))
 
   (test-assert "mapping=? accepts a single mapping"
     (guard (e (#t #f)) (mapping=? c (mapping c 1 'a))))

--- a/tests/scheme/srfi/srfi146-differential.scm
+++ b/tests/scheme/srfi/srfi146-differential.scm
@@ -594,33 +594,21 @@
   (test-equal "control: alist-> keeps the earlier association (hash)"
     'a (hashmap-ref (alist->hashmap c '((1 . a) (1 . b))) 1))
 
-  ;; FAIL: #2045 (the constructors and unfolds keep the LAST duplicate key)
-  ;; (test-equal "mapping keeps the earlier of two equal keys"
-  ;;   'a (mapping-ref (mapping c 1 'a 1 'b) 1))
-  ;; FAIL: #2045
-  ;; (test-equal "hashmap keeps the earlier of two equal keys"
-  ;;   'a (hashmap-ref (hashmap c 1 'a 1 'b) 1))
-  ;; FAIL: #2045
-  ;; (test-equal "mapping/ordered keeps the earlier of two equal keys"
-  ;;   'a (mapping-ref (mapping/ordered c 1 'a 1 'b) 1))
-  ;; FAIL: #2045
-  ;; (test-equal "mapping-unfold keeps the earliest association"
-  ;;   1 (mapping-ref (mapping-unfold (lambda (s) (> s 2)) (lambda (s) (values 'k s))
-  ;;                                  (lambda (s) (+ s 1)) 1 c) 'k))
-  ;; FAIL: #2045
-  ;; (test-equal "mapping-unfold/ordered keeps the earliest association"
-  ;;   1 (mapping-ref (mapping-unfold/ordered (lambda (s) (> s 2)) (lambda (s) (values 'k s))
-  ;;                                          (lambda (s) (+ s 1)) 1 c) 'k))
-  ;; FAIL: #2045
-  ;; (test-equal "hashmap-unfold keeps the earliest association"
-  ;;   1 (hashmap-ref (hashmap-unfold (lambda (s) (> s 2)) (lambda (s) (values 'k s))
-  ;;                                  (lambda (s) (+ s 1)) 1 c) 'k))
-
-  ;; These pin the current, wrong answers so a change is never silent.
-  (test-equal "pins #2045: mapping currently keeps the later key"
-    'b (mapping-ref (mapping c 1 'a 1 'b) 1))
-  (test-equal "pins #2045: hashmap currently keeps the later key"
-    'b (hashmap-ref (hashmap c 1 'a 1 'b) 1)))
+  (test-equal "mapping keeps the earlier of two equal keys"
+    'a (mapping-ref (mapping c 1 'a 1 'b) 1))
+  (test-equal "hashmap keeps the earlier of two equal keys"
+    'a (hashmap-ref (hashmap c 1 'a 1 'b) 1))
+  (test-equal "mapping/ordered keeps the earlier of two equal keys"
+    'a (mapping-ref (mapping/ordered c 1 'a 1 'b) 1))
+  (test-equal "mapping-unfold keeps the earliest association"
+    1 (mapping-ref (mapping-unfold (lambda (s) (> s 2)) (lambda (s) (values 'k s))
+                                  (lambda (s) (+ s 1)) 1 c) 'k))
+  (test-equal "mapping-unfold/ordered keeps the earliest association"
+    1 (mapping-ref (mapping-unfold/ordered (lambda (s) (> s 2)) (lambda (s) (values 'k s))
+                                          (lambda (s) (+ s 1)) 1 c) 'k))
+  (test-equal "hashmap-unfold keeps the earliest association"
+    1 (hashmap-ref (hashmap-unfold (lambda (s) (> s 2)) (lambda (s) (values 'k s))
+                                  (lambda (s) (+ s 1)) 1 c) 'k)))
 
 ;;; --------------------------------------------------- comparator plumbing
 

--- a/tests/scheme/srfi/srfi146-differential.scm
+++ b/tests/scheme/srfi/srfi146-differential.scm
@@ -710,14 +710,8 @@
   ;; make-mapping-comparator / make-hashmap-comparator.
   (test-assert "mapping-comparator is a comparator" (comparator? mapping-comparator))
   (test-assert "hashmap-comparator is a comparator" (comparator? hashmap-comparator))
-  ;; FAIL: #2048 (make-mapping-comparator supplies no ordering predicate)
-  ;; (test-assert "mapping-comparator is ordered" (comparator-ordered? mapping-comparator))
-  ;; FAIL: #2048 (make-hashmap-comparator supplies no hash function)
-  ;; (test-assert "hashmap-comparator is hashable" (comparator-hashable? hashmap-comparator))
-  (test-assert "pins #2048: mapping-comparator has no ordering yet"
-    (not (comparator-ordered? mapping-comparator)))
-  (test-assert "pins #2048: hashmap-comparator has no hash yet"
-    (not (comparator-hashable? hashmap-comparator)))
+  (test-assert "mapping-comparator is ordered" (comparator-ordered? mapping-comparator))
+  (test-assert "hashmap-comparator is hashable" (comparator-hashable? hashmap-comparator))
 
   (test-assert "mapping=? separates mappings with different comparators"
     (not (mapping=? c (mapping (make-default-comparator) 1 'a)

--- a/tests/scheme/srfi/srfi146-reference.scm
+++ b/tests/scheme/srfi/srfi146-reference.scm
@@ -526,16 +526,13 @@
           (test-assert "mapping-comparator"
             (comparator? mapping-comparator))
 
-          ;; FAIL: #2048 (mapping-comparator supplies no ordering predicate, so the outer
-          ;;              mapping is built with an inconsistent one) and #2045 (once that
-          ;;              is fixed, the constructor keeps the LAST of two equal keys)
-          ;; (test-equal "mapping-keyed mapping"
-          ;;   (list "a" "a" "c" "d" "e")
-          ;;   (list (mapping-ref mapping0 mapping1)
-          ;;         (mapping-ref mapping0 mapping2)
-          ;;         (mapping-ref mapping0 mapping3)
-          ;;         (mapping-ref mapping0 mapping4)
-          ;;         (mapping-ref mapping0 mapping5)))
+          (test-equal "mapping-keyed mapping"
+            (list "a" "a" "c" "d" "e")
+            (list (mapping-ref mapping0 mapping1)
+                  (mapping-ref mapping0 mapping2)
+                  (mapping-ref mapping0 mapping3)
+                  (mapping-ref mapping0 mapping4)
+                  (mapping-ref mapping0 mapping5)))
 
           (test-group "Ordering comparators"
             (test-assert "=?: equal mappings"
@@ -544,17 +541,14 @@
             (test-assert "=?: unequal mappings"
               (not (=? comparator mapping1 mapping4)))
 
-            ;; FAIL: #2048 (make-mapping-comparator supplies no ordering predicate)
-            ;; (test-assert "<?: case 1"
-            ;;   (<? comparator mapping3 mapping4))
+            (test-assert "<?: case 1"
+              (<? comparator mapping3 mapping4))
 
-            ;; FAIL: #2048 (make-mapping-comparator supplies no ordering predicate)
-            ;; (test-assert "<?: case 2"
-            ;;   (<? comparator mapping1 mapping4))
+            (test-assert "<?: case 2"
+              (<? comparator mapping1 mapping4))
 
-            ;; FAIL: #2048 (make-mapping-comparator supplies no ordering predicate)
-            ;; (test-assert "<?: case 3"
-            ;;   (<? comparator mapping1 mapping5))
+            (test-assert "<?: case 3"
+              (<? comparator mapping1 mapping5))
             )))
 
       
@@ -951,16 +945,14 @@
           (test-assert "hashmap-comparator"
             (comparator? hashmap-comparator))
 
-          ;; FAIL: #2044 ((srfi 146 hash) discards its comparator, so hashmap-comparator
-          ;;              never decides key identity)
-          ;; (test-equal "hashmap-keyed hashmap"
-          ;;   (list "a" "a" "c" "d" "e")
-          ;;   (list (hashmap-ref hashmap0 hashmap1)
-          ;;         (hashmap-ref hashmap0 hashmap2)
-          ;;         (hashmap-ref hashmap0 hashmap3)
-          ;;         (hashmap-ref hashmap0 hashmap4)
-          ;;         (hashmap-ref hashmap0 hashmap5)
-          ;;         ))
+          (test-equal "hashmap-keyed hashmap"
+            (list "a" "a" "c" "d" "e")
+            (list (hashmap-ref hashmap0 hashmap1)
+                  (hashmap-ref hashmap0 hashmap2)
+                  (hashmap-ref hashmap0 hashmap3)
+                  (hashmap-ref hashmap0 hashmap4)
+                  (hashmap-ref hashmap0 hashmap5)
+                  ))
 
           (test-group "Ordering comparators"
             (test-assert "=?: equal hashmaps"

--- a/tests/scheme/srfi/srfi146-reference.scm
+++ b/tests/scheme/srfi/srfi146-reference.scm
@@ -366,9 +366,8 @@
           (test-assert "mapping=?: unequal mappings"
             (not (mapping=? comparator mapping1 mapping4)))
 
-          ;; FAIL: #2047 (mapping=? omits the key-comparator identity check)
-          ;; (test-assert "mapping=?: different comparators"
-          ;;   (not (mapping=? comparator mapping1 mapping6)))
+          (test-assert "mapping=?: different comparators"
+            (not (mapping=? comparator mapping1 mapping6)))
 
           (test-assert "mapping<?: proper subset"
             (mapping<? comparator mapping3 mapping1))
@@ -870,9 +869,8 @@
           (test-assert "hashmap=?: unequal hashmaps"
             (not (hashmap=? comparator hashmap1 hashmap4)))
 
-          ;; FAIL: #2047 (hashmap=? omits the key-comparator identity check)
-          ;; (test-assert "hashmap=?: different comparators"
-          ;;   (not (hashmap=? comparator hashmap1 hashmap6)))
+          (test-assert "hashmap=?: different comparators"
+            (not (hashmap=? comparator hashmap1 hashmap6)))
 
           (test-assert "hashmap<?: proper subset"
             (hashmap<? comparator hashmap3 hashmap1))


### PR DESCRIPTION
Closes the SRFI-146 backlog from Systematic audit v2, Phase 3.4: **#2045 #2046 #2047 #2048 #2049 #2050 #2052 #2053** — the complete set of open SRFI-146 issues. Every fix aligns the implementation with the SRFI's reference implementation (`srfi-146.tgz`), and each commit re-enables the assertions the audit had disabled behind a `;; FAIL: #NNNN` marker.

## Changes (one commit per issue)

| Issue | Severity | Fix |
|---|---|---|
| #2045 | medium | `mapping`/`mapping-unfold`/`hashmap`/`hashmap-unfold` (and `/ordered` aliases) now keep the **first** of equal keys, per the Constructors spec, using the same first-wins semantics as `mapping-adjoin`/`alist->mapping` |
| #2046 | medium | `mapping-key-predecessor`/`-successor` tail-call `failure` only when no key exists, instead of evaluating it as the fold seed on every call |
| #2047 | medium | `mapping=?`/`hashmap=?` return `#f` for mappings with **different key comparators** (`eq?` identity check, as the reference does) |
| #2048 | medium | `make-mapping-comparator` now supplies the spec's **lexicographic ordering** (`mapping-ordering`); `make-hashmap-comparator` supplies a hash function (the constant the reference ships, whose TODO for a real hash is inherited) — mappings can now key mappings, the spec's stated purpose |
| #2049 | medium | `hashmap-ref/default` returns a **procedural default unchanged** via `hash-table-ref/default`, instead of invoking it as a failure thunk |
| #2050 | low | `mapping-any?`/`mapping-every?` return literal `#t`/`#f`, not the predicate's value, matching the hashmap twins |
| #2052 | low | all **ten** submapping comparison predicates accept the single-mapping form (`(mapping=? c m)` → `#t`) the signature allows |
| #2053 | low | deleted the discarded first fold in `mapping-map` (side-effecting `proc` was applied **twice** per association) and `mapping-find` |

## Tests

- Re-enabled every disabled assertion for these issues in `srfi146-differential.scm` and `srfi146-reference.scm`; dropped the pins that recorded the wrong answers. Includes the reference suite's `hashmap-keyed hashmap`, which was pinned under #2044 (closed separately) but actually needs this PR's hash function.
- Left the unrelated `#2023` (deep-keyed hash cliff) markers disabled.
- Full scheme suite: **703 files pass, 0 fail**; R7RS suite **1395 pass, 0 fail**. `srfi146.scm` 82/82, reference 174 passes, differential 526 passes.
- Also verified the SRFI-146 dependents (srfi 167, 168) still pass.
