### PR TITLE
Fix four SRFI audit findings: and-let*, SRFI 222, set->bag!, random seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`and-let*` with claws and no body returns the last claw's value**
+  (#2073). The base case expanded to `(begin #t body ...)`, so an `and-let*`
+  with at least one claw and an empty body — the value-producing guarded
+  lookup idiom SRFI 2 exists for — collapsed to a bare `#t`, discarding the
+  result. The expansion now ends on the last claw and returns its value for
+  all three claw shapes (`(VARIABLE EXPRESSION)`, `(EXPRESSION)`,
+  `BOUND-VARIABLE`), keeping the `#f` short-circuit; `(and-let* ())` is
+  still `#t` per the spec.
+
+- **SRFI 222 ships all ten procedures, `make-compound` flattens nested
+  compounds, and `compound-subobjects` no longer raises on a non-compound**
+  (#2072). `(srfi 222)` exported only 5 of the spec's 10 procedures —
+  `compound-map`, `compound-map->list`, `compound-filter`,
+  `compound-predicate` and `compound-access` were missing — `make-compound`
+  kept a nested compound as a single subobject instead of splicing in its
+  subobjects, and `compound-subobjects` was the bare record accessor, which
+  raised on a non-compound instead of returning a one-element list. The
+  library now implements the full spec: `compound-map` flattens compound
+  results, `compound-predicate` returns `#t` when the object or any
+  subobject satisfies the predicate, and `compound-access` implements the
+  spec's `(predicate accessor default obj)` worked-example shape.
+
+- **`set->bag!` adds the set's contribution to elements the bag already
+  holds** (#2086). It only inserted a set element the bag did not already
+  contain, leaving an element the bag held at its old count — a silent
+  wrong result for `(set->bag! (bag cmp 1 1) (set cmp 1 2))`, which must
+  give element 1 a count of 3. It now unconditionally increments, matching
+  the reference implementation and chibi-scheme.
+
+- **`%random-port-make-from-seed` rejects an all-zero seed** (#1913). An
+  all-zero seed put the xoshiro256** state at its degenerate fixed point,
+  so every byte drawn from the port was zero, silently. The sibling entry
+  points already rejected it (`isStateBytevector` in
+  `primitives_random_port.zig`, `bytevector-all-zero?` in
+  `lib/srfi/271/determinized.sld`); the raw seed primitive now does too.
+
 - **`,load` no longer mangles paths containing `"` or `\`** (#2273). The
   command spliced the path into a `(load "...")` string literal, so the
   reader's escapes broke or changed it: a quote ended the string (reader

--- a/lib/srfi/113.sld
+++ b/lib/srfi/113.sld
@@ -801,10 +801,13 @@
         b))
 
     (define (set->bag! b s)
+      ;; "The set->bag! procedure returns a bag containing the elements of
+      ;; both bag and set" -- every element of the set is ADDED to whatever
+      ;; count the bag already holds; a set contributes exactly 1 per
+      ;; element (#2086).
       (hash-table-walk (%set-ht s)
         (lambda (k v)
-          (if (not (hash-table-exists? (%bag-ht b) k))
-              (hash-table-set! (%bag-ht b) k 1))))
+          (bag-increment! b k 1)))
       b)
 
     (define (bag->alist b)

--- a/lib/srfi/2.sld
+++ b/lib/srfi/2.sld
@@ -4,8 +4,23 @@
   (begin
     (define-syntax and-let*
       (syntax-rules ()
+        ;; No claws: the form is #t, or the body runs (SRFI 2's
+        ;; eval[(AND-LET* () FORM1 ...)] = eval[(LET* () FORM1 ...)]).
         ((and-let* () body ...)
          (begin #t body ...))
+        ;; Last claw with no body: return the claw's value, per the formal
+        ;; semantics eval[(AND-LET* (CLAW)), env] = eval_claw[CLAW, env]
+        ;; (#2073). Each claw shape keeps the #f short-circuit.
+        ((and-let* ((var expr)))
+         (let ((var expr))
+           (if var var #f)))
+        ((and-let* ((expr)))
+         (let ((t expr))
+           (if t t #f)))
+        ((and-let* (bound-var))
+         (if bound-var bound-var #f))
+        ;; At least one claw consumed, recursing into the rest; the body (if
+        ;; any) runs once every claw has passed.
         ((and-let* ((var expr) rest ...) body ...)
          (let ((var expr))
            (if var (and-let* (rest ...) body ...) #f)))

--- a/lib/srfi/222.sld
+++ b/lib/srfi/222.sld
@@ -1,15 +1,37 @@
 (define-library (srfi 222)
   (import (scheme base))
   (export make-compound compound? compound-subobjects
-          compound-length compound-ref)
+          compound-length compound-ref
+          compound-map compound-map->list compound-filter
+          compound-predicate compound-access)
   (begin
     (define-record-type <compound>
       (make-compound-record subobjects)
       compound?
-      (subobjects compound-subobjects))
+      (subobjects %compound-subobjects))
 
-    (define (make-compound . subobjects)
-      (make-compound-record subobjects))
+    ;; "If obj is a compound object, returns a list of its subobjects;
+    ;; otherwise, returns a list containing only obj." (#2072: the bare
+    ;; record accessor used to raise on a non-compound.)
+    (define (compound-subobjects obj)
+      (if (compound? obj)
+          (%compound-subobjects obj)
+          (list obj)))
+
+    ;; Subobjects are never compounds: make-compound (and compound-map, which
+    ;; builds through it) flattens nested compound objects, so a compound's
+    ;; subobject list is always flat (#2072).
+    (define (flatten objs)
+      (let loop ((in objs) (out '()))
+        (if (null? in)
+            (reverse out)
+            (loop (cdr in)
+                  (if (compound? (car in))
+                      (append (reverse (compound-subobjects (car in))) out)
+                      (cons (car in) out))))))
+
+    (define (make-compound . objs)
+      (make-compound-record (flatten objs)))
 
     (define (compound-length obj)
       (if (compound? obj)
@@ -21,4 +43,40 @@
           (list-ref (compound-subobjects obj) k)
           (if (= k 0)
               obj
-              (error "compound-ref: index out of range" k))))))
+              (error "compound-ref: index out of range" k))))
+
+    (define (compound-map mapper obj)
+      ;; Mapper results that are themselves compounds are flattened into the
+      ;; result's subobjects, in sequence.
+      (make-compound-record
+       (append-map (lambda (o)
+                     (let ((r (mapper o)))
+                       (if (compound? r)
+                           (compound-subobjects r)
+                           (list r))))
+                   (compound-subobjects obj))))
+
+    (define (compound-map->list mapper obj)
+      (map mapper (compound-subobjects obj)))
+
+    (define (compound-filter pred obj)
+      (make-compound-record (filter pred (compound-subobjects obj))))
+
+    (define (compound-predicate pred obj)
+      (if (or (pred obj)
+              (and (compound? obj)
+                   (let loop ((os (compound-subobjects obj)))
+                     (cond ((null? os) #f)
+                           ((pred (car os)) #t)
+                           (else (loop (cdr os)))))))
+          #t
+          #f))
+
+    (define (compound-access predicate accessor default obj)
+      (cond ((predicate obj) (accessor obj))
+            ((compound? obj)
+             (let loop ((os (compound-subobjects obj)))
+               (cond ((null? os) default)
+                     ((predicate (car os)) (accessor (car os)))
+                     (else (loop (cdr os))))))
+            (else default)))))

--- a/lib/srfi/222.sld
+++ b/lib/srfi/222.sld
@@ -10,6 +10,25 @@
       compound?
       (subobjects %compound-subobjects))
 
+    ;; Local helpers: `filter' and `append-map' are not (scheme base)
+    ;; bindings in R7RS — kaappi resolves them only through its vm.globals
+    ;; fallback for library bodies, and other R7RS implementations would not
+    ;; load the library at all. The SRFI 222 reference implementation defines
+    ;; its own `filter', as does lib/srfi/217.sld, so this library stays
+    ;; loadable by any R7RS implementation.
+    (define (filter pred lst)
+      (let loop ((in lst) (out '()))
+        (cond ((null? in) (reverse out))
+              ((pred (car in)) (loop (cdr in) (cons (car in) out)))
+              (else (loop (cdr in) out)))))
+
+    ;; Apply f to every element and append the results, one level deep.
+    (define (append-map f lst)
+      (let loop ((in lst) (out '()))
+        (if (null? in)
+            (reverse out)
+            (loop (cdr in) (append (reverse (f (car in))) out)))))
+
     ;; "If obj is a compound object, returns a list of its subobjects;
     ;; otherwise, returns a list containing only obj." (#2072: the bare
     ;; record accessor used to raise on a non-compound.)
@@ -21,17 +40,13 @@
     ;; Subobjects are never compounds: make-compound (and compound-map, which
     ;; builds through it) flattens nested compound objects, so a compound's
     ;; subobject list is always flat (#2072).
-    (define (flatten objs)
-      (let loop ((in objs) (out '()))
-        (if (null? in)
-            (reverse out)
-            (loop (cdr in)
-                  (if (compound? (car in))
-                      (append (reverse (compound-subobjects (car in))) out)
-                      (cons (car in) out))))))
-
     (define (make-compound . objs)
-      (make-compound-record (flatten objs)))
+      (make-compound-record
+       (append-map (lambda (o)
+                     (if (compound? o)
+                         (compound-subobjects o)
+                         (list o)))
+                   objs)))
 
     (define (compound-length obj)
       (if (compound? obj)

--- a/src/primitives_random_port.zig
+++ b/src/primitives_random_port.zig
@@ -59,6 +59,16 @@ fn makeFromSeedFn(args: []const Value) PrimitiveError!Value {
     if (!types.isBytevector(args[0])) return primitives.typeError("%random-port-make-from-seed", "bytevector", args[0]);
     const bv = types.toBytevector(args[0]);
     if (bv.data.len < seed_len) return primitives.typeError("%random-port-make-from-seed", "bytevector of length >= 32", args[0]);
+    // An all-zero seed puts the xoshiro256** state at its degenerate fixed
+    // point, which emits only zero bytes forever. The sibling entry points
+    // already reject it (isStateBytevector above; bytevector-all-zero? in
+    // determinized.sld); without the same guard here the raw primitive
+    // silently built the broken generator (#1913).
+    for (bv.data[0..seed_len]) |b| {
+        if (b != 0) break;
+    } else {
+        return primitives.argError("%random-port-make-from-seed", "seed must contain at least one nonzero byte", .{});
+    }
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var gen = types.RandomGen{ .kind = .determinized };
     for (&gen.s, 0..) |*word, i| {

--- a/src/tests_random_port.zig
+++ b/src/tests_random_port.zig
@@ -114,3 +114,28 @@ test "stale default random source reseeds in place on next draw (fork child, #at
     // `advanced`; a fresh OS-entropy seed collides only with ~2^-64 odds.
     try testing.expect(!std.meta.eql(rs.prng, advanced));
 }
+
+test "all-zero seed rejected by %random-port-make-from-seed (#1913)" {
+    const th = @import("testing_helpers.zig");
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // The raw seed entry point must reject an all-zero seed, matching
+    // isStateBytevector and determinized.sld: an all-zero xoshiro256** state
+    // is a fixed point that emits only zero bytes (#1913).
+    const result = try ctx.vm.eval(
+        \\(guard (e (#t 'error-signaled))
+        \\  (%random-port-make-from-seed (make-bytevector 32 0)))
+    );
+    try testing.expect(types.isSymbol(result));
+    try testing.expectEqualStrings("error-signaled", types.symbolName(result));
+
+    // A nonzero seed still builds a working port whose first byte is nonzero.
+    const byte = try ctx.vm.eval(
+        \\(let ((p (%random-port-make-from-seed (make-bytevector 32 1))))
+        \\  (read-u8 p))
+    );
+    try testing.expect(types.isFixnum(byte));
+    try testing.expect(types.toFixnum(byte) != 0);
+}

--- a/tests/scheme/srfi/srfi113-audit.scm
+++ b/tests/scheme/srfi/srfi113-audit.scm
@@ -264,10 +264,10 @@
 ;;      (hash-table-for-each (lambda (key value) (sob-increment! bag key value))
 ;;                           (sob-hash-table set))
 ;;  — every element of the set is ADDED to whatever count the bag already has.
-;;  chibi-scheme 0.12.0 agrees with the reference here.
-;; FAIL: #2086 (set->bag! leaves an element already in the bag at its old count)
-;; (test-equal "set->bag! adds to the count of an element already in the bag"
-;;             '((1 . 3) (2 . 1)) (ba (set->bag! (B 1 1) (S 1 2))))
+;;  chibi-scheme 0.12.0 agrees with the reference here. (#2086: set->bag! used
+;;  to leave an element already in the bag at its old count.)
+(test-equal "set->bag! adds to the count of an element already in the bag"
+            '((1 . 3) (2 . 1)) (ba (set->bag! (B 1 1) (S 1 2))))
 
 ;; Discriminating control: the element the bag does NOT already hold is added
 ;; correctly, so only the already-present branch is wrong.

--- a/tests/scheme/srfi/srfi2.scm
+++ b/tests/scheme/srfi/srfi2.scm
@@ -8,7 +8,8 @@
 ;; The one defect this file pins is #2073: the spec's rule
 ;;     eval[ (AND-LET* (CLAW) ), env] = eval_claw[ CLAW, env ]
 ;; requires an and-let* with claws and NO body to return the last claw's
-;; value; lib/srfi/2.sld returns #t instead, for all three claw shapes.
+;; value; lib/srfi/2.sld used to return #t instead, for all three claw
+;; shapes, and now returns the claw value.
 ;;
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi2.scm
 
@@ -138,30 +139,38 @@
 ;;; --------------------------------------------------------------------
 ;;; #2073 -- an and-let* with claws and NO body must return the last claw's
 ;;; value, per the spec's own eval[ (AND-LET* (CLAW) ) ] = eval_claw[ CLAW ]
-;;; rule. All three claw shapes return #t instead. Chibi 0.12.0 returns the
-;;; claw value for every line below.
+;;; rule. lib/srfi/2.sld now ends the recursion on the last claw, so all
+;;; three claw shapes yield their value. Chibi 0.12.0 returns the claw value
+;;; for every line below.
 ;;;
-;;; The failure-path counterpart is pinned enabled just above/below, so the
-;;; disabled block isolates exactly the success value.
+;;; The failure-path counterpart is pinned enabled just above/below, so this
+;;; block isolates exactly the success value.
 ;;; --------------------------------------------------------------------
 
 (test-equal "empty body, failing claw still yields #f" #f (and-let* ((x #f))))
 
-;; FAIL: #2073 (and-let* with claws and an empty body returns #t, not the claw value)
-;; (test-equal "empty body, (VARIABLE EXPRESSION) claw yields its value" 1
-;;             (and-let* ((x 1))))
-;; (test-equal "empty body, (VARIABLE EXPRESSION) claw yields a symbol" 'sym
-;;             (and-let* ((x 'sym))))
-;; (test-equal "empty body, (EXPRESSION) claw yields its value" 3
-;;             (and-let* (((+ 1 2)))))
-;; (test-equal "empty body, BOUND-VARIABLE claw yields its value" 5
-;;             (let ((v 5)) (and-let* (v))))
-;; (test-equal "empty body, two claws yields the last one's value" 2
-;;             (and-let* ((x 1) (y 2))))
-;; (test-equal "empty body, last claw is an (EXPRESSION)" 7
-;;             (and-let* ((x 1) ((* x 7)))))
-;; (test-equal "empty body, last claw is a BOUND-VARIABLE" 9
-;;             (let ((v 9)) (and-let* ((x 1) v))))
+(test-equal "empty body, (VARIABLE EXPRESSION) claw yields its value" 1
+            (and-let* ((x 1))))
+(test-equal "empty body, (VARIABLE EXPRESSION) claw yields a symbol" 'sym
+            (and-let* ((x 'sym))))
+(test-equal "empty body, (EXPRESSION) claw yields its value" 3
+            (and-let* (((+ 1 2)))))
+(test-equal "empty body, BOUND-VARIABLE claw yields its value" 5
+            (let ((v 5)) (and-let* (v))))
+(test-equal "empty body, two claws yields the last one's value" 2
+            (and-let* ((x 1) (y 2))))
+(test-equal "empty body, last claw is an (EXPRESSION)" 7
+            (and-let* ((x 1) ((* x 7)))))
+(test-equal "empty body, last claw is a BOUND-VARIABLE" 9
+            (let ((v 9)) (and-let* ((x 1) v))))
+;; A failing claw still short-circuits with no body: the value of a false
+;; claw is #f, which is exactly what the and-let* must return.
+(test-equal "empty body, failing last claw yields #f" #f
+            (and-let* ((x 1) (y #f))))
+(test-equal "empty body, a side-effecting (EXPRESSION) claw runs once" 1
+            (let ((n 0))
+              (and-let* (((begin (set! n (+ n 1)) 2))))
+              n))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-2")

--- a/tests/scheme/srfi/srfi222.scm
+++ b/tests/scheme/srfi/srfi222.scm
@@ -5,11 +5,11 @@
 ;; section; chibi-scheme 0.12.0 does not ship SRFI 222, so there is no
 ;; cross-implementation oracle for this one.
 ;;
-;; What this file pins is #2072: (srfi 222) exports 5 of the spec's 10
-;; procedures, `make-compound' does not flatten nested compound objects, and
-;; `compound-subobjects' raises on a non-compound instead of returning a
+;; What this file pins is #2072: (srfi 222) used to export 5 of the spec's
+;; 10 procedures, `make-compound' did not flatten nested compound objects,
+;; and `compound-subobjects' raised on a non-compound instead of returning a
 ;; one-element list. `(cond-expand (srfi-222 ...))' answers #t regardless, so
-;; nothing else in the tree can detect the shortfall.
+;; nothing else in the tree could detect the shortfall.
 ;;
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi222.scm
 
@@ -129,82 +129,76 @@
 ;;; --------------------------------------------------------------------
 ;;; #2072 -- three defects, one root cause (an incomplete port).
 ;;;
-;;; (1) make-compound does not flatten nested compound objects, though the
+;;; (1) make-compound did not flatten nested compound objects, though the
 ;;;     spec says "If any object in objs is itself a compound object, it is
 ;;;     flattened into its subobjects, which are then added to the compound
 ;;;     object in sequence."
 ;;; --------------------------------------------------------------------
 
-;; FAIL: #2072 (make-compound does not flatten nested compound objects)
-;; (test-equal "make-compound flattens a nested compound (length)" 4
-;;             (compound-length (make-compound 1 2 (make-compound 3 4))))
-;; (test-equal "make-compound flattens a nested compound (subobjects)" '(1 2 3 4)
-;;             (compound-subobjects (make-compound 1 2 (make-compound 3 4))))
-;; (test-equal "make-compound flattens a leading nested compound" '(1 2 3)
-;;             (compound-subobjects (make-compound (make-compound 1 2) 3)))
-;; (test-equal "make-compound flattens an empty nested compound away" '(1 2)
-;;             (compound-subobjects (make-compound 1 (make-compound) 2)))
-;; (test-equal "make-compound flattens two nested compounds" '(1 2 3 4)
-;;             (compound-subobjects
-;;              (make-compound (make-compound 1 2) (make-compound 3 4))))
-;; (test-equal "flattening is one level deep per argument, applied recursively" '(1 2 3)
-;;             (compound-subobjects
-;;              (make-compound (make-compound 1 (make-compound 2)) 3)))
+(test-equal "make-compound flattens a nested compound (length)" 4
+            (compound-length (make-compound 1 2 (make-compound 3 4))))
+(test-equal "make-compound flattens a nested compound (subobjects)" '(1 2 3 4)
+            (compound-subobjects (make-compound 1 2 (make-compound 3 4))))
+(test-equal "make-compound flattens a leading nested compound" '(1 2 3)
+            (compound-subobjects (make-compound (make-compound 1 2) 3)))
+(test-equal "make-compound flattens an empty nested compound away" '(1 2)
+            (compound-subobjects (make-compound 1 (make-compound) 2)))
+(test-equal "make-compound flattens two nested compounds" '(1 2 3 4)
+            (compound-subobjects
+             (make-compound (make-compound 1 2) (make-compound 3 4))))
+(test-equal "flattening is one level deep per argument, applied recursively" '(1 2 3)
+            (compound-subobjects
+             (make-compound (make-compound 1 (make-compound 2)) 3)))
 
-;;; (2) compound-subobjects raises on a non-compound; the spec says
+;;; (2) compound-subobjects raised on a non-compound; the spec says
 ;;;     "otherwise, returns a list containing only obj".
 
-;; FAIL: #2072 (compound-subobjects raises on a non-compound)
-;; (test-equal "compound-subobjects of a non-compound is a one-element list" '(plain)
-;;             (compound-subobjects 'plain))
-;; (test-equal "compound-subobjects of a number" '(42) (compound-subobjects 42))
-;; (test-equal "compound-subobjects of a list is the list in a list" '((1 2))
-;;             (compound-subobjects (list 1 2)))
+(test-equal "compound-subobjects of a non-compound is a one-element list" '(plain)
+            (compound-subobjects 'plain))
+(test-equal "compound-subobjects of a number" '(42) (compound-subobjects 42))
+(test-equal "compound-subobjects of a list is the list in a list" '((1 2))
+            (compound-subobjects (list 1 2)))
 
-;;; (3) Five of the ten specified procedures are not exported at all:
+;;; (3) Five of the ten specified procedures were not exported at all:
 ;;;     compound-map, compound-map->list, compound-filter,
 ;;;     compound-predicate, compound-access. The assertions below are
-;;;     written against the spec's own examples and will not even compile
-;;;     until the names exist, so they stay commented out rather than
-;;;     guarded -- an `(environment ...)' probe would pin the absence but
-;;;     not the behaviour the fix has to deliver.
+;;;     written against the spec's own examples.
 
-;; FAIL: #2072 (compound-map/-map->list/-filter/-predicate/-access are not exported)
-;; (test-equal "compound-map over a compound" '(-1 -2 -3 -4 -5)
-;;             (compound-subobjects (compound-map - (make-compound 1 2 3 4 5))))
-;; (test-equal "compound-map wraps a non-compound in a compound" '(-1)
-;;             (compound-subobjects (compound-map - 1)))
-;; (test-equal "compound-map flattens compound results" '(1 2 3 4)
-;;             (compound-subobjects
-;;              (compound-map (lambda (x) (make-compound x (+ x 1)))
-;;                            (make-compound 1 3))))
-;; (test-equal "compound-map->list over a compound" '(-1 -2 -3 -4 -5)
-;;             (compound-map->list - (make-compound 1 2 3 4 5)))
-;; (test-equal "compound-map->list of a non-compound is a one-element list" '(-1)
-;;             (compound-map->list - 1))
-;; (test-equal "compound-filter keeps the matching subobjects" '(2 4)
-;;             (compound-subobjects (compound-filter even? (make-compound 1 2 3 4))))
-;; (test-equal "compound-filter on a matching non-compound" '(2)
-;;             (compound-subobjects (compound-filter even? 2)))
-;; (test-equal "compound-filter on a non-matching non-compound" '()
-;;             (compound-subobjects (compound-filter even? 1)))
-;; (test-equal "compound-predicate on a matching subobject" #t
-;;             (compound-predicate student? george))
-;; (test-equal "compound-predicate on a matching non-compound" #t
-;;             (compound-predicate student? alyssa))
-;; ;; The two #f-expecting cases are wrapped in a list: an undefined-variable
-;; ;; raise inside test-equal yields #f, which would satisfy a bare `#f'
-;; ;; expectation and pin nothing at all (checked by mutation test).
-;; (test-equal "compound-predicate on a non-matching compound" '(#f ran)
-;;             (list (compound-predicate string? george) 'ran))
-;; (test-equal "compound-predicate on a non-matching non-compound" '(#f ran)
-;;             (list (compound-predicate teacher? alyssa) 'ran))
-;; (test-equal "compound-access finds the first matching subobject" 1983
-;;             (compound-access teacher? teacher-hire-year #f george))
-;; (test-equal "compound-access on a matching non-compound" 1979
-;;             (compound-access student? student-year #f alyssa))
-;; (test-equal "compound-access falls back to the default" 'none
-;;             (compound-access teacher? teacher-hire-year 'none alyssa))
+(test-equal "compound-map over a compound" '(-1 -2 -3 -4 -5)
+            (compound-subobjects (compound-map - (make-compound 1 2 3 4 5))))
+(test-equal "compound-map wraps a non-compound in a compound" '(-1)
+            (compound-subobjects (compound-map - 1)))
+(test-equal "compound-map flattens compound results" '(1 2 3 4)
+            (compound-subobjects
+             (compound-map (lambda (x) (make-compound x (+ x 1)))
+                           (make-compound 1 3))))
+(test-equal "compound-map->list over a compound" '(-1 -2 -3 -4 -5)
+            (compound-map->list - (make-compound 1 2 3 4 5)))
+(test-equal "compound-map->list of a non-compound is a one-element list" '(-1)
+            (compound-map->list - 1))
+(test-equal "compound-filter keeps the matching subobjects" '(2 4)
+            (compound-subobjects (compound-filter even? (make-compound 1 2 3 4))))
+(test-equal "compound-filter on a matching non-compound" '(2)
+            (compound-subobjects (compound-filter even? 2)))
+(test-equal "compound-filter on a non-matching non-compound" '()
+            (compound-subobjects (compound-filter even? 1)))
+(test-equal "compound-predicate on a matching subobject" #t
+            (compound-predicate student? george))
+(test-equal "compound-predicate on a matching non-compound" #t
+            (compound-predicate student? alyssa))
+;; The two #f-expecting cases are wrapped in a list: an undefined-variable
+;; raise inside test-equal yields #f, which would satisfy a bare `#f'
+;; expectation and pin nothing at all (checked by mutation test).
+(test-equal "compound-predicate on a non-matching compound" '(#f ran)
+            (list (compound-predicate string? george) 'ran))
+(test-equal "compound-predicate on a non-matching non-compound" '(#f ran)
+            (list (compound-predicate teacher? alyssa) 'ran))
+(test-equal "compound-access finds the first matching subobject" 1983
+            (compound-access teacher? teacher-hire-year #f george))
+(test-equal "compound-access on a matching non-compound" 1979
+            (compound-access student? student-year #f alyssa))
+(test-equal "compound-access falls back to the default" 'none
+            (compound-access teacher? teacher-hire-year 'none alyssa))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-222")

--- a/tests/scheme/srfi/srfi271.scm
+++ b/tests/scheme/srfi/srfi271.scm
@@ -7,7 +7,8 @@
         (srfi 64)
         (srfi 271)                         ; alias for randomized
         (prefix (srfi 271 randomized) r:)
-        (prefix (srfi 271 determinized) d:))
+        (prefix (srfi 271 determinized) d:)
+        (kaappi primitives))               ; the raw %random-port-* helpers
 
 (test-begin "srfi-271")
 
@@ -132,6 +133,22 @@
 (test-assert (not (d:random-port-initialization-error? 'nope)))
 (test-assert (not (d:random-port-initialization-error?
                    (guard (e (#t e)) (error "unrelated")))))
+
+;;; --- #1913: the raw seed entry point rejects an all-zero seed -------------
+
+;; The library layer already rejects an all-zero seed (seed-from-port raises
+;; random-port-initialization-error); the raw %random-port-make-from-seed
+;; primitive must not silently build the degenerate generator either — an
+;; all-zero xoshiro256** state is a fixed point that emits only zero bytes.
+(test-assert
+ (guard (e (#t #t))
+   (%random-port-make-from-seed (make-bytevector 32 0))
+   #f))
+;; A nonzero seed still builds a working port, and its first byte is nonzero.
+(test-assert
+ (let ((p (%random-port-make-from-seed (make-bytevector 32 1))))
+   (let ((b (read-u8 p)))
+     (and (exact-integer? b) (not (= b 0))))))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-271")


### PR DESCRIPTION
Fixes #2073, #2072, #2086, #1913 — four independent SRFI conformance defects from the systematic audit, one PR.

## #2073 — and-let* with claws and an empty body returns #t instead of the last claw's value

SRFI 2's formal semantics (`eval[(AND-LET* (CLAW)), env] = eval_claw[CLAW, env]`) require the last claw's value when there is no body; the base case expanded to `(begin #t body ...)`, collapsing the value-producing guarded-lookup idiom to a bare `#t`. The expansion now ends on the last claw and returns its value for all three claw shapes, keeping the `#f` short-circuit (`(and-let* ())` is still `#t`).

## #2072 — SRFI 222 ships 5 of 10 procedures; make-compound doesn't flatten; compound-subobjects raises on non-compounds

`lib/srfi/222.sld` now exports all ten spec procedures. `make-compound` flattens nested compounds recursively, `compound-subobjects` returns a one-element list for non-compounds (per spec), and the five missing procedures are implemented: `compound-map` (flattening compound results), `compound-map->list`, `compound-filter`, `compound-predicate`, `compound-access` — the two the SRFI's rationale is built around.

## #2086 — set->bag! silently drops the set's contribution for elements the bag already holds

`set->bag!` only inserted elements the bag didn't already contain, so an element the bag held kept its old count. It now unconditionally increments (`bag-increment! b k 1`), matching the reference implementation and chibi-scheme.

## #1913 — %random-port-make-from-seed accepts an all-zero seed; the port then emits only zeros forever

An all-zero seed puts the xoshiro256** state at its degenerate fixed point. The sibling entry points already rejected it (`isStateBytevector`, `determinized.sld`); `makeFromSeedFn` now does too. Unit test added in `src/tests_random_port.zig` plus Scheme-level tests in `srfi271.scm`.

## Testing

- All four previously-disabled regression suites are enabled and pass: `srfi2.scm` (45), `srfi222.scm` (63), `srfi113-audit.scm` (246), `srfi271.scm` (37)
- `zig build test` — full unit suite green (including the new #1913 test)
- `bash tests/scheme/run-all.sh` — 703 Scheme files pass; R7RS suite 1395/1395
- The single failing item (WASM differential: `sbc-constants-numeric`, `complex-neg-zero`, `large-index-bounds-1912`) is **pre-existing** — verified identical failures on the clean tree via `git stash`
