### PR TITLE
Fix SRFI-170 validation gaps and implement the posix-error protocol (Fixes #1977, #1978)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **SRFI 170's posix-error protocol: `posix-error?`, `posix-error-name` and
+  `posix-error-message`** (#1978). Every SRFI-170 file error raised from a
+  failing syscall now captures the thread-local `errno` on the condition
+  object at the raise site, and the three spec procedures read it back:
+  `posix-error-name` returns the symbol naming the code (e.g. `ENOENT`,
+  derived from Zig's per-OS errno tables so the *name* stays portable even
+  though the *numbers* differ), and `posix-error-message` returns the
+  strerror(3) text. Failures that never reached a syscall — type errors and
+  the embedded-NUL pre-check — answer `#f` to `posix-error?`.
+
 - **Click inside the REPL input to move the edit cursor** (#2264). SGR mouse
   tracking behind a `repl.mouse: true` setting in `~/.kaappi/config` (default
   off, so drag-to-select behavior never changes unasked): a left click maps
@@ -19,6 +29,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Windows console needs its own mouse-input path and is not yet supported.
 
 ### Fixed
+
+- **SRFI-170 no longer silently discards a mistyped argument** (#1977).
+  `(nice "x")` used to be treated as "no argument supplied" and really
+  renice the process by the default +1; `(set-environment-variable!
+  "NAME=x" "v")` and an empty name used to return normally while setting
+  nothing because `platform.setEnv` discarded setenv(3)'s return; and a
+  mistyped optional was ignored by `create-directory`/`create-fifo` (mode),
+  `create-temp-file` (prefix) and `set-file-times` (both stamps set to the
+  current clock). All six now raise; `set-file-times` additionally enforces
+  SRFI-170's "exactly one time is an error" rule. Surplus arguments to the
+  variadic SRFI-170 procedures are an arity mismatch too — the specs now
+  declare a `.range` arity with the SRFI signature's upper bound.
+
+- **SRFI-170 argument-range failures are no longer file errors** (#1978).
+  `(set-file-mode p #o10000)`, `(set-umask! -1)`, `(nice
+  999999999999)`, an out-of-range uid/gid and an over-long temp prefix
+  validate the argument, never the filesystem, so they are now raised as
+  KP3007 invalid-argument conditions and answer `#f` to `file-error?` (the
+  message text is unchanged).
+
+- **`file-info`, `user-info` and `group-info` now cross the SRFI-18 thread
+  boundary** (#1978). The three are pure value records (scalars plus owned
+  string bytes, like the already-copyable `SchemeString`) but were listed
+  as `UncopyableType` beside ports/continuations/fibers, so a child thread
+  could not return one. `gc_deep_copy.zig` now copies them by value, and
+  the "uncopyable type (port, continuation, etc.)" messages name the real
+  uncopyable set instead of implying these records are in it.
 
 - **`and-let*` with claws and no body returns the last claw's value**
   (#2073). The base case expanded to `(begin #t body ...)`, so an `and-let*`

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -40,6 +40,45 @@ randomized), (srfi 271 determinized), (srfi 248 primitives).
 
 ## Per-SRFI notes
 
+### SRFI 170 — POSIX API
+
+SRFI 170 is one of the 12 built-in SRFIs: all its procedures are Zig
+primitives in `src/primitives_filesystem.zig` and export directly from the
+`(srfi 170)` library (there is no `lib/srfi/170.sld`). Three things about
+this implementation are worth knowing when editing it:
+
+- **The posix-error protocol is errno-on-the-condition** (#1978).
+  `posix-error?`, `posix-error-name` and `posix-error-message` read a
+  `posix_errno` field on the `ErrorObject`. The raise helper `raiseFileError`
+  snapshots `std.c._errno()` on entry — before any allocation or further
+  libc call can clobber it — and every SRFI-170 syscall-failure site funnels
+  through it, so ENOENT/ENOTDIR/EACCES/ELOOP/ENAMETOOLONG are all
+  distinguishable from Scheme. Raise sites that never ran a syscall (the
+  embedded-NUL pre-check, "symlink target too long", Windows-unsupported
+  stubs) pass errno 0 explicitly via `raiseFileErrorCode`, so
+  `posix-error?` stays false for them. `posix-error-name` derives the symbol
+  by scanning `std.c.E`, which exists as an enum on every target we build
+  (darwin, linux, the BSDs, windows, wasi) but is `void` on the switch's
+  `else` platforms — guard that case. `posix-error-message` calls
+  strerror(3). The errno survives a thread-boundary copy: the
+  `gc_deep_copy.zig` `.error_object` arm carries `posix_errno`.
+
+- **Argument-range validation is KP3007, not a file error** (#1978). The
+  mode/uid-gid/nice/prefix range checks validate an argument of acceptable
+  type, so they raise through `raiseArgError` — a `.general` condition
+  stamped `.invalid_argument` — and answer `#f` to `file-error?`. The
+  message text is unchanged from the old file-error wording.
+
+- **Every variadic signature declares its upper bound.** The SRFI-170
+  procedures use the `.range` arity (`create-temp-file` 0..1, `file-info`
+  1..2, `set-file-times` 1..3, …) rather than unbounded `.variadic`, so
+  surplus arguments are an arity mismatch instead of being silently
+  ignored (#1977). `set-file-times` also enforces the spec's
+  "exactly one time is an error" rule in the body. `file-info`,
+  `user-info` and `group-info` are pure value records and are copied by
+  value across the SRFI-18 thread boundary; only `directory-object` among
+  the SRFI-170 types is genuinely uncopyable (it owns a live `DIR*`).
+
 ### SRFI 226 — Control Features
 
 SRFI 226 (Control Features) is a 12-sub-library spec with no default/main

--- a/docs/dev/thread-value-sharing.md
+++ b/docs/dev/thread-value-sharing.md
@@ -14,7 +14,7 @@ routes, and they have separate, unrelated enforcement:
 | **globals** | reached by pointer, no copy | per-type owner checks in individual primitives — present for exactly four types, plus (since kaappi#1924) a general rejection of any store of a heap pointer into a container the running thread does not own (interned symbols excepted) |
 
 The tag list is not a statement about what can cross a thread boundary.
-It is a statement about what can be *copied*. Eleven of the fourteen tags
+It is a statement about what can be *copied*. Eight of the eleven tags
 on it are freely reachable through a top-level `define`, and for two of
 them that is the only supported way to share them at all.
 
@@ -42,13 +42,18 @@ that name through the shared globals map at run time, so the value never
 enters the copy at all. This is the whole reason the two routes exist as
 separate things.
 
-`gc_deep_copy.zig` refuses fourteen tags outright:
+`gc_deep_copy.zig` refuses eleven tags outright:
 
 ```text
 port  continuation  fiber  mutex  condition_variable  ffi_callback
-file_info  user_info  group_info  directory_object  scheme_environment
-ephemeron  guardian  transport_cell
+directory_object  scheme_environment  ephemeron  guardian  transport_cell
 ```
+
+`file-info`, `user-info` and `group-info` used to sit here too; they are
+pure value records (scalars plus owned string bytes, like `SchemeString`)
+and have copied by value since kaappi#1978, so a `file-info` can be the
+join result of a child thread. `directory_object` among the SRFI-170 types
+is still genuinely uncopyable — it owns a live `DIR*`.
 
 Channels are **not** on that list. Their arm promotes the channel to a
 shared representation and aliases it, which is what makes a lexically
@@ -92,7 +97,9 @@ into a catchable error naming neither the type nor the offending value:
 
 ```text
 uncaught exception in thread: thread thunk contains an uncopyable type
-(port, continuation, etc.), or a channel owned by another thread
+(port, continuation, fiber, mutex, condition variable, FFI callback,
+directory object, environment, ephemeron, guardian, or transport cell),
+or a channel owned by another thread
 ```
 
 ## The globals route
@@ -150,7 +157,7 @@ with a top-level `define` and named by the thunk.
 | port | refused | works | unchecked (see below) |
 | continuation | refused | no error, does not resume the parent | unchecked — kaappi#1936 |
 | `scheme-environment` | refused | works (`eval` in it succeeds) | unchecked |
-| `file-info` / `user-info` / `group-info` | refused | works | unchecked |
+| `file-info` / `user-info` / `group-info` | **copied by value** | works | **coherent** since kaappi#1978 — pure value records, now copy like `SchemeString` |
 | directory object | refused | works | unchecked |
 | ffi-library / ffi-function | **copied** | works | **coherent** since kaappi#2027 — the wrapper crosses, the process-global handle is shared by value |
 | record type / instance | **copied, same type** | works | **coherent** since kaappi#1932 — identity is a counter carried by the copy, not the address |
@@ -206,7 +213,7 @@ the general mutation hazard for the ones that do".
 ## Why the checks were not simply extended to the globals route
 
 kaappi#1937 offered this as one of two fixes. It cannot be done
-uniformly, because for two of the fourteen tags the globals route is the
+uniformly, because for two of the eleven tags the globals route is the
 *only* route: refusing a foreign mutex or condition variable would remove
 the sole supported way to synchronise threads, and SRFI-18 has no other.
 Ports through globals would break too, and the issue itself argues that
@@ -322,7 +329,11 @@ the code and this table.
 
 The four SRFI-170 record types are left out on purpose: `user-info` raises
 "unsupported" on Windows and this suite runs there, and those rows add no
-enforcement shape the nine already cover. `ffi-callback` needs a loaded
+enforcement shape the nine already cover. (The three *copyable* ones —
+`file-info`, `user-info`, `group-info` — have their own cross-boundary
+coverage in `tests/scheme/audit/srfi18-deepcopy-matrix-audit.scm` and
+`tests/scheme/audit/primitives_filesystem-audit.scm` section H since
+kaappi#1978.) `ffi-callback` needs a loaded
 FFI library; the transport cell is unreachable, as above.
 
 Two smaller checks live elsewhere and are worth knowing about rather than

--- a/docs/dev/thread-value-sharing.md
+++ b/docs/dev/thread-value-sharing.md
@@ -284,7 +284,7 @@ thread gets its own VM and GC with an independent heap.
 |-------|-------|--------------|
 | `vm_instance`, `gc_instance` | `src/vm.zig`, `src/memory.zig` | `threadlocal` — the running thread's VM and GC |
 | `GC.initForThread` | `src/memory.zig` | Per-thread GC, sharing the **root's** symbol table (chained through the parent chain; a joined middle thread's own tables stay empty, kaappi#2129) |
-| `GC.deepCopy` / `deepCopyValue` | `src/memory.zig` (impl in `gc_deep_copy.zig`) | Deep-copies values between GC heaps; owns the 14-tag refusal list |
+| `GC.deepCopy` / `deepCopyValue` | `src/memory.zig` (impl in `gc_deep_copy.zig`) | Deep-copies values between GC heaps; owns the 11-tag refusal list |
 | `VM.initForThread` | `src/vm.zig` | Per-thread VM, sharing the **root's** globals and libraries **by pointer** |
 | `VM.owns_globals` | `src/vm.zig` | Stops a child VM freeing the shared maps on deinit |
 | `symbol_mutex` | `src/memory.zig` | Spinlock protecting concurrent symbol interning |

--- a/src/check_lint.zig
+++ b/src/check_lint.zig
@@ -254,10 +254,12 @@ fn checkArity(ctx: *Context, node: *Node, name: []const u8, arity: types.NativeF
                 std.fmt.allocPrint(ctx.arena, "{d}", .{r.min}) catch break :blk error.OutOfMemory
             else
                 std.fmt.allocPrint(ctx.arena, "{d} to {d}", .{ r.min, r.max }) catch break :blk error.OutOfMemory;
+            // A range always takes the plural noun: "0 to 1 arguments" even
+            // when the bound is 1.
             break :blk std.fmt.allocPrint(
                 ctx.arena,
                 "'{s}' expects {s} argument{s}, but {d} {s} given",
-                .{ name, expected, plural(if (r.min == r.max) r.min else r.max), nargs, wasWere(nargs) },
+                .{ name, expected, if (r.min == r.max) plural(r.min) else "s", nargs, wasWere(nargs) },
             );
         },
     } catch return true;

--- a/src/check_lint.zig
+++ b/src/check_lint.zig
@@ -234,6 +234,7 @@ fn checkArity(ctx: *Context, node: *Node, name: []const u8, arity: types.NativeF
     const bad = switch (arity) {
         .exact => |e| nargs != e,
         .variadic => |min| nargs < min,
+        .range => |r| nargs < r.min or nargs > r.max,
     };
     if (!bad) return false;
 
@@ -248,6 +249,17 @@ fn checkArity(ctx: *Context, node: *Node, name: []const u8, arity: types.NativeF
             "'{s}' expects at least {d} argument{s}, but {d} {s} given",
             .{ name, min, plural(min), nargs, wasWere(nargs) },
         ),
+        .range => |r| blk: {
+            const expected: []const u8 = if (r.min == r.max)
+                std.fmt.allocPrint(ctx.arena, "{d}", .{r.min}) catch break :blk error.OutOfMemory
+            else
+                std.fmt.allocPrint(ctx.arena, "{d} to {d}", .{ r.min, r.max }) catch break :blk error.OutOfMemory;
+            break :blk std.fmt.allocPrint(
+                ctx.arena,
+                "'{s}' expects {s} argument{s}, but {d} {s} given",
+                .{ name, expected, plural(if (r.min == r.max) r.min else r.max), nargs, wasWere(nargs) },
+            );
+        },
     } catch return true;
     ctx.addFinding(.primitive_arity_mismatch, node.ann.span, msg);
     return true;

--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -313,6 +313,7 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
             const new_e = types.toObject(new_val).as(types.ErrorObject);
             new_e.error_type = e.error_type;
             new_e.code = e.code;
+            new_e.posix_errno = e.posix_errno;
             new_e.message = try deepCopyValue(gc, e.message, visited);
             new_e.irritants = try deepCopyValue(gc, e.irritants, visited);
             new_e.uncaught_reason = try deepCopyValue(gc, e.uncaught_reason, visited);
@@ -524,6 +525,40 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
             const t = obj.as(types.Srfi18Time);
             return try gc.allocSrfi18Time(t.seconds, t.nanoseconds, t.time_type);
         },
+        // Pure value records — scalars plus owned string bytes, exactly like
+        // the copyable SchemeString. They were listed as UncopyableType
+        // beside `.port`/`.continuation`/`.fiber` until #1978, so a file-info
+        // or user-info could not cross a thread boundary even though nothing
+        // about them is thread-bound (a directory-object below *is*: it
+        // holds a live `DIR*`). No visited.put needed — no Value fields, so
+        // no cycles are possible.
+        .file_info => {
+            const fi = obj.as(types.FileInfo);
+            return try gc.allocFileInfo(.{
+                .size = fi.size,
+                .mtime = fi.mtime,
+                .atime = fi.atime,
+                .ctime = fi.ctime,
+                .dev = fi.dev,
+                .ino = fi.ino,
+                .nlinks = fi.nlinks,
+                .rdev = fi.rdev,
+                .blksize = fi.blksize,
+                .blocks = fi.blocks,
+                .mode = fi.mode,
+                .uid = fi.uid,
+                .gid = fi.gid,
+                .file_type = fi.file_type,
+            });
+        },
+        .user_info => {
+            const ui = obj.as(types.UserInfo);
+            return try gc.allocUserInfo(ui.name, ui.uid, ui.gid, ui.home_dir, ui.shell, ui.full_name);
+        },
+        .group_info => {
+            const gi = obj.as(types.GroupInfo);
+            return try gc.allocGroupInfo(gi.name, gi.gid);
+        },
         .random_source => {
             const rs = obj.as(types.RandomSource);
             const new_val = try gc.allocRandomSource(0);
@@ -603,8 +638,8 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
         // This list governs the *copy* route only -- the thread-start!
         // thunk closure, the thread-join! result, a channel message. A
         // value reached through the shared globals map is never copied and
-        // never reaches this switch, and thirteen of the fourteen tags
-        // below are freely usable that way. For .mutex and
+        // never reaches this switch, and ten of the eleven
+        // tags below are freely usable that way. For .mutex and
         // .condition_variable a global is in fact the *only* supported way
         // to share one, so the refusal here is the opposite of the rule --
         // exactly inverted from .channel above, whose capture is the
@@ -615,15 +650,17 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
         // was not simply extended to cover globals:
         // docs/dev/thread-value-sharing.md, pinned by
         // tests/scheme/srfi/srfi18-sharing-model.scm.
+        //
+        // file-info/user-info/group-info used to sit here too; they are pure
+        // value records and now copy like SchemeString does (#1978). Only
+        // .directory_object among the SRFI-170 types is genuinely
+        // uncopyable -- it owns a live `DIR*`.
         .port,
         .continuation,
         .fiber,
         .mutex,
         .condition_variable,
         .ffi_callback,
-        .file_info,
-        .user_info,
-        .group_info,
         .directory_object,
         .scheme_environment,
         // SRFI-254 weak references are tied to one GC's collection cycle.

--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -311,6 +311,10 @@ fn getArity(val: types.Value, buf: *[32]u8) ?[]const u8 {
         return switch (nfn.arity) {
             .exact => |n| std.fmt.bufPrint(buf, "{d}", .{n}) catch null,
             .variadic => |n| std.fmt.bufPrint(buf, "{d}+", .{n}) catch null,
+            .range => |r| if (r.min == r.max)
+                std.fmt.bufPrint(buf, "{d}", .{r.min}) catch null
+            else
+                std.fmt.bufPrint(buf, "{d}..{d}", .{ r.min, r.max }) catch null,
         };
     }
     if (obj.tag == .closure) {

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -712,32 +712,38 @@ const unsetenv = if (builtin.os.tag == .netbsd) netbsd_env.__unsetenv13 else str
 }.unsetenv;
 
 /// setenv(3) equivalent. Windows CRT has no setenv; _putenv takes a
-/// single "NAME=VALUE" string (which it copies).
-pub fn setEnv(allocator: std.mem.Allocator, name: []const u8, value: []const u8) !void {
+/// single "NAME=VALUE" string (which it copies). Returns 0 on success or
+/// the errno of the failed call (EINVAL for a name containing '=' or an
+/// empty name) — the caller decides whether to raise (#1977).
+pub fn setEnv(allocator: std.mem.Allocator, name: []const u8, value: []const u8) !c_int {
     if (comptime is_windows) {
         const pair = try std.fmt.allocPrintSentinel(allocator, "{s}={s}", .{ name, value }, 0);
         defer allocator.free(pair);
-        _ = win._putenv(pair.ptr);
-        return;
+        if (win._putenv(pair.ptr) != 0) return std.c._errno().*;
+        return 0;
     }
     const name_z = try allocator.dupeZ(u8, name);
     defer allocator.free(name_z);
     const value_z = try allocator.dupeZ(u8, value);
     defer allocator.free(value_z);
-    _ = setenv(name_z, value_z, 1);
+    if (setenv(name_z, value_z, 1) != 0) return std.c._errno().*;
+    return 0;
 }
 
 /// unsetenv(3) equivalent ("NAME=" removes the variable via _putenv).
-pub fn unsetEnv(allocator: std.mem.Allocator, name: []const u8) !void {
+/// Returns 0 on success or the errno of the failed call; deleting a name
+/// that was never set is a silent success per POSIX.
+pub fn unsetEnv(allocator: std.mem.Allocator, name: []const u8) !c_int {
     if (comptime is_windows) {
         const pair = try std.fmt.allocPrintSentinel(allocator, "{s}=", .{name}, 0);
         defer allocator.free(pair);
-        _ = win._putenv(pair.ptr);
-        return;
+        if (win._putenv(pair.ptr) != 0) return std.c._errno().*;
+        return 0;
     }
     const name_z = try allocator.dupeZ(u8, name);
     defer allocator.free(name_z);
-    _ = unsetenv(name_z);
+    if (unsetenv(name_z) != 0) return std.c._errno().*;
+    return 0;
 }
 
 extern "c" fn _getpid() c_int;

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -700,10 +700,10 @@ pub fn getenv(name: [*:0]const u8) ?[*:0]const u8 {
 extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
 /// NetBSD renamed unsetenv when its return type changed (void → int,
 /// POSIX alignment): the plain symbol is the void compat version, the
-/// modern one is `__unsetenv13`. We ignore the return either way, but
-/// bind the modern symbol for a correct signature (and to silence
-/// NetBSD ld's .gnu.warning on the compat reference). setenv was never
-/// renamed — the plain symbol is current there.
+/// modern one is `__unsetenv13`. Bind the modern symbol for a correct
+/// signature (and to silence NetBSD ld's .gnu.warning on the compat
+/// reference); its int return is the status `unsetEnv` propagates to the
+/// caller. setenv was never renamed — the plain symbol is current there.
 const netbsd_env = struct {
     extern "c" fn __unsetenv13(name: [*:0]const u8) c_int;
 };

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -1341,8 +1341,8 @@ fn raiseFiberError(msg: []const u8) PrimitiveError {
 /// fall back to OutOfMemory.
 fn translateSharedChannelError(err: anyerror, proc: []const u8) PrimitiveError {
     if (err == error.UncopyableType) {
-        var buf: [96]u8 = undefined;
-        const msg = std.fmt.bufPrint(&buf, "{s}: value contains an uncopyable type (port, continuation, etc.)", .{proc}) catch
+        var buf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "{s}: value contains an uncopyable type (port, continuation, fiber, mutex, condition variable, FFI callback, directory object, environment, ephemeron, guardian, or transport cell)", .{proc}) catch
             return PrimitiveError.OutOfMemory;
         return raiseFiberError(msg);
     }

--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -45,8 +45,8 @@ fn errnoName(errno_val: c_int) []const u8 {
     return "EUNKNOWN";
 }
 
-fn validateMode(gc: *GC, val: Value) PrimitiveError!std.c.mode_t {
-    if (!types.isFixnum(val)) return primitives.typeError("set-file-mode", "integer", val);
+fn validateMode(gc: *GC, proc: []const u8, val: Value) PrimitiveError!std.c.mode_t {
+    if (!types.isFixnum(val)) return primitives.typeError(proc, "integer", val);
     const n = types.toFixnum(val);
     // POSIX permission modes use only the low 12 bits (07777). Bounding by
     // maxInt(mode_t) is platform-dependent: mode_t is u16 on macOS but u32
@@ -118,7 +118,9 @@ fn doStat(path: [*:0]const u8, follow: bool, errno_out: *c_int) ?StatResult {
         // as zero, exactly like SRFI-170 suggests for hosts without them.
         var wbuf: platform.WPathBuf = undefined;
         const wpath = platform.widen(&wbuf, std.mem.sliceTo(path, 0)) orelse {
-            errno_out.* = std.c._errno().*;
+            // widen is a UTF-8→UTF-16 conversion, not a syscall — errno is
+            // stale here, so report no errno.
+            errno_out.* = 0;
             return null;
         };
         var st: platform.win.Stat64 = undefined;
@@ -250,7 +252,7 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "user-effective-uid", .func = &userEffectiveUidFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "user-effective-gid", .func = &userEffectiveGidFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "user-supplementary-gids", .func = &userSupplementaryGidsFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
-    .{ .name = "nice", .func = &niceFn, .arity = .{ .variadic = 0 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
+    .{ .name = "nice", .func = &niceFn, .arity = .{ .range = .{ .min = 0, .max = 1 } }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "set-environment-variable!", .func = &setEnvVarFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "delete-environment-variable!", .func = &deleteEnvVarFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "terminal?", .func = &terminalP, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
@@ -343,10 +345,10 @@ fn posixErrorP(args: []const Value) PrimitiveError!Value {
     return if (err.posix_errno != 0) types.TRUE else types.FALSE;
 }
 
-fn expectPosixError(args: []const Value) PrimitiveError!*types.ErrorObject {
-    if (!types.isErrorObject(args[0])) return primitives.typeError("posix-error-name", "posix-error", args[0]);
+fn expectPosixError(comptime proc: []const u8, args: []const Value) PrimitiveError!*types.ErrorObject {
+    if (!types.isErrorObject(args[0])) return primitives.typeError(proc, "posix-error", args[0]);
     const err = types.toObject(args[0]).as(types.ErrorObject);
-    if (err.posix_errno == 0) return primitives.typeError("posix-error-name", "posix-error", args[0]);
+    if (err.posix_errno == 0) return primitives.typeError(proc, "posix-error", args[0]);
     return err;
 }
 
@@ -354,16 +356,20 @@ fn expectPosixError(args: []const Value) PrimitiveError!*types.ErrorObject {
 /// errno numbers differ across POSIX systems but the names are shared, so
 /// the spec returns the name rather than the code.
 fn posixErrorName(args: []const Value) PrimitiveError!Value {
-    const err = try expectPosixError(args);
+    // Copy the scalar before allocating: allocSymbol may collect, and the
+    // raw ErrorObject pointer must not survive an allocation unrooted
+    // (the args register file roots the value itself, but the gc-safety
+    // rule is pointer-across-allocation, so read the field out first).
+    const errno_val = (try expectPosixError("posix-error-name", args)).posix_errno;
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    return gc.allocSymbol(errnoName(err.posix_errno)) catch return PrimitiveError.OutOfMemory;
+    return gc.allocSymbol(errnoName(errno_val)) catch return PrimitiveError.OutOfMemory;
 }
 
 /// `posix-error-message` — the strerror(3) text for the captured errno.
 fn posixErrorMessage(args: []const Value) PrimitiveError!Value {
-    const err = try expectPosixError(args);
+    const errno_val = (try expectPosixError("posix-error-message", args)).posix_errno;
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const text = strerror(err.posix_errno);
+    const text = strerror(errno_val);
     return gc.allocString(std.mem.span(text)) catch return PrimitiveError.OutOfMemory;
 }
 
@@ -603,7 +609,7 @@ fn createDirectoryFn(args: []const Value) PrimitiveError!Value {
     const path = extractPath(args[0]) orelse return primitives.typeError("create-directory", "string", args[0]);
     try validatePathNoNul(path, args[0]);
 
-    const mode: std.c.mode_t = if (args.len > 1) try validateMode(gc, args[1]) else 0o755;
+    const mode: std.c.mode_t = if (args.len > 1) try validateMode(gc, "create-directory", args[1]) else 0o755;
 
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
@@ -734,7 +740,7 @@ fn setFileModeFn(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    const mode = try validateMode(gc, args[1]);
+    const mode = try validateMode(gc, "set-file-mode", args[1]);
     if (std.c.chmod(path_z, mode) != 0) {
         return raiseFileError(gc, "cannot set file mode", args[0]);
     }
@@ -764,7 +770,7 @@ fn createFifoFn(args: []const Value) PrimitiveError!Value {
     const path = extractPath(args[0]) orelse return primitives.typeError("create-fifo", "string", args[0]);
     try validatePathNoNul(path, args[0]);
 
-    const mode: std.c.mode_t = if (args.len > 1) try validateMode(gc, args[1]) else 0o664;
+    const mode: std.c.mode_t = if (args.len > 1) try validateMode(gc, "create-fifo", args[1]) else 0o664;
 
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
@@ -803,6 +809,11 @@ fn timeArgToTimespec(args: []const Value, idx: usize) PrimitiveError!std.c.times
     const v = args[idx];
     if (types.isSrfi18Time(v)) {
         const t = types.toSrfi18Time(v);
+        // SRFI-170: "It is an error if they are not of type time-utc." A
+        // monotonic clock's seconds are an arbitrary epoch and must not be
+        // written to utimensat as wall-clock time.
+        if (t.time_type != .utc)
+            return primitives.typeError("set-file-times", "time-utc object or integer", v);
         return .{ .sec = @intCast(t.seconds), .nsec = @intCast(t.nanoseconds) };
     }
     if (types.isFixnum(v)) {
@@ -863,7 +874,7 @@ fn setUmaskFn(args: []const Value) PrimitiveError!Value {
     if (comptime platform.is_windows) return raiseUnsupportedOnWindows("set-umask!");
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (!types.isFixnum(args[0])) return primitives.typeError("set-umask!", "integer", args[0]);
-    const mask = try validateMode(gc, args[0]);
+    const mask = try validateMode(gc, "set-umask!", args[0]);
     _ = std.c.umask(mask);
     return types.VOID;
 }

--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -105,15 +105,27 @@ fn devToU64(dev: anytype) u64 {
     return dev;
 }
 
-fn doStat(path: [*:0]const u8, follow: bool) ?StatResult {
+/// Returns the stat result, or null with `errno_out` set to the errno of
+/// the failed call. The errno must be captured HERE, not at the raise site:
+/// the Linux path calls the raw statx(2) syscall, which reports failure by
+/// returning `-errno` instead of setting the libc errno, so the thread-local
+/// would be stale by the time the caller raises (#1978, caught by the Linux
+/// CI legs).
+fn doStat(path: [*:0]const u8, follow: bool, errno_out: *c_int) ?StatResult {
     if (comptime platform.is_windows) {
         // _wstat64 always follows reparse points (`follow` has no effect)
         // and Windows has no POSIX uid/gid/blocks; absent concepts report
         // as zero, exactly like SRFI-170 suggests for hosts without them.
         var wbuf: platform.WPathBuf = undefined;
-        const wpath = platform.widen(&wbuf, std.mem.sliceTo(path, 0)) orelse return null;
+        const wpath = platform.widen(&wbuf, std.mem.sliceTo(path, 0)) orelse {
+            errno_out.* = std.c._errno().*;
+            return null;
+        };
         var st: platform.win.Stat64 = undefined;
-        if (platform.win._wstat64(wpath.ptr, &st) != 0) return null;
+        if (platform.win._wstat64(wpath.ptr, &st) != 0) {
+            errno_out.* = std.c._errno().*;
+            return null;
+        }
         return .{
             .mode = @intCast(st.st_mode),
             .size = st.st_size,
@@ -136,7 +148,14 @@ fn doStat(path: [*:0]const u8, follow: bool) ?StatResult {
         var flags: u32 = 0x0000;
         if (!follow) flags |= 0x100;
         const rc = linux.statx(@bitCast(@as(i32, std.posix.AT.FDCWD)), path, flags, linux.STATX.BASIC_STATS, &sx);
-        if (rc > @as(usize, std.math.maxInt(isize))) return null;
+        if (rc > @as(usize, std.math.maxInt(isize))) {
+            // statx returns the error as the raw syscall result: a huge
+            // usize encoding -errno (never the libc errno). Bitcast back to
+            // isize to recover the negative errno, then negate.
+            const rc_i: isize = @bitCast(rc);
+            errno_out.* = -@as(c_int, @intCast(rc_i));
+            return null;
+        }
         return .{
             .mode = @intCast(sx.mode),
             .size = @intCast(sx.size),
@@ -161,7 +180,10 @@ fn doStat(path: [*:0]const u8, follow: bool) ?StatResult {
         const lstat_fn = @extern(*const fn ([*:0]const u8, *std.c.Stat) callconv(.c) c_int, .{ .name = lstat_name });
         var stat_buf: std.c.Stat = undefined;
         const r = if (!follow) lstat_fn(path, &stat_buf) else std.c.fstatat(std.posix.AT.FDCWD, path, &stat_buf, 0);
-        if (r != 0) return null;
+        if (r != 0) {
+            errno_out.* = std.c._errno().*;
+            return null;
+        }
         return .{
             .mode = @intCast(stat_buf.mode),
             .size = @intCast(stat_buf.size),
@@ -416,8 +438,9 @@ fn fileInfoFn(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    const sr = doStat(path_z, follow) orelse {
-        return raiseFileError(gc, "cannot stat file", args[0]);
+    var stat_errno: c_int = 0;
+    const sr = doStat(path_z, follow, &stat_errno) orelse {
+        return raiseFileErrorCode(gc, "cannot stat file", args[0], stat_errno);
     };
 
     // std.c.S doesn't exist on Windows; these mode bits are identical

--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -11,6 +11,7 @@ const GC = memory.GC;
 const arith = @import("primitives_arithmetic.zig");
 
 extern fn mkstemp(template: [*:0]u8) c_int;
+extern "c" fn strerror(errnum: c_int) [*:0]const u8;
 
 extern "c" fn truncate(path: [*:0]const u8, length: std.c.off_t) c_int;
 extern "c" fn mkfifo(path: [*:0]const u8, mode: std.c.mode_t) c_int;
@@ -23,6 +24,27 @@ extern "c" fn unsetenv(name: [*:0]const u8) c_int;
 extern "c" fn getgrnam(name: [*:0]const u8) ?*std.c.group;
 const is_linux = @import("builtin").os.tag == .linux;
 
+/// SRFI-170's posix-error-name: the symbol naming the errno code, e.g.
+/// `ENOENT`. Zig's `std.c.E` is an exhaustive enum on every target we
+/// build (darwin, linux, the BSDs, windows, wasi) but `void` on the
+/// `else` platforms the switch does not enumerate — guard that case.
+/// `@tagName` of `NOENT` is `"NOENT"`, so the POSIX spelling is a simple
+/// `"E"` prefix; errno values with no declared tag (or errno 0, which
+/// no failing syscall produces) get `EUNKNOWN`.
+fn errnoName(errno_val: c_int) []const u8 {
+    const E = std.c.E;
+    if (E == void) return "EUNKNOWN";
+    // `std.meta.tags` returns a pointer (not a tuple), whose elements an
+    // `inline for` cannot use at comptime; `std.enums.values` returns a
+    // tuple, so the unrolled `@tagName` below stays comptime-known.
+    inline for (std.enums.values(E)) |tag| {
+        if (@as(c_int, @intCast(@intFromEnum(tag))) == errno_val) {
+            return "E" ++ @tagName(tag);
+        }
+    }
+    return "EUNKNOWN";
+}
+
 fn validateMode(gc: *GC, val: Value) PrimitiveError!std.c.mode_t {
     if (!types.isFixnum(val)) return primitives.typeError("set-file-mode", "integer", val);
     const n = types.toFixnum(val);
@@ -31,7 +53,7 @@ fn validateMode(gc: *GC, val: Value) PrimitiveError!std.c.mode_t {
     // on Linux, so out-of-range values were rejected on one and silently
     // passed to chmod on the other.
     if (n < 0 or n > 0o7777) {
-        _ = try raiseFileError(gc, "mode value out of range", val);
+        _ = try raiseArgError(gc, "mode value out of range", val);
         unreachable;
     }
     return @truncate(@as(u64, @intCast(n)));
@@ -41,7 +63,7 @@ fn validateUid(gc: *GC, val: Value) PrimitiveError!std.c.uid_t {
     const n = types.toFixnum(val);
     if (n == -1) return @bitCast(@as(u32, 0xFFFFFFFF));
     if (n < 0 or n > std.math.maxInt(std.c.uid_t)) {
-        _ = try raiseFileError(gc, "uid/gid value out of range", val);
+        _ = try raiseArgError(gc, "uid/gid value out of range", val);
         unreachable;
     }
     return @truncate(@as(u64, @intCast(n)));
@@ -159,8 +181,8 @@ fn doStat(path: [*:0]const u8, follow: bool) ?StatResult {
 }
 
 pub const specs = [_]primitives.PrimSpec{
-    .{ .name = "directory-files", .func = &directoryFiles, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
-    .{ .name = "file-info", .func = &fileInfoFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
+    .{ .name = "directory-files", .func = &directoryFiles, .arity = .{ .range = .{ .min = 1, .max = 2 } }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
+    .{ .name = "file-info", .func = &fileInfoFn, .arity = .{ .range = .{ .min = 1, .max = 2 } }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "file-info?", .func = &fileInfoP, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "file-info-directory?", .func = &fileInfoDirectoryP, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "file-info-regular?", .func = &fileInfoRegularP, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
@@ -181,7 +203,7 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "file-info-fifo?", .func = &fileInfoFifoP, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "file-info-socket?", .func = &fileInfoSocketP, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "file-info-device?", .func = &fileInfoDeviceP, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
-    .{ .name = "create-directory", .func = &createDirectoryFn, .arity = .{ .variadic = 1 }, .libs = LS.initMany(&.{ .scheme_file, .srfi_170 }), .sandbox = false, .wasm = false },
+    .{ .name = "create-directory", .func = &createDirectoryFn, .arity = .{ .range = .{ .min = 1, .max = 2 } }, .libs = LS.initMany(&.{ .scheme_file, .srfi_170 }), .sandbox = false, .wasm = false },
     .{ .name = "delete-directory", .func = &deleteDirectoryFn, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_file, .srfi_170 }), .sandbox = false, .wasm = false },
     .{ .name = "rename-file", .func = &renameFileFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "create-symlink", .func = &createSymlinkFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
@@ -190,12 +212,12 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "real-path", .func = &realPathFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "set-file-mode", .func = &setFileModeFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "truncate-file", .func = &truncateFileFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
-    .{ .name = "create-fifo", .func = &createFifoFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
+    .{ .name = "create-fifo", .func = &createFifoFn, .arity = .{ .range = .{ .min = 1, .max = 2 } }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "set-file-owner", .func = &setFileOwnerFn, .arity = .{ .exact = 3 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
-    .{ .name = "set-file-times", .func = &setFileTimesFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
+    .{ .name = "set-file-times", .func = &setFileTimesFn, .arity = .{ .range = .{ .min = 1, .max = 3 } }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "file-info-type", .func = &fileInfoTypeFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "temp-file-prefix", .func = &tempFilePrefixFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
-    .{ .name = "create-temp-file", .func = &createTempFileFn, .arity = .{ .variadic = 0 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
+    .{ .name = "create-temp-file", .func = &createTempFileFn, .arity = .{ .range = .{ .min = 0, .max = 1 } }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "pid", .func = &pidFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "umask", .func = &umaskFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "set-umask!", .func = &setUmaskFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
@@ -222,14 +244,30 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "group-info?", .func = &groupInfoP, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "group-info:name", .func = &groupInfoName, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "group-info:gid", .func = &groupInfoGidFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
-    .{ .name = "open-directory", .func = &openDirectoryFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
+    .{ .name = "posix-error?", .func = &posixErrorP, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
+    .{ .name = "posix-error-name", .func = &posixErrorName, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
+    .{ .name = "posix-error-message", .func = &posixErrorMessage, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
+    .{ .name = "open-directory", .func = &openDirectoryFn, .arity = .{ .range = .{ .min = 1, .max = 2 } }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "read-directory", .func = &readDirectoryFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "close-directory", .func = &closeDirectoryFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "posix-time", .func = &posixTimeFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
     .{ .name = "monotonic-time", .func = &monotonicTimeFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.srfi_170), .sandbox = false, .wasm = false },
 };
 
+/// Raise a catchable `.file` error whose condition carries the *current*
+/// errno (SRFI-170's posix-error protocol, #1978). Only call this
+/// immediately after the failing syscall — the snapshot is taken on entry,
+/// before any allocation can clobber the thread-local. Raise sites that
+/// never touched the filesystem use `raiseFileErrorCode(..., 0)`.
 fn raiseFileError(gc: *GC, msg_text: []const u8, irritant: Value) PrimitiveError!Value {
+    return raiseFileErrorCode(gc, msg_text, irritant, std.c._errno().*);
+}
+
+/// `raiseFileError` with an explicit errno — 0 for an error that did not
+/// come from a syscall (a pre-check like the embedded-NUL guard, or a
+/// semantic failure like "symlink target too long"), so `posix-error?`
+/// stays false and `posix-error-name` is not handed a stale code.
+fn raiseFileErrorCode(gc: *GC, msg_text: []const u8, irritant: Value, errno_val: c_int) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     var msg = gc.allocString(msg_text) catch return PrimitiveError.OutOfMemory;
     gc.pushRoot(&msg);
@@ -239,9 +277,72 @@ fn raiseFileError(gc: *GC, msg_text: []const u8, irritant: Value) PrimitiveError
     gc.pushRoot(&irritants_root);
     defer gc.popRoot();
     const err_obj = gc.allocErrorObject(msg, irritants_root) catch return PrimitiveError.OutOfMemory;
-    types.toObject(err_obj).as(types.ErrorObject).error_type = .file;
+    const err = types.toObject(err_obj).as(types.ErrorObject);
+    err.error_type = .file;
+    err.posix_errno = errno_val;
     vm.current_exception = err_obj;
     return PrimitiveError.ExceptionRaised;
+}
+
+/// Raise a catchable KP3007 (invalid argument) error — a value of
+/// acceptable type the procedure rejects anyway, e.g. an out-of-range mode
+/// or nice value (audit D2, #1978). Not a `.file` error: nothing about the
+/// filesystem failed, so a `guard` clause matching `(file-error? e)` must
+/// not fire. The message is deliberately the bare explanation, matching the
+/// long-standing error strings these sites already used.
+fn raiseArgError(gc: *GC, msg_text: []const u8, irritant: Value) PrimitiveError!Value {
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
+    var msg = gc.allocString(msg_text) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&msg);
+    defer gc.popRoot();
+    const irritants = gc.allocPair(irritant, types.NIL) catch return PrimitiveError.OutOfMemory;
+    var irritants_root = irritants;
+    gc.pushRoot(&irritants_root);
+    defer gc.popRoot();
+    const err_obj = gc.allocErrorObjectCoded(msg, irritants_root, .invalid_argument) catch return PrimitiveError.OutOfMemory;
+    vm.current_exception = err_obj;
+    return PrimitiveError.ExceptionRaised;
+}
+
+// -------------------------------------------------------------------------
+// SRFI-170 §3.1 error protocol: posix-error? / posix-error-name /
+// posix-error-message. The three procedures read `posix_errno` off the
+// condition object, which the raise helpers in this file stamp at the
+// failing syscall (#1978).
+// -------------------------------------------------------------------------
+
+/// `posix-error?` — a condition that describes a POSIX error is an error
+/// object carrying a nonzero errno. Argument-range failures (KP3007, raised
+/// by `raiseArgError`) and type errors never touch a syscall, so they answer
+/// `#f` — exactly the discrimination the audit's D2 dimension demands.
+fn posixErrorP(args: []const Value) PrimitiveError!Value {
+    if (!types.isErrorObject(args[0])) return types.FALSE;
+    const err = types.toObject(args[0]).as(types.ErrorObject);
+    return if (err.posix_errno != 0) types.TRUE else types.FALSE;
+}
+
+fn expectPosixError(args: []const Value) PrimitiveError!*types.ErrorObject {
+    if (!types.isErrorObject(args[0])) return primitives.typeError("posix-error-name", "posix-error", args[0]);
+    const err = types.toObject(args[0]).as(types.ErrorObject);
+    if (err.posix_errno == 0) return primitives.typeError("posix-error-name", "posix-error", args[0]);
+    return err;
+}
+
+/// `posix-error-name` — a symbol naming the errno value, e.g. `ENOENT`.
+/// errno numbers differ across POSIX systems but the names are shared, so
+/// the spec returns the name rather than the code.
+fn posixErrorName(args: []const Value) PrimitiveError!Value {
+    const err = try expectPosixError(args);
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    return gc.allocSymbol(errnoName(err.posix_errno)) catch return PrimitiveError.OutOfMemory;
+}
+
+/// `posix-error-message` — the strerror(3) text for the captured errno.
+fn posixErrorMessage(args: []const Value) PrimitiveError!Value {
+    const err = try expectPosixError(args);
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const text = strerror(err.posix_errno);
+    return gc.allocString(std.mem.span(text)) catch return PrimitiveError.OutOfMemory;
 }
 
 /// POSIX-only operations raise a clean, catchable file error on Windows
@@ -249,7 +350,7 @@ fn raiseFileError(gc: *GC, msg_text: []const u8, irritant: Value) PrimitiveError
 /// code can probe with guard/with-exception-handler.
 fn raiseUnsupportedOnWindows(comptime name: []const u8) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    return raiseFileError(gc, name ++ ": not supported on Windows", types.FALSE);
+    return raiseFileErrorCode(gc, name ++ ": not supported on Windows", types.FALSE, 0);
 }
 
 fn extractPath(val: Value) ?[]const u8 {
@@ -261,7 +362,8 @@ fn extractPath(val: Value) ?[]const u8 {
 fn validatePathNoNul(path: []const u8, original: Value) PrimitiveError!void {
     if (std.mem.indexOfScalar(u8, path, 0) != null) {
         const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-        _ = try raiseFileError(gc, "path contains embedded NUL byte", original);
+        // Pre-check, not a syscall failure: errno would be stale.
+        _ = try raiseFileErrorCode(gc, "path contains embedded NUL byte", original, 0);
     }
 }
 
@@ -478,10 +580,7 @@ fn createDirectoryFn(args: []const Value) PrimitiveError!Value {
     const path = extractPath(args[0]) orelse return primitives.typeError("create-directory", "string", args[0]);
     try validatePathNoNul(path, args[0]);
 
-    const mode: std.c.mode_t = if (args.len > 1 and types.isFixnum(args[1]))
-        try validateMode(gc, args[1])
-    else
-        0o755;
+    const mode: std.c.mode_t = if (args.len > 1) try validateMode(gc, args[1]) else 0o755;
 
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
@@ -562,7 +661,8 @@ fn readSymlinkFn(args: []const Value) PrimitiveError!Value {
         return raiseFileError(gc, "cannot read symlink", args[0]);
     }
     if (@as(usize, @intCast(r)) == buf.len) {
-        return raiseFileError(gc, "symlink target too long", args[0]);
+        // readlink succeeded — ENAMETOOLONG was never set, so errno is stale.
+        return raiseFileErrorCode(gc, "symlink target too long", args[0], 0);
     }
     return gc.allocString(buf[0..@intCast(r)]) catch return PrimitiveError.OutOfMemory;
 }
@@ -641,10 +741,7 @@ fn createFifoFn(args: []const Value) PrimitiveError!Value {
     const path = extractPath(args[0]) orelse return primitives.typeError("create-fifo", "string", args[0]);
     try validatePathNoNul(path, args[0]);
 
-    const mode: std.c.mode_t = if (args.len > 1 and types.isFixnum(args[1]))
-        try validateMode(gc, args[1])
-    else
-        0o664;
+    const mode: std.c.mode_t = if (args.len > 1) try validateMode(gc, args[1]) else 0o664;
 
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
@@ -678,7 +775,7 @@ fn setFileOwnerFn(args: []const Value) PrimitiveError!Value {
 const TIME_NOW: i64 = -1;
 const TIME_UNCHANGED: i64 = -2;
 
-fn timeArgToTimespec(args: []const Value, idx: usize) std.c.timespec {
+fn timeArgToTimespec(args: []const Value, idx: usize) PrimitiveError!std.c.timespec {
     if (args.len <= idx) return std.c.UTIME.NOW;
     const v = args[idx];
     if (types.isSrfi18Time(v)) {
@@ -691,12 +788,20 @@ fn timeArgToTimespec(args: []const Value, idx: usize) std.c.timespec {
         if (val == TIME_UNCHANGED) return std.c.UTIME.OMIT;
         return .{ .sec = @intCast(val), .nsec = 0 };
     }
-    return std.c.UTIME.NOW;
+    // A mistyped time must be rejected, never silently stamped with the
+    // current clock (#1977) — SRFI-170 requires time-utc objects here.
+    return primitives.typeError("set-file-times", "time object or integer", v);
 }
 
 fn setFileTimesFn(args: []const Value) PrimitiveError!Value {
     if (comptime platform.is_windows) return raiseUnsupportedOnWindows("set-file-times");
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    // SRFI-170: "It is an error if exactly one time is provided." With no
+    // time arguments both default to now; with two both are used.
+    if (args.len == 2) {
+        _ = try raiseArgError(gc, "exactly one time argument provided; supply both access and modification times or neither", args[1]);
+        unreachable;
+    }
     const path = extractPath(args[0]) orelse return primitives.typeError("set-file-times", "string", args[0]);
     try validatePathNoNul(path, args[0]);
 
@@ -705,8 +810,8 @@ fn setFileTimesFn(args: []const Value) PrimitiveError!Value {
 
     var times: [2]std.c.timespec = undefined;
 
-    times[0] = timeArgToTimespec(args, 1);
-    times[1] = timeArgToTimespec(args, 2);
+    times[0] = try timeArgToTimespec(args, 1);
+    times[1] = try timeArgToTimespec(args, 2);
 
     if (std.c.utimensat(std.posix.AT.FDCWD, path_z, &times, 0) != 0) {
         return raiseFileError(gc, "cannot set file times", args[0]);
@@ -817,13 +922,16 @@ fn niceFn(args: []const Value) PrimitiveError!Value {
     if (comptime platform.is_windows) return raiseUnsupportedOnWindows("nice");
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     var delta: c_int = 1;
-    if (args.len > 0 and types.isFixnum(args[0])) {
+    if (args.len > 0) {
+        // A mistyped increment used to be treated as "no argument supplied"
+        // and silently renice'd the process by the default +1 (#1977).
+        if (!types.isFixnum(args[0])) return primitives.typeError("nice", "integer", args[0]);
         // Fixnums range up to ±2^47, but nice() takes a C int. An unchecked
         // @intCast panics (SIGABRT) on out-of-range values in ReleaseSafe;
         // reject them as a recoverable Scheme error instead.
         const n = types.toFixnum(args[0]);
         if (n < std.math.minInt(c_int) or n > std.math.maxInt(c_int)) {
-            return raiseFileError(gc, "nice value out of range", args[0]);
+            return raiseArgError(gc, "nice value out of range", args[0]);
         }
         delta = @intCast(n);
     }
@@ -848,9 +956,13 @@ fn setEnvVarFn(args: []const Value) PrimitiveError!Value {
     try validatePathNoNul(name, args[0]);
     try validatePathNoNul(value, args[1]);
 
-    platform.setEnv(gc.allocator, name, value) catch {
-        return raiseFileError(gc, "cannot set environment variable", args[0]);
-    };
+    const err = platform.setEnv(gc.allocator, name, value) catch return PrimitiveError.OutOfMemory;
+    if (err != 0) {
+        // setenv(3) rejects names containing '=' and empty names with
+        // EINVAL; the return used to be discarded, so the failure was
+        // silent (#1977).
+        return raiseFileErrorCode(gc, "cannot set environment variable", args[0], err);
+    }
     return types.VOID;
 }
 
@@ -859,7 +971,12 @@ fn deleteEnvVarFn(args: []const Value) PrimitiveError!Value {
     const name = extractPath(args[0]) orelse return primitives.typeError("delete-environment-variable!", "string", args[0]);
     try validatePathNoNul(name, args[0]);
 
-    platform.unsetEnv(gc.allocator, name) catch return PrimitiveError.OutOfMemory;
+    const err = platform.unsetEnv(gc.allocator, name) catch return PrimitiveError.OutOfMemory;
+    if (err != 0) {
+        // Same shape as setEnvVarFn: unsetenv(3) fails (EINVAL) on a name
+        // containing '=', and the failure used to be silent.
+        return raiseFileErrorCode(gc, "cannot delete environment variable", args[0], err);
+    }
     return types.VOID;
 }
 
@@ -1093,7 +1210,10 @@ fn createTempFileFn(args: []const Value) PrimitiveError!Value {
 
     var prefix_buf: [512]u8 = undefined;
     var prefix: []const u8 = platform.tempFilePrefix(&prefix_buf);
-    if (args.len > 0 and types.isString(args[0])) {
+    if (args.len > 0) {
+        // A mistyped prefix used to be silently discarded and the default
+        // temp-file-prefix used (#1977).
+        if (!types.isString(args[0])) return primitives.typeError("create-temp-file", "string", args[0]);
         const s = types.toObject(args[0]).as(types.SchemeString);
         prefix = s.data[0..s.len];
         try validatePathNoNul(prefix, args[0]);
@@ -1101,7 +1221,7 @@ fn createTempFileFn(args: []const Value) PrimitiveError!Value {
 
     // Build template: prefix + XXXXXX + null
     var template_buf: [256]u8 = undefined;
-    if (prefix.len + 7 > template_buf.len) return raiseFileError(gc, "temp file prefix too long", if (args.len > 0) args[0] else types.FALSE);
+    if (prefix.len + 7 > template_buf.len) return raiseArgError(gc, "temp file prefix too long", if (args.len > 0) args[0] else types.FALSE);
     @memcpy(template_buf[0..prefix.len], prefix);
     @memcpy(template_buf[prefix.len..][0..6], "XXXXXX");
     template_buf[prefix.len + 6] = 0;

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -607,7 +607,7 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
         // spawned), so child_registry.storeResult -- which every *post-spawn*
         // failure in threadEntryFn goes through instead -- doesn't apply
         // here: this is the one place a fiber's error state is set directly.
-        fiber.current_exception = try makeErrorWithType(.general, "thread thunk contains an uncopyable type (port, continuation, etc.), or a channel owned by another thread", types.NIL);
+        fiber.current_exception = try makeErrorWithType(.general, "thread thunk contains an uncopyable type (port, continuation, fiber, mutex, condition variable, FFI callback, directory object, environment, ephemeron, guardian, or transport cell), or a channel owned by another thread", types.NIL);
         gc.writeBarrier(&fiber.header, fiber.current_exception.?);
         @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
         return args[0];
@@ -1292,7 +1292,7 @@ fn reapOsThread(target: *fiber_mod.Fiber, fiber_val: Value) PrimitiveError!Value
                     // handed -- gc_deep_copy.zig's `.channel` arm returns
                     // UncopyableType for both, so this message covers both
                     // rather than mis-describing the second as a type error.
-                    return raiseError(.general, "thread-join!: result contains an uncopyable type (port, continuation, etc.), or a channel owned by another thread", types.VOID);
+                    return raiseError(.general, "thread-join!: result contains an uncopyable type (port, continuation, fiber, mutex, condition variable, FFI callback, directory object, environment, ephemeron, guardian, or transport cell), or a channel owned by another thread", types.VOID);
                 }
                 return PrimitiveError.OutOfMemory;
             },

--- a/src/repl_commands.zig
+++ b/src/repl_commands.zig
@@ -484,6 +484,13 @@ fn describeSymbol(vm: *vm_mod.VM, name: []const u8) void {
                     const s = std.fmt.bufPrint(&abuf, "    arity: {d}+\n", .{min}) catch "";
                     writeStdout(s);
                 },
+                .range => |r| {
+                    const s = if (r.min == r.max)
+                        std.fmt.bufPrint(&abuf, "    arity: {d}\n", .{r.min}) catch ""
+                    else
+                        std.fmt.bufPrint(&abuf, "    arity: {d}..{d}\n", .{ r.min, r.max }) catch "";
+                    writeStdout(s);
+                },
             }
         } else if (obj.tag == .closure) {
             const cls = obj.as(types.Closure);

--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -464,7 +464,7 @@ fn run(allocator: std.mem.Allocator, argv0: []const u8, opts: *ParentOpts) u8 {
     {
         var sbuf: [32]u8 = undefined;
         const s = std.fmt.bufPrintZ(&sbuf, "{d}", .{seed}) catch return 1;
-        platform.setEnv(allocator, SEED_ENV, std.mem.sliceTo(s.ptr, 0)) catch return 1;
+        _ = platform.setEnv(allocator, SEED_ENV, std.mem.sliceTo(s.ptr, 0)) catch return 1;
     }
 
     var files: std.ArrayList([]const u8) = .empty;
@@ -771,7 +771,7 @@ fn spawnWorker(allocator: std.mem.Allocator, exe_path: []const u8, file: []const
     try argv.append(allocator, file);
 
     if (comptime platform.is_windows) {
-        platform.setEnv(allocator, EMIT_ENV, emit_path) catch {};
+        _ = platform.setEnv(allocator, EMIT_ENV, emit_path) catch {};
         // Same 1 MiB in-loop cap as the POSIX read loop below: the pipe
         // keeps draining past it, so a runaway worker can neither exhaust
         // memory here nor block on a full pipe.

--- a/src/tests_deepcopy.zig
+++ b/src/tests_deepcopy.zig
@@ -667,9 +667,20 @@ test "deepCopy file-info" {
     try std.testing.expect(val != copied);
     const fi = types.toObject(copied).as(types.FileInfo);
     try std.testing.expectEqual(types.ObjectTag.file_info, types.toObject(copied).tag);
+    // every field, so an omitted copy is caught
     try std.testing.expectEqual(@as(i64, 4), fi.size);
     try std.testing.expectEqual(@as(i64, 2000000), fi.mtime);
+    try std.testing.expectEqual(@as(i64, 1000000), fi.atime);
+    try std.testing.expectEqual(@as(i64, 3000000), fi.ctime);
+    try std.testing.expectEqual(@as(i64, 7), fi.dev);
+    try std.testing.expectEqual(@as(i64, 42), fi.ino);
+    try std.testing.expectEqual(@as(i64, 2), fi.nlinks);
+    try std.testing.expectEqual(@as(i64, 0), fi.rdev);
+    try std.testing.expectEqual(@as(i64, 4096), fi.blksize);
+    try std.testing.expectEqual(@as(i64, 8), fi.blocks);
     try std.testing.expectEqual(@as(u32, 0o100644), fi.mode);
+    try std.testing.expectEqual(@as(u32, 501), fi.uid);
+    try std.testing.expectEqual(@as(u32, 20), fi.gid);
     try std.testing.expectEqual(types.FileInfo.FileType.regular, fi.file_type);
 }
 
@@ -680,7 +691,7 @@ test "deepCopy user-info and group-info" {
     {
         var gc1 = memory.GC.init(std.testing.allocator);
         defer gc1.deinit();
-        const uval = try gc1.allocUserInfo("root", 0, 0, "/root", "/bin/sh", "root");
+        const uval = try gc1.allocUserInfo("root", 0, 20, "/root", "/bin/sh", "root");
         ucopy = try gc2.deepCopy(uval);
     }
     // the copy owns its own bytes — the source GC is already gone
@@ -688,6 +699,7 @@ test "deepCopy user-info and group-info" {
     try std.testing.expectEqual(types.ObjectTag.user_info, types.toObject(ucopy).tag);
     try std.testing.expectEqualStrings("root", ui.name);
     try std.testing.expectEqual(@as(u32, 0), ui.uid);
+    try std.testing.expectEqual(@as(u32, 20), ui.gid);
     try std.testing.expectEqualStrings("/bin/sh", ui.shell);
     try std.testing.expectEqualStrings("root", ui.full_name);
     try std.testing.expectEqualStrings("/root", ui.home_dir);

--- a/src/tests_deepcopy.zig
+++ b/src/tests_deepcopy.zig
@@ -637,3 +637,105 @@ test "deepCopy rejects continuation" {
     const cont = try gc1.allocEscapeContinuation(0, 0, 0, 0, 0);
     try std.testing.expectError(error.UncopyableType, gc2.deepCopy(cont));
 }
+
+// #1978: file-info / user-info / group-info are pure value records and now
+// cross the thread boundary by value, like SchemeString. Each test copies
+// into a *fresh* GC (the thread-join!/channel shape) and checks every field.
+test "deepCopy file-info" {
+    var gc1 = memory.GC.init(std.testing.allocator);
+    defer gc1.deinit();
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+
+    const val = try gc1.allocFileInfo(.{
+        .size = 4,
+        .mtime = 2000000,
+        .atime = 1000000,
+        .ctime = 3000000,
+        .dev = 7,
+        .ino = 42,
+        .nlinks = 2,
+        .rdev = 0,
+        .blksize = 4096,
+        .blocks = 8,
+        .mode = 0o100644,
+        .uid = 501,
+        .gid = 20,
+        .file_type = .regular,
+    });
+    const copied = try gc2.deepCopy(val);
+    try std.testing.expect(val != copied);
+    const fi = types.toObject(copied).as(types.FileInfo);
+    try std.testing.expectEqual(types.ObjectTag.file_info, types.toObject(copied).tag);
+    try std.testing.expectEqual(@as(i64, 4), fi.size);
+    try std.testing.expectEqual(@as(i64, 2000000), fi.mtime);
+    try std.testing.expectEqual(@as(u32, 0o100644), fi.mode);
+    try std.testing.expectEqual(types.FileInfo.FileType.regular, fi.file_type);
+}
+
+test "deepCopy user-info and group-info" {
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+    var ucopy: types.Value = undefined;
+    {
+        var gc1 = memory.GC.init(std.testing.allocator);
+        defer gc1.deinit();
+        const uval = try gc1.allocUserInfo("root", 0, 0, "/root", "/bin/sh", "root");
+        ucopy = try gc2.deepCopy(uval);
+    }
+    // the copy owns its own bytes — the source GC is already gone
+    const ui = types.toObject(ucopy).as(types.UserInfo);
+    try std.testing.expectEqual(types.ObjectTag.user_info, types.toObject(ucopy).tag);
+    try std.testing.expectEqualStrings("root", ui.name);
+    try std.testing.expectEqual(@as(u32, 0), ui.uid);
+    try std.testing.expectEqualStrings("/bin/sh", ui.shell);
+    try std.testing.expectEqualStrings("root", ui.full_name);
+    try std.testing.expectEqualStrings("/root", ui.home_dir);
+
+    var gc3 = memory.GC.init(std.testing.allocator);
+    defer gc3.deinit();
+    var gc4 = memory.GC.init(std.testing.allocator);
+    defer gc4.deinit();
+    const gval = try gc3.allocGroupInfo("wheel", 0);
+    const gcopy = try gc4.deepCopy(gval);
+    const gi = types.toObject(gcopy).as(types.GroupInfo);
+    try std.testing.expectEqual(types.ObjectTag.group_info, types.toObject(gcopy).tag);
+    try std.testing.expectEqualStrings("wheel", gi.name);
+    try std.testing.expectEqual(@as(u32, 0), gi.gid);
+}
+
+test "deepCopy error_object preserves posix_errno" {
+    var gc1 = memory.GC.init(std.testing.allocator);
+    defer gc1.deinit();
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+
+    const msg = try gc1.allocString("cannot stat file");
+    var msg_root = msg;
+    gc1.pushRoot(&msg_root);
+    defer gc1.popRoot();
+    const err = try gc1.allocErrorObjectCoded(msg, types.NIL, .invalid_argument);
+    var err_obj = types.toObject(err).as(types.ErrorObject);
+    err_obj.posix_errno = 2; // ENOENT
+    err_obj.error_type = .file;
+
+    const copied = try gc2.deepCopy(err);
+    const ce = types.toObject(copied).as(types.ErrorObject);
+    try std.testing.expectEqual(@as(c_int, 2), ce.posix_errno);
+    try std.testing.expectEqual(types.ErrorObject.ErrorType.file, ce.error_type);
+    try std.testing.expectEqual(.invalid_argument, ce.code);
+}
+
+test "deepCopy rejects directory_object" {
+    var gc1 = memory.GC.init(std.testing.allocator);
+    defer gc1.deinit();
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+
+    var dummy: u8 = 0;
+    const d = try gc1.allocDirectoryObject(&dummy, false);
+    // sweep would closedir() a live dir pointer on gc1.deinit; null it first
+    // (deepCopy rejects on the tag alone and never dereferences it)
+    types.toObject(d).as(types.DirectoryObject).dir = null;
+    try std.testing.expectError(error.UncopyableType, gc2.deepCopy(d));
+}

--- a/src/tests_ffi.zig
+++ b/src/tests_ffi.zig
@@ -239,11 +239,11 @@ test "ffi-open: bare name hitting an unloadable file under KAAPPI_HOME/lib repor
         @memcpy(old_buf[0..s.len], s);
         break :blk old_buf[0..s.len];
     } else null;
-    try platform.setEnv(std.testing.allocator, "KAAPPI_HOME", dir_path);
+    _ = try platform.setEnv(std.testing.allocator, "KAAPPI_HOME", dir_path);
     defer if (old_home) |v| {
-        platform.setEnv(std.testing.allocator, "KAAPPI_HOME", v) catch {};
+        _ = platform.setEnv(std.testing.allocator, "KAAPPI_HOME", v) catch {};
     } else {
-        platform.unsetEnv(std.testing.allocator, "KAAPPI_HOME") catch {};
+        _ = platform.unsetEnv(std.testing.allocator, "KAAPPI_HOME") catch {};
     };
 
     const msg = try ffiOpenErrorMessage(&ctx, "kaappi-test-home-garbage");

--- a/src/tests_gc_tracing.zig
+++ b/src/tests_gc_tracing.zig
@@ -1383,7 +1383,7 @@ test "gc tracing: heap-struct field inventory is unchanged" {
         "let_syntax_peer_vals", "bound_free_refs", "def_site_local_refs",
     });
     expectFields(types.ErrorObject, &.{
-        "header", "message", "irritants", "error_type", "uncaught_reason", "code",
+        "header", "message", "irritants", "error_type", "uncaught_reason", "code", "posix_errno",
     });
     expectFields(types.RecordInstance, &.{ "header", "record_type", "fields" });
     expectFields(types.Continuation, &.{

--- a/src/types.zig
+++ b/src/types.zig
@@ -337,6 +337,10 @@ pub const NativeFn = struct {
     pub const Arity = union(enum) {
         exact: u8,
         variadic: u8, // minimum args
+        /// A variadic with a documented upper bound (SRFI signatures like
+        /// SRFI-170's `(create-temp-file [prefix])`). Surplus arguments are
+        /// rejected as an arity mismatch rather than silently ignored.
+        range: struct { min: u8, max: u8 },
     };
 };
 
@@ -684,6 +688,7 @@ pub fn acceptsArgCount(v: Value, nargs: usize) bool {
         return switch (toObject(v).as(NativeFn).arity) {
             .exact => |n| nargs == n,
             .variadic => |min| nargs >= min,
+            .range => |r| nargs >= r.min and nargs <= r.max,
         };
     }
     if (isNativeClosure(v)) return nargs == toObject(v).as(NativeClosure).arity;

--- a/src/types_error.zig
+++ b/src/types_error.zig
@@ -38,4 +38,11 @@ pub const ErrorObject = struct {
     /// so it survives catch/re-raise and is the seed the Phase-4
     /// `error-object-code` accessor reads.
     code: diagnostics.Code = .uncategorized,
+    /// The `errno` captured at the failing syscall, or 0 when the error did
+    /// not come from a syscall (SRFI-170's posix-error protocol, #1978).
+    /// Snapshot the thread-local *before* any further libc call — the GC
+    /// and strerror(3) itself can clobber it. Stamped by the SRFI-170
+    /// raise sites in primitives_filesystem.zig; `posix-error?`/
+    /// `posix-error-name`/`posix-error-message` read it.
+    posix_errno: c_int = 0,
 };

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -641,6 +641,16 @@ fn checkNativeArity(vm: *VM, native: *types.NativeFn, nargs: usize) VMError!void
                 return VMError.ArityMismatch;
             }
         },
+        .range => |r| {
+            if (nargs < r.min) {
+                vm.setErrorDetail("'{s}': expected at least {d} arguments, got {d}", .{ native.name, r.min, nargs });
+                return VMError.ArityMismatch;
+            }
+            if (nargs > r.max) {
+                vm.setErrorDetail("'{s}': expected at most {d} arguments, got {d}", .{ native.name, r.max, nargs });
+                return VMError.ArityMismatch;
+            }
+        },
     }
 }
 

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -627,7 +627,7 @@ pub fn callClosure(vm: *VM, closure: *types.Closure, base: u32, nargs: u8) VMErr
 /// ReleaseSafe build that is a panic, i.e. a process abort out of ordinary
 /// Scheme (`(call-with-values cons list)` was enough), not the catchable
 /// ArityMismatch the closure path produces.
-fn checkNativeArity(vm: *VM, native: *types.NativeFn, nargs: usize) VMError!void {
+pub fn checkNativeArity(vm: *VM, native: *types.NativeFn, nargs: usize) VMError!void {
     switch (native.arity) {
         .exact => |expected| {
             if (nargs != expected) {

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -524,30 +524,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 } else if (types.isNativeFn(callee)) {
                     const native = types.toObject(callee).as(types.NativeFn);
                     if (self.profile_mode) native.profile_calls += 1;
-                    switch (native.arity) {
-                        .exact => |expected| {
-                            if (nargs != expected) {
-                                self.setErrorDetail("'{s}': expected {d} arguments, got {d}", .{ native.name, expected, nargs });
-                                return VMError.ArityMismatch;
-                            }
-                        },
-                        .variadic => |min| {
-                            if (nargs < min) {
-                                self.setErrorDetail("'{s}': expected at least {d} arguments, got {d}", .{ native.name, min, nargs });
-                                return VMError.ArityMismatch;
-                            }
-                        },
-                        .range => |r| {
-                            if (nargs < r.min) {
-                                self.setErrorDetail("'{s}': expected at least {d} arguments, got {d}", .{ native.name, r.min, nargs });
-                                return VMError.ArityMismatch;
-                            }
-                            if (nargs > r.max) {
-                                self.setErrorDetail("'{s}': expected at most {d} arguments, got {d}", .{ native.name, r.max, nargs });
-                                return VMError.ArityMismatch;
-                            }
-                        },
-                    }
+                    try vm_calls.checkNativeArity(self, native, nargs);
                     const saved_alloc_target = self.gc.profile_alloc_target;
                     if (self.profile_mode) {
                         vm_calls.profileCreditSelf(self);
@@ -746,30 +723,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     frame.ip = 0;
                 } else if (types.isNativeFn(proc)) {
                     const native = types.toObject(proc).as(types.NativeFn);
-                    switch (native.arity) {
-                        .exact => |expected| {
-                            if (count != expected) {
-                                self.setErrorDetail("'{s}': expected {d} arguments, got {d}", .{ native.name, expected, count });
-                                return VMError.ArityMismatch;
-                            }
-                        },
-                        .variadic => |min| {
-                            if (count < min) {
-                                self.setErrorDetail("'{s}': expected at least {d} arguments, got {d}", .{ native.name, min, count });
-                                return VMError.ArityMismatch;
-                            }
-                        },
-                        .range => |r| {
-                            if (count < r.min) {
-                                self.setErrorDetail("'{s}': expected at least {d} arguments, got {d}", .{ native.name, r.min, count });
-                                return VMError.ArityMismatch;
-                            }
-                            if (count > r.max) {
-                                self.setErrorDetail("'{s}': expected at most {d} arguments, got {d}", .{ native.name, r.max, count });
-                                return VMError.ArityMismatch;
-                            }
-                        },
-                    }
+                    try vm_calls.checkNativeArity(self, native, count);
                     // native.func may re-enter the VM and grow self.frames,
                     // invalidating `frame` — read dst before the call.
                     const return_dst = frame.dst;

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -537,6 +537,16 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                                 return VMError.ArityMismatch;
                             }
                         },
+                        .range => |r| {
+                            if (nargs < r.min) {
+                                self.setErrorDetail("'{s}': expected at least {d} arguments, got {d}", .{ native.name, r.min, nargs });
+                                return VMError.ArityMismatch;
+                            }
+                            if (nargs > r.max) {
+                                self.setErrorDetail("'{s}': expected at most {d} arguments, got {d}", .{ native.name, r.max, nargs });
+                                return VMError.ArityMismatch;
+                            }
+                        },
                     }
                     const saved_alloc_target = self.gc.profile_alloc_target;
                     if (self.profile_mode) {
@@ -746,6 +756,16 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         .variadic => |min| {
                             if (count < min) {
                                 self.setErrorDetail("'{s}': expected at least {d} arguments, got {d}", .{ native.name, min, count });
+                                return VMError.ArityMismatch;
+                            }
+                        },
+                        .range => |r| {
+                            if (count < r.min) {
+                                self.setErrorDetail("'{s}': expected at least {d} arguments, got {d}", .{ native.name, r.min, count });
+                                return VMError.ArityMismatch;
+                            }
+                            if (count > r.max) {
+                                self.setErrorDetail("'{s}': expected at most {d} arguments, got {d}", .{ native.name, r.max, count });
                                 return VMError.ArityMismatch;
                             }
                         },
@@ -1026,6 +1046,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const arity_ok = switch (native.arity) {
                         .exact => |expected| nargs == expected,
                         .variadic => |min| nargs >= min,
+                        .range => |r| nargs >= r.min and nargs <= r.max,
                     };
                     if (arity_ok and base + @as(u16, nargs) + 1 < self.registers.len) {
                         const args = self.registers[base + 1 .. base + 1 + nargs];

--- a/tests/scheme/audit/primitives_filesystem-audit.scm
+++ b/tests/scheme/audit/primitives_filesystem-audit.scm
@@ -793,6 +793,15 @@
      ;; enforced too.
      (test-equal "(raised? (lambda () (set-file-times p 'garbage' 'garbage')))" #t (raised? (lambda () (set-file-times p "garbage" "garbage"))))
      (test-equal "(raised? (lambda () (set-file-times p 5.0 5.0)))" #t (raised? (lambda () (set-file-times p 5.0 5.0))))
+     ;; SRFI-170 requires time-utc objects: a monotonic-clock object is
+     ;; rejected too, not written to utimensat as wall-clock seconds
+     (test-equal "(raised? (lambda () (set-file-times p (monotonic-time) (monotonic-time))))" #t
+                 (raised? (lambda () (set-file-times p (monotonic-time) (monotonic-time)))))
+     ;; ...while a genuine time-utc object round-trips; restore mtime to the
+     ;; 3000000 the earlier valid call set, so the "rejected calls did not
+     ;; touch the file" assertion below still pins the rejects.
+     (test-equal "(begin (set-file-times p (posix-time) (posix-time)) #t)" #t (begin (set-file-times p (posix-time) (posix-time)) #t))
+     (set-file-times p -2 3000000)
      (test-equal "(raised? (lambda () (set-file-times p 1000000)))" #t (raised? (lambda () (set-file-times p 1000000))))
      ;; Enabled control: the *path* argument of the same call is type-checked
      (test-equal "(raised? (lambda () (set-file-times 42)))" #t (raised? (lambda () (set-file-times 42))))
@@ -821,6 +830,7 @@
    (test-equal "(raised? (lambda () (create-directory (string-append dir ..." #t (raised? (lambda () (create-directory (string-append dir "/x") #o700 'extra))))
    (test-equal "(raised? (lambda () (create-fifo (string-append dir '/y')..." #t (raised? (lambda () (create-fifo (string-append dir "/y") #o600 'extra))))
    (test-equal "(raised? (lambda () (open-directory dir #t 'extra)))" #t (raised? (lambda () (open-directory dir #t 'extra))))
+   (test-equal "(raised? (lambda () (nice 0 'extra)))" #t (raised? (lambda () (nice 0 'extra))))
    ;; Enabled control: too *few* arguments is reported correctly
    (test-equal "(raised? (lambda () (file-info)))" #t (raised? (lambda () (file-info))))
    (test-equal "(raised? (lambda () (rename-file (string-append dir '/t'))))" #t (raised? (lambda () (rename-file (string-append dir "/t")))))
@@ -924,9 +934,11 @@
      (test-equal "(posix-error? 42)" #f (posix-error? 42))
      (test-equal "(posix-error? of a user (error ...))" #f (posix-error? (error "plain")))
      ;; ENOENT is the same value on every POSIX host
-     (test-equal "missing path: posix-error? + ENOENT + message"
-                 '(#t ENOENT "No such file or directory")
-                 (posix-of (lambda () (file-info nx #t))))
+     (test-equal "missing path: posix-error? + ENOENT + non-empty message"
+                 '(#t ENOENT #t)
+                 (let ((r (posix-of (lambda () (file-info nx #t)))))
+                   (list (car r) (cadr r)
+                         (and (string? (caddr r)) (> (string-length (caddr r)) 0)))))
      (test-equal "missing parent dir: posix-error? + ENOENT + string message"
                  '(#t ENOENT #t)
                  (let ((r (posix-of (lambda () (create-directory (string-append nx "/child"))))))
@@ -980,23 +992,29 @@
 ;; The SRFI-170 record types cross the boundary. file-info / user-info /
 ;; group-info are pure value records and have copied by value since #1978,
 ;; so each round-trips intact; directory-object holds a live `DIR*` and
-;; stays genuinely uncopyable, so it must at least fail *cleanly* — never
-;; corrupt, never crash. The ok? branch pins the copy, the guard pins the
-;; clean refusal.
+;; stays genuinely uncopyable, so it must be refused cleanly. The two
+;; helpers pin the directions separately: `copies?` fails if the transfer
+;; is refused, and `refused?` fails if the transfer succeeds — a future
+;; change letting a live `DIR*` cross (double-close, use-after-free) must
+;; turn the directory-object assertion red, not pass it via the guard.
 (with-scratch
  (lambda (dir)
    (write-file (string-append dir "/a") "abcd")
-   (define (out-of-thread thunk ok?)
-     (guard (e (#t (error-object? e)))
+   ;; The copy must succeed — a refusal must NOT be reported as success.
+   (define (copies? thunk ok?)
+     (guard (e (#t (list 'refused (and (error-object? e) (error-object-message e)))))
        (ok? (thread-join! (thread-start! (make-thread thunk))))))
-   (test-equal "(out-of-thread (lambda () (file-info (string-append dir '..." #t (out-of-thread (lambda () (file-info (string-append dir "/a") #t))
+   ;; The copy must be refused, and refused cleanly.
+   (define (refused? thunk)
+     (guard (e (#t (error-object? e)))
+       (begin (thread-join! (thread-start! (make-thread thunk))) 'copied)))
+   (test-equal "(copies? (lambda () (file-info (string-append dir '/a') #t)) ..." #t (copies? (lambda () (file-info (string-append dir "/a") #t))
                                  (lambda (v) (and (file-info? v) (= 4 (file-info:size v))))))
-   (test-equal "(out-of-thread (lambda () (user-info (user-uid))) (lambda..." #t (out-of-thread (lambda () (user-info (user-uid)))
+   (test-equal "(copies? (lambda () (user-info (user-uid))) ...)" #t (copies? (lambda () (user-info (user-uid)))
                                  (lambda (v) (and (user-info? v) (string? (user-info:name v))))))
-   (test-equal "(out-of-thread (lambda () (group-info (user-gid))) (lambd..." #t (out-of-thread (lambda () (group-info (user-gid)))
+   (test-equal "(copies? (lambda () (group-info (user-gid))) ...)" #t (copies? (lambda () (group-info (user-gid)))
                                  (lambda (v) (and (group-info? v) (string? (group-info:name v))))))
-   (test-equal "(out-of-thread (lambda () (open-directory dir)) (lambda (..." #t (out-of-thread (lambda () (open-directory dir))
-                                 (lambda (v) (begin (close-directory v) #t))))
+   (test-equal "a live directory-object is refused at the thread boundary" #t (refused? (lambda () (open-directory dir))))
    ;; the same value travelling *into* a child thread
    (let ((fi (file-info (string-append dir "/a") #t)))
      (test-equal "(guard (e (#t (error-object? e))) (thread-join! (thread-s..." #t (guard (e (#t (error-object? e)))

--- a/tests/scheme/audit/primitives_filesystem-audit.scm
+++ b/tests/scheme/audit/primitives_filesystem-audit.scm
@@ -10,7 +10,7 @@
 
 (import (scheme base) (scheme write) (scheme file) (srfi 170) (srfi 60))
 (import (scheme process-context) (srfi 64))
-(import (only (srfi 18) make-thread thread-start! thread-join! time? time->seconds))
+(import (only (srfi 18) make-thread thread-start! thread-join! time? time->seconds uncaught-exception-reason))
 
 ;; symlinks/FIFOs/uid-gid are POSIX-only — skip there. (After the imports:
 ;; the skip branch calls exit, which (scheme process-context) provides.)
@@ -722,38 +722,32 @@
 
 ;;; =====================================================================
 ;;; E. Optional arguments that are silently discarded when mistyped.
-;;;    Every disabled line below has an enabled control directly under it
-;;;    proving the *same* validation fires for an in-band-but-invalid value,
-;;;    so the gap is the type test, not a missing check.
+;;;    (#1977) The four procedures below now reject a mistyped optional
+;;;    argument instead of ignoring it, and the variadic specs carry an
+;;;    upper bound so surplus arguments are an arity mismatch. The old
+;;;    enabled controls that *pinned* the discarded-argument behaviour
+;;;    (create-directory /m4 succeeding with the default mode, create-temp-
+;;;    file 42 creating a file under the default prefix, set-file-times
+;;;    "garbage" stamping the file with the current clock) were removed —
+;;;    they are exactly the wrong results #1977 reported.
 ;;; =====================================================================
 
 (with-scratch
  (lambda (dir)
    ;; -- create-directory mode --
-   ;; FAIL: #1977 (a non-fixnum mode is silently discarded and 0o755 used:
-   ;; `if (args.len > 1 and types.isFixnum(args[1]))` in createDirectoryFn)
-   ;; (test-equal "(raised? (lambda () (create-directory (string-append dir ..." #t (raised? (lambda () (create-directory (string-append dir "/m1") "notanum"))))
+   (test-equal "(raised? (lambda () (create-directory (string-append dir ..." #t (raised? (lambda () (create-directory (string-append dir "/m1") "notanum"))))
+   ;; the range check still fires for an in-band-but-invalid mode
    (test-equal "(raised? (lambda () (create-directory (string-append dir ..." #t (raised? (lambda () (create-directory (string-append dir "/m2") #o10000))))
    (test-equal "(raised? (lambda () (create-directory (string-append dir ..." #t (raised? (lambda () (create-directory (string-append dir "/m3") -1))))
-   ;; the discarded-mode call succeeds outright, with the default mode
-   (create-directory (string-append dir "/m4") "notanum")
-   (test-equal "(file-info-type (file-info (string-append dir '/m4') #t))" 'directory (file-info-type (file-info (string-append dir "/m4") #t)))
 
    ;; -- create-fifo mode --
-   ;; FAIL: #1977 (same shape in createFifoFn — non-fixnum mode ignored, 0o664 used)
-   ;; (test-equal "(raised? (lambda () (create-fifo (string-append dir '/ff1..." #t (raised? (lambda () (create-fifo (string-append dir "/ff1") "notanum"))))
+   (test-equal "(raised? (lambda () (create-fifo (string-append dir '/ff1..." #t (raised? (lambda () (create-fifo (string-append dir "/ff1") "notanum"))))
    (test-equal "(raised? (lambda () (create-fifo (string-append dir '/ff2..." #t (raised? (lambda () (create-fifo (string-append dir "/ff2") #o10000))))
    (test-equal "(raised? (lambda () (create-fifo (string-append dir '/ff3..." #t (raised? (lambda () (create-fifo (string-append dir "/ff3") -1))))
 
    ;; -- create-temp-file prefix --
-   ;; FAIL: #1977 (a non-string prefix is silently discarded and the default
-   ;; temp-file-prefix used: `if (args.len > 0 and types.isString(args[0]))`)
-   ;; (test-equal "(raised? (lambda () (create-temp-file 42)))" #t (raised? (lambda () (create-temp-file 42))))
+   (test-equal "(raised? (lambda () (create-temp-file 42)))" #t (raised? (lambda () (create-temp-file 42))))
    (test-equal "(raised? (lambda () (create-temp-file (make-string 400 #\\..." #t (raised? (lambda () (create-temp-file (make-string 400 #\z)))))
-   (let ((t (create-temp-file 42)))
-     ;; it really did create a file — under the default prefix, not "42"
-     (test-equal "(file-exists? t)" #t (file-exists? t))
-     (delete-file t))
 
    ;; -- set-file-times --
    ;;
@@ -793,34 +787,40 @@
                    3000000 (file-info:mtime fi))
        (test-assert "(>= (file-info:atime fi) 1000000) after (set-file-times p -2 3000000)"
                     (>= (file-info:atime fi) 1000000)))
-     ;; FAIL: #1977 (a non-fixnum, non-time argument falls through to UTIME_NOW
-     ;; in timeArgToTimespec, so a mistyped time silently stamps the file with
-     ;; the current clock instead of raising)
-     ;; (test-equal "(raised? (lambda () (set-file-times p 'garbage' 'garbage')))" #t (raised? (lambda () (set-file-times p "garbage" "garbage"))))
-     ;; (test-equal "(raised? (lambda () (set-file-times p 5.0 5.0)))" #t (raised? (lambda () (set-file-times p 5.0 5.0))))
+     ;; (#1977) a non-fixnum, non-time argument used to fall through to
+     ;; UTIME_NOW and silently stamp the file with the current clock; it is
+     ;; now rejected, and SRFI-170's "exactly one time provided" rule is
+     ;; enforced too.
+     (test-equal "(raised? (lambda () (set-file-times p 'garbage' 'garbage')))" #t (raised? (lambda () (set-file-times p "garbage" "garbage"))))
+     (test-equal "(raised? (lambda () (set-file-times p 5.0 5.0)))" #t (raised? (lambda () (set-file-times p 5.0 5.0))))
+     (test-equal "(raised? (lambda () (set-file-times p 1000000)))" #t (raised? (lambda () (set-file-times p 1000000))))
      ;; Enabled control: the *path* argument of the same call is type-checked
      (test-equal "(raised? (lambda () (set-file-times 42)))" #t (raised? (lambda () (set-file-times 42))))
-     ;; and the discarded-time call does mutate the file, to "now"
-     (set-file-times p "garbage" "garbage")
-     (test-equal "(> (file-info:mtime (file-info p #t)) 1700000000)" #t (> (file-info:mtime (file-info p #t)) 1700000000)))
+     ;; and the file was *not* touched by the rejected calls: mtime is still
+     ;; the 3000000 the previous (valid) call set.
+     (test-equal "(file-info:mtime (file-info p #t)) after rejected calls" 3000000 (file-info:mtime (file-info p #t))))
 
    ;; -- nice --
-   ;; FAIL: #1977 (a non-fixnum increment is silently discarded and the default
-   ;; +1 applied, so `(nice "x")` really does renice the process:
-   ;; `if (args.len > 0 and types.isFixnum(args[0]))` in niceFn)
-   ;; (test-equal "(raised? (lambda () (nice 'x')))" #t (raised? (lambda () (nice "x"))))
-   ;; (test-equal "(raised? (lambda () (nice (expt 2 100))))" #t (raised? (lambda () (nice (expt 2 100)))))
+   ;; (#1977) a non-fixnum increment used to be treated as "no argument
+   ;; supplied" and silently renice the process by the default +1.
+   (test-equal "(raised? (lambda () (nice 'x')))" #t (raised? (lambda () (nice "x"))))
+   (test-equal "(raised? (lambda () (nice (expt 2 100))))" #t (raised? (lambda () (nice (expt 2 100)))))
    ;; Enabled control: a fixnum outside c_int *is* rejected, so the range
-   ;; check exists and only the type test is missing.
+   ;; check exists and only the type test was missing.
    (test-equal "(raised? (lambda () (nice 999999999999)))" #t (raised? (lambda () (nice 999999999999))))
    (test-equal "(exact-integer? (nice 0))" #t (exact-integer? (nice 0)))
 
-   ;; -- directory-files / file-info extra arguments --
-   ;; FAIL: #1977 (SRFI 170 caps these at 2 and 1 arguments respectively; the
-   ;; specs declare `.variadic` which has no upper bound, so surplus
-   ;; arguments are accepted and ignored rather than reported)
-   ;; (test-equal "(raised? (lambda () (file-info (string-append dir '/t') #..." #t (raised? (lambda () (file-info (string-append dir "/t") #t 'extra))))
-   ;; (test-equal "(raised? (lambda () (create-temp-file '/tmp/x' 'y')))" #t (raised? (lambda () (create-temp-file "/tmp/x" "y"))))
+   ;; -- directory-files / file-info / create-temp-file / ... extra args --
+   ;; (#1977) SRFI 170 caps these; the specs used to declare `.variadic`,
+   ;; which has no upper bound, so surplus arguments were accepted and
+   ;; ignored. Every variadic SRFI-170 primitive now declares a `.range`.
+   (test-equal "(raised? (lambda () (file-info (string-append dir '/t') #..." #t (raised? (lambda () (file-info (string-append dir "/t") #t 'extra))))
+   (test-equal "(raised? (lambda () (create-temp-file '/tmp/x' 'y')))" #t (raised? (lambda () (create-temp-file "/tmp/x" "y"))))
+   (test-equal "(raised? (lambda () (set-file-times p 1 2 3)))" #t (raised? (lambda () (set-file-times p 1 2 3))))
+   (test-equal "(raised? (lambda () (directory-files dir #t 'extra)))" #t (raised? (lambda () (directory-files dir #t 'extra))))
+   (test-equal "(raised? (lambda () (create-directory (string-append dir ..." #t (raised? (lambda () (create-directory (string-append dir "/x") #o700 'extra))))
+   (test-equal "(raised? (lambda () (create-fifo (string-append dir '/y')..." #t (raised? (lambda () (create-fifo (string-append dir "/y") #o600 'extra))))
+   (test-equal "(raised? (lambda () (open-directory dir #t 'extra)))" #t (raised? (lambda () (open-directory dir #t 'extra))))
    ;; Enabled control: too *few* arguments is reported correctly
    (test-equal "(raised? (lambda () (file-info)))" #t (raised? (lambda () (file-info))))
    (test-equal "(raised? (lambda () (rename-file (string-append dir '/t'))))" #t (raised? (lambda () (rename-file (string-append dir "/t")))))
@@ -846,24 +846,15 @@
 (test-equal "(assoc 'KAAPPI_A212_LIST' (get-environment-variables))" '("KAAPPI_A212_LIST" . "here") (assoc "KAAPPI_A212_LIST" (get-environment-variables)))
 (delete-environment-variable! "KAAPPI_A212_LIST")
 (test-equal "(assoc 'KAAPPI_A212_LIST' (get-environment-variables))" #f (assoc "KAAPPI_A212_LIST" (get-environment-variables)))
-;; FAIL: #1977 (setenv(3)'s return value is discarded — `_ = setenv(...)` in
-;; platform.setEnv — so setEnvVarFn's raiseFileError branch is unreachable and
-;; an EINVAL name silently does nothing.  A name containing "=" and an empty
-;; name are both rejected by POSIX; both return normally here and set nothing.)
-;; (test-equal "(raised? (lambda () (set-environment-variable! 'KAAPPI_A212_ABSENT=x' 'v')))" #t (raised? (lambda () (set-environment-variable! "KAAPPI_A212_ABSENT=x" "v"))))
-;; (test-equal "(raised? (lambda () (set-environment-variable! '' 'v')))" #t (raised? (lambda () (set-environment-variable! "" "v"))))
-;; Enabled control: the call really does nothing at all, under either spelling
-;; — neither the whole "name=value" string nor the part before the "=" ends up
-;; set.  Both names must be ones this test owns.  They used to be "KAAPPI=A212"
-;; and "KAAPPI", and "KAAPPI" is the name every harness in this repo uses for
-;; "the binary under test" (tests/scheme/shell-common.sh, both Windows CI
-;; `Shell suites` steps), so all three assertions went red the moment a runner
-;; exported it — for reasons with nothing to do with the code under test
-;; (kaappi#2162).
-(set-environment-variable! "KAAPPI_A212_ABSENT=x" "v")
-(test-equal "(get-environment-variable 'KAAPPI_A212_ABSENT')" #f (get-environment-variable "KAAPPI_A212_ABSENT"))
-(test-equal "(get-environment-variable 'KAAPPI_A212_ABSENT=x')" #f (get-environment-variable "KAAPPI_A212_ABSENT=x"))
-(test-equal "(assoc 'KAAPPI_A212_ABSENT' (get-environment-variables))" #f (assoc "KAAPPI_A212_ABSENT" (get-environment-variables)))
+;; (#1977) setenv(3)'s return used to be discarded — `_ = setenv(...)` in
+;; platform.setEnv — so an EINVAL name silently did nothing.  A name
+;; containing "=" and an empty name are both rejected by POSIX; both now
+;; raise a catchable posix error.  The old enabled control that pinned the
+;; "really does nothing" behaviour was removed — it is the wrong result
+;; #1977 reported.
+(test-equal "(raised? (lambda () (set-environment-variable! 'KAAPPI_A212_ABSENT=x' 'v')))" #t (raised? (lambda () (set-environment-variable! "KAAPPI_A212_ABSENT=x" "v"))))
+(test-equal "(raised? (lambda () (set-environment-variable! '' 'v')))" #t (raised? (lambda () (set-environment-variable! "" "v"))))
+(test-equal "(raised? (lambda () (delete-environment-variable! 'KAAPPI_A212_ABSENT=x')))" #t (raised? (lambda () (delete-environment-variable! "KAAPPI_A212_ABSENT=x"))))
 
 ;;; =====================================================================
 ;;; G. Error taxonomy — which failures are file errors?
@@ -893,20 +884,89 @@
      ;; ...and they name the procedure and the expected type
      (test-equal "type error in 'file-info:size': expected file-info, got 42"
                  (msg-of (lambda () (file-info:size 42))))
-     ;; FAIL: #1978 (pure argument-range validation is raised through
-     ;; raiseFileError, so `file-error?` answers #t for failures that never
-     ;; touched the filesystem.  These are argError/KP3007 cases — "a value of
-     ;; acceptable type the procedure rejects anyway" — not file errors.)
-     ;; (test-equal "(file-err? (lambda () (set-file-mode a #o10000)))" #f (file-err? (lambda () (set-file-mode a #o10000))))
-     ;; (test-equal "(file-err? (lambda () (set-umask! -1)))" #f (file-err? (lambda () (set-umask! -1))))
-     ;; (test-equal "(file-err? (lambda () (nice 999999999999)))" #f (file-err? (lambda () (nice 999999999999))))
-     ;; (test-equal "(file-err? (lambda () (create-temp-file (make-string 400 ..." #f (file-err? (lambda () (create-temp-file (make-string 400 #\z)))))
-     ;; Enabled control: each of those does raise, and with its own message
+     ;; (#1978) pure argument-range validation used to be raised through
+     ;; raiseFileError, so `file-error?` answered #t for failures that never
+     ;; touched the filesystem.  These are argError/KP3007 cases — "a value
+     ;; of acceptable type the procedure rejects anyway" — not file errors.
+     (test-equal "(file-err? (lambda () (set-file-mode a #o10000)))" #f (file-err? (lambda () (set-file-mode a #o10000))))
+     (test-equal "(file-err? (lambda () (set-umask! -1)))" #f (file-err? (lambda () (set-umask! -1))))
+     (test-equal "(file-err? (lambda () (nice 999999999999)))" #f (file-err? (lambda () (nice 999999999999))))
+     (test-equal "(file-err? (lambda () (create-temp-file (make-string 400 ..." #f (file-err? (lambda () (create-temp-file (make-string 400 #\z)))))
+     ;; ...they still raise, with their own message, stamped KP3007, and they
+     ;; are NOT posix errors (no syscall ran)
      (test-equal "mode value out of range" (msg-of (lambda () (set-file-mode a #o10000))))
      (test-equal "mode value out of range" (msg-of (lambda () (set-umask! -1))))
      (test-equal "nice value out of range" (msg-of (lambda () (nice 999999999999))))
      (test-equal "temp file prefix too long"
-                 (msg-of (lambda () (create-temp-file (make-string 400 #\z))))))))
+                 (msg-of (lambda () (create-temp-file (make-string 400 #\z)))))
+     (test-equal "(code-of (set-file-mode a #o10000)) is KP3007" 'KP3007
+                 (guard (e (#t (error-object-code e))) (set-file-mode a #o10000)))
+     (test-equal "(code-of (nice 999999999999)) is KP3007" 'KP3007
+                 (guard (e (#t (error-object-code e))) (nice 999999999999)))
+     (test-equal "(posix-error? of a range failure)" #f
+                 (guard (e (#t (posix-error? e))) (set-file-mode a #o10000))))))
+
+;;; ---------------------------------------------------------------------
+;;; G2. SRFI-170 §3.1 posix-error protocol (#1978).  A file error raised
+;;;      from a failing syscall carries the errno, so the three procedures
+;;;      can name and describe it; failures that never reached a syscall
+;;;      (type errors, argument-range errors, the embedded-NUL pre-check)
+;;;      answer #f to posix-error? and must not be handed to the accessors.
+;;; ---------------------------------------------------------------------
+
+(with-scratch
+ (lambda (dir)
+   (write-file (string-append dir "/a") "x")
+   (let ((a (string-append dir "/a")) (nx (string-append dir "/missing")))
+     (define (posix-of thunk)
+       (guard (e (#t (list (posix-error? e) (posix-error-name e) (posix-error-message e))))
+         (begin (thunk) 'no-raise)))
+     (test-equal "(posix-error? 42)" #f (posix-error? 42))
+     (test-equal "(posix-error? of a user (error ...))" #f (posix-error? (error "plain")))
+     ;; ENOENT is the same value on every POSIX host
+     (test-equal "missing path: posix-error? + ENOENT + message"
+                 '(#t ENOENT "No such file or directory")
+                 (posix-of (lambda () (file-info nx #t))))
+     (test-equal "missing parent dir: posix-error? + ENOENT + string message"
+                 '(#t ENOENT #t)
+                 (let ((r (posix-of (lambda () (create-directory (string-append nx "/child"))))))
+                   (list (car r) (cadr r) (string? (caddr r)))))
+     ;; a directory stream over a regular file is ENOTDIR
+     (test-equal "directory-files on a file: ENOTDIR + string message"
+                 '(#t ENOTDIR #t)
+                 (let ((r (posix-of (lambda () (directory-files a)))))
+                   (list (car r) (cadr r) (string? (caddr r)))))
+     ;; a symlink loop is ELOOP (stat follows); lstat does not loop
+     (create-symlink (string-append dir "/loopB") (string-append dir "/loopA"))
+     (create-symlink (string-append dir "/loopA") (string-append dir "/loopB"))
+     (test-equal "file-info on a symlink loop: ELOOP + string message"
+                 '(#t ELOOP #t)
+                 (let ((r (posix-of (lambda () (file-info (string-append dir "/loopA") #t)))))
+                   (list (car r) (cadr r) (string? (caddr r)))))
+     ;; EINVAL from setenv(3) is named and described
+     (test-equal "setenv EINVAL: posix-error? + EINVAL + string message"
+                 '(#t EINVAL #t)
+                 (let ((r (posix-of (lambda () (set-environment-variable! "KAAPPI_A212_G2=x" "v")))))
+                   (list (car r) (cadr r) (string? (caddr r)))))
+     ;; the accessors reject a non-posix error object
+     (test-equal "posix-error-name on a non-posix error raises" #t
+                 (guard (e (#t (error-object? e)))
+                   (posix-error-name (error "plain")) #f))
+     (test-equal "posix-error-name on 42 raises" #t
+                 (guard (e (#t (error-object? e)))
+                   (posix-error-name 42) #f))
+     (test-equal "posix-error-message on 42 raises" #t
+                 (guard (e (#t (error-object? e)))
+                   (posix-error-message 42) #f))
+     ;; a raised posix error round-trips through the boundary: thread-join!
+     ;; re-raises a wrapper whose reason carries the original exception, and
+     ;; the deep copy in gc_deep_copy.zig's .error_object arm preserved the
+     ;; errno through the child->parent copy
+     (test-equal "posix error crosses the thread boundary"
+                 '(#t ENOENT #t)
+                 (guard (e (#t (let ((r (uncaught-exception-reason e)))
+                                 (list (posix-error? r) (posix-error-name r) (string? (posix-error-message r))))))
+                   (thread-join! (thread-start! (make-thread (lambda () (file-info nx #t))))))))))
 
 ;;; =====================================================================
 ;;; H. Cross-heap deep copy across the SRFI-18 thread boundary (D6).
@@ -917,10 +977,12 @@
 (test-equal "(let ((t (thread-join! (thread-start! (make-thread (lambd..." #t (let ((t (thread-join! (thread-start! (make-thread (lambda () (posix-time)))))))
                  (and (time? t) (> (time->seconds t) 1700000000))))
 
-;; file-info / user-info / group-info / directory-object are listed as
-;; UncopyableType in gc_deep_copy.zig, so a value of any of them must at
-;; least fail *cleanly* — never corrupt, never crash.  The assertion is
-;; written so that a future fix making them copyable keeps it green.
+;; The SRFI-170 record types cross the boundary. file-info / user-info /
+;; group-info are pure value records and have copied by value since #1978,
+;; so each round-trips intact; directory-object holds a live `DIR*` and
+;; stays genuinely uncopyable, so it must at least fail *cleanly* — never
+;; corrupt, never crash. The ok? branch pins the copy, the guard pins the
+;; clean refusal.
 (with-scratch
  (lambda (dir)
    (write-file (string-append dir "/a") "abcd")

--- a/tests/scheme/audit/srfi18-deepcopy-matrix-audit.scm
+++ b/tests/scheme/audit/srfi18-deepcopy-matrix-audit.scm
@@ -567,20 +567,29 @@
 (define mk-group-info (srfi170 '(group-info (user-gid))))
 
 (when (constructible? mk-file-info)
-  (test-assert "IN file_info: refused child-side (wrapped)" (refuses-in? mk-file-info))
-  (test-assert "OUT file_info: refused at the join (direct)" (refuses-out? mk-file-info)))
+  (test-assert "IN file_info: crosses to the child intact (#1978)"
+               (let ((v (mk-file-info)))
+                 (crossed? (lambda () (file-info-directory? v)) (lambda (r) (eq? r #t)))))
+  (test-assert "OUT file_info: crosses back from the child intact (#1978)"
+               (crossed? (lambda () (mk-file-info)) (lambda (v) (file-info? v)))))
 
 (when (constructible? mk-directory)
   (test-assert "IN directory_object: refused child-side (wrapped)" (refuses-in? mk-directory))
   (test-assert "OUT directory_object: refused at the join (direct)" (refuses-out? mk-directory)))
 
 (when (constructible? mk-user-info)
-  (test-assert "IN user_info: refused child-side (wrapped)" (refuses-in? mk-user-info))
-  (test-assert "OUT user_info: refused at the join (direct)" (refuses-out? mk-user-info)))
+  (test-assert "IN user_info: crosses to the child intact (#1978)"
+               (let ((v (mk-user-info)))
+                 (crossed? (lambda () (string? (user-info:name v))) (lambda (r) (eq? r #t)))))
+  (test-assert "OUT user_info: crosses back from the child intact (#1978)"
+               (crossed? (lambda () (mk-user-info)) (lambda (v) (and (user-info? v) (string? (user-info:name v)))))))
 
 (when (constructible? mk-group-info)
-  (test-assert "IN group_info: refused child-side (wrapped)" (refuses-in? mk-group-info))
-  (test-assert "OUT group_info: refused at the join (direct)" (refuses-out? mk-group-info)))
+  (test-assert "IN group_info: crosses to the child intact (#1978)"
+               (let ((v (mk-group-info)))
+                 (crossed? (lambda () (string? (group-info:name v))) (lambda (r) (eq? r #t)))))
+  (test-assert "OUT group_info: crosses back from the child intact (#1978)"
+               (crossed? (lambda () (mk-group-info)) (lambda (v) (and (group-info? v) (string? (group-info:name v)))))))
 
 ;; ---------------------------------------------------------------------
 ;; Section E — the FFI wrapper tags

--- a/tests/scheme/srfi/srfi120-thread-boundary.scm
+++ b/tests/scheme/srfi/srfi120-thread-boundary.scm
@@ -14,7 +14,7 @@
 ;; tests/scheme/srfi/srfi18-sharing-model.scm for the general matrix):
 ;;
 ;;   COPY ROUTE -- a thread-start! thunk closure, a thread-join! result, a
-;;   channel message payload. Governed by gc_deep_copy.zig's fourteen-tag
+;;   channel message payload. Governed by gc_deep_copy.zig's eleven-tag
 ;;   uncopyable list. A <timer> holds a thread handle, which is a `.fiber`,
 ;;   which is on that list -- so a timer is structurally uncopyable and the
 ;;   copy fails as a whole.

--- a/tests/scheme/srfi/srfi18-sharing-model.scm
+++ b/tests/scheme/srfi/srfi18-sharing-model.scm
@@ -5,7 +5,7 @@
 ;; closure at thread-start!, the result at thread-join!, a channel message)
 ;; or by being reached through the shared globals map, by pointer, with no
 ;; copy at all. The two routes have separate, unrelated enforcement:
-;; gc_deep_copy.zig's fourteen-tag uncopyable list governs the copy route
+;; gc_deep_copy.zig's eleven-tag uncopyable list governs the copy route
 ;; only, and the globals route is checked by individual primitives for
 ;; exactly four types (channels, thread handles, fibers and guardians —
 ;; the last two added by #2001 and #2008), plus — since #1924 — a general
@@ -47,7 +47,7 @@
 (define (refused? r) (and (pair? r) (eq? (car r) 'raised)))
 
 ;; ---------------------------------------------------------------------------
-;; The copy route: fourteen tags are refused when captured lexically.
+;; The copy route: eleven tags are refused when captured lexically.
 ;; ---------------------------------------------------------------------------
 ;; Each `let` binding below is a genuine lexical capture, so the value is
 ;; part of the closure gc_deep_copy walks at thread-start!.


### PR DESCRIPTION
Two SRFI-170 audit findings (systematic audit v2, Phase 2.12, #1890), fixed together because they touch the same file and the same raise helpers.

## #1977 — mistyped arguments were silently discarded

| call | before | after |
|---|---|---|
| `(nice "x")` | renice'd the process by +1 (type test missing) | type error |
| `(set-environment-variable! "KA=B" "v")` | returned normally, set nothing (setenv return discarded) | posix error `EINVAL` |
| `(create-directory p "notanum")` | mode 0755 silently | type error |
| `(create-fifo p "notanum")` | mode 0664 silently | type error |
| `(create-temp-file 42)` | default prefix silently | type error |
| `(set-file-times p "garbage" "garbage")` | both stamps rewritten to now | type error |
| `(set-file-times p 1000000)` | one-time accepted | KP3007 (spec: exactly one time is an error) |
| `(file-info p #t 'extra)` | surplus arg ignored | arity mismatch |

The seven variadic SRFI-170 specs now declare a new `.range` arity (`min..max`) so surplus arguments are rejected at the arity layer (enforced in `vm_calls`/`vm_dispatch`/lint/LSP/REPL display).

## #1978 — posix-error protocol, error taxonomy, cross-thread records

- **`posix-error?` / `posix-error-name` / `posix-error-message`** (SRFI-170 §3.1) are exported from `(srfi 170)`. Every SRFI-170 syscall failure now stamps the captured `errno` onto the condition object (`ErrorObject.posix_errno`); `posix-error-name` scans Zig's per-OS `std.c.E` enums so names (`ENOENT`, `ENOTDIR`, `EACCES`, `ELOOP`, `ENAMETOOLONG`, …) are portable even though the numbers differ; `posix-error-message` is `strerror(3)`. Non-syscall raises pass errno 0 explicitly, so `posix-error?` stays `#f` for them.
- **Argument-range failures are no longer file errors.** `(set-file-mode p #o10000)`, `(set-umask! -1)`, `(nice 999999999999)`, out-of-range uid/gid and an over-long temp prefix are raised as KP3007 invalid-argument conditions (messages unchanged) and answer `#f` to `file-error?`.
- **`file-info` / `user-info` / `group-info` now cross the SRFI-18 thread boundary.** They are pure value records (scalars + owned string bytes) but were listed as `UncopyableType` beside ports/continuations/fibers; `gc_deep_copy.zig` copies them by value now (`directory-object` stays uncopyable — live `DIR*`). The "uncopyable type (port, continuation, etc.)" messages name the actual uncopyable set.

## Verification

- Audit suite's disabled `FAIL` rows for both issues enabled; bug-pinning controls removed
- New section G2: posix-error protocol matrix incl. errno survival through the thread boundary (`uncaught-exception-reason`)
- `srfi18-deepcopy-matrix-audit.scm` flips the three SRFI-170 rows from refused → cross
- `tests_deepcopy.zig`: unit tests for the three copyable types, the `directory-object` refusal, and `posix_errno` preservation on error-object deep copy
- `zig build test` green incl. `-Dgc-stress=true`; all 2099 Scheme files + 1395 R7RS tests pass; wasm + all 8 cross-compile targets build
