### PR TITLE
Fix SRFI 150 hygiene collapse: resolve field identity at expansion time (Fixes #2051)

### DIFF
--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -910,12 +910,14 @@ query macro: each `define-record-type` use attaches its own field/
 accessor-name pairs to the type name via `define-property`, a child
 reads its parent's via `lookup`, and `lookup` is only reachable from a
 procedural transformer, so `define-record-type` itself is a SRFI 211
-`er-macro-transformer` rather than an `em-syntax-rules` macro. Since this
-engine represents every identifier as a plain, hygiene-renamed symbol,
-plain `equal?` on that raw symbol already implements both
-bound-identifier=? and free-identifier=? for SRFI 213's stored names —
-specific to this engine's rename-by-spelling hygiene representation, not
-a portable assumption. This design surfaced the library global-resolution
+`er-macro-transformer` rather than an `em-syntax-rules` macro. (The
+matching and index resolution themselves happen entirely inside that
+transformer — see the kaappi#2051 paragraph below, which replaced an
+earlier scheme that stored field-name symbols in the property table and
+compared them by plain `equal?` on the raw, hygiene-renamed spelling.
+That scheme was unsound: quoted data strips the rename, so the stored
+symbols collapsed across hygienically-distinct fields.) This design
+surfaced the library global-resolution
 bug fixed in kaappi#1831, which first presented as `cadar` specifically —
 not `caar`/`cadr`/`cddr`, and not its own unrolled spelling
 `(cadr (car x))` — failing when called from a helper function invoked
@@ -927,20 +929,62 @@ cxr-only name (`cdddr`) sits inside the transformer's own lambda, which
 is evaluated at macro-definition time in the global environment and so
 never consults lib_env at all. The real rule was tail vs. non-tail
 position (see the SRFI 237 paragraph above); the idiomatic `cadar`
-spelling is back in `field-alist-ref`. SRFI 150 ships with one
-documented, unfixed gap rather than blocking on an engine fix: 21 of 25
-tests ported from the reference suite pass; the other 4 (two "Hygiene 1"
-assertions, one "Hygiene 2" assertion, and Alex Shinn's
-explicit-construction tuple
-example, marked `test-expect-fail`/annotated in
-`tests/scheme/srfi/srfi150.scm`) hit a precise, minimal, record-free
-reproduction (kaappi#1832) of the already-documented "a use-site
-top-level redefinition of a referenced name reaches the expansion"
-limitation noted in the SRFI 211 paragraph below — a `syntax-rules`
-template's own field-name literal can lose its hygienic rename on one of
-two internal re-expansions specifically when it collides in spelling
-with a pre-existing top-level binding, which is exactly the adversarial
-case SRFI 150's own hygiene tests are designed to probe. Issue #1694 (the
+spelling is back in `field-alist-ref`.
+
+SRFI 150's own final design (kaappi#2051) then had to be reworked twice:
+field identity was originally carried from expansion time to run time
+inside `quote`, on the theory that the engine's rename-by-spelling
+hygiene representation made the stored symbol's full spelling a sufficient
+runtime key. It is not: the compiler strips a `__hyg_N_` rename from any
+quoted datum (`compileQuote`'s `stripHygieneFromDatum`, which is correct
+and required — a `syntax-rules` template's `'foo` must yield `foo`, not
+`__hyg_1_foo`), so two hygienically-distinct field identifiers whose
+spellings strip to the same name (a macro template's own field-name
+literal and the same-spelled identifier the use site supplies, e.g.
+`__hyg_2_a` and `a`) collapsed into one runtime field. All four of the
+reference suite's hygiene assertions failed on it, and the defect was
+misattributed to kaappi#1832 (a pre-existing top-level binding of the
+colliding spelling is NOT required — the no-binding control fails
+identically). The current design therefore resolves field identity
+ENTIRELY at macro-expansion time, while the renamed symbols are still in
+hand, and never round-trips a hygienic symbol through `quote`:
+
+* A constructor spec entry matches the current form's own fields by
+    FULL spelling (same template identifier, same gensym — this engine's
+    bound-identifier=?), then inherited fields by hygiene-STRIPPED
+    spelling against the parent's stored property (free-identifier=? for
+    the top-level bindings a parent's field name actually refers to), and
+    resolves to a numeric ABSOLUTE index into the full
+    (inherited-then-own) field layout. `named-constructor` fills the
+    record's field vector by index; no by-name lookup happens at run
+    time.
+* Each own field gets a runtime name for the record-type-descriptor
+    and accessor/mutator creation: its stripped spelling, deduped with a
+    numeric suffix when two own fields strip to the same name (the
+    Hygiene 1 shape); a non-identifier constant field name gets a
+    generated `field-<index>` name (the rtd layer requires a symbol). An
+    own field matching an inherited field's stripped spelling is
+    deliberately NOT deduped — that is ordinary shadowing, resolved
+    own-fields-first at run time.
+* The property table stores the parent's total field count plus an
+    alist of stripped-spelling KEYs to absolute indices — keys and
+    indices only, no renamed symbols.
+
+One separate hazard surfaced while re-enabling the tests: the emitted
+type-name binding is also emitted hygiene-STRIPPED, because a
+macro-introduced `__hyg_N_<t>` reference whose base `<t>` is an
+already-bound global is intercepted by the #1832 referential-transparency
+alias (it loads the PRE-EXISTING global's value for every such reference,
+even inside the same expansion that defines it), so the accessors would
+bind against the old record type when a macro redefines an already-bound
+type name. The type name is a define target, not a genuinely free
+reference, so the stripped spelling is the correct emission — it rebinds
+the global like any top-level redefinition (R7RS 5.3.1) and matches what
+SRFI 131 emits for its type names. The reference suite now passes in
+full; `tests/scheme/srfi/srfi150.scm` adds the issue's discriminating
+controls (the no-binding C5 variant, the non-colliding-spelling C6
+control, constant field names, and the quoted-`__hyg_`-strip note) as
+regression tests. Issue #1694 (the
 numeric-vector and array family) is now fully closed: the vector-family
 subset — 4 (already shipped pre-Phase-4, just undocumented until Phase 4
 Slice 4), 160, 66, 74 — shipped in Phase 4 Slice 4 on one shared native

--- a/lib/srfi/150.sld
+++ b/lib/srfi/150.sld
@@ -163,7 +163,11 @@
   ;; below. They used to arrive with (scheme base), which reserved their
   ;; names against every user library (kaappi#1856).
   (import (scheme base) (srfi 211 explicit-renaming) (srfi 213)
-          (srfi 237) (srfi 237 primitives) (kaappi primitives))
+          (srfi 237) (srfi 237 primitives) (kaappi primitives)
+          ;; string-prefix?/string-index are (srfi 13) exports; imported
+          ;; explicitly rather than relying on the vm.globals fallback
+          ;; (the #1831 hazard this file's header documents below).
+          (only (srfi 13) string-prefix? string-index))
   (export define-record-type)
   (begin
 
@@ -246,14 +250,20 @@
     ;; Per-own-field expansion-time data, walked once. Returns three
     ;; values: the runtime names (one per field, deduped), the own alist
     ;; keyed by FULL spelling (for in-form, bound-identifier=-style
-    ;; matching; field-name key before accessor-name key per SRFI 150's
-    ;; precedence rule), and the property alist keyed by STRIPPED
-    ;; spelling (for a child's cross-form matching). `base` is the number
-    ;; of inherited fields, so own field i sits at absolute index base+i.
+    ;; matching), and the property alist keyed by STRIPPED spelling (for a
+    ;; child's cross-form matching). In both alists every field-name key
+    ;; precedes every accessor-name key (SRFI 150: a label that is both a
+    ;; field name and an accessor name resolves to the field, whatever the
+    ;; two fields' relative order), preserving field order within each
+    ;; group. `base` is the number of inherited fields, so own field i
+    ;; sits at absolute index base+i.
     (define (own-field-data specs base)
-      (let loop ((specs specs) (i 0) (used '()) (rnames '()) (okeys '()) (oprops '()))
+      (let loop ((specs specs) (i 0) (used '()) (rnames '())
+                 (fkeys '()) (akeys '()) (fprops '()) (aprops '()))
         (if (null? specs)
-            (values (reverse rnames) (reverse okeys) (reverse oprops))
+            (values (reverse rnames)
+                    (append (reverse fkeys) (reverse akeys))
+                    (append (reverse fprops) (reverse aprops)))
             (let* ((fs (car specs))
                    (abs (+ base i))
                    (cand (if (symbol? (car fs))
@@ -267,17 +277,18 @@
                     (+ i 1)
                     (cons nm used)
                     (cons nm rnames)
-                    (cons (cons field-key abs) (cons (cons acc-key abs) okeys))
-                    (cons (cons (hygiene-strip-key field-key) abs)
-                          (cons (cons (hygiene-strip-key acc-key) abs) oprops)))))))
+                    (cons (cons field-key abs) fkeys)
+                    (cons (cons acc-key abs) akeys)
+                    (cons (cons (hygiene-strip-key field-key) abs) fprops)
+                    (cons (cons (hygiene-strip-key acc-key) abs) aprops))))))
 
     ;; Resolve one constructor-spec entry to its absolute index: own
     ;; fields first (full spelling), then inherited fields (stripped
     ;; spelling against the parent's stored property). The precedence
     ;; rule -- a name that is both a field name and an accessor name
-    ;; resolves to the FIELD -- falls out of the alists' ordering:
-    ;; within each field's pair of keys the field name comes first, and
-    ;; the entries are in field order.
+    ;; resolves to the FIELD -- falls out of the alists' ordering: every
+    ;; field-name key precedes every accessor-name key, in field order
+    ;; (see own-field-data).
     (define (field-alist-ref key alist)
       (cond
         ((null? alist) #f)

--- a/lib/srfi/150.sld
+++ b/lib/srfi/150.sld
@@ -75,39 +75,75 @@
 ;;;     211's `capture-lookup` convention; `em-syntax-rules`/plain
 ;;;     syntax-rules transformers have no way to receive a procedure), so
 ;;;     define-record-type itself is an er-macro-transformer, not an
-;;;     em-syntax-rules macro. This turns out to simplify the hygienic
-;;;     comparison too: since this engine represents every identifier as
-;;;     a plain, hygiene-renamed symbol (see lib/srfi/211/explicit-
-;;;     renaming.sld's own header), and SRFI 213's property storage keeps
-;;;     a stored value exactly as given (it is not itself macro-expanded
-;;;     or re-processed), a stored field-name/accessor-name symbol was
-;;;     believed to retain its full hygienic spelling (rename prefix
-;;;     included) across the definition/lookup boundary, so that plain
-;;;     `equal?` on that raw symbol would already implement both
-;;;     bound-identifier=? and free-identifier=? with no
-;;;     em-bound-identifier=?-style machinery at all.
+;;;     em-syntax-rules macro.
 ;;;
-;;;     *** THAT IS FALSE -- see kaappi#2051. *** The rename does NOT
-;;;     survive the boundary, because this library carries field names
-;;;     across it inside `quote`, and quoting strips the hygiene prefix:
-;;;     (eq? '__hyg_2_a 'a) is #t. Expansion is correct (`kaappi expand`
-;;;     shows the two names properly distinguished), and both then strip
-;;;     to the same bare symbol before the runtime by-name lookup below
-;;;     ever sees them, so two hygienically-distinct fields collapse into
-;;;     one. This is what all four KNOWN FAILURES in
-;;;     tests/scheme/srfi/srfi150.scm are; the claim above was previously
-;;;     recorded as "verified against the exact scenario each SRFI 150
-;;;     hygiene test group requires", which is precisely the scenario
-;;;     that fails. A fix has to stop round-tripping hygienic identity
-;;;     through `quote` -- resolve field names entirely at expansion
-;;;     time, or key the property table on something that is not a quoted
-;;;     symbol. The rename-by-spelling representation described here is
-;;;     otherwise accurate, and is specific to this
-;;;     engine's rename-by-spelling hygiene representation, noted as a
-;;;     `(srfi 213)` conformance property already ("nominal... matching
-;;;     this symbol-based expander's identity model") -- a portable
-;;;     implementation on a syntax-object-based Scheme could not assume
-;;;     this and would need real bound-identifier=?/free-identifier=?.
+;;; The hygienic comparison and the constructor's field-name resolution
+;;; BOTH happen entirely at macro-expansion time, against the already-
+;;; hygiene-renamed form the expander hands the transformer. Nothing
+;;; hygienic is carried into runtime data at all, which is the point of
+;;; the redesign (kaappi#2051):
+;;;
+;;;   * Field identity is resolved to a numeric ABSOLUTE index into the
+;;;     full (inherited-then-own) field layout while the transformer still
+;;;     has the renamed symbols in hand: a constructor spec entry first
+;;;     matches the current form's own fields by FULL spelling (the same
+;;;     template identifier renames to the same gensym within one
+;;;     expansion, so this is bound-identifier=? in this engine's
+;;;     rename-by-spelling model), then falls back to the parent's stored
+;;;     entries matched by hygiene-STRIPPED spelling (free-identifier=?
+;;;     for the top-level bindings a parent's field name actually refers
+;;;     to). The named constructor then fills the record's field vector by
+;;;     index; no field name ever crosses the expansion/runtime boundary
+;;;     to be looked up by name at run time.
+;;;
+;;;   * Each own field gets a RUNTIME NAME for the record-type-descriptor
+;;;     and for `record-accessor`/`record-mutator` creation: the field
+;;;     name's hygiene-stripped spelling, or -- when two own fields of one
+;;;     type strip to the same spelling (the Hygiene 1 shape: a macro
+;;;     template's own field-name literal colliding in spelling with the
+;;;     identifier the use site supplies, e.g. `__hyg_2_a` and `a`) -- the
+;;;     stripped spelling with a numeric suffix, deduped against the type's
+;;;     other own fields. These runtime names are quoted data and must
+;;;     survive `quote` intact, so they are never hygiene-renamed; a
+;;;     non-identifier constant field name (a number, string, boolean, or
+;;;     character) has no spelling to preserve and gets a generated
+;;;     `field-<index>` name instead (the rtd layer requires a symbol).
+;;;     An own field whose stripped spelling matches an inherited field's
+;;;     is fine and deliberately NOT deduped -- that is ordinary shadowing
+;;;     (SRFI 150: "field names in children shadow field names in
+;;;     parents"), and the runtime by-name walk resolves own-fields-first
+;;;     anyway.
+;;;
+;;;   * The property table stores, per type, the type's TOTAL field count
+;;;     (the child's own-field base) plus an alist mapping each field's
+;;;     (and accessor's) stripped-spelling KEY to its absolute index --
+;;;     keys and indices only, never runtime names and never renamed
+;;;     symbols. Matching keys for a child's inherited-field reference are
+;;;     the parent's stored stripped spellings, which is what makes
+;;;     cross-form matching work at all: a rename gensym is
+;;;     per-expansion, so a child could never reproduce a parent's
+;;;     `__hyg_N_` spelling to compare against it.
+;;;
+;;;   * The emitted TYPE-NAME binding is the hygiene-stripped spelling,
+;;;     not the renamed one: the type name is a define target, and a
+;;;     template-introduced `__hyg_N_<t>` reference whose base `<t>` is an
+;;;     already-bound global is intercepted by the engine's #1832
+;;;     referential-transparency alias (it loads the PRE-EXISTING global's
+;;;     value for every such reference, even inside the same expansion
+;;;     that defines it), so accessors and constructor would bind against
+;;;     the OLD record type whenever a macro redefined an already-bound
+;;;     type name. The bare spelling rebinds the global like any top-level
+;;;     redefinition (R7RS 5.3.1) and matches what SRFI 131 emits for its
+;;;     type names; the property table key strips either way.
+;;;
+;;; This is specific to this engine's rename-by-spelling hygiene
+;;; representation, noted as a `(srfi 213)` conformance property already
+;;; ("nominal... matching this symbol-based expander's identity model") --
+;;; a portable implementation on a syntax-object-based Scheme could not
+;;; assume it and would need real bound-identifier=?/free-identifier=?.
+;;; The reference implementation's own test suite (ported verbatim in
+;;; tests/scheme/srfi/srfi150.scm) passes in full; the four assertions it
+;;; used to mark `test-expect-fail` for kaappi#2051 are now unmarked.
 ;;;
 ;;; `field-alist-ref` below spelled its second-element lookup as the
 ;;; unrolled `(cadr (car alist))` until kaappi#1831 was fixed. `cadar`
@@ -133,71 +169,131 @@
 
     ;; ------------------------------------------------------------------
     ;; Runtime helpers -- adapted from lib/srfi/131.sld's own named-
-    ;; constructor and index-resolution machinery. `field` here is always
-    ;; a field's own canonical name (a plain datum), already resolved
-    ;; hygienically by resolve-field-name below at macro-expansion time,
-    ;; so no hygiene concern reaches this layer.
+    ;; constructor machinery. `indices` is a list of ABSOLUTE indices
+    ;; into the full (inherited-then-own) field layout, resolved
+    ;; hygienically at macro-expansion time, so no hygiene concern
+    ;; reaches this layer and no runtime by-name lookup happens at all.
     ;; ------------------------------------------------------------------
 
     (define (fresh-rcd rtd)
       (let ((parent (record-type-parent rtd)))
         (make-record-descriptor rtd (if parent (fresh-rcd parent) #f) #f)))
 
-    (define (field-index rtd name)
-      (let ((parent (record-type-parent rtd)))
-        (let ((parent-count (if parent (%record-type-total-field-count parent) 0)))
-          ;; %record-type-field-names, not the public record-type-field-names:
-          ;; the public one answers with a vector (R6RS), the primitive with
-          ;; the list this walk wants.
-          (field-index-loop rtd name parent (%record-type-field-names rtd) parent-count))))
-
-    (define (field-index-loop rtd name parent names i)
-      (cond
-        ((null? names) (if parent (field-index parent name) (error "unknown field" name)))
-        ((equal? (car names) name) i)
-        (else (field-index-loop rtd name parent (cdr names) (+ i 1)))))
-
-    (define (named-constructor rtd field-names)
+    (define (named-constructor rtd indices)
       (let ((total (%record-type-total-field-count rtd)))
         (lambda args
           (let ((field-values (make-vector total (if #f #f))))
-            (named-constructor-fill! rtd field-values field-names args)
+            (named-constructor-fill! field-values indices args)
             (apply %make-record rtd (vector->list field-values))))))
 
-    (define (named-constructor-fill! rtd field-values field-names args)
-      (if (null? field-names)
+    (define (named-constructor-fill! field-values indices args)
+      (if (null? indices)
           (if #f #f)
-          (let ((idx (field-index rtd (car field-names))))
-            (vector-set! field-values idx (car args))
-            (named-constructor-fill! rtd field-values (cdr field-names) (cdr args)))))
+          (begin
+            (vector-set! field-values (car indices) (car args))
+            (named-constructor-fill! field-values (cdr indices) (cdr args)))))
 
     ;; ------------------------------------------------------------------
-    ;; Hygienic field-name resolution -- see the header comment for why
-    ;; plain `equal?` on the raw (possibly hygiene-renamed) symbol is
-    ;; correct here. `alist` entries are (field-name accessor-name).
-    ;; Field names take precedence over accessor names (field-name
-    ;; checked first), and own fields shadow inherited ones (own-alist
-    ;; checked entirely before parent-alist), per SRFI 150's own stated
-    ;; precedence rules.
+    ;; Expansion-time helpers. Everything below runs inside the
+    ;; transformer's lambda -- or in a library-level helper it calls --
+    ;; against the hygiene-renamed `form` the expander hands it.
     ;; ------------------------------------------------------------------
 
-    (define (field-alist-ref field alist)
+    ;; hygiene-strip-name mirrors types.stripHygienicPrefix: remove a
+    ;; `__hyg_<n>_` gensym prefix (and a `__kaappi_defenv__<lib>\x1f`
+    ;; definition-environment prefix), looping, leaving the underlying
+    ;; name. A name that merely starts with one of the markers but has no
+    ;; separator (e.g. `__hyg_foo` or `__kaappi_defenv__foo`) is left
+    ;; untouched, exactly as the engine's own quote-time stripping does.
+    (define (hygiene-strip-name s)
+      (let loop ((s s))
+        (cond
+          ((and (string-prefix? "__hyg_" s)
+                (string-index s #\_ 6))
+           => (lambda (sep)
+                (loop (substring s (+ sep 1) (string-length s)))))
+          ((string-prefix? "__kaappi_defenv__" s)
+           (let ((rest (substring s (string-length "__kaappi_defenv__"))))
+             (if (string-index rest #\x1f)
+                 (loop (substring rest (+ (string-index rest #\x1f) 1)))
+                 s)))
+          (else s))))
+
+    ;; A matching KEY for a field/accessor name: the name's hygiene-
+    ;; stripped spelling when it is an identifier, the datum itself (a
+    ;; constant) otherwise. An identifier is never equal? to a constant,
+    ;; so the two kinds never collide in an alist lookup.
+    (define (hygiene-strip-key x)
+      (if (symbol? x)
+          (string->symbol (hygiene-strip-name (symbol->string x)))
+          x))
+
+    ;; The runtime name of an own field: its stripped spelling, with a
+    ;; numeric suffix appended while the candidate collides with an
+    ;; already-assigned runtime name of the same type (two own fields
+    ;; stripping to one spelling -- the kaappi#2051 shape). `used` is the
+    ;; list of runtime names assigned so far.
+    (define (dedupe-name name used)
+      (if (not (member name used))
+          name
+          (let loop ((n 2))
+            (let ((cand (string->symbol
+                         (string-append (symbol->string name) "-" (number->string n)))))
+              (if (not (member cand used))
+                  cand
+                  (loop (+ n 1)))))))
+
+    ;; Per-own-field expansion-time data, walked once. Returns three
+    ;; values: the runtime names (one per field, deduped), the own alist
+    ;; keyed by FULL spelling (for in-form, bound-identifier=-style
+    ;; matching; field-name key before accessor-name key per SRFI 150's
+    ;; precedence rule), and the property alist keyed by STRIPPED
+    ;; spelling (for a child's cross-form matching). `base` is the number
+    ;; of inherited fields, so own field i sits at absolute index base+i.
+    (define (own-field-data specs base)
+      (let loop ((specs specs) (i 0) (used '()) (rnames '()) (okeys '()) (oprops '()))
+        (if (null? specs)
+            (values (reverse rnames) (reverse okeys) (reverse oprops))
+            (let* ((fs (car specs))
+                   (abs (+ base i))
+                   (cand (if (symbol? (car fs))
+                             (hygiene-strip-key (car fs))
+                             (string->symbol
+                              (string-append "field-" (number->string abs)))))
+                   (nm (dedupe-name cand used))
+                   (field-key (car fs))
+                   (acc-key (cadr fs)))
+              (loop (cdr specs)
+                    (+ i 1)
+                    (cons nm used)
+                    (cons nm rnames)
+                    (cons (cons field-key abs) (cons (cons acc-key abs) okeys))
+                    (cons (cons (hygiene-strip-key field-key) abs)
+                          (cons (cons (hygiene-strip-key acc-key) abs) oprops)))))))
+
+    ;; Resolve one constructor-spec entry to its absolute index: own
+    ;; fields first (full spelling), then inherited fields (stripped
+    ;; spelling against the parent's stored property). The precedence
+    ;; rule -- a name that is both a field name and an accessor name
+    ;; resolves to the FIELD -- falls out of the alists' ordering:
+    ;; within each field's pair of keys the field name comes first, and
+    ;; the entries are in field order.
+    (define (field-alist-ref key alist)
       (cond
         ((null? alist) #f)
-        ((equal? field (caar alist)) (caar alist))
-        ((equal? field (cadar alist)) (caar alist))
-        (else (field-alist-ref field (cdr alist)))))
+        ((equal? key (caar alist)) (cdar alist))
+        (else (field-alist-ref key (cdr alist)))))
 
-    (define (resolve-field-name field own-alist parent-alist)
-      (or (field-alist-ref field own-alist)
-          (field-alist-ref field parent-alist)
+    (define (resolve-field-index field own-keys parent-map)
+      (or (field-alist-ref field own-keys)
+          (field-alist-ref (hygiene-strip-key field) parent-map)
           (error "record field not found" field)))
 
-    (define (resolve-field-names fields own-alist parent-alist)
+    (define (resolve-field-indices fields own-keys parent-map)
       (if (null? fields)
           '()
-          (cons (resolve-field-name (car fields) own-alist parent-alist)
-                (resolve-field-names (cdr fields) own-alist parent-alist))))
+          (cons (resolve-field-index (car fields) own-keys parent-map)
+                (resolve-field-indices (cdr fields) own-keys parent-map))))
 
     (define (keep-truthy lst)
       (cond
@@ -218,48 +314,68 @@
                 (field-specs (cdr (cdddr form)))
                 (name (if (pair? type-spec) (car type-spec) type-spec))
                 (parent (if (pair? type-spec) (cadr type-spec) #f))
-                (own-alist (map (lambda (fs) (list (car fs) (cadr fs))) field-specs)))
+                ;; The emitted binding name for the type. Deliberately the
+                ;; hygiene-STRIPPED spelling, not the renamed one `name`: the
+                ;; type name is a define target, and a template-introduced
+                ;; __hyg_N_<t> reference whose base <t> is an already-bound
+                ;; global is intercepted by the engine's #1832 referential-
+                ;; transparency alias (it loads the PRE-EXISTING global's
+                ;; value for every __hyg_N_<t> reference, even inside the
+                ;; same expansion that defines it), so the accessors and
+                ;; constructor would bind against the OLD record type. The
+                ;; bare spelling rebinds the global like any top-level
+                ;; redefinition (R7RS 5.3.1), and matches what SRFI 131
+                ;; emits for its type names; the property table key strips
+                ;; either way.
+                (type-name (hygiene-strip-key name)))
            (capture-lookup
             (lambda (lookup)
-              (let* ((parent-alist (if parent (lookup parent 'srfi150-fields) '()))
-                     (field-vec-spec
-                      (map (lambda (fs)
-                             (list (if (>= (length fs) 3) 'mutable 'immutable) (car fs)))
-                           field-specs))
+              (let* ((parent-data (if parent (lookup parent 'srfi150-fields) #f))
+                     (parent-count (if parent-data (car parent-data) 0))
+                     (parent-map (if parent-data (cadr parent-data) '()))
+                     (own-data (own-field-data field-specs parent-count)))
+                (let-values (((runtime-names own-keys own-property) own-data))
+                  (let* ((field-vec-spec
+                      (map (lambda (fs nm)
+                             (list (if (>= (length fs) 3) 'mutable 'immutable) nm))
+                           field-specs runtime-names))
                      (accessor-defs
-                      (map (lambda (fs)
+                      (map (lambda (fs nm)
                              (list (rename 'define) (cadr fs)
-                                   (list (rename 'record-accessor) name (list (rename 'quote) (car fs)))))
-                           field-specs))
+                                   (list (rename 'record-accessor) type-name
+                                         (list (rename 'quote) nm))))
+                           field-specs runtime-names))
                      (mutator-defs
                       (keep-truthy
-                       (map (lambda (fs)
+                       (map (lambda (fs nm)
                               (and (>= (length fs) 3)
                                    (list (rename 'define) (car (cddr fs))
-                                         (list (rename 'record-mutator) name (list (rename 'quote) (car fs))))))
-                            field-specs)))
+                                         (list (rename 'record-mutator) type-name
+                                               (list (rename 'quote) nm)))))
+                            field-specs runtime-names)))
                      (predicate-def
                       (list (rename 'define)
                             (if predicate-spec predicate-spec (rename 'suppressed-predicate))
-                            (list (rename 'record-predicate) name)))
+                            (list (rename 'record-predicate) type-name)))
                      (ctor-def
                       (cond
                         ((not constructor-spec)
                          (list (rename 'define) (rename 'suppressed-constructor)
-                               (list (rename 'record-constructor) (list (rename 'fresh-rcd) name))))
+                               (list (rename 'record-constructor) (list (rename 'fresh-rcd) type-name))))
                         ((pair? constructor-spec)
                          (list (rename 'define) (car constructor-spec)
-                               (list (rename 'named-constructor) name
+                               (list (rename 'named-constructor) type-name
                                      (list (rename 'quote)
-                                           (resolve-field-names (cdr constructor-spec) own-alist parent-alist)))))
+                                           (resolve-field-indices
+                                            (cdr constructor-spec) own-keys parent-map)))))
                         (else
                          (list (rename 'define) constructor-spec
-                               (list (rename 'record-constructor) (list (rename 'fresh-rcd) name)))))))
+                               (list (rename 'record-constructor) (list (rename 'fresh-rcd) type-name)))))))
                 (append
                  (list (rename 'begin)
-                       (list (rename 'define) name
+                       (list (rename 'define) type-name
                              (list (rename 'make-record-type-descriptor)
-                                   (list (rename 'quote) name)
+                                   (list (rename 'quote) type-name)
                                    parent
                                    #f #f #f
                                    (list (rename 'list->vector) (list (rename 'quote) field-vec-spec))))
@@ -267,5 +383,7 @@
                  accessor-defs
                  mutator-defs
                  (list ctor-def
-                       (list (rename 'define-property) name 'srfi150-fields
-                             (list (rename 'quote) (append own-alist parent-alist))))))))))))))
+                       (list (rename 'define-property) type-name 'srfi150-fields
+                             (list (rename 'quote)
+                                   (list (+ parent-count (length field-specs))
+                                         (append own-property parent-map)))))))))))))))))

--- a/tests/scheme/srfi/srfi150.scm
+++ b/tests/scheme/srfi/srfi150.scm
@@ -20,35 +20,22 @@
 ;;     reference gained a descriptive string label, matching every other
 ;;     test file in this directory (srfi131.scm included).
 ;;
-;; Four assertions below are annotated as KNOWN FAILURES, all four of
-;; them one defect: kaappi#2051. They were originally attributed to
-;; kaappi#1832 ("a pre-existing top-level binding same-spelled as a
-;; macro template's own field-name literal leaks through unrenamed on
-;; one of a macro's two internal expansion passes"). Audit v2 Phase 3.10
-;; established that attribution is wrong on both halves. #1832 is fixed
-;; and its own regression test passes; its exact shape works correctly
-;; under plain (scheme base) define-record-type. And a pre-existing
-;; top-level binding is not required here at all -- removing it leaves
-;; every one of these cases failing identically.
-;;
-;; The real mechanism is that lib/srfi/150.sld carries field names from
-;; expansion time to run time inside `quote`, and a hygiene rename does
-;; not survive quoting ((eq? '__hyg_2_a 'a) is #t). The expansion is
-;; correct -- `kaappi expand` shows the two field names properly
-;; distinguished as __hyg_2_a and a -- and both then strip to `a` before
-;; the runtime by-name lookup sees them, so the two fields collapse into
-;; one. The trigger is purely a spelling collision between the template's
-;; own field-name literal and the identifier the use site supplies;
-;; giving the use site a different spelling makes each case pass.
-;;
-;; Two of the four additionally hard-
-;; error at the record-type-definition site itself, not merely at the
-;; assertion that reads a field back -- SRFI-64's `test-expect-fail`
-;; only covers a wrong-value assertion, not a top-level form throwing
-;; before any assertion runs, so those two are wrapped in `guard`
-;; instead: if the known limitation is ever fixed, the `guard` simply
-;; stops catching anything and the real assertions inside it start
-;; running and being checked normally, with no further edits needed here.
+;; The whole reference suite passes, including the four assertions
+;; (Hygiene 1's two, Hygiene 2's own-field one, and Alex Shinn's
+;; explicitly-constructed tuple) that used to be marked `test-expect-fail`
+;; for kaappi#2051. That defect -- lib/srfi/150.sld carried field names
+;; from expansion time to run time inside `quote`, and a hygiene rename
+;; does not survive quoting ((eq? '__hyg_2_a 'a) is #t), so two fields
+;; the expander had correctly distinguished (e.g. __hyg_2_a and a)
+;; collapsed into one name before the runtime by-name lookup saw them --
+;; is fixed by resolving field identity to absolute layout indices and
+;; deduped runtime names entirely at macro-expansion time. The reference
+;; suite's own shapes are below, followed by the issue's discriminating
+;; controls as regression tests: the no-top-level-binding variant (C5),
+;; the non-colliding-spelling control (C6), constant field names, and the
+;; type-name-redefinition shape (the pre-existing `<record>` binding is
+;; NOT the trigger for the field-name collapse; it is a separate,
+;; also-fixed hazard for the type-name binding itself).
 ;;
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi150.scm
 
@@ -162,32 +149,20 @@
        (a get-a)
        (b get-b)))))
 
-;; KNOWN FAILURE: kaappi#2051 (see the file header above). `def`'s own
-;; field-name literal `a` and the `a` this use site passes as `b` are
-;; distinct after expansion (__hyg_2_a vs a) but collapse to one name
-;; when SRFI 150 carries them through `quote` into its runtime lookup.
-;; The `(define a #f)` above is NOT the trigger -- deleting it leaves
-;; this failing identically; passing a different spelling at the use
-;; site is what makes it pass. This hard-errors at
-;; definition time on kaappi (reported directly to stderr below) rather
-;; than merely returning a wrong value -- `get-a`/`get-b` are therefore
-;; never defined, and both dependent assertions below fail by reference
-;; error. `guard` cannot isolate this the way it would on a spec-
-;; conformant Scheme: `def`'s expansion contains a nested
-;; define-record-type call, and kaappi's define-record-type-shadowing-
-;; by-macro mechanism only fires at real top level (the same limitation
-;; the file header above already documents for `test-group`) -- wrapping
-;; it in `guard`'s body form breaks that shadowing outright. Left
-;; unguarded at true top level instead, matching the reference's own
-;; structure; kaappi's batch runner tolerates one top-level form
-;; erroring and continues to the next, so the rest of the suite still
-;; runs and reports correctly.
 (def a make-record get-a get-b)
 
-(test-expect-fail "hygiene 1: macro's own field name, unconfused by caller's same-spelled argument")
+;; kaappi#2051: `def`'s own field-name literal `a` and the `a` this use
+;; site passes as `b` are distinct after expansion (__hyg_2_a vs a) but
+;; used to collapse to one name when SRFI 150 carried them through `quote`
+;; into its runtime by-name lookup. The `(define a #f)` above is NOT the
+;; trigger (see the C5 control below); a pre-existing top-level binding of
+;; the type name `<record>` from the field-referral section above IS a
+;; separate hazard that used to surface here too -- the type-name binding
+;; is now emitted hygiene-stripped, so the accessors below bind against the
+;; freshly redefined type rather than the old one. Both are fixed; these
+;; used to be `test-expect-fail`.
 (test-eqv "hygiene 1: macro's own field name, unconfused by caller's same-spelled argument"
   1 (get-a (make-record 1 2)))
-(test-expect-fail "hygiene 1: caller's argument correctly becomes its own, separate field")
 (test-eqv "hygiene 1: caller's argument correctly becomes its own, separate field"
   2 (get-b (make-record 1 2)))
 
@@ -210,13 +185,12 @@
 
 (define-child make-child child-get x)
 
-;; KNOWN FAILURE: kaappi#2051, same root cause as hygiene 1 above --
-;; the template's own field `x` and the inherited parent field the use
-;; site names `x` collapse to one name through `quote`. This one returns
-;; a wrong value instead of hard-erroring, so plain test-expect-fail
-;; covers it. Control: renaming the template's own field to `y` (no
-;; spelling collision) makes it return the correct (1 2).
-(test-expect-fail "hygiene 2: inherited field set via macro-introduced reference")
+;; kaappi#2051, same root cause as hygiene 1: the template's own field `x`
+;; and the inherited parent field the use site names `x` collapse to one
+;; name through `quote`. The constructor now resolves its arguments to
+;; absolute indices at expansion time, so the parent field (index 0) and
+;; the shadowing own field (index 1) are filled separately even though
+;; both spellings strip to `x`. Used to be `test-expect-fail`.
 (test-eqv "hygiene 2: inherited field set via macro-introduced reference"
   1 (parent-get (make-child 1 2)))
 (test-eqv "hygiene 2: own field, unconfused by the macro's own same-spelled field name"
@@ -251,27 +225,114 @@
 
 (test-equal "Alex Shinn's example: default-filled tuple"
   '(0 0) (let ((pt (make-point))) (list (point-ref pt 0) (point-ref pt 1))))
-;; KNOWN FAILURE: kaappi#2051, same root cause as the hygiene tests
-;; above -- both explicitly-supplied fields read back as the second
-;; argument ((2 2), not (1 2)). The earlier guess here, that deftuple's
-;; per-step `tmp` template literal collapses to one shared name across
-;; its recursive expansion, is now confirmed and its mechanism traced:
-;; `kaappi expand` shows the fields correctly distinguished as
-;; __hyg_1_tmp and __hyg_2_tmp, and both strip to `tmp` when SRFI 150
-;; carries them through `quote` into its runtime by-name lookup.
-(test-expect-fail "Alex Shinn's example: explicitly-constructed tuple")
+;; kaappi#2051, same root cause as the hygiene tests: deftuple's per-step
+;; `tmp` template literal is renamed per step (__hyg_1_tmp, __hyg_2_tmp)
+;; and the two fields used to strip to one shared `tmp` through `quote`,
+;; so both explicitly-supplied fields read back as the second argument
+;; ((2 2) instead of (1 2)). Used to be `test-expect-fail`.
 (test-equal "Alex Shinn's example: explicitly-constructed tuple"
   '(1 2) (let ((pt (make-point 1 2))) (list (point-ref pt 0) (point-ref pt 1))))
 
-;; The "hygiene 1" block above deliberately triggers one uncaught,
-;; directly-to-stderr top-level error (the known engine limitation
-;; documented at the top of this file and in lib/srfi/150.sld's header)
-;; -- kaappi's batch runner tolerates it and keeps running, but it still
-;; leaves the process's OWN natural exit status non-zero even though the
-;; SRFI-64 summary below is clean (0 unexpected failures). Exit
-;; explicitly on the success path rather than relying on fall-through,
-;; so this known, harmless error doesn't make run-all.sh treat this
-;; suite as failed.
+;;; --- kaappi#2051 regression controls ----------------------------------------
+
+;; C5 from the issue: the exact Hygiene 1 shape with NO top-level `a` at
+;; all. It failed identically to the reference shape before the fix --
+;; proving a pre-existing binding of the colliding spelling was never
+;; required -- and must pass now.
+(define-syntax def-no-binding
+  (syntax-rules ()
+    ((def-no-binding b make-record get-a get-b)
+     (define-record-type <r-no-binding>
+       (make-record a b)
+       r-no-binding?
+       (a get-a)
+       (b get-b)))))
+
+(def-no-binding a make-record get-a get-b)
+
+(test-equal "issue C5: no pre-existing binding of the colliding spelling"
+  '(1 2) (list (get-a (make-record 1 2)) (get-b (make-record 1 2))))
+
+;; C6 from the issue: same macro, but the use site passes a NON-colliding
+;; spelling. This passed even before the fix and pins down that the
+;; trigger is purely the spelling collision, not the macro shape.
+(define-syntax def-non-colliding
+  (syntax-rules ()
+    ((def-non-colliding b make-record get-a get-b)
+     (define-record-type <r-non-colliding>
+       (make-record a b)
+       r-non-colliding?
+       (a get-a)
+       (b get-b)))))
+
+(def-non-colliding q make-record get-a get-b)
+
+(test-equal "issue C6: non-colliding use-site spelling"
+  '(1 2) (list (get-a (make-record 1 2)) (get-b (make-record 1 2))))
+
+;; The issue's minimal reproduction, verbatim.
+(define-syntax def-minimal
+  (syntax-rules ()
+    ((def-minimal b mk ga gb)
+     (define-record-type <r-minimal> (mk a b) r-minimal? (a ga) (b gb)))))
+
+(def-minimal a mk ga gb)
+
+(test-equal "issue minimal reproduction"
+  '(1 2) (list (ga (mk 1 2)) (gb (mk 1 2))))
+
+;; The type-name-redefinition hazard is exercised by the reference suite's
+;; Hygiene 1 shape above: `<record>` is already bound (field-referral
+;; section) when `def` redefines it through a macro, and the accessors
+;; still bind against the freshly redefined type. The type-name binding is
+;; emitted hygiene-stripped, so the redefinition lands on the global like
+;; any top-level redefinition instead of being shadowed by the engine's
+;; referential-transparency alias for the old type.
+
+;; Non-identifier constant field names (SRFI 150: field names may be
+;; numbers, strings, booleans, or characters; matched with equal?, never
+;; against an identifier).
+(define-record-type <const-rec>
+  (make-const-rec 1 2)
+  const-rec?
+  (1 get-one)
+  (2 get-two))
+
+(test-equal "constant field names: numbers"
+  '(10 20) (list (get-one (make-const-rec 10 20)) (get-two (make-const-rec 10 20))))
+
+(define-record-type <const-str>
+  (make-const-str "x" "y")
+  const-str?
+  ("x" get-str-x)
+  ("y" get-str-y))
+
+(test-equal "constant field names: strings"
+  '(1 2) (list (get-str-x (make-const-str 1 2)) (get-str-y (make-const-str 1 2))))
+
+;; An inherited constant field, referenced through the constructor.
+(define-record-type <const-parent>
+  (make-const-parent 1)
+  const-parent?
+  (1 get-parent-one))
+
+(define-record-type (<const-child> <const-parent>)
+  (make-const-child 1 2)
+  const-child?
+  (2 get-child-two))
+
+(test-equal "constant field names: inherited, set through child constructor"
+  '(10 20) (list (get-parent-one (make-const-child 10 20))
+                 (get-child-two (make-const-child 10 20))))
+
+;; The `__hyg_` note from the issue: the strip is by spelling, not by
+;; provenance -- a symbol a user literally types as `'__hyg_2_a` also
+;; reads back as `a` in quoted data. That is engine behavior, unchanged by
+;; this fix; pinned here so the SRFI's own field-name handling stays
+;; visibly distinct from it.
+(test-assert "engine: quoted __hyg_-prefixed symbol strips by spelling"
+  (eq? '__hyg_2_a 'a))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-150")
   (if (> (test-runner-fail-count runner) 0) (exit 1) (exit 0)))

--- a/tests/scheme/srfi/srfi150.scm
+++ b/tests/scheme/srfi/srfi150.scm
@@ -235,20 +235,24 @@
 
 ;;; --- kaappi#2051 regression controls ----------------------------------------
 
-;; C5 from the issue: the exact Hygiene 1 shape with NO top-level `a` at
-;; all. It failed identically to the reference shape before the fix --
-;; proving a pre-existing binding of the colliding spelling was never
-;; required -- and must pass now.
+;; C5 from the issue: the exact Hygiene 1 shape with NO top-level binding
+;; of the colliding spelling at all. `nb` is never defined at top level in
+;; this file -- unlike `a`, which the reference suite's Hygiene 1 binds
+;; above -- so this genuinely tests the "no pre-existing binding" control:
+;; the template's own field-name literal `nb` (renamed __hyg_N_nb) and the
+;; use-site identifier `nb` collide in spelling with no global behind
+;; either. It failed identically to the reference shape before the fix and
+;; must pass now.
 (define-syntax def-no-binding
   (syntax-rules ()
     ((def-no-binding b make-record get-a get-b)
      (define-record-type <r-no-binding>
-       (make-record a b)
+       (make-record nb b)
        r-no-binding?
-       (a get-a)
+       (nb get-a)
        (b get-b)))))
 
-(def-no-binding a make-record get-a get-b)
+(def-no-binding nb make-record get-a get-b)
 
 (test-equal "issue C5: no pre-existing binding of the colliding spelling"
   '(1 2) (list (get-a (make-record 1 2)) (get-b (make-record 1 2))))
@@ -324,6 +328,23 @@
 (test-equal "constant field names: inherited, set through child constructor"
   '(10 20) (list (get-parent-one (make-const-child 10 20))
                  (get-child-two (make-const-child 10 20))))
+
+;; SRFI 150 precedence: "if a field name is considered equal to an
+;; identifier naming a field name and an identifier naming an accessor,
+;; the field name takes precedence" -- even when the coinciding field sits
+;; at a HIGHER index than the accessor. Here `y` is field 1's field name
+;; AND field 0's accessor name; `(mk-prec y)` must address field 1. The
+;; reference suite's field-referral case only exercises the opposite
+;; direction, so this is the discriminating one (before the fix, 99 lands
+;; in field 0 and get-y reads the unfilled field 1).
+(define-record-type <prec>
+  (mk-prec y)
+  prec?
+  (a y)
+  (y get-y))
+
+(test-eqv "precedence: field name beats earlier field's accessor name"
+  99 (get-y (mk-prec 99)))
 
 ;; The `__hyg_` note from the issue: the strip is by spelling, not by
 ;; provenance -- a symbol a user literally types as `'__hyg_2_a` also


### PR DESCRIPTION
## Summary

Fixes #2051 — all four `test-expect-fail` cases in `tests/scheme/srfi/srfi150.scm` share one root cause: `lib/srfi/150.sld` carried field names from macro-expansion time to run time inside `quote`, and the compiler strips a `__hyg_N_` rename from any quoted datum (`compileQuote`'s `stripHygieneFromDatum`, correct and required for `syntax-rules` templates). Two field identifiers the expander had correctly distinguished (e.g. `__hyg_2_a` and `a`) therefore stripped to one runtime name and collapsed into a single field — `(get-a (mk 1 2))` and `(get-b (mk 1 2))` both read back `2`.

The attribution to #1832 (a pre-existing top-level binding of the colliding spelling) was wrong on both halves: #1832 is fixed and its exact shape passes under plain `(scheme base)` `define-record-type`, and the no-binding control (C5) fails identically.

## Fix

Resolve field identity **entirely at macro-expansion time**, while the renamed symbols are still in hand — nothing hygienic crosses the expansion/runtime boundary:

- **Constructor specs resolve to numeric absolute layout indices.** A spec entry matches the current form's own fields by full spelling (bound-identifier=? in this engine's rename-by-spelling model), then inherited fields by hygiene-stripped spelling against the parent's stored property (free-identifier=?). `named-constructor` fills the field vector by index; no runtime by-name lookup happens at all.
- **Own fields get deduped runtime names** for the rtd and accessor/mutator creation: the stripped spelling, with a numeric suffix when two own fields strip to the same spelling (the Hygiene 1 shape). An own field matching an inherited field's spelling is deliberately *not* deduped — that is ordinary shadowing.
- **The property table stores keys and indices only** — total field count plus stripped-spelling keys to absolute indices, never renamed symbols.
- **The emitted type-name binding is hygiene-stripped too.** A template-introduced `__hyg_N_<t>` reference whose base `<t>` is already bound is intercepted by the #1832 referential-transparency alias (it loads the pre-existing global's value even inside the same expansion that defines it), so accessors used to bind against the *old* record type whenever a macro redefined an already-bound type name. This was the separate hard-error at the Hygiene 1 definition site.
- **Constant field names now actually work** (the header promised them): a non-identifier field name gets a generated `field-<index>` runtime name, making SRFI 150's "field names may be constants" conformant (previously errored in `symbol->string`).

## Tests

- Reference suite passes in full: **25/25** (previously 21 passes + 4 expected failures). The four `test-expect-fail` annotations and their obsolete mechanism comments are removed.
- New regression tests: the issue's C5 (no pre-existing binding) and C6 (non-colliding spelling) controls, the minimal repro verbatim, and constant field names (numbers, strings, inherited constants).
- Verified: `tests/scheme/run-all.sh` (703 scheme files + 1395 R7RS tests, 0 failures), `zig build test`, `zig build test -Dgc-stress=true`, markdownlint, and the `kaappi test` runner.
- `docs/dev/srfi-implementation-notes.md` updated (the SRFI 150 section described the old, unsound mechanism and the "21 of 25" gap).

## Files

- `lib/srfi/150.sld` — the redesign + header/doc rewrite
- `tests/scheme/srfi/srfi150.scm` — unmark the 4 failures, add regression controls
- `docs/dev/srfi-implementation-notes.md` — SRFI 150 section rewrite
