### PR TITLE
Enforce lambda-style arity in top-level define-values (Fixes #550)

### DIFF
--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -636,6 +636,51 @@ test "define-values clause where one bound name calls another (#1719)" {
     , 42);
 }
 
+test "top-level define-values enforces lambda-style arity (#550)" {
+    // handleDefineValues (the top-level interception in vm_eval.zig) used to
+    // bind a prefix of the formals and continue whenever the producer yielded
+    // a single non-`values` result, so fixed-arity mismatches ran silently —
+    // unlike the internal-definition path, which desugars through
+    // call-with-values and a consumer lambda. Each shape below must now raise
+    // ArityMismatch (KP3003) at true top level, before defining any global.
+    const mismatches = [_][]const u8{
+        "(define-values (a b) (values 1))", // too few fixed values
+        "(define-values (a b) (values 1 2 3))", // too many fixed values
+        "(define-values () 42)", // zero formals against one value
+        "(define-values (a b) 1)", // a bare single value for two formals
+        "(define-values (a b . rest) (values 1))", // dotted: below the minimum
+        "(define-values (a b c) (values 1 2))", // multi-value below the count
+    };
+    for (mismatches) |src| {
+        var ctx: th.TestContext = undefined;
+        try ctx.init();
+        defer ctx.deinit();
+        try std.testing.expectError(vm_mod.VMError.ArityMismatch, ctx.vm.eval(src));
+    }
+}
+
+test "top-level define-values accepts every well-matched formals shape (#550)" {
+    // The arity check must not reject a correct match. A fresh VM per case
+    // keeps a raised binding from leaking into the next.
+    const Case = struct { src: []const u8, want: i64 };
+    const cases = [_]Case{
+        .{ .src = "(define-values (a b) (values 1 2)) (+ a b)", .want = 3 },
+        .{ .src = "(define-values (x) (+ 20 22)) x", .want = 42 },
+        .{ .src = "(define-values (h . t) (values 1 2 3)) (+ h (car t) (cadr t))", .want = 6 },
+        .{ .src = "(define-values (h . t) (values 9)) (if (null? t) h -1)", .want = 9 },
+        .{ .src = "(define-values xs (values 1 2 3)) (apply + xs)", .want = 6 },
+        .{ .src = "(define-values xs (values)) (length xs)", .want = 0 },
+        .{ .src = "(define-values () (values)) 7", .want = 7 },
+    };
+    for (cases) |c| {
+        var ctx: th.TestContext = undefined;
+        try ctx.init();
+        defer ctx.deinit();
+        const result = try ctx.vm.eval(c.src);
+        try std.testing.expectEqual(c.want, types.toFixnum(result));
+    }
+}
+
 test "begin-wrapped internal define stays local at top level (#2075)" {
     // R7RS 4.2.3: a definition-context `begin` behaves exactly as if the
     // wrapper were absent, so a define inside it must shadow an enclosing

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -413,78 +413,99 @@ fn handleDefineValues(vm: *VM, args: Value) VMError!Value {
     compiler_mod.Compiler.unrootFunction(vm.gc, func);
     const result = runTopLevelFunction(vm, func) catch |err| return err;
 
-    if (types.isMultipleValues(result)) {
-        const mv = types.toObject(result).as(types.MultipleValues);
-        if (types.isSymbol(formals)) {
-            // (define-values x (values 1 2 3)) → x = (1 2 3)
-            var result_root = result;
-            vm.gc.pushRoot(&result_root);
-            defer vm.gc.popRoot();
-            var list: Value = types.NIL;
-            vm.gc.pushRoot(&list);
-            defer vm.gc.popRoot();
-            const mv2 = types.toObject(result_root).as(types.MultipleValues);
-            var j: usize = mv2.values.len;
-            while (j > 0) {
-                j -= 1;
-                list = vm.gc.allocPair(mv2.values[j], list) catch return VMError.OutOfMemory;
-            }
-            vm.defineGlobal(types.symbolName(formals), list) catch return VMError.OutOfMemory;
-        } else {
-            var formal = formals;
-            var i: usize = 0;
-            var has_rest = false;
-            while (formal != types.NIL and i < mv.values.len) {
-                if (types.isSymbol(formal)) {
-                    // Rest parameter: (define-values (a b . rest) ...)
-                    has_rest = true;
-                    var result_root = result;
-                    vm.gc.pushRoot(&result_root);
-                    defer vm.gc.popRoot();
-                    var rest_list: Value = types.NIL;
-                    vm.gc.pushRoot(&rest_list);
-                    defer vm.gc.popRoot();
-                    const mv2 = types.toObject(result_root).as(types.MultipleValues);
-                    var j: usize = mv2.values.len;
-                    while (j > i) {
-                        j -= 1;
-                        rest_list = vm.gc.allocPair(mv2.values[j], rest_list) catch return VMError.OutOfMemory;
-                    }
-                    vm.defineGlobal(types.symbolName(formal), rest_list) catch return VMError.OutOfMemory;
-                    formal = types.NIL;
-                    i = mv.values.len;
-                    break;
-                }
-                if (!types.isPair(formal)) return VMError.CompileError;
-                const var_sym = types.car(formal);
-                if (!types.isSymbol(var_sym)) return VMError.CompileError;
-                vm.defineGlobal(types.symbolName(var_sym), mv.values[i]) catch return VMError.OutOfMemory;
-                formal = types.cdr(formal);
-                i += 1;
-            }
-            if (!has_rest) {
-                if (types.isPair(formal)) return VMError.CompileError;
-                if (i < mv.values.len and formal == types.NIL) return VMError.CompileError;
-            }
+    // Root the producer's result across the pair allocations below.
+    var result_root = result;
+    vm.gc.pushRoot(&result_root);
+    defer vm.gc.popRoot();
+
+    // Normalize the produced values into a count. A non-`MultipleValues`
+    // result is exactly one value (R7RS: an ordinary expression returns a
+    // single value); `mvValueAt` re-derives the values array from the rooted
+    // result each call so a collection during binding cannot leave it dangling.
+    const is_mv = types.isMultipleValues(result_root);
+    const value_count: usize = if (is_mv)
+        types.toObject(result_root).as(types.MultipleValues).values.len
+    else
+        1;
+
+    // A bare-identifier formals spec collects every produced value as a list,
+    // with no arity constraint: (define-values x (values 1 2 3)) → x = (1 2 3).
+    if (types.isSymbol(formals)) {
+        var list: Value = types.NIL;
+        vm.gc.pushRoot(&list);
+        defer vm.gc.popRoot();
+        var j: usize = value_count;
+        while (j > 0) {
+            j -= 1;
+            list = vm.gc.allocPair(mvValueAt(result_root, is_mv, j), list) catch return VMError.OutOfMemory;
         }
-    } else {
-        if (types.isSymbol(formals)) {
-            // (define-values x expr) → x = (result)
-            var result_root = result;
-            vm.gc.pushRoot(&result_root);
-            defer vm.gc.popRoot();
-            const list = vm.gc.allocPair(result_root, types.NIL) catch return VMError.OutOfMemory;
-            vm.defineGlobal(types.symbolName(formals), list) catch return VMError.OutOfMemory;
-        } else if (types.isPair(formals)) {
-            const var_sym = types.car(formals);
-            if (types.isSymbol(var_sym)) {
-                vm.defineGlobal(types.symbolName(var_sym), result) catch return VMError.OutOfMemory;
-                const next = types.cdr(formals);
-                if (types.isSymbol(next)) {
-                    vm.defineGlobal(types.symbolName(next), types.NIL) catch return VMError.OutOfMemory;
-                }
+        vm.defineGlobal(types.symbolName(formals), list) catch return VMError.OutOfMemory;
+        return types.VOID;
+    }
+
+    // Fixed/dotted formals. Parse into a fixed count plus an optional dotted
+    // rest, validating each position is a symbol (matching the compiler's
+    // parseDefineValuesFormals). R7RS 5.3.3 / SRFI 244: the values are matched
+    // to the formals exactly as a lambda matches call arguments — a fixed list
+    // requires an exact count, a dotted list a minimum. Until #550 this
+    // top-level handler bound a prefix and continued on a single-value
+    // mismatch, unlike the compiler desugaring one scope in; check arity
+    // *before* defining any global so a mismatch leaves no partial bindings and
+    // raises the same KP3003 the internal call-with-values consumer lambda does.
+    var fixed_count: usize = 0;
+    var has_rest = false;
+    {
+        var formal = formals;
+        while (formal != types.NIL) {
+            if (types.isSymbol(formal)) {
+                has_rest = true;
+                break;
             }
+            if (!types.isPair(formal)) return VMError.CompileError;
+            if (!types.isSymbol(types.car(formal))) return VMError.CompileError;
+            fixed_count += 1;
+            formal = types.cdr(formal);
         }
     }
+
+    if (has_rest) {
+        if (value_count < fixed_count) {
+            vm.setErrorDetail("expected at least {d} arguments, got {d}", .{ fixed_count, value_count });
+            return VMError.ArityMismatch;
+        }
+    } else if (value_count != fixed_count) {
+        vm.setErrorDetail("expected {d} arguments, got {d}", .{ fixed_count, value_count });
+        return VMError.ArityMismatch;
+    }
+
+    // Bind the fixed formals, then the dotted rest (if any) as a list of the
+    // leftover values.
+    var formal = formals;
+    var i: usize = 0;
+    while (i < fixed_count) : (i += 1) {
+        vm.defineGlobal(types.symbolName(types.car(formal)), mvValueAt(result_root, is_mv, i)) catch return VMError.OutOfMemory;
+        formal = types.cdr(formal);
+    }
+    if (has_rest) {
+        // `formal` now points at the dotted rest symbol.
+        var rest_list: Value = types.NIL;
+        vm.gc.pushRoot(&rest_list);
+        defer vm.gc.popRoot();
+        var j: usize = value_count;
+        while (j > fixed_count) {
+            j -= 1;
+            rest_list = vm.gc.allocPair(mvValueAt(result_root, is_mv, j), rest_list) catch return VMError.OutOfMemory;
+        }
+        vm.defineGlobal(types.symbolName(formal), rest_list) catch return VMError.OutOfMemory;
+    }
     return types.VOID;
+}
+
+/// The i-th produced value of a `define-values` result. Re-derives the
+/// `MultipleValues` array from `result` on every call so the read stays valid
+/// even if an intervening allocation collected — `result` must be GC-rooted by
+/// the caller. A non-`MultipleValues` result is the single value itself.
+inline fn mvValueAt(result: Value, is_mv: bool, i: usize) Value {
+    if (is_mv) return types.toObject(result).as(types.MultipleValues).values[i];
+    return result;
 }

--- a/tests/scheme/errors/define-values-toplevel-arity-550.sh
+++ b/tests/scheme/errors/define-values-toplevel-arity-550.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Regression test for #550: a *top-level* (define-values <formals> <expr>)
+# must match its produced values to <formals> with lambda-style arity, exactly
+# as the internal-definition path (compiler_lambda.zig's call-with-values
+# desugaring) already did. handleDefineValues in vm_eval.zig used to bind a
+# prefix and continue whenever the producer yielded a single non-`values`
+# result — so too few / too many / zero-formals mismatches ran with exit 0.
+#
+# This path only fires for a bare top-level form (not one wrapped in a let /
+# lambda body, nor one handed to `eval` with an explicit immutable
+# `(environment ...)`), which is why it needs an out-of-process test rather
+# than a SRFI-64 assertion — a top-level raise flips the whole file's exit
+# code. See tests/scheme/srfi/srfi244.scm.
+
+set -euo pipefail
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+PASS=0
+FAIL=0
+
+# A mismatch must (a) exit non-zero and (b) report KP3003, the same arity
+# diagnostic the internal call-with-values consumer lambda raises — not the
+# KP2001 "invalid syntax" the multi-value arm used to return.
+assert_raises() {
+    local label="$1"
+    local prog="$2"
+    local out status=0
+    out=$(printf '%s\n' "$prog" | "$KAAPPI" 2>&1) || status=$?
+    if [[ "$status" -ne 0 ]] && grep -q "KP3003" <<< "$out"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — status=$status, output: $out"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# A well-matched form must exit 0 and print the expected marker.
+assert_ok() {
+    local label="$1"
+    local prog="$2"
+    local expected="$3"
+    local out status=0
+    out=$(printf '%s\n' "$prog" | "$KAAPPI" 2>&1) || status=$?
+    if [[ "$status" -eq 0 ]] && [[ "$out" == "$expected" ]]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — status=$status, output: $out (expected: $expected)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+P='(import (scheme base) (scheme write))'
+
+# --- mismatches: the #550 reproductions, plus their dotted/multi-value kin ---
+assert_raises "too few fixed values (values 1) for (a b)" \
+    "$P
+(define-values (a b) (values 1))"
+assert_raises "too many fixed values (values 1 2 3) for (a b)" \
+    "$P
+(define-values (a b) (values 1 2 3))"
+assert_raises "zero formals against one value" \
+    "$P
+(define-values () 42)"
+assert_raises "single bare value for two formals" \
+    "$P
+(define-values (a b) 1)"
+assert_raises "dotted formals with too few fixed values" \
+    "$P
+(define-values (a b . rest) (values 1))"
+assert_raises "multi-value too few for three formals" \
+    "$P
+(define-values (a b c) (values 1 2))"
+
+# --- well-matched forms of every <formals> shape must still work ---
+assert_ok "exact fixed arity" \
+    "$P
+(define-values (a b) (values 1 2))
+(display (+ a b))(newline)" "3"
+assert_ok "zero formals over zero values" \
+    "$P
+(define-values () (values))
+(display 'ok)(newline)" "ok"
+assert_ok "single non-values expression is one value" \
+    "$P
+(define-values (x) (+ 20 22))
+(display x)(newline)" "42"
+assert_ok "dotted formals collect the rest" \
+    "$P
+(define-values (h . t) (values 1 2 3))
+(write (cons h t))(newline)" "(1 2 3)"
+assert_ok "dotted tail may collect nothing" \
+    "$P
+(define-values (h . t) (values 9))
+(write (cons h t))(newline)" "(9)"
+assert_ok "bare identifier collects every value as a list" \
+    "$P
+(define-values xs (values 1 2 3))
+(write xs)(newline)" "(1 2 3)"
+assert_ok "bare identifier over zero values is the empty list" \
+    "$P
+(define-values xs (values))
+(write xs)(newline)" "()"
+
+echo ""
+echo "define-values-toplevel-arity-550: $PASS pass, $FAIL fail"
+[[ $FAIL -eq 0 ]]

--- a/tests/scheme/srfi/srfi244.scm
+++ b/tests/scheme/srfi/srfi244.scm
@@ -9,9 +9,9 @@
 ;; context (top level, let body, lambda body, nested), and the arity-matching
 ;; rule -- "the <formals> are matched to the return values in the same way
 ;; that the <formals> in a lambda expression are matched to the arguments in
-;; a procedure call".  Top level does not enforce that rule at all when the
-;; expression yields exactly one value (#550, reopened by this unit), while
-;; the identical definition one scope in does.
+;; a procedure call".  #550 was that top level did not enforce that rule when
+;; the expression yielded exactly one value, while the identical definition
+;; one scope in did; it now does (see the #550 note further down).
 
 (import (scheme base) (scheme process-context) (srfi 244) (srfi 64))
 
@@ -129,52 +129,21 @@
   (eval '((lambda () (define-values (p q) (values 1)) p))
         (environment '(scheme base) '(srfi 244))))
 
-;;; The three top-level cases below are #550's own reproductions. Each
-;;; produces exactly one value, which is the arm handleDefineValues never
-;;; grew a check for; they are silently accepted with exit 0.
+;;; #550 (fixed): a *top-level* define-values whose producer yields a
+;;; single value now enforces the same lambda-style arity as the internal
+;;; cases above -- `(define-values (a b) (values 1))`, `(define-values () 42)`
+;;; and `(define-values (a b) 1)` each raise KP3003 instead of binding a
+;;; prefix and continuing.
 ;;;
-;;; NOTE for whoever fixes #550: these three are top-level definitions, not
-;;; assertions, so once they raise this file will abort while loading rather
-;;; than report a failure. That is the signal to swap the disabled block
-;;; below for the enabled one and delete the three probes.
-
-(define dv-tf-reached #f)
-(define-values (dv-tf-a dv-tf-b) (values 1))
-(set! dv-tf-reached #t)
-
-(define dv-zf-reached #f)
-(define-values () 42)
-(set! dv-zf-reached #t)
-
-(define dv-bare-reached #f)
-(define-values (dv-bare-a dv-bare-b) 1)
-(set! dv-bare-reached #t)
-
-;; FAIL: #550 (top-level define-values does not check a one-value mismatch)
-;; (test-assert "top level: too few values must not silently continue"
-;;   (not dv-tf-reached))
-;; FAIL: #550 (zero formals against one value is silently accepted)
-;; (test-assert "top level: () formals against one value must not continue"
-;;   (not dv-zf-reached))
-;; FAIL: #550 (two formals against a bare single value is silently accepted)
-;; (test-assert "top level: (a b) against a bare single value must not continue"
-;;   (not dv-bare-reached))
-
-(test-assert "top level: too few values is silently accepted (see #550)"
-  dv-tf-reached)
-(test-equal "top level: the first formal is bound anyway (see #550)" 1 dv-tf-a)
-(test-assert "top level: () formals against one value is accepted (see #550)"
-  dv-zf-reached)
-(test-assert "top level: a bare single value is accepted (see #550)"
-  dv-bare-reached)
-(test-equal "top level: the bare single value lands in the first formal (see #550)"
-  1 dv-bare-a)
-
-;;; the boundary: a mismatch that DOES produce a MultipleValues object is
-;;; caught, which is what makes the single-value arm the discriminating half.
-(test-error "top level: a genuine multi-value mismatch is caught"
-  (eval '(define-values (mv-a mv-b mv-c) (values 1 2))
-        (environment '(scheme base) '(srfi 244))))
+;;; That path (handleDefineValues in vm_eval.zig) cannot be asserted from
+;;; here: it fires only for a *bare* top-level form, not for one wrapped in a
+;;; `let`/`lambda` body (compiler path) or handed to `eval` with an explicit
+;;; immutable `(environment ...)` (which raises KP3007 before arity is even
+;;; reached). And a bare top-level raise flips the whole file's exit code,
+;;; which run-all.sh reads as failure. So the top-level regression lives
+;;; out-of-process in tests/scheme/errors/define-values-toplevel-arity-550.sh,
+;;; which runs each snippet as its own program and checks the exit code and
+;;; the KP3003 message.
 
 ;;; --- the derived cond-expand feature id (#1649) ---
 (test-equal "cond-expand srfi-244" 'yes (cond-expand (srfi-244 'yes) (else 'no)))


### PR DESCRIPTION
## Summary

Top-level `(define-values <formals> <expr>)` is intercepted by `handleDefineValues` in `src/vm_eval.zig` instead of going through the normal `call-with-values`/consumer-lambda desugaring. Its handwritten binding logic walked formals and values in lockstep and stopped when *either* ran out, so it bound a prefix, ignored extra values, left missing bindings uncreated, and kept running. Every fixed-arity mismatch that produced a **single** value was accepted silently with exit 0 — while the identical definition one scope in (a `let`/`lambda` body) already raised, because the compiler desugaring enforces arity through a lambda.

Before (all silently `REACHED`, exit 0):

```scheme
(define-values (a b) (values 1))     ; too few
(define-values (a b) (values 1 2 3)) ; too many
(define-values () 42)                ; zero formals, one value
(define-values (a b) 1)              ; one bare value for two formals
```

After — each raises `KP3003` before binding any global, matching the internal-definition path:

```text
error[KP3003]: expected 2 arguments, got 1
```

## What changed

- **`src/vm_eval.zig`** — rewrote `handleDefineValues` to match values to formals with lambda-style arity (R7RS 5.3.3 / SRFI 244): a fixed list requires an exact count, a dotted list a minimum, a bare identifier collects every value with no constraint. Arity is checked **before** any `defineGlobal`, so a mismatch leaves no partial bindings and returns `VMError.ArityMismatch` (KP3003) — the same diagnostic the internal consumer lambda raises, replacing the KP2001 the old multi-value arm returned for the same condition. A single `mvValueAt` helper re-derives the values array from the rooted result on each read (GC safety).

## Tests

- **`tests/scheme/errors/define-values-toplevel-arity-550.sh`** (new) — the genuine top-level path fires only for a *bare* top-level form (not one wrapped in a body, nor one handed to `eval` with an immutable `(environment ...)`, which raises KP3007 first), and a top-level raise flips the whole file's exit code — so it can't be asserted inside a SRFI-64 file. This out-of-process test checks exit code + KP3003 for every mismatch shape and exit 0 + output for every well-matched shape.
- **`src/tests_core_eval.zig`** — two Zig unit tests exercising `handleDefineValues` directly (every mismatch shape → `ArityMismatch`; every well-matched shape → correct value).
- **`tests/scheme/srfi/srfi244.scm`** — retired the now-obsolete `#550` probes that pinned the old "silently accepted" behaviour; the top-level regression now lives in the shell test.

## Verification

- `zig build test` — green (also under `-Dgc-stress=true` for the affected tests)
- New shell test: 13 pass, 0 fail
- `tests/scheme/errors/exit-code.sh`, `srfi244.scm`, and the define-values smoke tests — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)