### PR TITLE
thottam: strict SemVer tag parsing, npm-style ^/~ ranges, and constraint diagnostics

### DIFF
--- a/docs/dev/thottam.md
+++ b/docs/dev/thottam.md
@@ -60,7 +60,9 @@ Every field except `name` is optional.
   Whitespace between an operator and its version is accepted (`>= 1.0.0`).
 
   A git tag only counts as a release candidate if it is a valid SemVer
-  2.0.0 version: exactly `X.Y.Z`, digits only, no leading zeroes. A tag like
+  2.0.0 version: one to three numeric components, digits only, no leading
+  zeroes (`v1` and `v1.2` are accepted, filling omitted components with 0;
+  a fourth component is not a version). A tag like
   `v2.0.0.nightly-UNRELEASED` or `v1_0.0.0` is not a version and is ignored,
   never outranking a real release.
 - `build` runs only if the package has native code (conventionally a `csrc/`

--- a/docs/dev/thottam.md
+++ b/docs/dev/thottam.md
@@ -53,8 +53,19 @@ Every field except `name` is optional.
   (patch-level), and comma-separated ranges (`>=1.0.0,<2.0.0`):
   `depends: kaappi-net@">=0.2.0"`. Constraints resolve against git tags via
   `git ls-remote --tags`.
+
+  `^` and `~` follow node-semver's range grammar, including its abbreviated
+  forms: `^1` is `>=1.0.0 <2.0.0`, `~1` is likewise `>=1.0.0 <2.0.0` (not
+  `~1.0.0`'s `>=1.0.0 <1.1.0`), and `^0.0` is the whole `0.0.x` line.
+  Whitespace between an operator and its version is accepted (`>= 1.0.0`).
+
+  A git tag only counts as a release candidate if it is a valid SemVer
+  2.0.0 version: exactly `X.Y.Z`, digits only, no leading zeroes. A tag like
+  `v2.0.0.nightly-UNRELEASED` or `v1_0.0.0` is not a version and is ignored,
+  never outranking a real release.
 - `build` runs only if the package has native code (conventionally a `csrc/`
-  directory with a `Makefile` in the repo root).
+  directory with a `Makefile` in the repo root). An empty `build:` line is
+  treated as absent.
 
 ## Ecosystem library layout
 

--- a/src/tests_thottam.zig
+++ b/src/tests_thottam.zig
@@ -54,9 +54,18 @@ test "Semver.parse accepts X.Y.Z with and without the conventional v prefix" {
 
 test "Semver.parse defaults omitted trailing components to zero" {
     // Deliberate leniency: git tags in this ecosystem are sometimes `v1.2`.
-    try std.testing.expectEqual(sv(1, 2, 0), Semver.parse("1.2").?);
-    try std.testing.expectEqual(sv(1, 0, 0), Semver.parse("1").?);
-    try std.testing.expectEqual(sv(1, 2, 0), Semver.parse("v1.2").?);
+    // The filled value is 0, but `written` records how much was written so
+    // `^`/`~` can tell `~1` from `~1.0.0` (#2131).
+    const one_two = Semver.parse("1.2").?;
+    try std.testing.expectEqual(sv(1, 2, 0).major, one_two.major);
+    try std.testing.expectEqual(sv(1, 2, 0).minor, one_two.minor);
+    try std.testing.expectEqual(sv(1, 2, 0).patch, one_two.patch);
+    try std.testing.expectEqual(@as(u8, 2), one_two.written);
+    const one = Semver.parse("1").?;
+    try std.testing.expectEqual(sv(1, 0, 0).major, one.major);
+    try std.testing.expectEqual(@as(u8, 1), one.written);
+    try std.testing.expectEqual(@as(u8, 2), Semver.parse("v1.2").?.written);
+    try std.testing.expectEqual(@as(u8, 3), Semver.parse("1.2.3").?.written);
 }
 
 test "Semver.parse rejects non-numeric, signed and empty components" {
@@ -105,25 +114,25 @@ test "Semver.parse rejects a tag that is not a version (issue #2130)" {
     // "at least three". A `git ls-remote --tags` sweep sees whatever the
     // repo tagged, so a tag that is not a version must not become a
     // candidate release.
-    //
-    // FAIL: #2130 (Semver.parse reads three components and discards the rest,
-    // so v2.0.0.nightly-UNRELEASED parses as 2.0.0 and >=1.0.0 installs it)
-    // try std.testing.expect(Semver.parse("2.0.0.nightly-UNRELEASED") == null);
-    // try std.testing.expect(Semver.parse("1.2.3.4") == null);
-    // try std.testing.expect(Semver.parse("1.2.3.") == null);
+    try std.testing.expect(Semver.parse("2.0.0.nightly-UNRELEASED") == null);
+    try std.testing.expect(Semver.parse("1.2.3.4") == null);
+    try std.testing.expect(Semver.parse("1.2.3.") == null);
 
     // SemVer 2.0.0 s2: "and MUST NOT contain leading zeroes".
-    // FAIL: #2130
-    // try std.testing.expect(Semver.parse("01.02.03") == null);
+    try std.testing.expect(Semver.parse("01.02.03") == null);
+    try std.testing.expect(Semver.parse("1.02.3") == null);
+    try std.testing.expect(Semver.parse("1.2.03") == null);
+    // A single 0 is not a leading zero.
+    try std.testing.expect(Semver.parse("0.0.0") != null);
 
-    // Each component goes to std.fmt.parseInt, which implements *Zig's*
+    // `std.fmt.parseInt` (the pre-fix parser) implements *Zig's*
     // integer-literal grammar — an explicit '+' sign and '_' digit
-    // separators are both legal there and neither is a SemVer digit.
-    // `v1_0.0.0` therefore parses as version 10.0.0.
-    // FAIL: #2130
-    // try std.testing.expect(Semver.parse("+1.2.3") == null);
-    // try std.testing.expect(Semver.parse("1.+2.3") == null);
-    // try std.testing.expect(Semver.parse("1_0.0.0") == null);
+    // separators are both legal there and neither is a SemVer digit, so
+    // `v1_0.0.0` parsed as version 10.0.0.
+    try std.testing.expect(Semver.parse("+1.2.3") == null);
+    try std.testing.expect(Semver.parse("1.+2.3") == null);
+    try std.testing.expect(Semver.parse("1_0.0.0") == null);
+    try std.testing.expect(Semver.parse("1.0.0_") == null);
 
     // Discriminating control — the adjacent malformed spellings ARE
     // rejected, so the leniency is specific to extra dot-separated
@@ -222,11 +231,10 @@ test "caret on an abbreviated range (issue #2131)" {
     try std.testing.expect(!try allows("^0.2", sv(0, 3, 0)));
 
     // node-semver: `^0.0` is `>=0.0.0 <0.1.0` — the whole 0.0.x line.
-    // FAIL: #2131 (an omitted component is filled with 0 and then treated as
-    // if it had been written, so ^0.0 collapses to ^0.0.0 = exactly 0.0.0)
-    // try std.testing.expect(try allows("^0.0", sv(0, 0, 5)));
+    try std.testing.expect(try allows("^0.0", sv(0, 0, 5)));
     try std.testing.expect(try allows("^0.0", sv(0, 0, 0)));
     try std.testing.expect(!try allows("^0.0", sv(0, 1, 0)));
+    try std.testing.expect(!try allows("^0.0", sv(1, 0, 0)));
 }
 
 test "tilde ~X.Y.Z is >=X.Y.Z <X.(Y+1).0 (node-semver Ranges)" {
@@ -246,14 +254,12 @@ test "tilde on an abbreviated range (issue #2131)" {
 
     // node-semver: `~1` is `>=1.0.0 <2.0.0` — "allows minor-level changes
     // when only the major version is specified".
-    // FAIL: #2131 (`~1` is filled to 1.0.0 and then pinned to minor 0, so it
-    // means `~1.0.0` = `>=1.0.0 <1.1.0` instead)
-    // try std.testing.expect(try allows("~1", sv(1, 9, 0)));
+    try std.testing.expect(try allows("~1", sv(1, 9, 0)));
     try std.testing.expect(try allows("~1", sv(1, 0, 0)));
     try std.testing.expect(!try allows("~1", sv(2, 0, 0)));
 
-    // Discriminating control: `~1.0.0` and `~1` are DIFFERENT ranges in
-    // node-semver but identical here — the fully-spelled form is correct.
+    // Discriminating control: `~1.0.0` and `~1` are DIFFERENT ranges — and
+    // now behave differently here too: the fully-spelled form pins minor 0.
     try std.testing.expect(try allows("~1.0.0", sv(1, 0, 9)));
     try std.testing.expect(!try allows("~1.0.0", sv(1, 1, 0)));
 }
@@ -302,16 +308,34 @@ test "parseConstraints rejects malformed ranges rather than matching loosely" {
 
 test "parseConstraints accepts a four-part range (issue #2132)" {
     try std.testing.expect(semver.parseConstraints(">=1.0.0,<2.0.0,>0.5.0,<=1.9.0") != null);
-    // Four is the ceiling (`[4]?Constraint`): a fifth part makes the whole
-    // range `null`, which reaches the user as "no version matching ...",
-    // indistinguishable from "no such tag". Not asserted either way — the
-    // limit is undocumented, and a fix may raise it or diagnose it.
+    // Four is the ceiling (`[4]?Constraint`): a fifth part is reported as a
+    // too_many_parts diagnostic rather than silently nulling the range.
+    var diag: semver.ConstraintParseError = undefined;
+    try std.testing.expect(semver.parseConstraintsDiag(">=1.0.0,<2.0.0,>0.5.0,<=1.9.0,>0.1.0", &diag) == null);
+    try std.testing.expectEqual(semver.ConstraintParseError{ .kind = .too_many_parts, .part_index = 4 }, diag);
+    _ = semver.parseConstraintsDiag(">=1.0.0,<2.0.0", &diag); // parses; leaves no error
 
     // node-semver allows whitespace between an operator and its version
     // (`>= 1.0.0` is the same range as `>=1.0.0`).
-    // FAIL: #2132 (the space is handed to Semver.parse, which rejects it, and
-    // the whole range is then reported as "no version matching")
-    // try std.testing.expect(semver.parseConstraints(">= 1.0.0") != null);
+    try std.testing.expect(semver.parseConstraints(">= 1.0.0") != null);
+    try std.testing.expect(semver.parseConstraints(">=1.0.0, < 2.0.0") != null);
+    try std.testing.expect(try allows(">= 1.0.0", sv(1, 0, 0)));
+    try std.testing.expect(!try allows(">= 1.0.0", sv(0, 9, 9)));
+}
+
+test "parseConstraintsDiag names the offending part (issue #2132)" {
+    var diag: semver.ConstraintParseError = undefined;
+    // The second part is the malformed one; the first part parses fine.
+    try std.testing.expect(semver.parseConstraintsDiag(">=1.0.0,>=>2.0.0", &diag) == null);
+    try std.testing.expectEqual(semver.ConstraintParseError{ .kind = .bad_part, .part_index = 1 }, diag);
+
+    // A pre-release in any part fails that part.
+    try std.testing.expect(semver.parseConstraintsDiag(">=1.0.0-rc1", &diag) == null);
+    try std.testing.expectEqual(@as(usize, 0), diag.part_index);
+
+    // An empty spec has no part to name beyond the first.
+    try std.testing.expect(semver.parseConstraintsDiag("", &diag) == null);
+    try std.testing.expectEqual(@as(usize, 0), diag.part_index);
 }
 
 test "isConstraintSpec routes the six operator-led forms and nothing else" {
@@ -384,9 +408,7 @@ test "parsePkgSpec on degenerate specs (issue #2132)" {
 
     // A trailing @ with nothing after it should mean "no version pinned",
     // the same as omitting the @ entirely.
-    // FAIL: #2132 (`pkg@` yields ver == "", which prints as `Installing pkg@`
-    // and then fails at checkout instead of installing the default branch)
-    // try std.testing.expect(state.parsePkgSpec("pkg@").ver == null);
+    try std.testing.expect(state.parsePkgSpec("pkg@").ver == null);
 
     // Discriminating control: omitting the @ does give null.
     try std.testing.expect(state.parsePkgSpec("pkg").ver == null);
@@ -508,9 +530,12 @@ test "parsePkgManifest on missing and empty values" {
     try std.testing.expect(state.parsePkgManifest("source: -evil\n").source == null);
 
     // An empty `build:` should mean "no build command", not "run the empty
-    // command" — thottam prints "Building <pkg>..." and runs `/bin/sh -c ""`.
-    // FAIL: #2132
-    // try std.testing.expect(state.parsePkgManifest("build:\n").build_cmd == null);
+    // command" — thottam used to print "Building <pkg>..." and run
+    // `/bin/sh -c ""`.
+    try std.testing.expect(state.parsePkgManifest("build:\n").build_cmd == null);
+    try std.testing.expect(state.parsePkgManifest("build: \n").build_cmd == null);
+    // A later non-empty build: still wins after an empty one.
+    try std.testing.expectEqualStrings("make", state.parsePkgManifest("build:\nbuild: make\n").build_cmd.?);
 
     // Discriminating control: a genuinely absent build: key is null.
     try std.testing.expect(state.parsePkgManifest("name: x\n").build_cmd == null);

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -183,15 +183,19 @@ fn joinPath3(allocator: std.mem.Allocator, a: []const u8, b: []const u8, c: []co
     return result;
 }
 
-/// Outcome of constraint resolution. The three cases were collapsed into a
-/// single `null` before kaappi#2132, which reported "no version matching" for
-/// a malformed range — indistinguishable from an unsatisfiable one.
+/// Outcome of constraint resolution. The cases were collapsed into a single
+/// `null` before kaappi#2132, which reported "no version matching" for a
+/// malformed range and for a failed `git ls-remote` alike — indistinguishable
+/// from an unsatisfiable one.
 const ResolveOutcome = union(enum) {
     resolved: []const u8,
     /// The range parsed but no tag satisfies it.
     no_match,
     /// The range itself does not parse; carries where and why.
     invalid_constraint: semver.ConstraintParseError,
+    /// `git ls-remote --tags` itself failed (missing/private repo, no
+    /// network). Not the same as "no matching tag": the range may be fine.
+    git_failed,
 };
 
 fn resolveVersion(allocator: std.mem.Allocator, clone_url: []const u8, constraint_str: []const u8) ResolveOutcome {
@@ -199,7 +203,7 @@ fn resolveVersion(allocator: std.mem.Allocator, clone_url: []const u8, constrain
     const constraints = semver.parseConstraintsDiag(constraint_str, &diag) orelse
         return .{ .invalid_constraint = diag };
 
-    const output = runGitCapture(allocator, &.{ "ls-remote", "--tags", "--", clone_url }) catch return .no_match;
+    const output = runGitCapture(allocator, &.{ "ls-remote", "--tags", "--", clone_url }) catch return .git_failed;
     defer allocator.free(output);
 
     var best: ?Semver = null;
@@ -454,6 +458,13 @@ fn doInstall(
                         .too_many_parts => std.fmt.bufPrint(&buf, "invalid version constraint '{s}' for {s}: a comma-separated range has at most 4 parts\n", .{ v, pkg }) catch "invalid version constraint\n",
                     };
                     writeStderr(detail);
+                    return error.GitFailed;
+                },
+                .git_failed => {
+                    var buf: [320]u8 = undefined;
+                    printErrColor(Color.red, "error: ");
+                    const msg = std.fmt.bufPrint(&buf, "failed to list tags for {s} (cannot resolve {s})\n", .{ clone_url, v }) catch "failed to resolve version\n";
+                    writeStderr(msg);
                     return error.GitFailed;
                 },
             }

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -25,7 +25,6 @@ const state = @import("thottam_state.zig");
 const tfs = @import("thottam_fs.zig");
 
 const Semver = semver.Semver;
-const parseConstraints = semver.parseConstraints;
 const matchesAllConstraints = semver.matchesAllConstraints;
 const isConstraintSpec = semver.isConstraintSpec;
 
@@ -184,10 +183,23 @@ fn joinPath3(allocator: std.mem.Allocator, a: []const u8, b: []const u8, c: []co
     return result;
 }
 
-fn resolveVersion(allocator: std.mem.Allocator, clone_url: []const u8, constraint_str: []const u8) ?[]const u8 {
-    const constraints = parseConstraints(constraint_str) orelse return null;
+/// Outcome of constraint resolution. The three cases were collapsed into a
+/// single `null` before kaappi#2132, which reported "no version matching" for
+/// a malformed range — indistinguishable from an unsatisfiable one.
+const ResolveOutcome = union(enum) {
+    resolved: []const u8,
+    /// The range parsed but no tag satisfies it.
+    no_match,
+    /// The range itself does not parse; carries where and why.
+    invalid_constraint: semver.ConstraintParseError,
+};
 
-    const output = runGitCapture(allocator, &.{ "ls-remote", "--tags", "--", clone_url }) catch return null;
+fn resolveVersion(allocator: std.mem.Allocator, clone_url: []const u8, constraint_str: []const u8) ResolveOutcome {
+    var diag: semver.ConstraintParseError = undefined;
+    const constraints = semver.parseConstraintsDiag(constraint_str, &diag) orelse
+        return .{ .invalid_constraint = diag };
+
+    const output = runGitCapture(allocator, &.{ "ls-remote", "--tags", "--", clone_url }) catch return .no_match;
     defer allocator.free(output);
 
     var best: ?Semver = null;
@@ -218,9 +230,10 @@ fn resolveVersion(allocator: std.mem.Allocator, clone_url: []const u8, constrain
     }
 
     if (best_tag) |bt| {
-        return allocator.dupe(u8, bt) catch return null;
+        const dup = allocator.dupe(u8, bt) catch return .no_match;
+        return .{ .resolved = dup };
     }
-    return null;
+    return .no_match;
 }
 
 fn getPkgSha(allocator: std.mem.Allocator, src_dir: []const u8, pkg: []const u8) ?[]const u8 {
@@ -417,19 +430,32 @@ fn doInstall(
             const clone_url = parsed.source orelse blk: {
                 break :blk std.fmt.allocPrint(allocator, "{s}/{s}.git", .{ config.org, pkg }) catch return error.OutOfMemory;
             };
-            if (resolveVersion(allocator, clone_url, v)) |resolved| {
-                writeStdout("  Resolved ");
-                writeStdout(v);
-                writeStdout(" -> ");
-                writeStdout(resolved);
-                writeStdout("\n");
-                install_version = resolved;
-            } else {
-                var buf: [256]u8 = undefined;
-                printErrColor(Color.red, "error: ");
-                const msg = std.fmt.bufPrint(&buf, "no version matching {s} for {s}\n", .{ v, pkg }) catch "no matching version\n";
-                writeStderr(msg);
-                return error.GitFailed;
+            switch (resolveVersion(allocator, clone_url, v)) {
+                .resolved => |resolved| {
+                    writeStdout("  Resolved ");
+                    writeStdout(v);
+                    writeStdout(" -> ");
+                    writeStdout(resolved);
+                    writeStdout("\n");
+                    install_version = resolved;
+                },
+                .no_match => {
+                    var buf: [256]u8 = undefined;
+                    printErrColor(Color.red, "error: ");
+                    const msg = std.fmt.bufPrint(&buf, "no version matching {s} for {s}\n", .{ v, pkg }) catch "no matching version\n";
+                    writeStderr(msg);
+                    return error.GitFailed;
+                },
+                .invalid_constraint => |diag| {
+                    var buf: [320]u8 = undefined;
+                    printErrColor(Color.red, "error: ");
+                    const detail = switch (diag.kind) {
+                        .bad_part => std.fmt.bufPrint(&buf, "invalid version constraint '{s}' for {s}: part {d} is not a valid constraint (<op><version>)\n", .{ v, pkg, diag.part_index + 1 }) catch "invalid version constraint\n",
+                        .too_many_parts => std.fmt.bufPrint(&buf, "invalid version constraint '{s}' for {s}: a comma-separated range has at most 4 parts\n", .{ v, pkg }) catch "invalid version constraint\n",
+                    };
+                    writeStderr(detail);
+                    return error.GitFailed;
+                },
             }
         }
     }
@@ -878,7 +904,10 @@ pub fn main(init: std.process.Init.Minimal) !void {
         var visited = std.StringHashMap(void).init(allocator);
         defer freeVisited(allocator, &visited);
         doInstall(allocator, config, spec, locked_mode, &visited) catch |err| {
-            if (err == error.GitFailed or err == error.BuildFailed or err == error.CopyFailed) std.process.exit(1);
+            // InvalidPackageName already printed its own message; exiting here
+            // keeps Zig's default handler from printing the raw error name as a
+            // second line (kaappi#2132).
+            if (err == error.GitFailed or err == error.BuildFailed or err == error.CopyFailed or err == error.InvalidPackageName) std.process.exit(1);
             return err;
         };
     } else if (std.mem.eql(u8, cmd, "remove")) {
@@ -887,7 +916,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
             std.process.exit(1);
         };
         doRemove(allocator, config, pkg) catch |err| {
-            if (err == error.NotInstalled) std.process.exit(1);
+            if (err == error.NotInstalled or err == error.InvalidPackageName) std.process.exit(1);
             return err;
         };
     } else if (std.mem.eql(u8, cmd, "list")) {

--- a/src/thottam_semver.zig
+++ b/src/thottam_semver.zig
@@ -1,17 +1,56 @@
 const std = @import("std");
 
+/// Parse one dot-separated version component under SemVer 2.0.0 §2: digits
+/// only, no leading zeroes. This is deliberately NOT `std.fmt.parseInt`,
+/// which implements Zig's integer-literal grammar and would accept a leading
+/// '+' sign and '_' digit separators (`v1_0.0.0` parsing as 10.0.0 was
+/// kaappi#2130).
+fn parseComponent(s: []const u8) ?u32 {
+    if (s.len == 0) return null;
+    if (s.len > 1 and s[0] == '0') return null; // SemVer 2.0.0 §2: no leading zeroes
+    var n: u64 = 0;
+    for (s) |c| {
+        if (c < '0' or c > '9') return null;
+        n = n * 10 + (c - '0');
+        if (n > std.math.maxInt(u32)) return null;
+    }
+    return @intCast(n);
+}
+
 pub const Semver = struct {
     major: u32,
     minor: u32,
     patch: u32,
+    /// How many dot-separated components the author actually wrote (1–3).
+    /// Omitted trailing components are filled with 0, but for `^`/`~`
+    /// ranges node-semver's meaning depends on how much was written, not on
+    /// the filled value — `~1` is `>=1.0.0 <2.0.0` while `~1.0.0` is
+    /// `>=1.0.0 <1.1.0` (kaappi#2131). Defaults to 3 so a hand-built
+    /// `.{ .major, .minor, .patch }` literal is the fully-spelled form.
+    written: u8 = 3,
 
     pub fn parse(s: []const u8) ?Semver {
         const ver = if (s.len > 0 and s[0] == 'v') s[1..] else s;
+        if (ver.len == 0) return null;
         var it = std.mem.splitScalar(u8, ver, '.');
-        const major = std.fmt.parseInt(u32, it.next() orelse return null, 10) catch return null;
-        const minor = std.fmt.parseInt(u32, it.next() orelse "0", 10) catch return null;
-        const patch = std.fmt.parseInt(u32, it.next() orelse "0", 10) catch return null;
-        return .{ .major = major, .minor = minor, .patch = patch };
+        const major_str = it.next() orelse return null;
+        const minor_str = it.next();
+        const patch_str = it.next();
+        // SemVer 2.0.0 §2: a normal version is exactly X.Y.Z. A fourth (or
+        // later) component means this is some other kind of tag — a nightly
+        // marker, a build id — and must not become a release candidate
+        // (kaappi#2130). Rejecting is safe: an unparsed tag is simply not a
+        // candidate.
+        if (it.next() != null) return null;
+        const major = parseComponent(major_str) orelse return null;
+        // `splitScalar` yields "" for consecutive dots ("1..3") and a null
+        // next only for a genuine trailing omission ("1.2"). Only the latter
+        // is lenient — an empty intermediate component is not a version.
+        if (minor_str == null) return .{ .major = major, .minor = 0, .patch = 0, .written = 1 };
+        const minor = parseComponent(minor_str.?) orelse return null;
+        if (patch_str == null) return .{ .major = major, .minor = minor, .patch = 0, .written = 2 };
+        const patch = parseComponent(patch_str.?) orelse return null;
+        return .{ .major = major, .minor = minor, .patch = patch, .written = 3 };
     }
 
     pub fn order(a: Semver, b: Semver) std.math.Order {
@@ -36,54 +75,110 @@ pub const Constraint = struct {
             .eq => Semver.order(v, self.ver) == .eq,
             .caret => blk: {
                 if (Semver.order(v, self.ver) == .lt) break :blk false;
-                if (self.ver.major != 0) break :blk v.major == self.ver.major;
-                if (self.ver.minor != 0) break :blk v.major == 0 and v.minor == self.ver.minor;
-                break :blk v.major == 0 and v.minor == 0 and v.patch == self.ver.patch;
+                switch (self.ver.written) {
+                    // `^1` := `>=1.0.0 <2.0.0` (node-semver Ranges).
+                    1 => break :blk v.major == self.ver.major,
+                    // `^1.2` locks major; `^0.2` locks minor: `>=0.2.0 <0.3.0`.
+                    // `^0.0` is `>=0.0.0 <0.1.0` — the whole 0.0.x line, NOT
+                    // exactly 0.0.0 (kaappi#2131).
+                    2 => {
+                        if (self.ver.major != 0) break :blk v.major == self.ver.major;
+                        break :blk v.major == 0 and v.minor == self.ver.minor;
+                    },
+                    else => {
+                        if (self.ver.major != 0) break :blk v.major == self.ver.major;
+                        if (self.ver.minor != 0) break :blk v.major == 0 and v.minor == self.ver.minor;
+                        break :blk v.major == 0 and v.minor == 0 and v.patch == self.ver.patch;
+                    },
+                }
             },
-            .tilde => v.major == self.ver.major and v.minor == self.ver.minor and Semver.order(v, self.ver) != .lt,
+            .tilde => blk: {
+                if (self.ver.written <= 1)
+                    // `~1` is `>=1.0.0 <2.0.0` — "allows minor-level changes
+                    // when only the major version is specified" — not
+                    // `~1.0.0`'s `>=1.0.0 <1.1.0` (kaappi#2131).
+                    break :blk v.major == self.ver.major and Semver.order(v, self.ver) != .lt;
+                break :blk v.major == self.ver.major and v.minor == self.ver.minor and Semver.order(v, self.ver) != .lt;
+            },
         };
     }
 };
 
-pub fn parseConstraints(spec: []const u8) ?[4]?Constraint {
+/// Why a range spec failed to parse. `resolveVersion` uses this to tell the
+/// user "your constraint is malformed" apart from "no tag satisfies it",
+/// which used to be one indistinguishable message (kaappi#2132).
+pub const ConstraintParseError = struct {
+    kind: enum {
+        /// One comma-separated part is not a valid `<op><version>`.
+        bad_part,
+        /// More comma-separated parts than the fixed ceiling of 4.
+        too_many_parts,
+    },
+    /// Zero-based index of the offending part.
+    part_index: usize,
+};
+
+pub fn parseConstraintsDiag(spec: []const u8, diag: *ConstraintParseError) ?[4]?Constraint {
     var result: [4]?Constraint = .{ null, null, null, null };
     const clean = std.mem.trim(u8, spec, "\"");
     var it = std.mem.splitScalar(u8, clean, ',');
     var i: usize = 0;
     while (it.next()) |part| {
-        if (i >= 4) return null;
+        if (i >= 4) {
+            diag.* = .{ .kind = .too_many_parts, .part_index = i };
+            return null;
+        }
         const trimmed = std.mem.trim(u8, part, " ");
-        result[i] = parseSingleConstraint(trimmed) orelse return null;
+        result[i] = parseSingleConstraint(trimmed) orelse {
+            diag.* = .{ .kind = .bad_part, .part_index = i };
+            return null;
+        };
         i += 1;
     }
-    if (i == 0) return null;
+    if (i == 0) {
+        diag.* = .{ .kind = .bad_part, .part_index = 0 };
+        return null;
+    }
     return result;
+}
+
+pub fn parseConstraints(spec: []const u8) ?[4]?Constraint {
+    var diag: ConstraintParseError = undefined;
+    return parseConstraintsDiag(spec, &diag);
+}
+
+/// node-semver allows whitespace between an operator and its version
+/// (`>= 1.0.0` is the same range as `>=1.0.0`); without this the space was
+/// handed to Semver.parse and the whole range was reported as "no version
+/// matching" (kaappi#2132).
+fn afterOp(s: []const u8, op_len: usize) []const u8 {
+    return std.mem.trim(u8, s[op_len..], " \t");
 }
 
 pub fn parseSingleConstraint(s: []const u8) ?Constraint {
     if (s.len == 0) return null;
     if (s[0] == '^') {
-        const ver = Semver.parse(s[1..]) orelse return null;
+        const ver = Semver.parse(afterOp(s, 1)) orelse return null;
         return .{ .op = .caret, .ver = ver };
     }
     if (s[0] == '~') {
-        const ver = Semver.parse(s[1..]) orelse return null;
+        const ver = Semver.parse(afterOp(s, 1)) orelse return null;
         return .{ .op = .tilde, .ver = ver };
     }
     if (std.mem.startsWith(u8, s, ">=")) {
-        const ver = Semver.parse(s[2..]) orelse return null;
+        const ver = Semver.parse(afterOp(s, 2)) orelse return null;
         return .{ .op = .gte, .ver = ver };
     }
     if (std.mem.startsWith(u8, s, "<=")) {
-        const ver = Semver.parse(s[2..]) orelse return null;
+        const ver = Semver.parse(afterOp(s, 2)) orelse return null;
         return .{ .op = .lte, .ver = ver };
     }
     if (s[0] == '>') {
-        const ver = Semver.parse(s[1..]) orelse return null;
+        const ver = Semver.parse(afterOp(s, 1)) orelse return null;
         return .{ .op = .gt, .ver = ver };
     }
     if (s[0] == '<') {
-        const ver = Semver.parse(s[1..]) orelse return null;
+        const ver = Semver.parse(afterOp(s, 1)) orelse return null;
         return .{ .op = .lt, .ver = ver };
     }
     const ver = Semver.parse(s) orelse return null;

--- a/src/thottam_semver.zig
+++ b/src/thottam_semver.zig
@@ -135,10 +135,9 @@ pub fn parseConstraintsDiag(spec: []const u8, diag: *ConstraintParseError) ?[4]?
         };
         i += 1;
     }
-    if (i == 0) {
-        diag.* = .{ .kind = .bad_part, .part_index = 0 };
-        return null;
-    }
+    // No `i == 0` guard is needed: `splitScalar` always yields at least one
+    // token, so an empty or whitespace spec reaches `parseSingleConstraint("")`
+    // in the loop body and returns `bad_part`/index 0 there.
     return result;
 }
 

--- a/src/thottam_state.zig
+++ b/src/thottam_state.zig
@@ -34,7 +34,11 @@ pub fn parsePkgSpec(spec: []const u8) PkgSpec {
         }
     }
     if (std.mem.indexOfScalar(u8, name_ver, '@')) |at| {
-        return .{ .name = name_ver[0..at], .ver = name_ver[at + 1 ..], .source = source };
+        const ver = name_ver[at + 1 ..];
+        // `pkg@` (trailing @ with nothing after it) means "no version pinned",
+        // the same as omitting the @ entirely — an empty string here printed
+        // as `Installing pkg@` and then failed at checkout (kaappi#2132).
+        return .{ .name = name_ver[0..at], .ver = if (ver.len > 0) ver else null, .source = source };
     }
     return .{ .name = name_ver, .ver = null, .source = source };
 }
@@ -63,7 +67,10 @@ pub fn parsePkgManifest(content: []const u8) PkgManifest {
         } else if (parseField(line, "depends:")) |val| {
             result.depends = val;
         } else if (parseField(line, "build:")) |val| {
-            result.build_cmd = val;
+            // An empty `build:` is an absence, not a command — running
+            // `/bin/sh -c ""` behind a "Building <pkg>..." banner helped
+            // nobody (kaappi#2132).
+            if (val.len > 0) result.build_cmd = val;
         } else if (parseField(line, "source:")) |val| {
             if (val.len > 0 and val[0] != '-') result.source = val;
         }

--- a/tests/scheme/thottam/thottam-lifecycle.sh
+++ b/tests/scheme/thottam/thottam-lifecycle.sh
@@ -233,11 +233,26 @@ check "constraint ^1.2.3 stays inside major 1"          "v1.9.0" "$(resolve kaap
 check "constraint ^0.2.0 stays inside minor 0.2"        "v0.2.5" "$(resolve kaappi-alpha '^0.2.0')"
 check "constraint ~1.2.3 stays inside minor 1.2"        "v1.2.3" "$(resolve kaappi-alpha '~1.2.3')"
 check "range >=1.0.0,<2.0.0 excludes the upper bound"   "v1.9.0" "$(resolve kaappi-alpha '>=1.0.0,<2.0.0')"
+# node-semver allows whitespace between the operator and its version; the
+# space used to make the whole range unparseable and was reported as "no
+# version matching" (#2132).
+check "constraint '>= 1.0.0' tolerates operator whitespace" "v2.0.0" "$(resolve kaappi-alpha '>= 1.0.0')"
 
 fresh_home
 out="$("$THOTTAM" install 'kaappi-alpha@>=9.0.0' 2>&1)" && ec=0 || ec=$?
 check_exit "an unsatisfiable constraint fails" 1 "$ec"
 check "an unsatisfiable constraint says so" "no version matching" "$out"
+
+# A constraint that does not PARSE is a different failure from one that
+# matches nothing: the old single message sent users hunting through the
+# remote's tags for a range that was never valid (#2132).
+for bad in '>=>1.0.0' '>=1.0.0,' '>=1.0.0-rc1'; do
+    fresh_home
+    out="$($THOTTAM install "kaappi-alpha@$bad" 2>&1)" && ec=0 || ec=$?
+    check_exit "a malformed constraint fails [$bad]" 1 "$ec"
+    check "a malformed constraint is reported as invalid [$bad]" "invalid version constraint" "$out"
+    check_not "a malformed constraint is not called unmatched [$bad]" "no version matching" "$out"
+done
 
 # A tag that is a SemVer pre-release must not satisfy a plain range
 # (node-semver: a range with no pre-release of its own excludes them).
@@ -246,12 +261,21 @@ check "a -rc1 pre-release tag does not satisfy >=1.0.0" \
 
 # ...but SemVer 2.0.0 s2 says a version is exactly three numeric components,
 # so a tag with a fourth is not a version at all and must not be a candidate.
-# FAIL: #2130 (Semver.parse reads three components and discards the rest, so
-# v2.0.0.nightly-UNRELEASED parses as 2.0.0 and wins this range; the fixture
-# is identical to kaappi-odd above except for that one tag, which is what
-# makes the pair discriminating)
-# check "a four-component tag is not treated as a release" \
-#     "v1.0.0" "$(resolve kaappi-nightly '>=1.0.0')"
+check "a four-component tag is not treated as a release" \
+    "v1.0.0" "$(resolve kaappi-nightly '>=1.0.0')"
+
+# Same property, sharper case: v1_0.0.0 used to parse as 10.0.0 via Zig's
+# integer-literal grammar ('_' digit separator) and so outranked v2.0.0,
+# REORDERING the release history (#2130).
+mkpkg kaappi-underscore "" v2.0.0
+(
+    cd "$WORK/kaappi-underscore"
+    git tag 'v1_0.0.0'
+)
+rm -rf "$ORG/kaappi-underscore.git"
+git clone -q --bare "$WORK/kaappi-underscore" "$ORG/kaappi-underscore.git"
+check "an underscore tag does not outrank a real release" \
+    "v2.0.0" "$(resolve kaappi-underscore '>=2.0.0')"
 
 # ---------------------------------------------------------------------------
 # 4. The package-name guard: nothing escapes KAAPPI_HOME

--- a/tests/scheme/thottam/thottam-lifecycle.sh
+++ b/tests/scheme/thottam/thottam-lifecycle.sh
@@ -248,11 +248,20 @@ check "an unsatisfiable constraint says so" "no version matching" "$out"
 # remote's tags for a range that was never valid (#2132).
 for bad in '>=>1.0.0' '>=1.0.0,' '>=1.0.0-rc1'; do
     fresh_home
-    out="$($THOTTAM install "kaappi-alpha@$bad" 2>&1)" && ec=0 || ec=$?
+    out="$("$THOTTAM" install "kaappi-alpha@$bad" 2>&1)" && ec=0 || ec=$?
     check_exit "a malformed constraint fails [$bad]" 1 "$ec"
     check "a malformed constraint is reported as invalid [$bad]" "invalid version constraint" "$out"
     check_not "a malformed constraint is not called unmatched [$bad]" "no version matching" "$out"
 done
+
+# A constraint whose repository cannot be listed (here: it does not exist)
+# is a fetch failure, not "no version matching" — the range is never even
+# evaluated, and saying otherwise sends the user hunting through tags (#2132).
+fresh_home
+out="$("$THOTTAM" install 'kaappi-missing@>=1.0.0' 2>&1)" && ec=0 || ec=$?
+check_exit "an unavailable repository fails" 1 "$ec"
+check "an unavailable repository is reported as a fetch error" "failed to list tags" "$out"
+check_not "an unavailable repository is not called unmatched" "no version matching" "$out"
 
 # A tag that is a SemVer pre-release must not satisfy a plain range
 # (node-semver: a range with no pre-release of its own excludes them).


### PR DESCRIPTION
Fixes #2130, fixes #2131, fixes #2132.

Three thottam version-resolution defects from the Phase 6E audit, fixed together because they all live in the same `Semver.parse` → constraint-matcher → `resolveVersion` path and share the disabled-test fixtures.

## #2130 — a non-version git tag became a release candidate

`Semver.parse` split on `.`, took the first three fields, and handed each to `std.fmt.parseInt` — so `v2.0.0.nightly-UNRELEASED` parsed as `2.0.0`, and `v1_0.0.0` (via Zig's integer-literal `_` separators) as `10.0.0`, outranking `v2.0.0`.

- Components are now parsed by a hand-rolled digit loop (digits only, no leading zeroes, u32-bounded).
- A fourth dot-separated component disqualifies the tag.
- Empty *intermediate* components (`1..3`) are rejected while genuinely omitted trailing components (`v1.2`) stay lenient.

## #2131 — abbreviated `^`/`~` ranges collapsed to their filled-in zeros

`Semver.parse` filled omitted components with `0` and discarded how much was written, so `~1` meant `~1.0.0` (`>=1.0.0 <1.1.0`) and `^0.0` meant exactly `0.0.0`.

- `Semver` now carries a `written` component count (1–3).
- `^` and `~` match against it per node-semver: `^1`/`~1` are `>=1.0.0 <2.0.0`, `^0.0` is the whole `0.0.x` line, `~1.2` is unchanged.

## #2132 — malformed constraints reported as "no version matching"

`resolveVersion` collapsed "didn't parse" and "no tag matched" into one `null`, and six distinct parse failures shared one message.

- `resolveVersion` returns a `ResolveOutcome` union; a malformed range now reports `invalid version constraint '…' for …: part N is not a valid constraint (<op><version>)` (and the undocumented 4-part ceiling is diagnosed as `too_many_parts`).
- Operator/version whitespace (`>= 1.0.0`) is accepted, matching node-semver.
- `InvalidPackageName` is handled in `main` (install and remove) so the raw `error: InvalidPackageName` line no longer leaks after the real message.
- `pkg@` (trailing `@`) is now an absent version, not an empty string that failed at checkout.
- An empty `build:` line is treated as absent, not a command run via `/bin/sh -c ""`.

## Tests

- Re-enabled every `FAIL: #N` assertion across `src/tests_thottam.zig` and `tests/scheme/thottam/thottam-lifecycle.sh`, plus new unit tests for the component-count semantics, `too_many_parts`, and part-index diagnostics, and new lifecycle checks for the underscore-tag reorder and malformed-vs-unmatched messaging.
- Docs (`docs/dev/thottam.md`) updated for the node-semver `^`/`~` abbreviations and the strict tag rules.

`zig build test` and the thottam lifecycle suite (81 checks) both pass.
