### PR TITLE
thottam: verify the installation, enforce --locked provenance, tolerate CRLF

### DIFF
--- a/src/tests_thottam.zig
+++ b/src/tests_thottam.zig
@@ -696,12 +696,8 @@ test "lockfile reader tolerates CRLF line endings (issue #2133)" {
     defer if (e.source) |s| allocator.free(s);
 
     // The lockfile is meant to be committed and shared between machines, so
-    // a checkout that normalised it to CRLF must still compare equal.
-    // FAIL: #2133 (the \r stays in the SHA, and `thottam verify` then prints
-    // "MISMATCH (locked: 75f253e118c0, actual: 75f253e118c0)" — the trailing
-    // \r is outside the 12-character display prefix, so the two reported
-    // values are identical and the message is unusable)
-    // try std.testing.expectEqualStrings(sha, e.sha);
+    // a checkout that normalised it to CRLF must still compare equal (#2133).
+    try std.testing.expectEqualStrings(sha, e.sha);
 
     // Discriminating control: with LF, the same line reads back exactly.
     try thottam.writeFile(allocator, lock, "kaappi-alpha " ++ "75f253e118c0976ac2caabec574af39394e7bc4e" ++ "\n");

--- a/src/tests_thottam.zig
+++ b/src/tests_thottam.zig
@@ -725,6 +725,18 @@ test "installed-list membership is exact, never a prefix match" {
     try std.testing.expect(state.isInstalled(allocator, inst, "kaappi-net-extra"));
 }
 
+test "installed-list membership tolerates CRLF line endings (issue #2133)" {
+    const allocator = std.testing.allocator;
+    var buf: [512]u8 = undefined;
+    const inst = try tempPath(&buf, "inst2");
+    defer thottam.removeDir(allocator, inst) catch {};
+
+    try thottam.writeFile(allocator, inst, "kaappi-json\r\nkaappi-csv\n");
+    try std.testing.expect(state.isInstalled(allocator, inst, "kaappi-json"));
+    try std.testing.expect(state.isInstalled(allocator, inst, "kaappi-csv"));
+    try std.testing.expect(!state.isInstalled(allocator, inst, "kaappi"));
+}
+
 test "appendLockEntry emits the documented two- and three-column shapes" {
     const allocator = std.testing.allocator;
     var out: std.ArrayList(u8) = .empty;

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -41,7 +41,6 @@ const parsePkgManifest = state.parsePkgManifest;
 const isInstalled = state.isInstalled;
 const LockEntry = state.LockEntry;
 const getLockedEntry = state.getLockedEntry;
-const getLockedSha = state.getLockedSha;
 const appendLockEntry = state.appendLockEntry;
 const updateLockfile = state.updateLockfile;
 const removeFromLockfile = state.removeFromLockfile;
@@ -101,6 +100,19 @@ fn fatal(msg: []const u8) noreturn {
     if (use_color) writeStderr(Color.reset);
     writeStderr("\n");
     std.process.exit(1);
+}
+
+/// Strip a trailing carriage return from a line read out of a state file
+/// (`thottam.lock` / `installed.txt`). These files exist to be committed and
+/// shared between machines, so a checkout that a colleague's
+/// `core.autocrlf=true` (or a Windows editor) normalised to CRLF must read
+/// back the same values as the `\n` that thottam itself writes (#2133).
+///
+/// Only `\r` is stripped, not surrounding whitespace: a trailing space is
+/// load-bearing — it is the delimiter between a package name and an (empty)
+/// SHA in a truncated line.
+pub fn trimStateLine(line: []const u8) []const u8 {
+    return std.mem.trimEnd(u8, line, "\r");
 }
 
 pub fn readFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
@@ -400,6 +412,15 @@ fn doInstall(
     const pkg = parsed.name;
     var install_version = parsed.ver;
 
+    // --locked mode: the lockfile is authoritative for both the SHA and the
+    // clone URL. Both are read up front so the source is enforced before any
+    // clone happens, and the recorded provenance is never rewritten by the
+    // very operation that is checking it (#2137).
+    var locked_sha: ?[]const u8 = null;
+    var locked_source: ?[]const u8 = null;
+    defer if (locked_sha) |s| allocator.free(s);
+    defer if (locked_source) |s| allocator.free(s);
+
     if (!isValidPkgName(pkg)) {
         printErrColor(Color.red, "error: ");
         writeStderr("invalid package name '");
@@ -418,15 +439,33 @@ fn doInstall(
     }
 
     if (locked_mode) {
-        const locked_sha = getLockedSha(allocator, config.lockfile, pkg);
-        if (locked_sha == null) {
+        const entry = getLockedEntry(allocator, config.lockfile, pkg) orelse {
             var buf: [256]u8 = undefined;
             printErrColor(Color.red, "error: ");
             const msg = std.fmt.bufPrint(&buf, "{s} is not in the lockfile (running in --locked mode)\n", .{pkg}) catch "package not in lockfile\n";
             writeStderr(msg);
             std.process.exit(1);
+        };
+        locked_sha = entry.sha;
+        locked_source = entry.source;
+        install_version = entry.sha;
+
+        // A `::url` handed to a --locked install must agree with the source
+        // the lockfile recorded (or, absent one, the org default). Refuse
+        // before cloning so a fork or mirror that merely shares history
+        // cannot redirect a locked install (#2137).
+        if (parsed.source) |supplied| {
+            var url_buf: [512]u8 = undefined;
+            const expected = locked_source orelse
+                (std.fmt.bufPrint(&url_buf, "{s}/{s}.git", .{ config.org, pkg }) catch return error.OutOfMemory);
+            if (!std.mem.eql(u8, supplied, expected)) {
+                var msg_buf: [512]u8 = undefined;
+                printErrColor(Color.red, "error: ");
+                const msg = std.fmt.bufPrint(&msg_buf, "source URL mismatch for {s}: lockfile records '{s}', got '{s}' (running in --locked mode)\n", .{ pkg, expected, supplied }) catch "source URL mismatch\n";
+                writeStderr(msg);
+                std.process.exit(1);
+            }
         }
-        install_version = locked_sha;
     }
 
     if (install_version) |v| {
@@ -483,7 +522,14 @@ fn doInstall(
     const pkg_dir = try joinPath(allocator, config.src_dir, pkg);
     defer allocator.free(pkg_dir);
 
-    const clone_url = if (parsed.source) |s| s else blk: {
+    // In --locked mode the lockfile's recorded source is the clone URL (the
+    // org default when it recorded none); otherwise the URL handed to this
+    // invocation, or the org default.
+    const clone_url = if (locked_mode)
+        (locked_source orelse blk: {
+            break :blk std.fmt.bufPrint(&buf, "{s}/{s}.git", .{ config.org, pkg }) catch return error.OutOfMemory;
+        })
+    else if (parsed.source) |s| s else blk: {
         break :blk std.fmt.bufPrint(&buf, "{s}/{s}.git", .{ config.org, pkg }) catch return error.OutOfMemory;
     };
 
@@ -512,14 +558,11 @@ fn doInstall(
     printBuf(&buf, "  Resolved: {s}\n", .{resolved_sha});
 
     if (locked_mode) {
-        if (getLockedSha(allocator, config.lockfile, pkg)) |locked_sha| {
-            defer allocator.free(locked_sha);
-            if (!std.mem.eql(u8, resolved_sha, locked_sha)) {
-                printErrColor(Color.red, "error: ");
-                const msg = std.fmt.bufPrint(&buf, "SHA mismatch for {s} (locked: {s}, got: {s})\n", .{ pkg, locked_sha, resolved_sha }) catch "SHA mismatch\n";
-                writeStderr(msg);
-                std.process.exit(1);
-            }
+        if (!std.mem.eql(u8, resolved_sha, locked_sha.?)) {
+            printErrColor(Color.red, "error: ");
+            const msg = std.fmt.bufPrint(&buf, "SHA mismatch for {s} (locked: {s}, got: {s})\n", .{ pkg, locked_sha.?, resolved_sha }) catch "SHA mismatch\n";
+            writeStderr(msg);
+            std.process.exit(1);
         }
     }
 
@@ -552,7 +595,9 @@ fn doInstall(
     }
 
     try appendFile(allocator, config.installed, pkg);
-    try updateLockfile(allocator, config.lockfile, pkg, resolved_sha, parsed.source);
+    // A --locked install must not rewrite the lockfile's recorded source: the
+    // provenance it is checking must survive the check (#2137).
+    try updateLockfile(allocator, config.lockfile, pkg, resolved_sha, if (locked_mode) locked_source else parsed.source);
     writeStdout("  ");
     printColor(Color.green, pkg);
     printBuf(&buf, " installed (locked at {s})\n", .{resolved_sha});
@@ -611,7 +656,8 @@ fn doList(allocator: std.mem.Allocator, config: Config) !void {
     writeStdout("Installed packages:\n");
     var buf: [512]u8 = undefined;
     var lines = std.mem.splitScalar(u8, content, '\n');
-    while (lines.next()) |pkg| {
+    while (lines.next()) |line| {
+        const pkg = trimStateLine(line);
         if (pkg.len == 0) continue;
         const entry = getLockedEntry(allocator, config.lockfile, pkg);
         const sha_short = if (entry) |e| e.sha[0..@min(12, e.sha.len)] else "unknown";
@@ -718,8 +764,9 @@ fn doUpdate(allocator: std.mem.Allocator, config: Config, pkg: ?[]const u8) !voi
         defer packages.deinit(allocator);
         var lines = std.mem.splitScalar(u8, content, '\n');
         while (lines.next()) |line| {
-            if (line.len > 0) {
-                const copy = allocator.dupe(u8, line) catch continue;
+            const name = trimStateLine(line);
+            if (name.len > 0) {
+                const copy = allocator.dupe(u8, name) catch continue;
                 packages.append(allocator, copy) catch continue;
             }
         }
@@ -738,23 +785,73 @@ fn doUpdate(allocator: std.mem.Allocator, config: Config, pkg: ?[]const u8) !voi
 }
 
 fn doVerify(allocator: std.mem.Allocator, config: Config) !void {
-    const content = readFile(allocator, config.lockfile) catch {
+    const lock_content = readFile(allocator, config.lockfile) catch {
         writeStdout("No lockfile found\n");
         return error.NoLockfile;
     };
-    defer allocator.free(content);
+    defer allocator.free(lock_content);
 
     writeStdout("Verifying installed packages against lockfile...\n");
     var buf: [512]u8 = undefined;
     var ok = true;
-    var lines = std.mem.splitScalar(u8, content, '\n');
-    while (lines.next()) |line| {
-        if (line.len == 0) continue;
-        const space = std.mem.indexOfScalar(u8, line, ' ') orelse continue;
-        const pkg = line[0..space];
-        const rest = line[space + 1 ..];
-        const locked_sha = if (std.mem.indexOfScalar(u8, rest, ' ')) |sp2| rest[0..sp2] else rest;
 
+    // The lockfile is checked for structure first: a non-empty line with no
+    // SHA delimiter (binary garbage, a hand-edit) or with an empty name/SHA
+    // is corruption, not something to `continue` past (#2135).
+    {
+        var lines = std.mem.splitScalar(u8, lock_content, '\n');
+        while (lines.next()) |line| {
+            const l = trimStateLine(line);
+            if (l.len == 0) continue;
+            const malformed = if (std.mem.indexOfScalar(u8, l, ' ')) |sp|
+                sp == 0 or sp + 1 == l.len
+            else
+                true;
+            if (malformed) {
+                writeStdout("  ");
+                printColor(Color.red, "MALFORMED");
+                printBuf(&buf, ": {s}\n", .{l});
+                ok = false;
+            }
+        }
+    }
+
+    // Then walk the *installation*, not the lockfile: every installed package
+    // must have a lockfile entry, and be checked out at that entry's SHA.
+    // A package that is installed but absent from the lockfile is otherwise
+    // unverifiable by construction, and the run must not report success.
+    const inst_content = readFile(allocator, config.installed) catch {
+        // Nothing installed: the structure pass above is the whole check.
+        if (ok) {
+            printColor(Color.green, "All packages verified.\n");
+        } else {
+            printColor(Color.red, "Verification failed.\n");
+            return error.VerifyFailed;
+        }
+        return;
+    };
+    defer allocator.free(inst_content);
+
+    var lines = std.mem.splitScalar(u8, inst_content, '\n');
+    while (lines.next()) |line| {
+        const pkg = trimStateLine(line);
+        if (pkg.len == 0) continue;
+
+        const entry = getLockedEntry(allocator, config.lockfile, pkg);
+        defer if (entry) |e| {
+            allocator.free(e.sha);
+            if (e.source) |s| allocator.free(s);
+        };
+
+        if (entry == null) {
+            writeStdout("  ");
+            printColor(Color.red, "UNLOCKED");
+            printBuf(&buf, ": {s} (no lockfile entry)\n", .{pkg});
+            ok = false;
+            continue;
+        }
+
+        const locked_sha = entry.?.sha;
         const current_sha = getPkgSha(allocator, config.src_dir, pkg);
         if (current_sha == null) {
             writeStdout("  ");
@@ -762,11 +859,11 @@ fn doVerify(allocator: std.mem.Allocator, config: Config) !void {
             printBuf(&buf, ": {s} (not cloned)\n", .{pkg});
             ok = false;
         } else if (!std.mem.eql(u8, current_sha.?, locked_sha)) {
-            const cur_short = current_sha.?[0..@min(12, current_sha.?.len)];
-            const lock_short = locked_sha[0..@min(12, locked_sha.len)];
+            // Print the full SHAs: a 12-character truncation must never be
+            // able to render two different values identically (#2133).
             writeStdout("  ");
             printColor(Color.yellow, "MISMATCH");
-            printBuf(&buf, ": {s} (locked: {s}, actual: {s})\n", .{ pkg, lock_short, cur_short });
+            printBuf(&buf, ": {s} (locked: {s}, actual: {s})\n", .{ pkg, locked_sha, current_sha.? });
             ok = false;
         } else {
             const lock_short = locked_sha[0..@min(12, locked_sha.len)];

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -795,18 +795,26 @@ fn doVerify(allocator: std.mem.Allocator, config: Config) !void {
     var buf: [512]u8 = undefined;
     var ok = true;
 
-    // The lockfile is checked for structure first: a non-empty line with no
-    // SHA delimiter (binary garbage, a hand-edit) or with an empty name/SHA
-    // is corruption, not something to `continue` past (#2135).
+    // The lockfile is checked for structure first: a well-formed line is
+    // `<name> <sha> [<source>]` with a non-empty name, a non-empty SHA, and,
+    // when a source separator is present, a non-empty source. Anything else
+    // (binary garbage, a hand-edit) is corruption, not something to
+    // `continue` past (#2135).
     {
         var lines = std.mem.splitScalar(u8, lock_content, '\n');
         while (lines.next()) |line| {
             const l = trimStateLine(line);
             if (l.len == 0) continue;
-            const malformed = if (std.mem.indexOfScalar(u8, l, ' ')) |sp|
-                sp == 0 or sp + 1 == l.len
-            else
-                true;
+            const malformed = blk: {
+                const sp = std.mem.indexOfScalar(u8, l, ' ') orelse break :blk true;
+                if (sp == 0) break :blk true; // empty name
+                const rest = l[sp + 1 ..];
+                if (rest.len == 0 or rest[0] == ' ') break :blk true; // empty SHA
+                if (std.mem.indexOfScalar(u8, rest, ' ')) |sp2| {
+                    if (sp2 + 1 == rest.len) break :blk true; // empty source
+                }
+                break :blk false;
+            };
             if (malformed) {
                 writeStdout("  ");
                 printColor(Color.red, "MALFORMED");

--- a/src/thottam_state.zig
+++ b/src/thottam_state.zig
@@ -83,7 +83,7 @@ pub fn isInstalled(allocator: std.mem.Allocator, installed_path: []const u8, pkg
     defer allocator.free(content);
     var lines = std.mem.splitScalar(u8, content, '\n');
     while (lines.next()) |line| {
-        if (std.mem.eql(u8, line, pkg)) return true;
+        if (std.mem.eql(u8, thottam.trimStateLine(line), pkg)) return true;
     }
     return false;
 }
@@ -98,8 +98,9 @@ pub fn getLockedEntry(allocator: std.mem.Allocator, lockfile_path: []const u8, p
     defer allocator.free(content);
     var lines = std.mem.splitScalar(u8, content, '\n');
     while (lines.next()) |line| {
-        if (std.mem.startsWith(u8, line, pkg) and line.len > pkg.len and line[pkg.len] == ' ') {
-            const rest = line[pkg.len + 1 ..];
+        const l = thottam.trimStateLine(line);
+        if (std.mem.startsWith(u8, l, pkg) and l.len > pkg.len and l[pkg.len] == ' ') {
+            const rest = l[pkg.len + 1 ..];
             if (std.mem.indexOfScalar(u8, rest, ' ')) |sp| {
                 return .{
                     .sha = allocator.dupe(u8, rest[0..sp]) catch return null,
@@ -141,12 +142,13 @@ pub fn updateLockfile(allocator: std.mem.Allocator, lockfile_path: []const u8, p
         defer allocator.free(content);
         var lines = std.mem.splitScalar(u8, content, '\n');
         while (lines.next()) |line| {
-            if (line.len == 0) continue;
-            if (std.mem.startsWith(u8, line, pkg) and line.len > pkg.len and line[pkg.len] == ' ') {
+            const l = thottam.trimStateLine(line);
+            if (l.len == 0) continue;
+            if (std.mem.startsWith(u8, l, pkg) and l.len > pkg.len and l[pkg.len] == ' ') {
                 try appendLockEntry(&output, allocator, pkg, sha, source);
                 found = true;
             } else {
-                output.appendSlice(allocator, line) catch return error.OutOfMemory;
+                output.appendSlice(allocator, l) catch return error.OutOfMemory;
                 output.append(allocator, '\n') catch return error.OutOfMemory;
             }
         }
@@ -167,9 +169,10 @@ pub fn removeFromLockfile(allocator: std.mem.Allocator, lockfile_path: []const u
 
     var lines = std.mem.splitScalar(u8, content, '\n');
     while (lines.next()) |line| {
-        if (line.len == 0) continue;
-        if (std.mem.startsWith(u8, line, pkg) and line.len > pkg.len and line[pkg.len] == ' ') continue;
-        output.appendSlice(allocator, line) catch return error.OutOfMemory;
+        const l = thottam.trimStateLine(line);
+        if (l.len == 0) continue;
+        if (std.mem.startsWith(u8, l, pkg) and l.len > pkg.len and l[pkg.len] == ' ') continue;
+        output.appendSlice(allocator, l) catch return error.OutOfMemory;
         output.append(allocator, '\n') catch return error.OutOfMemory;
     }
 
@@ -184,9 +187,10 @@ pub fn removeFromInstalled(allocator: std.mem.Allocator, installed_path: []const
 
     var lines = std.mem.splitScalar(u8, content, '\n');
     while (lines.next()) |line| {
-        if (line.len == 0) continue;
-        if (std.mem.eql(u8, line, pkg)) continue;
-        output.appendSlice(allocator, line) catch return error.OutOfMemory;
+        const l = thottam.trimStateLine(line);
+        if (l.len == 0) continue;
+        if (std.mem.eql(u8, l, pkg)) continue;
+        output.appendSlice(allocator, l) catch return error.OutOfMemory;
         output.append(allocator, '\n') catch return error.OutOfMemory;
     }
 

--- a/src/thottam_state.zig
+++ b/src/thottam_state.zig
@@ -116,12 +116,6 @@ pub fn getLockedEntry(allocator: std.mem.Allocator, lockfile_path: []const u8, p
     return null;
 }
 
-pub fn getLockedSha(allocator: std.mem.Allocator, lockfile_path: []const u8, pkg: []const u8) ?[]const u8 {
-    const entry = getLockedEntry(allocator, lockfile_path, pkg) orelse return null;
-    if (entry.source) |s| allocator.free(s);
-    return entry.sha;
-}
-
 pub fn appendLockEntry(output: *std.ArrayList(u8), allocator: std.mem.Allocator, pkg: []const u8, sha: []const u8, source: ?[]const u8) !void {
     output.appendSlice(allocator, pkg) catch return error.OutOfMemory;
     output.append(allocator, ' ') catch return error.OutOfMemory;

--- a/tests/scheme/thottam/thottam-lifecycle.sh
+++ b/tests/scheme/thottam/thottam-lifecycle.sh
@@ -117,6 +117,18 @@ check_file() {
     fi
 }
 
+check_files_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if cmp -s "$expected" "$actual"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label"
+        echo "  files differ: $expected vs $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
 git_q() { git -c user.email=t@example.com -c user.name=Test -c commit.gpgsign=false "$@"; }
 
 # mkpkg <name> <extra-sld-basename-or-empty> <tag>...
@@ -402,12 +414,23 @@ grep -v '^kaappi-one ' "$KAAPPI_HOME/thottam.lock" > "$KAAPPI_HOME/thottam.lock.
 mv "$KAAPPI_HOME/thottam.lock.new" "$KAAPPI_HOME/thottam.lock"
 out="$("$THOTTAM" verify 2>&1)" && ec=0 || ec=$?
 check_exit "verify fails when an installed package has no lockfile entry" 1 "$ec"
+check "verify names the unlocked package" "UNLOCKED: kaappi-one" "$out"
 
 # An empty lockfile is the degenerate case of the same thing: nothing is
 # checked, and the command reports that everything is fine.
 : > "$KAAPPI_HOME/thottam.lock"
 out="$("$THOTTAM" verify 2>&1)" && ec=0 || ec=$?
 check_exit "verify fails on an empty lockfile with packages installed" 1 "$ec"
+
+# A lockfile line whose SHA field is empty is malformed, not an ordinary
+# mismatch: verify must name it MALFORMED rather than comparing a SHA it
+# never actually had.
+fresh_home
+"$THOTTAM" install kaappi-alpha > /dev/null 2>&1
+printf 'kaappi-alpha  %s/kaappi-alpha.git\n' "$ORG" > "$KAAPPI_HOME/thottam.lock"
+out="$("$THOTTAM" verify 2>&1)" && ec=0 || ec=$?
+check_exit "verify fails on a lockfile line with an empty SHA" 1 "$ec"
+check "verify names the malformed line" "MALFORMED: kaappi-alpha" "$out"
 # Discriminating control: an ABSENT lockfile *is* caught, so the blind spot
 # is specific to a lockfile that exists and says nothing.
 rm -f "$KAAPPI_HOME/thottam.lock"
@@ -479,6 +502,7 @@ out="$("$THOTTAM" update kaappi-alpha 2>&1)" && ec=0 || ec=$?
 fresh_home
 "$THOTTAM" install "kaappi-alpha::$ORG/kaappi-alpha.git" > /dev/null 2>&1
 saved_lock="$(cat "$KAAPPI_HOME/thottam.lock")"
+cp "$KAAPPI_HOME/thottam.lock" "$KAAPPI_HOME/thottam.lock.saved"
 
 out="$("$THOTTAM" --locked install kaappi-nosuch 2>&1)" && ec=0 || ec=$?
 check_exit "--locked refuses a package absent from the lockfile" 1 "$ec"
@@ -492,8 +516,8 @@ rm -rf "$KAAPPI_HOME/src" "$KAAPPI_HOME/lib"
 out="$("$THOTTAM" --locked install kaappi-alpha 2>&1)" && ec=0 || ec=$?
 check_exit "--locked restores a locked package" 0 "$ec"
 check "--locked checks out the locked SHA" "Checking out" "$out"
-check "--locked restore leaves the lockfile byte-for-byte unchanged" \
-    "$saved_lock" "$(cat "$KAAPPI_HOME/thottam.lock")"
+check_files_eq "--locked restore leaves the lockfile byte-for-byte unchanged" \
+    "$KAAPPI_HOME/thottam.lock.saved" "$KAAPPI_HOME/thottam.lock"
 # Discriminating control: the SHA half of the line does survive the restore.
 check "--locked restore preserves the locked SHA" \
     "$(printf '%s' "$saved_lock" | cut -d' ' -f2)" "$(cat "$KAAPPI_HOME/thottam.lock")"
@@ -516,7 +540,22 @@ rm -rf "$KAAPPI_HOME/src" "$KAAPPI_HOME/lib"
 : > "$KAAPPI_HOME/installed.txt"
 out="$("$THOTTAM" --locked install "kaappi-alpha::$ORG/FORK-kaappi-alpha.git" 2>&1)" && ec=0 || ec=$?
 check_exit "--locked refuses a source URL that differs from the lockfile" 1 "$ec"
+check "--locked names the source URL mismatch" "source URL mismatch" "$out"
+check_not "--locked refuses before cloning the fork" "yes" \
+    "$([[ -d "$KAAPPI_HOME/src/kaappi-alpha" ]] && echo yes || echo no)"
 check "--locked leaves the recorded provenance intact" \
+    "$ORG/kaappi-alpha.git" "$(cat "$KAAPPI_HOME/thottam.lock")"
+
+# Control for the reject path above: a ::url that MATCHES the recorded source
+# is accepted, so the enforcement is exact rather than a blanket refusal of
+# every explicit ::url.
+fresh_home
+"$THOTTAM" install "kaappi-alpha::$ORG/kaappi-alpha.git" > /dev/null 2>&1
+rm -rf "$KAAPPI_HOME/src" "$KAAPPI_HOME/lib"
+: > "$KAAPPI_HOME/installed.txt"
+out="$("$THOTTAM" --locked install "kaappi-alpha::$ORG/kaappi-alpha.git" 2>&1)" && ec=0 || ec=$?
+check_exit "--locked accepts a source URL that matches the lockfile" 0 "$ec"
+check "--locked matching-source restore records the same provenance" \
     "$ORG/kaappi-alpha.git" "$(cat "$KAAPPI_HOME/thottam.lock")"
 
 # ---------------------------------------------------------------------------

--- a/tests/scheme/thottam/thottam-lifecycle.sh
+++ b/tests/scheme/thottam/thottam-lifecycle.sh
@@ -401,16 +401,13 @@ check "verify names the mismatched package" "MISMATCH: kaappi-one" "$out"
 grep -v '^kaappi-one ' "$KAAPPI_HOME/thottam.lock" > "$KAAPPI_HOME/thottam.lock.new"
 mv "$KAAPPI_HOME/thottam.lock.new" "$KAAPPI_HOME/thottam.lock"
 out="$("$THOTTAM" verify 2>&1)" && ec=0 || ec=$?
-# FAIL: #2135 (verify iterates the lockfile, so dropping a line silently
-# removes that package from verification and the run reports success)
-# check_exit "verify fails when an installed package has no lockfile entry" 1 "$ec"
+check_exit "verify fails when an installed package has no lockfile entry" 1 "$ec"
 
 # An empty lockfile is the degenerate case of the same thing: nothing is
 # checked, and the command reports that everything is fine.
 : > "$KAAPPI_HOME/thottam.lock"
 out="$("$THOTTAM" verify 2>&1)" && ec=0 || ec=$?
-# FAIL: #2135
-# check_exit "verify fails on an empty lockfile with packages installed" 1 "$ec"
+check_exit "verify fails on an empty lockfile with packages installed" 1 "$ec"
 # Discriminating control: an ABSENT lockfile *is* caught, so the blind spot
 # is specific to a lockfile that exists and says nothing.
 rm -f "$KAAPPI_HOME/thottam.lock"
@@ -495,12 +492,8 @@ rm -rf "$KAAPPI_HOME/src" "$KAAPPI_HOME/lib"
 out="$("$THOTTAM" --locked install kaappi-alpha 2>&1)" && ec=0 || ec=$?
 check_exit "--locked restores a locked package" 0 "$ec"
 check "--locked checks out the locked SHA" "Checking out" "$out"
-# FAIL: #2137 (doInstall rewrites the lockfile from `parsed.source`, which is
-# null when no ::url was given, so restoring from the lockfile ERASES the
-# provenance column the lockfile exists to carry — the SHA survives, the URL
-# does not)
-# check "--locked restore leaves the lockfile byte-for-byte unchanged" \
-#     "$saved_lock" "$(cat "$KAAPPI_HOME/thottam.lock")"
+check "--locked restore leaves the lockfile byte-for-byte unchanged" \
+    "$saved_lock" "$(cat "$KAAPPI_HOME/thottam.lock")"
 # Discriminating control: the SHA half of the line does survive the restore.
 check "--locked restore preserves the locked SHA" \
     "$(printf '%s' "$saved_lock" | cut -d' ' -f2)" "$(cat "$KAAPPI_HOME/thottam.lock")"
@@ -522,12 +515,9 @@ fresh_home
 rm -rf "$KAAPPI_HOME/src" "$KAAPPI_HOME/lib"
 : > "$KAAPPI_HOME/installed.txt"
 out="$("$THOTTAM" --locked install "kaappi-alpha::$ORG/FORK-kaappi-alpha.git" 2>&1)" && ec=0 || ec=$?
-# FAIL: #2137 (--locked compares only the SHA; the clone comes from the URL
-# passed on this invocation and the lockfile's recorded source is then
-# overwritten with it)
-# check_exit "--locked refuses a source URL that differs from the lockfile" 1 "$ec"
-# check "--locked leaves the recorded provenance intact" \
-#     "$ORG/kaappi-alpha.git" "$(cat "$KAAPPI_HOME/thottam.lock")"
+check_exit "--locked refuses a source URL that differs from the lockfile" 1 "$ec"
+check "--locked leaves the recorded provenance intact" \
+    "$ORG/kaappi-alpha.git" "$(cat "$KAAPPI_HOME/thottam.lock")"
 
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Three related audit findings in the package manager (`thottam`), fixed together because they share the same files and the same root cause: thottam trusting a lockfile it did not write, and reading the wrong half of the install state.

- **Closes #2135** — `verify` iterated the lockfile, not `installed.txt`, so an installed-but-unlocked package (or an empty/binary-garbage lockfile) silently passed. `doVerify` now walks `installed.txt`; every installed package must have a lockfile entry at the SHA it is checked out at, and a malformed lockfile line fails the run instead of being skipped.
- **Closes #2137** — `--locked` checked only the SHA, cloned from whatever URL the invocation was handed, then overwrote the lockfile's recorded provenance. The lockfile entry is now read once: the recorded source is the clone URL, an explicit `::url` that disagrees is refused before cloning, and a `--locked` install never rewrites the recorded source.
- **Closes #2133** — a CRLF-normalised lockfile left a trailing `\r` in the SHA, so `verify` printed `MISMATCH (locked: X, actual: X)` and `--locked` handed `<sha>\r` to `git checkout`. Every reader of `thottam.lock` / `installed.txt` now strips the trailing `\r`, and the mismatch message prints full SHAs so it cannot render two different values identically.

## Changes

- `src/thottam.zig`: `doVerify` rewrite (iterate `installed.txt`, validate lockfile structure, full-SHA mismatch output); `--locked` source-URL enforcement in `doInstall`; `trimStateLine` helper; CRLF trimming in `doList`/`doUpdate`.
- `src/thottam_state.zig`: strip trailing `\r` in `getLockedEntry`, `isInstalled`, `updateLockfile`, `removeFromLockfile`, `removeFromInstalled`.
- `src/tests_thottam.zig`: re-enable the #2133 CRLF assertion.
- `tests/scheme/thottam/thottam-lifecycle.sh`: re-enable the #2135 and #2137 regression checks.

## Testing

- `zig build test`: 1795/1802 tests pass (7 skipped, 0 failed).
- `thottam-tests`: 72/72 pass.
- `bash tests/scheme/thottam/thottam-lifecycle.sh`: 89 passed, 0 failed.
