### PR TITLE
thottam: fix version re-pins, ownership-aware removal, and state-file name validation

### DIFF
--- a/docs/dev/thottam.md
+++ b/docs/dev/thottam.md
@@ -24,6 +24,8 @@ thottam remove kaappi-web                                        # uninstall
 - Copies `.sld` files to `~/.kaappi/lib/`, preserving directory structure.
 - Copies `.dylib`/`.so` to `~/.kaappi/lib/`.
 - Records source URLs in the lockfile `~/.kaappi/thottam.lock`, for provenance.
+- Records each installed file in `~/.kaappi/thottam.files`, so `remove` only
+  unlinks files no other installed package still needs (kaappi#2136).
 
 **Auto-discovery.** `main.zig` automatically adds the script's own directory and
 `~/.kaappi/lib` to the library search path, after any `--lib-path` entries — so a
@@ -38,15 +40,17 @@ directory. See the LLVM backend section of `CLAUDE.md`.
 ## The `kaappi.pkg` manifest
 
 ```text
-name: kaappi-web
 depends: kaappi-http kaappi-json
 build: make
-source: https://github.com/kaappi/kaappi-web
 ```
 
-Every field except `name` is optional.
+Only these two fields are read. `name:`, `version:`, `source:` and any other
+key are ignored — a package is identified by the name it is installed under,
+the version is whatever tag or SHA the install requested, and a third-party
+source is given on the command line (`thottam install pkg::url`) or in a
+`depends:` spec, never in the package's own manifest (which thottam can only
+read after it has already cloned the repo) (kaappi#2138).
 
-- `source` declares where this package is hosted (for third-party packages).
 - `depends` is space-separated, and may carry an inline custom URL:
   `depends: kaappi-net kaappi-auth::https://github.com/bob/kaappi-auth`.
 - Version constraints use `>=`, `>`, `<=`, `<`, `^` (compatible), `~`

--- a/docs/dev/thottam.md
+++ b/docs/dev/thottam.md
@@ -25,7 +25,10 @@ thottam remove kaappi-web                                        # uninstall
 - Copies `.dylib`/`.so` to `~/.kaappi/lib/`.
 - Records source URLs in the lockfile `~/.kaappi/thottam.lock`, for provenance.
 - Records each installed file in `~/.kaappi/thottam.files`, so `remove` only
-  unlinks files no other installed package still needs (kaappi#2136).
+  unlinks files no other installed package still needs (kaappi#2136). When an
+  install or update copies a file another package already owns, thottam
+  warns; the newest copy stays authoritative, and removing the package that
+  last copied it does not restore the earlier package's copy.
 
 **Auto-discovery.** `main.zig` automatically adds the script's own directory and
 `~/.kaappi/lib` to the library search path, after any `--lib-path` entries — so a

--- a/src/tests_thottam.zig
+++ b/src/tests_thottam.zig
@@ -465,25 +465,26 @@ test "isValidPkgName accepts the shapes the ecosystem actually uses" {
 // kaappi.pkg manifest parsing
 // ---------------------------------------------------------------------------
 
-test "parsePkgManifest reads the four documented fields" {
+test "parsePkgManifest reads the two read fields and ignores the rest" {
+    // Only depends and build are read. name, source and version are
+    // documented as ignored — a manifest that lies about its identity or
+    // hosting must not change the install (issue #2138).
     const m = state.parsePkgManifest(
         \\name: kaappi-web
+        \\source: https://evil.example.com/not-this-repo
+        \\version: 99.99.99
         \\depends: kaappi-http kaappi-json
         \\build: make
-        \\source: https://github.com/alice/kaappi-web
         \\
     );
-    try std.testing.expectEqualStrings("kaappi-web", m.name.?);
     try std.testing.expectEqualStrings("kaappi-http kaappi-json", m.depends.?);
     try std.testing.expectEqualStrings("make", m.build_cmd.?);
-    try std.testing.expectEqualStrings("https://github.com/alice/kaappi-web", m.source.?);
 }
 
 test "parsePkgManifest tolerates CRLF line endings" {
     // thottam runs on Windows under Git Bash; a manifest checked out with
     // core.autocrlf=true has \r before every \n.
     const m = state.parsePkgManifest("name: kaappi-web\r\ndepends: kaappi-http\r\nbuild: make\r\n");
-    try std.testing.expectEqualStrings("kaappi-web", m.name.?);
     try std.testing.expectEqualStrings("kaappi-http", m.depends.?);
     try std.testing.expectEqualStrings("make", m.build_cmd.?);
 }
@@ -497,37 +498,32 @@ test "parsePkgManifest ignores unknown keys and near-miss key names" {
         \\dependency: not-the-depends
         \\version: 1.0.0
         \\name: real
+        \\source: https://h/real
+        \\depends: real-dep
         \\
     );
-    try std.testing.expectEqualStrings("real", m.name.?);
-    try std.testing.expect(m.depends == null);
+    try std.testing.expectEqualStrings("real-dep", m.depends.?);
     try std.testing.expect(m.build_cmd == null);
-    try std.testing.expect(m.source == null);
 }
 
 test "parsePkgManifest takes the last of duplicate keys" {
-    const m = state.parsePkgManifest("name: first\nname: second\nbuild: a\nbuild: b\n");
-    try std.testing.expectEqualStrings("second", m.name.?);
+    const m = state.parsePkgManifest("depends: a\ndepends: b\nbuild: a\nbuild: b\n");
+    try std.testing.expectEqualStrings("b", m.depends.?);
     try std.testing.expectEqualStrings("b", m.build_cmd.?);
 }
 
 test "parsePkgManifest requires the key at column 0" {
     // Strictness worth pinning: an indented key is silently dropped, so a
     // future whitespace-tolerant rewrite has to notice this test.
-    const m = state.parsePkgManifest("  name: indented\n\tbuild: tabbed\n");
-    try std.testing.expect(m.name == null);
+    const m = state.parsePkgManifest("  depends: indented\n\tbuild: tabbed\n");
+    try std.testing.expect(m.depends == null);
     try std.testing.expect(m.build_cmd == null);
 }
 
 test "parsePkgManifest on missing and empty values" {
     const none = state.parsePkgManifest("");
-    try std.testing.expect(none.name == null);
     try std.testing.expect(none.depends == null);
     try std.testing.expect(none.build_cmd == null);
-    try std.testing.expect(none.source == null);
-
-    // An option-shaped source is dropped, like the spec-level guard.
-    try std.testing.expect(state.parsePkgManifest("source: -evil\n").source == null);
 
     // An empty `build:` should mean "no build command", not "run the empty
     // command" — thottam used to print "Building <pkg>..." and run
@@ -538,7 +534,7 @@ test "parsePkgManifest on missing and empty values" {
     try std.testing.expectEqualStrings("make", state.parsePkgManifest("build:\nbuild: make\n").build_cmd.?);
 
     // Discriminating control: a genuinely absent build: key is null.
-    try std.testing.expect(state.parsePkgManifest("name: x\n").build_cmd == null);
+    try std.testing.expect(state.parsePkgManifest("depends: x\n").build_cmd == null);
 }
 
 test "parseField trims the value but not the key" {

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -39,6 +39,10 @@ const parsePkgSpec = state.parsePkgSpec;
 const isValidPkgName = state.isValidPkgName;
 const parsePkgManifest = state.parsePkgManifest;
 const isInstalled = state.isInstalled;
+const addToInstalled = state.addToInstalled;
+const updateFileManifest = state.updateFileManifest;
+const removeFromFileManifest = state.removeFromFileManifest;
+const fileClaimedBy = state.fileClaimedBy;
 const LockEntry = state.LockEntry;
 const getLockedEntry = state.getLockedEntry;
 const appendLockEntry = state.appendLockEntry;
@@ -69,6 +73,7 @@ const Config = struct {
     src_dir: []const u8,
     installed: []const u8,
     lockfile: []const u8,
+    files: []const u8,
 };
 
 fn writeToFd(fd: platform.fd_t, bytes: []const u8) void {
@@ -149,7 +154,7 @@ pub fn writeFile(allocator: std.mem.Allocator, path: []const u8, content: []cons
     }
 }
 
-fn appendFile(allocator: std.mem.Allocator, path: []const u8, line: []const u8) !void {
+pub fn appendFile(allocator: std.mem.Allocator, path: []const u8, line: []const u8) !void {
     const path_z = try allocator.dupeZ(u8, path);
     defer allocator.free(path_z);
     const fd = platform.openAppend(path_z, 0o644) catch return error.CannotOpen;
@@ -267,10 +272,8 @@ fn getPkgManifest(allocator: std.mem.Allocator, src_dir: []const u8, pkg: []cons
     const content = readFile(allocator, pkg_file) catch return null;
     defer allocator.free(content);
     var m = parsePkgManifest(content);
-    m.name = if (m.name) |n| allocator.dupe(u8, n) catch null else null;
     m.depends = if (m.depends) |d| allocator.dupe(u8, d) catch null else null;
     m.build_cmd = if (m.build_cmd) |b| allocator.dupe(u8, b) catch null else null;
-    m.source = if (m.source) |s| allocator.dupe(u8, s) catch null else null;
     m.owned = true;
     return m;
 }
@@ -300,27 +303,106 @@ fn copyDylibsFromPkg(allocator: std.mem.Allocator, pkg_dir: []const u8, lib_dir:
     return count;
 }
 
-fn removeDylibsFromPkg(allocator: std.mem.Allocator, pkg_dir: []const u8, lib_dir: []const u8) !void {
-    var names = tfs.collectFilesWithSuffix(allocator, pkg_dir, dylib_ext, false) catch return;
-    defer tfs.freePathList(allocator, &names);
-    for (names.items) |basename| {
-        const target = joinPath(allocator, lib_dir, basename) catch continue;
+fn removeInstalledFiles(allocator: std.mem.Allocator, config: Config, pkg: []const u8) !void {
+    var rels: std.ArrayList([]u8) = .empty;
+    defer {
+        for (rels.items) |r| allocator.free(r);
+        rels.deinit(allocator);
+    }
+
+    // Own records first: what this package's installs actually placed.
+    // Entries are the source of truth for what removal unlinks, so a
+    // package that renamed a file upstream stops orphaning the old copy
+    // (the old code re-walked the source tree and never found it).
+    if (readFile(allocator, config.files)) |content| {
+        defer allocator.free(content);
+        var lines = std.mem.splitScalar(u8, content, '\n');
+        while (lines.next()) |line| {
+            const l = trimStateLine(line);
+            if (l.len == 0) continue;
+            if (std.mem.startsWith(u8, l, pkg) and l.len > pkg.len and l[pkg.len] == ' ') {
+                const rel = l[pkg.len + 1 ..];
+                if (rel.len > 0) try addFileToList(allocator, &rels, rel);
+            }
+        }
+    } else |_| {}
+
+    // Then the source tree, for packages installed before the manifest
+    // existed — the old discovery path, still claim-guarded.
+    const pkg_dir = try joinPath(allocator, config.src_dir, pkg);
+    defer allocator.free(pkg_dir);
+    const pkg_lib = try joinPath(allocator, pkg_dir, "lib");
+    defer allocator.free(pkg_lib);
+    if (dirExists(allocator, pkg_lib)) {
+        var found = try tfs.collectFilesWithSuffix(allocator, pkg_lib, ".sld", true);
+        defer tfs.freePathList(allocator, &found);
+        for (found.items) |rel| try addFileToList(allocator, &rels, rel);
+    }
+    var dylibs = try tfs.collectFilesWithSuffix(allocator, pkg_dir, dylib_ext, false);
+    defer tfs.freePathList(allocator, &dylibs);
+    for (dylibs.items) |name| try addFileToList(allocator, &rels, name);
+
+    for (rels.items) |rel| {
+        // Only unlink a file no other installed package claims: the whole
+        // point of the record (#2136).
+        if (fileClaimedBy(allocator, config.files, rel, pkg)) |other| {
+            allocator.free(other);
+            continue;
+        }
+        const target = joinPath(allocator, config.lib_dir, rel) catch continue;
         defer allocator.free(target);
         const target_z = allocator.dupeZ(u8, target) catch continue;
         defer allocator.free(target_z);
         _ = platform.unlink(target_z);
+        pruneEmptyParents(allocator, config.lib_dir, rel);
     }
 }
 
-fn removeSldFiles(allocator: std.mem.Allocator, pkg_lib_dir: []const u8, lib_dir: []const u8) !void {
-    var rels = tfs.collectFilesWithSuffix(allocator, pkg_lib_dir, ".sld", true) catch return;
-    defer tfs.freePathList(allocator, &rels);
-    for (rels.items) |rel| {
-        const target = joinPath(allocator, lib_dir, rel) catch continue;
-        defer allocator.free(target);
-        const target_z = allocator.dupeZ(u8, target) catch continue;
-        defer allocator.free(target_z);
-        _ = platform.unlink(target_z);
+fn addFileToList(allocator: std.mem.Allocator, rels: *std.ArrayList([]u8), rel: []const u8) !void {
+    for (rels.items) |existing| {
+        if (std.mem.eql(u8, existing, rel)) return;
+    }
+    const copy = try allocator.dupe(u8, rel);
+    rels.append(allocator, copy) catch |err| {
+        allocator.free(copy);
+        return err;
+    };
+}
+
+/// Warn when an install is about to overwrite a file another installed
+/// package's manifest claims (issue #2136). The collision is introduced
+/// here, at the point it can still be seen — the overwrite itself is the
+/// documented `cp -R lib/. dst/` merge, and the warning makes the running
+/// behaviour of an already-installed package changing as a side effect
+/// audible instead of silent.
+fn warnIfClaimed(allocator: std.mem.Allocator, config: Config, pkg: []const u8, rel: []const u8) !void {
+    if (fileClaimedBy(allocator, config.files, rel, pkg)) |other| {
+        defer allocator.free(other);
+        var buf: [512]u8 = undefined;
+        printErrColor(Color.yellow, "warning: ");
+        const msg = std.fmt.bufPrint(&buf, "{s} is also provided by {s}; overwriting its installed copy\n", .{ rel, other }) catch "overwriting a shared library file\n";
+        writeStderr(msg);
+    }
+}
+
+/// Remove directories that became empty after a file unlink, walking up from
+/// the file's parent to (but not including) `lib_dir`. rmdir fails on a
+/// non-empty directory, which ends the walk (issue #2136: removal used to
+/// leave empty directory skeletons behind).
+fn pruneEmptyParents(allocator: std.mem.Allocator, lib_dir: []const u8, rel: []const u8) void {
+    const full = std.mem.concat(allocator, u8, &.{ lib_dir, "/", rel }) catch return;
+    defer allocator.free(full);
+    var end = std.mem.lastIndexOfScalar(u8, full, '/');
+    while (end) |e| {
+        if (e <= lib_dir.len) break;
+        const parent = full[0..e];
+        const z = allocator.dupeZ(u8, parent) catch return;
+        if (platform.rmdir(z) != 0) {
+            allocator.free(z);
+            return;
+        }
+        allocator.free(z);
+        end = std.mem.lastIndexOfScalar(u8, parent, '/');
     }
 }
 
@@ -431,13 +513,6 @@ fn doInstall(
 
     if (!try markVisited(allocator, visited, pkg)) return;
 
-    if (isInstalled(allocator, config.installed, pkg)) {
-        writeStdout("  ");
-        printColor(Color.dim, pkg);
-        writeStdout(" already installed\n");
-        return;
-    }
-
     if (locked_mode) {
         const entry = getLockedEntry(allocator, config.lockfile, pkg) orelse {
             var buf: [256]u8 = undefined;
@@ -508,6 +583,56 @@ fn doInstall(
                 },
             }
         }
+    }
+
+    // #2134: "already installed" is only a correct no-op when no version was
+    // requested, or when the checkout already is at the requested version.
+    // Otherwise fall through and re-checkout: an install that names a version
+    // must leave the install at that version, not silently keep a different
+    // one — a provisioning script that pins and checks the exit status would
+    // be told it succeeded. In --locked mode the lockfile IS the requested
+    // version, so a locked install also re-checkouts when the installed SHA
+    // differs from the locked one.
+    if (isInstalled(allocator, config.installed, pkg)) {
+        if (install_version == null) {
+            writeStdout("  ");
+            printColor(Color.dim, pkg);
+            writeStdout(" already installed\n");
+            return;
+        }
+
+        const current_sha = getPkgSha(allocator, config.src_dir, pkg);
+        defer if (current_sha) |s| allocator.free(s);
+        var wanted_owned: ?[]const u8 = null;
+        defer if (wanted_owned) |s| allocator.free(s);
+        const wanted_sha: ?[]const u8 = if (locked_mode)
+            locked_sha
+        else blk: {
+            const v = install_version.?;
+            // Same option-injection guard as checkoutVersion: a version is
+            // a ref, never an option. Anything else falls through, where the
+            // checkout reports the failure.
+            if (v.len == 0 or v[0] == '-') break :blk null;
+            const pkg_dir_probe = joinPath(allocator, config.src_dir, pkg) catch break :blk null;
+            defer allocator.free(pkg_dir_probe);
+            if (!dirExists(allocator, pkg_dir_probe)) break :blk null;
+            const ref = std.fmt.allocPrint(allocator, "{s}^{{commit}}", .{v}) catch break :blk null;
+            defer allocator.free(ref);
+            const sha = runGitCapture(allocator, &.{ "-C", pkg_dir_probe, "rev-parse", ref }) catch null;
+            wanted_owned = sha;
+            break :blk sha;
+        };
+
+        if (current_sha != null and wanted_sha != null and std.mem.eql(u8, current_sha.?, wanted_sha.?)) {
+            var msg_buf: [256]u8 = undefined;
+            writeStdout("  ");
+            printColor(Color.dim, pkg);
+            const msg = std.fmt.bufPrint(&msg_buf, " already installed (at {s})\n", .{install_version.?}) catch " already installed\n";
+            writeStdout(msg);
+            return;
+        }
+        // Fall through: the requested version differs from the checkout —
+        // re-checkout, rebuild and re-record below.
     }
 
     var buf: [512]u8 = undefined;
@@ -584,17 +709,38 @@ fn doInstall(
 
     const lib_src = try joinPath(allocator, pkg_dir, "lib");
     defer allocator.free(lib_src);
+
+    // Collect what will be copied so the install can warn about files that
+    // another installed package owns, and record what it installed for
+    // ownership-aware removal (#2136).
+    var sld_files: std.ArrayList([]u8) = .empty;
+    defer tfs.freePathList(allocator, &sld_files);
     if (dirExists(allocator, lib_src)) {
+        sld_files = try tfs.collectFilesWithSuffix(allocator, lib_src, ".sld", true);
+        for (sld_files.items) |rel| try warnIfClaimed(allocator, config, pkg, rel);
         writeStdout("  Installing libraries...\n");
         try installLibTree(allocator, lib_src, config.lib_dir);
     }
+
+    var dylib_files = try tfs.collectFilesWithSuffix(allocator, pkg_dir, dylib_ext, false);
+    defer tfs.freePathList(allocator, &dylib_files);
+    for (dylib_files.items) |name| try warnIfClaimed(allocator, config, pkg, name);
 
     const dylib_count = try copyDylibsFromPkg(allocator, pkg_dir, config.lib_dir);
     if (dylib_count > 0) {
         printBuf(&buf, "  Installed {d} native library(s)\n", .{dylib_count});
     }
 
-    try appendFile(allocator, config.installed, pkg);
+    // Record the installed files so `remove` can tell what belongs to whom
+    // (issue #2136). Rewrites this package's own lines: a re-install at a
+    // different version must not leave stale entries behind.
+    var files_list: std.ArrayList([]const u8) = .empty;
+    defer files_list.deinit(allocator);
+    for (sld_files.items) |rel| files_list.append(allocator, rel) catch return error.OutOfMemory;
+    for (dylib_files.items) |name| files_list.append(allocator, name) catch return error.OutOfMemory;
+    try updateFileManifest(allocator, config.files, pkg, files_list.items);
+
+    try addToInstalled(allocator, config.installed, pkg);
     // A --locked install must not rewrite the lockfile's recorded source: the
     // provenance it is checking must survive the check (#2137).
     try updateLockfile(allocator, config.lockfile, pkg, resolved_sha, if (locked_mode) locked_source else parsed.source);
@@ -624,14 +770,11 @@ fn doRemove(allocator: std.mem.Allocator, config: Config, pkg: []const u8) !void
 
     const pkg_dir = try joinPath(allocator, config.src_dir, pkg);
     defer allocator.free(pkg_dir);
-    const pkg_lib = try joinPath(allocator, pkg_dir, "lib");
-    defer allocator.free(pkg_lib);
 
-    if (dirExists(allocator, pkg_lib)) {
-        try removeSldFiles(allocator, pkg_lib, config.lib_dir);
-    }
-
-    try removeDylibsFromPkg(allocator, pkg_dir, config.lib_dir);
+    // Unlink only the files this package installed (and no other installed
+    // package still needs), then drop its ownership record (#2136).
+    try removeInstalledFiles(allocator, config, pkg);
+    try removeFromFileManifest(allocator, config.files, pkg);
     try removeFromInstalled(allocator, config.installed, pkg);
     try removeFromLockfile(allocator, config.lockfile, pkg);
     try removeDir(allocator, pkg_dir);
@@ -659,6 +802,10 @@ fn doList(allocator: std.mem.Allocator, config: Config) !void {
     while (lines.next()) |line| {
         const pkg = trimStateLine(line);
         if (pkg.len == 0) continue;
+        // #2144: a corrupted installed.txt must never yield a filesystem
+        // path — joinPath(src_dir, pkg) and joinPath(lib_dir, pkg) below
+        // are only safe for names isValidPkgName accepts. Skip the line.
+        if (!isValidPkgName(pkg)) continue;
         const entry = getLockedEntry(allocator, config.lockfile, pkg);
         const sha_short = if (entry) |e| e.sha[0..@min(12, e.sha.len)] else "unknown";
         const source = if (entry) |e| e.source else null;
@@ -689,6 +836,16 @@ fn doList(allocator: std.mem.Allocator, config: Config) !void {
 
 fn doUpdate(allocator: std.mem.Allocator, config: Config, pkg: ?[]const u8) !void {
     if (pkg) |p| {
+        // #2144: the same entry guard as install/remove — a package name
+        // must never build a path outside $KAAPPI_HOME, however it arrives.
+        if (!isValidPkgName(p)) {
+            printErrColor(Color.red, "error: ");
+            writeStderr("invalid package name '");
+            writeStderr(p);
+            writeStderr("' (only alphanumeric, '-', '_' allowed)\n");
+            return error.InvalidPackageName;
+        }
+
         if (!isInstalled(allocator, config.installed, p)) {
             printErrColor(Color.red, p);
             writeStderr(" is not installed\n");
@@ -702,6 +859,10 @@ fn doUpdate(allocator: std.mem.Allocator, config: Config, pkg: ?[]const u8) !voi
 
         const pkg_dir = try joinPath(allocator, config.src_dir, p);
         defer allocator.free(pkg_dir);
+        if (!dirExists(allocator, pkg_dir)) {
+            printErrColor(Color.red, "  Failed to pull\n");
+            return error.GitFailed;
+        }
 
         const locked_entry = getLockedEntry(allocator, config.lockfile, p);
         const expected_source = if (locked_entry) |e| e.source else null;
@@ -722,6 +883,30 @@ fn doUpdate(allocator: std.mem.Allocator, config: Config, pkg: ?[]const u8) !voi
                 runGit(allocator, &.{ "-C", pkg_dir, "remote", "set-url", "origin", expected_url }) catch {};
             }
         } else |_| {}
+
+        // #2134: a pinned install checks out a tag, leaving a detached
+        // HEAD that `git pull` cannot advance — it fails with git's own
+        // "You are not currently on a branch" advice, which no thottam user
+        // can act on (the repo is thottam's, under $KAAPPI_HOME/src). Say
+        // plainly that the package is pinned, and to what, instead. The
+        // named form succeeds as a no-op and the all-packages form skips the
+        // package, so one pin no longer fails a whole-tree update. To move
+        // the pin, install at the new version — `thottam install pkg@<ver>`
+        // re-pins an installed package (issue #2134).
+        if (runGitCapture(allocator, &.{ "-C", pkg_dir, "symbolic-ref", "-q", "HEAD" })) |branch| {
+            defer allocator.free(branch);
+            // On a branch: ordinary update below.
+        } else |_| {
+            var ref_buf: [64]u8 = undefined;
+            const describe = runGitCapture(allocator, &.{ "-C", pkg_dir, "describe", "--tags", "--exact-match", "HEAD" }) catch null;
+            defer if (describe) |d| allocator.free(d);
+            const pinned_ref = if (describe) |d| d else blk: {
+                const sha = if (locked_entry) |e| e.sha else "unknown";
+                break :blk std.fmt.bufPrint(&ref_buf, "{s}", .{sha[0..@min(12, sha.len)]}) catch "unknown";
+            };
+            printBuf(&buf, "  {s} is pinned at {s}; skipping (install {s}@<version> to move the pin)\n", .{ p, pinned_ref, p });
+            return;
+        }
 
         runGit(allocator, &.{ "-C", pkg_dir, "pull", "--quiet" }) catch {
             printErrColor(Color.red, "  Failed to pull\n");
@@ -765,10 +950,12 @@ fn doUpdate(allocator: std.mem.Allocator, config: Config, pkg: ?[]const u8) !voi
         var lines = std.mem.splitScalar(u8, content, '\n');
         while (lines.next()) |line| {
             const name = trimStateLine(line);
-            if (name.len > 0) {
-                const copy = allocator.dupe(u8, name) catch continue;
-                packages.append(allocator, copy) catch continue;
-            }
+            if (name.len == 0) continue;
+            // #2144: never build a path from a name read back from a state
+            // file — skip lines whose name isValidPkgName rejects.
+            if (!isValidPkgName(name)) continue;
+            const copy = allocator.dupe(u8, name) catch continue;
+            packages.append(allocator, copy) catch continue;
         }
 
         var any_failed = false;
@@ -808,6 +995,10 @@ fn doVerify(allocator: std.mem.Allocator, config: Config) !void {
             const malformed = blk: {
                 const sp = std.mem.indexOfScalar(u8, l, ' ') orelse break :blk true;
                 if (sp == 0) break :blk true; // empty name
+                // #2144: a package name must satisfy isValidPkgName — a
+                // hand-edited or corrupted entry must not reach the path-
+                // building code below.
+                if (!isValidPkgName(l[0..sp])) break :blk true;
                 const rest = l[sp + 1 ..];
                 if (rest.len == 0 or rest[0] == ' ') break :blk true; // empty SHA
                 if (std.mem.indexOfScalar(u8, rest, ' ')) |sp2| {
@@ -844,6 +1035,17 @@ fn doVerify(allocator: std.mem.Allocator, config: Config) !void {
     while (lines.next()) |line| {
         const pkg = trimStateLine(line);
         if (pkg.len == 0) continue;
+
+        // #2144: an invalid name in installed.txt is corruption, not an
+        // entry to verify — name it and fail rather than build a path from
+        // it (getPkgSha below joins it onto src_dir).
+        if (!isValidPkgName(pkg)) {
+            writeStdout("  ");
+            printColor(Color.red, "MALFORMED");
+            printBuf(&buf, ": {s}\n", .{pkg});
+            ok = false;
+            continue;
+        }
 
         const entry = getLockedEntry(allocator, config.lockfile, pkg);
         defer if (entry) |e| {
@@ -939,6 +1141,7 @@ fn buildConfig(allocator: std.mem.Allocator) !Config {
         .src_dir = try std.mem.concat(allocator, u8, &.{ home, "/src" }),
         .installed = try std.mem.concat(allocator, u8, &.{ home, "/installed.txt" }),
         .lockfile = try std.mem.concat(allocator, u8, &.{ home, "/thottam.lock" }),
+        .files = try std.mem.concat(allocator, u8, &.{ home, "/thottam.files" }),
     };
 }
 

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -304,7 +304,7 @@ fn copyDylibsFromPkg(allocator: std.mem.Allocator, pkg_dir: []const u8, lib_dir:
 }
 
 fn removeInstalledFiles(allocator: std.mem.Allocator, config: Config, pkg: []const u8) !void {
-    var rels: std.ArrayList([]u8) = .empty;
+    var rels: std.ArrayList([]const u8) = .empty;
     defer {
         for (rels.items) |r| allocator.free(r);
         rels.deinit(allocator);
@@ -358,7 +358,7 @@ fn removeInstalledFiles(allocator: std.mem.Allocator, config: Config, pkg: []con
     }
 }
 
-fn addFileToList(allocator: std.mem.Allocator, rels: *std.ArrayList([]u8), rel: []const u8) !void {
+fn addFileToList(allocator: std.mem.Allocator, rels: *std.ArrayList([]const u8), rel: []const u8) !void {
     for (rels.items) |existing| {
         if (std.mem.eql(u8, existing, rel)) return;
     }
@@ -442,6 +442,86 @@ fn installLibTree(allocator: std.mem.Allocator, lib_src: []const u8, lib_dir: []
         printErrColor(Color.red, "  Failed to install library files\n");
         return error.CopyFailed;
     };
+}
+
+/// Copy the package's lib tree and native libraries into the shared lib
+/// dir, warn about files another installed package claims, unlink files
+/// this package previously owned that the new version dropped (unless
+/// another package still claims them), and record the current file set in
+/// `thottam.files`. Keeping the copy and the record in lockstep is what
+/// makes the ownership guarantee hold across installs, re-pins and
+/// updates — before this, `update` copied the pulled tree and recorded
+/// nothing, so the guarantee lapsed after any pull (issue #2136).
+///
+/// Returns the number of native libraries copied.
+fn syncInstalledFiles(allocator: std.mem.Allocator, config: Config, pkg: []const u8, pkg_dir: []const u8) !u32 {
+    const lib_src = try joinPath(allocator, pkg_dir, "lib");
+    defer allocator.free(lib_src);
+
+    var sld_files: std.ArrayList([]u8) = .empty;
+    defer tfs.freePathList(allocator, &sld_files);
+    if (dirExists(allocator, lib_src)) {
+        sld_files = try tfs.collectFilesWithSuffix(allocator, lib_src, ".sld", true);
+        for (sld_files.items) |rel| try warnIfClaimed(allocator, config, pkg, rel);
+        writeStdout("  Installing libraries...\n");
+        try installLibTree(allocator, lib_src, config.lib_dir);
+    }
+
+    var dylib_files = try tfs.collectFilesWithSuffix(allocator, pkg_dir, dylib_ext, false);
+    defer tfs.freePathList(allocator, &dylib_files);
+    for (dylib_files.items) |name| try warnIfClaimed(allocator, config, pkg, name);
+
+    const dylib_count = try copyDylibsFromPkg(allocator, pkg_dir, config.lib_dir);
+
+    // The file set this package now owns: what the new checkout ships.
+    var new_files: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (new_files.items) |r| allocator.free(r);
+        new_files.deinit(allocator);
+    }
+    for (sld_files.items) |rel| try addFileToList(allocator, &new_files, rel);
+    for (dylib_files.items) |name| try addFileToList(allocator, &new_files, name);
+
+    // Unlink files this package owned before that the new version dropped —
+    // unless another package still claims them. Without this, a re-pin or
+    // update that removes a lib file leaves a stale copy in lib_dir that
+    // the rewritten manifest no longer records and removal can never find.
+    if (readFile(allocator, config.files)) |content| {
+        defer allocator.free(content);
+        var lines = std.mem.splitScalar(u8, content, '\n');
+        while (lines.next()) |line| {
+            const l = trimStateLine(line);
+            if (l.len == 0) continue;
+            if (!(std.mem.startsWith(u8, l, pkg) and l.len > pkg.len and l[pkg.len] == ' ')) continue;
+            const old_rel = l[pkg.len + 1 ..];
+            if (old_rel.len == 0) continue;
+            if (isInNewSet(new_files.items, old_rel)) continue;
+            if (fileClaimedBy(allocator, config.files, old_rel, pkg)) |other| {
+                allocator.free(other);
+                continue;
+            }
+            const target = joinPath(allocator, config.lib_dir, old_rel) catch continue;
+            defer allocator.free(target);
+            const target_z = allocator.dupeZ(u8, target) catch continue;
+            defer allocator.free(target_z);
+            _ = platform.unlink(target_z);
+            pruneEmptyParents(allocator, config.lib_dir, old_rel);
+        }
+    } else |_| {}
+
+    // Record the current set. Rewrites this package's own lines, so the
+    // dropped-file cleanup above and a re-install at a new version cannot
+    // leave stale entries behind.
+    try updateFileManifest(allocator, config.files, pkg, new_files.items);
+
+    return dylib_count;
+}
+
+fn isInNewSet(new_files: []const []const u8, rel: []const u8) bool {
+    for (new_files) |r| {
+        if (std.mem.eql(u8, r, rel)) return true;
+    }
+    return false;
 }
 
 fn printColor(comptime color: []const u8, text: []const u8) void {
@@ -707,38 +787,10 @@ fn doInstall(
         }
     }
 
-    const lib_src = try joinPath(allocator, pkg_dir, "lib");
-    defer allocator.free(lib_src);
-
-    // Collect what will be copied so the install can warn about files that
-    // another installed package owns, and record what it installed for
-    // ownership-aware removal (#2136).
-    var sld_files: std.ArrayList([]u8) = .empty;
-    defer tfs.freePathList(allocator, &sld_files);
-    if (dirExists(allocator, lib_src)) {
-        sld_files = try tfs.collectFilesWithSuffix(allocator, lib_src, ".sld", true);
-        for (sld_files.items) |rel| try warnIfClaimed(allocator, config, pkg, rel);
-        writeStdout("  Installing libraries...\n");
-        try installLibTree(allocator, lib_src, config.lib_dir);
-    }
-
-    var dylib_files = try tfs.collectFilesWithSuffix(allocator, pkg_dir, dylib_ext, false);
-    defer tfs.freePathList(allocator, &dylib_files);
-    for (dylib_files.items) |name| try warnIfClaimed(allocator, config, pkg, name);
-
-    const dylib_count = try copyDylibsFromPkg(allocator, pkg_dir, config.lib_dir);
+    const dylib_count = try syncInstalledFiles(allocator, config, pkg, pkg_dir);
     if (dylib_count > 0) {
         printBuf(&buf, "  Installed {d} native library(s)\n", .{dylib_count});
     }
-
-    // Record the installed files so `remove` can tell what belongs to whom
-    // (issue #2136). Rewrites this package's own lines: a re-install at a
-    // different version must not leave stale entries behind.
-    var files_list: std.ArrayList([]const u8) = .empty;
-    defer files_list.deinit(allocator);
-    for (sld_files.items) |rel| files_list.append(allocator, rel) catch return error.OutOfMemory;
-    for (dylib_files.items) |name| files_list.append(allocator, name) catch return error.OutOfMemory;
-    try updateFileManifest(allocator, config.files, pkg, files_list.items);
 
     try addToInstalled(allocator, config.installed, pkg);
     // A --locked install must not rewrite the lockfile's recorded source: the
@@ -920,13 +972,10 @@ fn doUpdate(allocator: std.mem.Allocator, config: Config, pkg: ?[]const u8) !voi
             }
         }
 
-        const lib_src = try joinPath(allocator, pkg_dir, "lib");
-        defer allocator.free(lib_src);
-        if (dirExists(allocator, lib_src)) {
-            try installLibTree(allocator, lib_src, config.lib_dir);
-        }
-
-        _ = try copyDylibsFromPkg(allocator, pkg_dir, config.lib_dir);
+        // Copy the pulled tree and keep the ownership record in lockstep:
+        // update must warn about, record and clean up exactly what install
+        // does (issue #2136).
+        _ = try syncInstalledFiles(allocator, config, p, pkg_dir);
 
         const new_sha = getPkgSha(allocator, config.src_dir, p) orelse "unknown";
         try updateLockfile(allocator, config.lockfile, p, new_sha, expected_source);

--- a/src/thottam_state.zig
+++ b/src/thottam_state.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const thottam = @import("thottam.zig");
 
 pub const PkgSpec = struct {
@@ -8,18 +9,14 @@ pub const PkgSpec = struct {
 };
 
 pub const PkgManifest = struct {
-    name: ?[]const u8 = null,
     depends: ?[]const u8 = null,
     build_cmd: ?[]const u8 = null,
-    source: ?[]const u8 = null,
     owned: bool = false,
 
     pub fn deinit(self: PkgManifest, allocator: std.mem.Allocator) void {
         if (!self.owned) return;
-        if (self.name) |n| allocator.free(n);
         if (self.depends) |d| allocator.free(d);
         if (self.build_cmd) |b| allocator.free(b);
-        if (self.source) |s| allocator.free(s);
     }
 };
 
@@ -62,17 +59,13 @@ pub fn parsePkgManifest(content: []const u8) PkgManifest {
     var result: PkgManifest = .{};
     var it = std.mem.splitScalar(u8, content, '\n');
     while (it.next()) |line| {
-        if (parseField(line, "name:")) |val| {
-            result.name = val;
-        } else if (parseField(line, "depends:")) |val| {
+        if (parseField(line, "depends:")) |val| {
             result.depends = val;
         } else if (parseField(line, "build:")) |val| {
             // An empty `build:` is an absence, not a command — running
             // `/bin/sh -c ""` behind a "Building <pkg>..." banner helped
             // nobody (kaappi#2132).
             if (val.len > 0) result.build_cmd = val;
-        } else if (parseField(line, "source:")) |val| {
-            if (val.len > 0 and val[0] != '-') result.source = val;
         }
     }
     return result;
@@ -86,6 +79,15 @@ pub fn isInstalled(allocator: std.mem.Allocator, installed_path: []const u8, pkg
         if (std.mem.eql(u8, thottam.trimStateLine(line), pkg)) return true;
     }
     return false;
+}
+
+/// Record `pkg` in installed.txt unless it is already listed. A re-install
+/// that re-checkouts a different version falls through to the full install
+/// flow with the package already listed, and must not grow a duplicate line
+/// (issue #2134).
+pub fn addToInstalled(allocator: std.mem.Allocator, installed_path: []const u8, pkg: []const u8) !void {
+    if (isInstalled(allocator, installed_path, pkg)) return;
+    try thottam.appendFile(allocator, installed_path, pkg);
 }
 
 pub const LockEntry = struct {
@@ -173,6 +175,87 @@ pub fn removeFromLockfile(allocator: std.mem.Allocator, lockfile_path: []const u
     try thottam.writeFile(allocator, lockfile_path, output.items);
 }
 
+// ---------------------------------------------------------------------------
+// Installed-file manifest (`thottam.files`)
+// ---------------------------------------------------------------------------
+//
+// One line per installed file: `<package> <relative-path>`, where the path
+// is relative to `$KAAPPI_HOME/lib` and '/'-joined (the spelling
+// `collectFilesWithSuffix` produces, and `joinPath` consumes). Written at
+// install time so `remove` can unlink only files no other installed package
+// claims — before this record existed, removal walked the package's own
+// source tree and deleted a shared file out from under a still-installed
+// neighbour (issue #2136).
+
+pub fn updateFileManifest(allocator: std.mem.Allocator, manifest_path: []const u8, pkg: []const u8, files: []const []const u8) !void {
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(allocator);
+
+    // Drop the package's own stale lines first (a re-install at a new
+    // version, or an upstream rename, must not leave old entries behind),
+    // then append the current set.
+    if (thottam.readFile(allocator, manifest_path)) |content| {
+        defer allocator.free(content);
+        var lines = std.mem.splitScalar(u8, content, '\n');
+        while (lines.next()) |line| {
+            const l = thottam.trimStateLine(line);
+            if (l.len == 0) continue;
+            if (std.mem.startsWith(u8, l, pkg) and l.len > pkg.len and l[pkg.len] == ' ') continue;
+            output.appendSlice(allocator, l) catch return error.OutOfMemory;
+            output.append(allocator, '\n') catch return error.OutOfMemory;
+        }
+    } else |_| {}
+
+    for (files) |rel| {
+        output.appendSlice(allocator, pkg) catch return error.OutOfMemory;
+        output.append(allocator, ' ') catch return error.OutOfMemory;
+        output.appendSlice(allocator, rel) catch return error.OutOfMemory;
+        output.append(allocator, '\n') catch return error.OutOfMemory;
+    }
+
+    try thottam.writeFile(allocator, manifest_path, output.items);
+}
+
+pub fn removeFromFileManifest(allocator: std.mem.Allocator, manifest_path: []const u8, pkg: []const u8) !void {
+    const content = thottam.readFile(allocator, manifest_path) catch return;
+    defer allocator.free(content);
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(allocator);
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        const l = thottam.trimStateLine(line);
+        if (l.len == 0) continue;
+        if (std.mem.startsWith(u8, l, pkg) and l.len > pkg.len and l[pkg.len] == ' ') continue;
+        output.appendSlice(allocator, l) catch return error.OutOfMemory;
+        output.append(allocator, '\n') catch return error.OutOfMemory;
+    }
+
+    try thottam.writeFile(allocator, manifest_path, output.items);
+}
+
+/// Return an owned copy of the first installed package other than `except`
+/// whose manifest claims `rel`, or null when nobody else claims it. The
+/// claim record is the manifest, so a package installed before the record
+/// existed cannot protect its files — the guarantee holds for installs made
+/// after this record is written (issue #2136).
+pub fn fileClaimedBy(allocator: std.mem.Allocator, manifest_path: []const u8, rel: []const u8, except: []const u8) ?[]u8 {
+    const content = thottam.readFile(allocator, manifest_path) catch return null;
+    defer allocator.free(content);
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        const l = thottam.trimStateLine(line);
+        if (l.len == 0) continue;
+        const sp = std.mem.indexOfScalar(u8, l, ' ') orelse continue;
+        const owner = l[0..sp];
+        if (std.mem.eql(u8, owner, except)) continue;
+        if (std.mem.eql(u8, l[sp + 1 ..], rel)) {
+            return allocator.dupe(u8, owner) catch null;
+        }
+    }
+    return null;
+}
+
 pub fn removeFromInstalled(allocator: std.mem.Allocator, installed_path: []const u8, pkg: []const u8) !void {
     const content = thottam.readFile(allocator, installed_path) catch return;
     defer allocator.free(content);
@@ -226,30 +309,29 @@ test "parsePkgSpec — version and source URL" {
     try std.testing.expectEqualStrings("https://github.com/a/b", spec.source.?);
 }
 
-test "parsePkgManifest — full" {
-    const content = "name: kaappi-web\ndepends: kaappi-http kaappi-json\nbuild: make\n";
+test "parsePkgManifest — depends and build only" {
+    const content = "name: kaappi-web\nsource: https://github.com/alice/kaappi-web\nversion: 9.9.9\ndepends: kaappi-http kaappi-json\nbuild: make\n";
     const m = parsePkgManifest(content);
-    try std.testing.expectEqualStrings("kaappi-web", m.name.?);
+    // Only depends and build are read; name, source, version and any other
+    // key are ignored (issue #2138).
     try std.testing.expectEqualStrings("kaappi-http kaappi-json", m.depends.?);
     try std.testing.expectEqualStrings("make", m.build_cmd.?);
-    try std.testing.expect(m.source == null);
 }
 
 test "parsePkgManifest — minimal" {
-    const content = "name: kaappi-json\n";
+    const content = "depends: kaappi-json\n";
     const m = parsePkgManifest(content);
-    try std.testing.expectEqualStrings("kaappi-json", m.name.?);
-    try std.testing.expect(m.depends == null);
+    try std.testing.expectEqualStrings("kaappi-json", m.depends.?);
     try std.testing.expect(m.build_cmd == null);
-    try std.testing.expect(m.source == null);
 }
 
-test "parsePkgManifest — with source" {
-    const content = "name: kaappi-matrix\ndepends: kaappi-net\nsource: https://github.com/alice/kaappi-matrix\n";
+test "parsePkgManifest — ignores name, source and version keys" {
+    // The fields the manifest grammar no longer documents are ignored like
+    // any unknown key (issue #2138).
+    const content = "name: WRONG-NAME-ENTIRELY\nsource: https://evil.example.com/not-this-repo\nversion: 99.99.99\ndepends: kaappi-net\n";
     const m = parsePkgManifest(content);
-    try std.testing.expectEqualStrings("kaappi-matrix", m.name.?);
     try std.testing.expectEqualStrings("kaappi-net", m.depends.?);
-    try std.testing.expectEqualStrings("https://github.com/alice/kaappi-matrix", m.source.?);
+    try std.testing.expect(m.build_cmd == null);
 }
 
 test "parseField" {
@@ -257,4 +339,80 @@ test "parseField" {
     try std.testing.expectEqualStrings("value", parseField("key:  value  ", "key:").?);
     try std.testing.expect(parseField("other: value", "key:") == null);
     try std.testing.expect(parseField("", "key:") == null);
+}
+
+test "addToInstalled is idempotent" {
+    const allocator = std.testing.allocator;
+    var tmp: [512]u8 = undefined;
+    const path = try std.fmt.bufPrint(&tmp, "{s}/kaappi-thottam-state-{d}-{s}", .{ platform.tempDir(), platform.getPid(), "addinst" });
+    defer thottam.removeDir(allocator, path) catch {};
+
+    try addToInstalled(allocator, path, "kaappi-one");
+    try addToInstalled(allocator, path, "kaappi-one");
+    const content = try thottam.readFile(allocator, path);
+    defer allocator.free(content);
+    try std.testing.expectEqualStrings("kaappi-one\n", content);
+}
+
+test "updateFileManifest rewrites a package's lines in place" {
+    const allocator = std.testing.allocator;
+    var tmp: [512]u8 = undefined;
+    const path = try std.fmt.bufPrint(&tmp, "{s}/kaappi-thottam-state-{d}-{s}", .{ platform.tempDir(), platform.getPid(), "fmanifest" });
+    defer thottam.removeDir(allocator, path) catch {};
+
+    try updateFileManifest(allocator, path, "kaappi-one", &.{ "kaappi/one.sld", "kaappi/shared.sld" });
+    try updateFileManifest(allocator, path, "kaappi-two", &.{ "kaappi/two.sld", "kaappi/shared.sld" });
+
+    // A re-install at a new version rewrites only the package's own lines.
+    try updateFileManifest(allocator, path, "kaappi-two", &.{"kaappi/two.sld"});
+    const content = try thottam.readFile(allocator, path);
+    defer allocator.free(content);
+    try std.testing.expectEqualStrings(
+        "kaappi-one kaappi/one.sld\nkaappi-one kaappi/shared.sld\nkaappi-two kaappi/two.sld\n",
+        content,
+    );
+
+    // An empty file list drops the package's lines entirely (a removal's
+    // worth of cleanup), but nobody else's.
+    try updateFileManifest(allocator, path, "kaappi-one", &.{});
+    const after = try thottam.readFile(allocator, path);
+    defer allocator.free(after);
+    try std.testing.expectEqualStrings("kaappi-two kaappi/two.sld\n", after);
+}
+
+test "fileClaimedBy finds the other claimant and skips the package itself" {
+    const allocator = std.testing.allocator;
+    var tmp: [512]u8 = undefined;
+    const path = try std.fmt.bufPrint(&tmp, "{s}/kaappi-thottam-state-{d}-{s}", .{ platform.tempDir(), platform.getPid(), "claim" });
+    defer thottam.removeDir(allocator, path) catch {};
+
+    try updateFileManifest(allocator, path, "kaappi-one", &.{ "kaappi/one.sld", "kaappi/shared.sld" });
+    try updateFileManifest(allocator, path, "kaappi-two", &.{ "kaappi/two.sld", "kaappi/shared.sld" });
+
+    const other = fileClaimedBy(allocator, path, "kaappi/shared.sld", "kaappi-two").?;
+    defer allocator.free(other);
+    try std.testing.expectEqualStrings("kaappi-one", other);
+
+    // Excluding the only claimant: nobody else claims it.
+    try std.testing.expect(fileClaimedBy(allocator, path, "kaappi/two.sld", "kaappi-two") == null);
+    // An unclaimed path is null.
+    try std.testing.expect(fileClaimedBy(allocator, path, "kaappi/other.sld", "kaappi-one") == null);
+}
+
+test "removeFromFileManifest drops only the named package's lines" {
+    const allocator = std.testing.allocator;
+    var tmp: [512]u8 = undefined;
+    const path = try std.fmt.bufPrint(&tmp, "{s}/kaappi-thottam-state-{d}-{s}", .{ platform.tempDir(), platform.getPid(), "rmmanifest" });
+    defer thottam.removeDir(allocator, path) catch {};
+
+    try updateFileManifest(allocator, path, "kaappi-one", &.{ "kaappi/one.sld", "kaappi/shared.sld" });
+    try updateFileManifest(allocator, path, "kaappi-two", &.{ "kaappi/two.sld", "kaappi/shared.sld" });
+    try removeFromFileManifest(allocator, path, "kaappi-two");
+
+    const content = try thottam.readFile(allocator, path);
+    defer allocator.free(content);
+    try std.testing.expectEqualStrings(
+        "kaappi-one kaappi/one.sld\nkaappi-one kaappi/shared.sld\n",
+        content,
+    );
 }

--- a/tests/scheme/thottam/thottam-lifecycle.sh
+++ b/tests/scheme/thottam/thottam-lifecycle.sh
@@ -319,14 +319,21 @@ fresh_home
 printf '../../../../../../tmp/kaappi-escape-probe\n' > "$KAAPPI_HOME/installed.txt"
 printf '../../../../../../tmp/kaappi-escape-probe deadbeef\n' > "$KAAPPI_HOME/thottam.lock"
 out="$("$THOTTAM" update '../../../../../../tmp/kaappi-escape-probe' 2>&1)" && ec=0 || ec=$?
-# FAIL: #2144 (isValidPkgName guards install and remove only; list, verify and
-# update take the name straight from installed.txt / thottam.lock, so `git -C
-# <escaped path>` runs outside KAAPPI_HOME)
-# check "update rejects a traversal name read back from installed.txt" \
-#     "invalid package name" "$out"
-# out="$("$THOTTAM" verify 2>&1)" && ec=0 || ec=$?
-# check "verify rejects a traversal name read back from the lockfile" \
-#     "invalid package name" "$out"
+check_exit "update rejects a traversal name from the command line" 1 "$ec"
+check "update names the rejected package" "invalid package name" "$out"
+out="$("$THOTTAM" verify 2>&1)" && ec=0 || ec=$?
+check_exit "verify fails on a traversal name read back from the lockfile" 1 "$ec"
+check "verify names the corrupted entry" "MALFORMED" "$out"
+# list must not even show a name it cannot act on — and must not touch the
+# filesystem for it either (the escaped repo outside KAAPPI_HOME stays intact).
+out="$("$THOTTAM" list 2>&1)" && ec=0 || ec=$?
+check_exit "list tolerates a corrupted installed.txt" 0 "$ec"
+check_not "list does not show the traversal name" "kaappi-escape-probe" "$out"
+# The all-packages update form skips the corrupted line instead of running
+# git outside KAAPPI_HOME.
+out="$("$THOTTAM" update 2>&1)" && ec=0 || ec=$?
+check_exit "update-all skips a corrupted installed.txt line" 0 "$ec"
+check_not "update-all does not run git on the traversal name" "kaappi-escape-probe" "$out"
 
 # Discriminating control: the destructive command does validate, so the
 # escaped path is never a removeTree target.
@@ -366,10 +373,12 @@ rm -rf /tmp/kaappi-ESCAPED
 # ---------------------------------------------------------------------------
 
 sha_v010="$(git -C "$WORK/kaappi-alpha" rev-parse 'v0.1.0^{commit}')"
+sha_v100="$(git -C "$WORK/kaappi-alpha" rev-parse 'v1.0.0^{commit}')"
+sha_v200="$(git -C "$WORK/kaappi-alpha" rev-parse 'v2.0.0^{commit}')"
 
 # Control: pinning on a FRESH home works. The pin machinery is fine, and this
 # assertion holds both before and after the fix below — it is what makes the
-# disabled one next to it about the *re*-install path specifically.
+# re-install checks next to it about the *re*-install path specifically.
 fresh_home
 "$THOTTAM" install kaappi-alpha@v0.1.0 > /dev/null 2>&1
 check "a first install at a pin records that pin's SHA" \
@@ -380,11 +389,29 @@ check "a first install at a pin records that pin's SHA" \
 # different version in place makes it unusable in a provisioning script.
 fresh_home
 "$THOTTAM" install kaappi-alpha > /dev/null 2>&1
-"$THOTTAM" install kaappi-alpha@v0.1.0 > /dev/null 2>&1 || true
-# FAIL: #2134 (the "already installed" short-circuit runs before the requested
-# version is looked at, so this exits 0 having done nothing)
-# check "re-installing at a pin records that pin's SHA" \
-#     "$sha_v010" "$(cat "$KAAPPI_HOME/thottam.lock")"
+out="$("$THOTTAM" install kaappi-alpha@v0.1.0 2>&1)" && ec=0 || ec=$?
+check_exit "re-installing at a pin succeeds" 0 "$ec"
+check "re-installing at a pin records that pin's SHA" \
+    "$sha_v010" "$(cat "$KAAPPI_HOME/thottam.lock")"
+check "re-installing at a pin copies the pinned lib" \
+    "v0.1.0" "$(sed -n 's/.*define tag "\([^"]*\)".*/\1/p' "$KAAPPI_HOME/lib/kaappi/alpha.sld")"
+
+# Installing again at the same version is a clean no-op.
+out="$("$THOTTAM" install kaappi-alpha@v0.1.0 2>&1)" && ec=0 || ec=$?
+check_exit "re-installing at the same pin is a clean no-op" 0 "$ec"
+check "re-installing at the same pin says already installed" "already installed (at v0.1.0)" "$out"
+
+# And installing at yet another version moves the pin again — this is the
+# workflow `update` points pinned users at.
+out="$("$THOTTAM" install kaappi-alpha@v2.0.0 2>&1)" && ec=0 || ec=$?
+check_exit "installing at a new version moves the pin" 0 "$ec"
+check "installing at a new version records the new SHA" \
+    "$sha_v200" "$(cat "$KAAPPI_HOME/thottam.lock")"
+
+# A versioned re-install must not duplicate the installed.txt line: the
+# record stays one line per package.
+check "re-installing does not duplicate the installed.txt line" \
+    "1" "$(grep -c '^kaappi-alpha$' "$KAAPPI_HOME/installed.txt")"
 
 # ---------------------------------------------------------------------------
 # 6. verify's coverage
@@ -442,6 +469,20 @@ check "verify says the lockfile is missing" "No lockfile found" "$out"
 # 7. remove, and the shared library namespace
 # ---------------------------------------------------------------------------
 
+# kaappi-deep ships a nested lib tree, so a full removal must prune the empty
+# directories it leaves behind (#2136).
+mkpkg kaappi-deep ""
+mkdir -p "$WORK/kaappi-deep/lib/kaappi/deep/deeper"
+printf '(define-library (kaappi deep) (export tag) (import (scheme base)) (begin (define tag "deep")))\n' \
+    > "$WORK/kaappi-deep/lib/kaappi/deep/deeper/x.sld"
+(
+    cd "$WORK/kaappi-deep"
+    git add -A
+    git_q commit -q -m deep
+)
+rm -rf "$ORG/kaappi-deep.git"
+git clone -q --bare "$WORK/kaappi-deep" "$ORG/kaappi-deep.git"
+
 fresh_home
 "$THOTTAM" install kaappi-one > /dev/null 2>&1
 out="$("$THOTTAM" remove kaappi-one 2>&1)" && ec=0 || ec=$?
@@ -459,15 +500,31 @@ check "removing an absent package says so" "is not installed" "$out"
 # must not take a file the other is still relying on.
 fresh_home
 "$THOTTAM" install kaappi-one > /dev/null 2>&1
-"$THOTTAM" install kaappi-two > /dev/null 2>&1
+out="$("$THOTTAM" install kaappi-two 2>&1)" && ec=0 || ec=$?
+# Installing kaappi-two overwrites a file kaappi-one's manifest claims; the
+# install still succeeds, but it must say so.
+check_exit "installing over another package's file still succeeds" 0 "$ec"
+check "installing over another package's file warns" "also provided by kaappi-one" "$out"
 check_file "both packages installed, shared.sld present" "$KAAPPI_HOME/lib/kaappi/shared.sld"
 "$THOTTAM" remove kaappi-two > /dev/null 2>&1
 check "kaappi-one is still listed as installed" "kaappi-one" "$("$THOTTAM" list)"
-# FAIL: #2136 (removal unlinks every .sld name the removed package ships, with
-# no record of which package a given installed file came from, so kaappi-one
-# loses lib/kaappi/shared.sld while still being reported as installed)
-# check_file "a still-installed package keeps its library file" \
-#     "$KAAPPI_HOME/lib/kaappi/shared.sld"
+check_file "a still-installed package keeps its library file" \
+    "$KAAPPI_HOME/lib/kaappi/shared.sld"
+check_file "removing one package keeps the other's .sld" "$KAAPPI_HOME/lib/kaappi/one.sld"
+check_not "removing one package deletes its own .sld" "yes" \
+    "$([[ -f "$KAAPPI_HOME/lib/kaappi/two.sld" ]] && echo yes || echo no)"
+# Removing the last claimant finally deletes the shared file.
+"$THOTTAM" remove kaappi-one > /dev/null 2>&1
+check_not "removing the last claimant deletes the shared file" "yes" \
+    "$([[ -f "$KAAPPI_HOME/lib/kaappi/shared.sld" ]] && echo yes || echo no)"
+
+# A full removal prunes the empty directories the files lived in.
+fresh_home
+"$THOTTAM" install kaappi-deep > /dev/null 2>&1
+check_file "nested library file lands in lib" "$KAAPPI_HOME/lib/kaappi/deep/deeper/x.sld"
+"$THOTTAM" remove kaappi-deep > /dev/null 2>&1
+check_not "removal prunes empty nested directories" "yes" \
+    "$([[ -d "$KAAPPI_HOME/lib/kaappi/deep" ]] && echo yes || echo no)"
 
 # ---------------------------------------------------------------------------
 # 8. update
@@ -489,11 +546,21 @@ check "update of an uninstalled package says so" "is not installed" "$out"
 fresh_home
 "$THOTTAM" install kaappi-alpha@v1.0.0 > /dev/null 2>&1
 out="$("$THOTTAM" update kaappi-alpha 2>&1)" && ec=0 || ec=$?
-# FAIL: #2134 (update runs `git pull` unconditionally; on the detached HEAD a
-# pinned install leaves behind, it fails with git's "You are not currently on
-# a branch" and no thottam-level explanation)
-# check_not "updating a pinned package does not leak raw git advice" \
-#     "You are not currently on a branch" "$out"
+check_exit "updating a pinned package succeeds as a no-op" 0 "$ec"
+check_not "updating a pinned package does not leak raw git advice" \
+    "You are not currently on a branch" "$out"
+check "updating a pinned package says it is pinned" "pinned at v1.0.0" "$out"
+check "updating a pinned package names the way to move the pin" "to move the pin" "$out"
+
+# One pinned package must not fail a whole-tree update: the pin is reported
+# and skipped, everything else still updates.
+fresh_home
+"$THOTTAM" install kaappi-alpha@v1.0.0 > /dev/null 2>&1
+"$THOTTAM" install kaappi-one > /dev/null 2>&1
+out="$("$THOTTAM" update 2>&1)" && ec=0 || ec=$?
+check_exit "updating all packages with one pinned succeeds" 0 "$ec"
+check "updating all reports the pinned package" "pinned at" "$out"
+check "updating all still updates the unpinned package" "kaappi-one updated" "$out"
 
 # ---------------------------------------------------------------------------
 # 9. --locked
@@ -557,6 +624,51 @@ out="$("$THOTTAM" --locked install "kaappi-alpha::$ORG/kaappi-alpha.git" 2>&1)" 
 check_exit "--locked accepts a source URL that matches the lockfile" 0 "$ec"
 check "--locked matching-source restore records the same provenance" \
     "$ORG/kaappi-alpha.git" "$(cat "$KAAPPI_HOME/thottam.lock")"
+
+# ---------------------------------------------------------------------------
+# 10. kaappi.pkg's name:/version:/source: fields are inert (issue #2138)
+# ---------------------------------------------------------------------------
+
+# A manifest that lies about its identity or hosting must not change the
+# install: only depends: and build: are read, and every other key is ignored
+# by construction — the parser no longer recognises them.
+mkdir -p "$WORK/kaappi-srcfield/lib/kaappi"
+(
+    cd "$WORK/kaappi-srcfield"
+    git init -q .
+    printf 'name: WRONG-NAME-ENTIRELY\nsource: https://evil.example.com/not-this-repo\nversion: 99.99.99\n' > kaappi.pkg
+    printf '(define-library (kaappi srcfield) (export tag) (import (scheme base)) (begin (define tag "srcfield")))\n' \
+        > lib/kaappi/srcfield.sld
+    git add -A
+    git_q commit -q -m base
+)
+git clone -q --bare "$WORK/kaappi-srcfield" "$ORG/kaappi-srcfield.git"
+fresh_home
+out="$("$THOTTAM" install kaappi-srcfield 2>&1)" && ec=0 || ec=$?
+check_exit "a manifest with an unrelated name and source installs" 0 "$ec"
+check_not "a manifest's source: never reaches the lockfile" \
+    "evil.example.com" "$(cat "$KAAPPI_HOME/thottam.lock")"
+check_not "a manifest's source: never shows in list" \
+    "evil.example.com" "$("$THOTTAM" list)"
+check "the installed package is verified under its real name" "OK: kaappi-srcfield" \
+    "$("$THOTTAM" verify)"
+
+# A manifest with only the two read fields installs cleanly too.
+mkdir -p "$WORK/kaappi-minimal/lib/kaappi"
+(
+    cd "$WORK/kaappi-minimal"
+    git init -q .
+    printf 'depends:\nbuild:\n' > kaappi.pkg
+    printf '(define-library (kaappi minimal) (export tag) (import (scheme base)) (begin (define tag "min")))\n' \
+        > lib/kaappi/minimal.sld
+    git add -A
+    git_q commit -q -m base
+)
+git clone -q --bare "$WORK/kaappi-minimal" "$ORG/kaappi-minimal.git"
+fresh_home
+out="$("$THOTTAM" install kaappi-minimal 2>&1)" && ec=0 || ec=$?
+check_exit "a manifest without name: installs cleanly" 0 "$ec"
+check "the manifest-less-name package installs" "installed (locked at" "$out"
 
 # ---------------------------------------------------------------------------
 

--- a/tests/scheme/thottam/thottam-lifecycle.sh
+++ b/tests/scheme/thottam/thottam-lifecycle.sh
@@ -545,6 +545,8 @@ check "update of an uninstalled package says so" "is not installed" "$out"
 # about a pinned package rather than surfacing git's own advice.
 fresh_home
 "$THOTTAM" install kaappi-alpha@v1.0.0 > /dev/null 2>&1
+check "a first install at the v1.0.0 pin records that pin's SHA" \
+    "$sha_v100" "$(cat "$KAAPPI_HOME/thottam.lock")"
 out="$("$THOTTAM" update kaappi-alpha 2>&1)" && ec=0 || ec=$?
 check_exit "updating a pinned package succeeds as a no-op" 0 "$ec"
 check_not "updating a pinned package does not leak raw git advice" \
@@ -561,6 +563,73 @@ out="$("$THOTTAM" update 2>&1)" && ec=0 || ec=$?
 check_exit "updating all packages with one pinned succeeds" 0 "$ec"
 check "updating all reports the pinned package" "pinned at" "$out"
 check "updating all still updates the unpinned package" "kaappi-one updated" "$out"
+
+# An upstream release that ADDS a file another package owns must record the
+# new ownership during `update` — otherwise removing the other claimant
+# later unlinks the file out from under the updated package (#2136 via the
+# update path). kaappi-grower ships only grower.sld at first; kaappi-two
+# already owns lib/kaappi/shared.sld.
+mkpkg kaappi-grower ""
+fresh_home
+"$THOTTAM" install kaappi-grower > /dev/null 2>&1
+"$THOTTAM" install kaappi-two > /dev/null 2>&1
+check_not "before the update, grower does not claim shared.sld" \
+    "kaappi-grower kaappi/shared.sld" "$(cat "$KAAPPI_HOME/thottam.files")"
+(
+    cd "$WORK/kaappi-grower"
+    printf '(define-library (kaappi shared) (export owner) (import (scheme base)) (begin (define owner "grower")))\n' \
+        > lib/kaappi/shared.sld
+    git add -A
+    git_q commit -q -m "add shared"
+)
+rm -rf "$ORG/kaappi-grower.git"
+git clone -q --bare "$WORK/kaappi-grower" "$ORG/kaappi-grower.git"
+out="$("$THOTTAM" update kaappi-grower 2>&1)" && ec=0 || ec=$?
+check_exit "update pulling a shared file succeeds" 0 "$ec"
+check "update warns it overwrites another package's file" "also provided by kaappi-two" "$out"
+check "update records the new ownership" \
+    "kaappi-grower kaappi/shared.sld" "$(cat "$KAAPPI_HOME/thottam.files")"
+"$THOTTAM" remove kaappi-two > /dev/null 2>&1
+check_file "removing the other claimant keeps the updated package's file" \
+    "$KAAPPI_HOME/lib/kaappi/shared.sld"
+
+# An upstream release that DROPS a file another package owns: update must
+# keep the other package's copy and drop the ownership record, so removing
+# the updated package cannot delete the file out from under the other one.
+mkpkg kaappi-shrinker ""
+(
+    cd "$WORK/kaappi-shrinker"
+    printf '(define-library (kaappi shared) (export owner) (import (scheme base)) (begin (define owner "shrinker")))\n' \
+        > lib/kaappi/shared.sld
+    git add -A
+    git_q commit -q -m "add shared"
+)
+rm -rf "$ORG/kaappi-shrinker.git"
+git clone -q --bare "$WORK/kaappi-shrinker" "$ORG/kaappi-shrinker.git"
+fresh_home
+"$THOTTAM" install kaappi-shrinker > /dev/null 2>&1
+"$THOTTAM" install kaappi-one > /dev/null 2>&1
+check "shrinker and one both claim shared.sld" \
+    "kaappi-shrinker kaappi/shared.sld" "$(cat "$KAAPPI_HOME/thottam.files")"
+(
+    cd "$WORK/kaappi-shrinker"
+    git rm -q lib/kaappi/shared.sld
+    git_q commit -q -m "drop shared"
+)
+rm -rf "$ORG/kaappi-shrinker.git"
+git clone -q --bare "$WORK/kaappi-shrinker" "$ORG/kaappi-shrinker.git"
+out="$("$THOTTAM" update kaappi-shrinker 2>&1)" && ec=0 || ec=$?
+check_exit "update dropping a shared file succeeds" 0 "$ec"
+check_not "update drops the ownership record" \
+    "kaappi-shrinker kaappi/shared.sld" "$(cat "$KAAPPI_HOME/thottam.files")"
+check_file "the other package's shared file survives the update" \
+    "$KAAPPI_HOME/lib/kaappi/shared.sld"
+"$THOTTAM" remove kaappi-shrinker > /dev/null 2>&1
+check_file "removing the updated package keeps the other's shared file" \
+    "$KAAPPI_HOME/lib/kaappi/shared.sld"
+"$THOTTAM" remove kaappi-one > /dev/null 2>&1
+check_not "removing the last claimant deletes the shared file" "yes" \
+    "$([[ -f "$KAAPPI_HOME/lib/kaappi/shared.sld" ]] && echo yes || echo no)"
 
 # ---------------------------------------------------------------------------
 # 9. --locked


### PR DESCRIPTION
Closes #2134, #2136, #2138, #2144 — four thottam audit findings from Phase 6E, in one PR since they all touch the same module (`src/thottam.zig`, `src/thottam_state.zig`) and the same state-file surface.

## #2134 — version pinning is a dead end

- **`install pkg@ver` on an already-installed package** now re-checkouts when the requested version differs from the checkout (rebuild, re-copy libs, re-record lockfile) instead of short-circuiting on `isInstalled` and exiting 0 while leaving the old version in place. In `--locked` mode the lockfile is the requested version, so a locked install also re-checkouts when the installed SHA differs. The constraint-resolution block moved *before* the already-installed check so `install pkg@">=1.0.0"` compares against the resolved tag too. `installed.txt` recording is now idempotent.
- **`update` on a pinned package** detects the detached HEAD (`git symbolic-ref -q HEAD`) and says plainly what the package is pinned to (`git describe --tags --exact-match`, falling back to the lockfile SHA) instead of surfacing git's raw "You are not currently on a branch" advice. The named form is a clean no-op (exit 0) and the all-packages form skips the pin, so **one pinned package no longer fails a whole-tree update**. To move a pin: `thottam install pkg@<version>` — which now works (above).

## #2136 — removal has no ownership record

- New state file **`~/.kaappi/thottam.files`**: one `<pkg> <relpath>` line per installed file, written at install time.
- **`remove`** unlinks only files no other installed package's manifest claims — removing `kaappi-two` no longer takes `lib/kaappi/shared.sld` away from a still-installed `kaappi-one`. The manifest is the source of truth, so removal also stops orphaning copies of files a package renamed upstream (legacy installs fall back to the old source-tree walk, still claim-guarded).
- **`install`** warns (to stderr, yellow) when it is about to overwrite a file another package owns, making the cross-package collision audible at the point it's introduced.
- Empty directory skeletons left behind by removal are pruned (`$KAAPPI_HOME/lib/kaappi/deep/deeper/` no longer survives a full removal).

## #2138 — kaappi.pkg `name:`/`source:` parsed but never read

Per the design decision in the issue, the inert fields are **deleted from the parser and the documented grammar** (Option 2): `parsePkgManifest` now reads only `depends:` and `build:`; `name:`, `version:`, `source:` and any other key are ignored by construction. `manifest.source` could never be the clone URL — the manifest is only readable after cloning — and the docs said it declared "where this package is hosted". `docs/dev/thottam.md` updated; third-party sourcing is `pkg::url` or `KAAPPI_ORG`.

## #2144 — list/verify/update build paths from unvalidated names

The `isValidPkgName` guard now holds for every consumer, not just install/remove:
- `update <name>` validates its argument at entry (same message as install/remove).
- `list` and `update` (all-packages form) skip lines whose name fails the guard.
- `verify` names invalid names in `installed.txt` and `thottam.lock` **MALFORMED** and fails the run (consistent with the existing #2135 structure checks) — the escaped repo outside `$KAAPPI_HOME` is never touched.

## Tests

- Zig unit suite: `thottam-tests` 77 pass (manifest tests rewritten for the two-field grammar; new `addToInstalled`, `updateFileManifest`, `removeFromFileManifest`, `fileClaimedBy` round-trips).
- `tests/scheme/thottam/thottam-lifecycle.sh`: the four disabled `FAIL: #NNNN` checks are re-enabled and extended (pin re-install records the pin's SHA + copies the pinned lib, same-pin no-op, pin move, pinned-update no-op names the ref, all-update with one pin, shared-file survival + last-claimant deletion + overwrite warning, empty-dir pruning, corrupted-state handling across list/update/verify, inert-manifest installs). **133 assertions, 0 failed**, offline against local bare repos.

## Follow-ups outside this repo

- `kaappi.github.io/docs/ecosystem/thottam.md` documents the same manifest grammar (`source:` field table row, manifest example) — needs the same update in the docs-site repo.
- Workspace-root `CLAUDE.md` § "kaappi.pkg manifest" quotes `source:` as meaningful — that file is outside this repo (workspace root is not a git repo), so it needs a manual edit.
