### PR TITLE
thottam: resolve git through PATH instead of hardcoding /usr/bin/git (Fixes #2152)

### DIFF
--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -744,9 +744,18 @@ fn doInstall(
         writeStdout("...\n");
         const url_copy = try allocator.dupe(u8, clone_url);
         defer allocator.free(url_copy);
-        runGit(allocator, &.{ "clone", "--quiet", "--", url_copy, pkg_dir }) catch {
-            printErrColor(Color.red, "  Failed to clone repository\n");
-            return error.GitFailed;
+        runGit(allocator, &.{ "clone", "--quiet", "--", url_copy, pkg_dir }) catch |err| switch (err) {
+            error.GitNotFound => {
+                // Distinguish a missing git binary from a clone failure: the
+                // old silent 127 made every /usr/bin/git-less platform report
+                // "Failed to clone repository" with no cause (#2152).
+                printErrColor(Color.red, "  git not found in PATH — thottam requires git to install packages\n");
+                return error.GitNotFound;
+            },
+            else => {
+                printErrColor(Color.red, "  Failed to clone repository\n");
+                return error.GitFailed;
+            },
         };
     }
 
@@ -960,9 +969,15 @@ fn doUpdate(allocator: std.mem.Allocator, config: Config, pkg: ?[]const u8) !voi
             return;
         }
 
-        runGit(allocator, &.{ "-C", pkg_dir, "pull", "--quiet" }) catch {
-            printErrColor(Color.red, "  Failed to pull\n");
-            return error.GitFailed;
+        runGit(allocator, &.{ "-C", pkg_dir, "pull", "--quiet" }) catch |err| switch (err) {
+            error.GitNotFound => {
+                printErrColor(Color.red, "  git not found in PATH — thottam requires git to update packages\n");
+                return error.GitNotFound;
+            },
+            else => {
+                printErrColor(Color.red, "  Failed to pull\n");
+                return error.GitFailed;
+            },
         };
 
         if (getPkgManifest(allocator, config.src_dir, p)) |manifest| {
@@ -1274,8 +1289,9 @@ pub fn main(init: std.process.Init.Minimal) !void {
         doInstall(allocator, config, spec, locked_mode, &visited) catch |err| {
             // InvalidPackageName already printed its own message; exiting here
             // keeps Zig's default handler from printing the raw error name as a
-            // second line (kaappi#2132).
-            if (err == error.GitFailed or err == error.BuildFailed or err == error.CopyFailed or err == error.InvalidPackageName) std.process.exit(1);
+            // second line (kaappi#2132). GitNotFound likewise prints its own
+            // message at the clone site (kaappi#2152).
+            if (err == error.GitFailed or err == error.BuildFailed or err == error.CopyFailed or err == error.InvalidPackageName or err == error.GitNotFound) std.process.exit(1);
             return err;
         };
     } else if (std.mem.eql(u8, cmd, "remove")) {
@@ -1291,7 +1307,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
         try doList(allocator, config);
     } else if (std.mem.eql(u8, cmd, "update")) {
         doUpdate(allocator, config, sub_arg) catch |err| {
-            if (err == error.NotInstalled or err == error.GitFailed or err == error.CopyFailed) std.process.exit(1);
+            if (err == error.NotInstalled or err == error.GitFailed or err == error.CopyFailed or err == error.GitNotFound) std.process.exit(1);
             return err;
         };
     } else if (std.mem.eql(u8, cmd, "verify")) {

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -213,6 +213,8 @@ const ResolveOutcome = union(enum) {
     /// `git ls-remote --tags` itself failed (missing/private repo, no
     /// network). Not the same as "no matching tag": the range may be fine.
     git_failed,
+    /// `git` is not on PATH — not a repo/network problem (#2152).
+    git_not_found,
 };
 
 fn resolveVersion(allocator: std.mem.Allocator, clone_url: []const u8, constraint_str: []const u8) ResolveOutcome {
@@ -220,7 +222,10 @@ fn resolveVersion(allocator: std.mem.Allocator, clone_url: []const u8, constrain
     const constraints = semver.parseConstraintsDiag(constraint_str, &diag) orelse
         return .{ .invalid_constraint = diag };
 
-    const output = runGitCapture(allocator, &.{ "ls-remote", "--tags", "--", clone_url }) catch return .git_failed;
+    const output = runGitCapture(allocator, &.{ "ls-remote", "--tags", "--", clone_url }) catch |err| switch (err) {
+        error.GitNotFound => return .git_not_found,
+        else => return .git_failed,
+    };
     defer allocator.free(output);
 
     var best: ?Semver = null;
@@ -536,6 +541,19 @@ fn printErrColor(comptime color: []const u8, text: []const u8) void {
     if (use_color) writeStderr(Color.reset);
 }
 
+/// The missing-git diagnostic, shared by every call site that can surface
+/// `error.GitNotFound`. One place to print it, so the distinction never folds
+/// back into a generic "clone/list/checkout failed" message the way it did
+/// before #2152. `verb` names the operation, e.g. "install packages". Returns
+/// the error so callers can `return missingGit(...)` in one statement.
+fn missingGit(verb: []const u8) error{GitNotFound} {
+    var buf: [96]u8 = undefined;
+    const msg = std.fmt.bufPrint(&buf, "  git not found in PATH — thottam requires git to {s}\n", .{verb}) catch
+        "  git not found in PATH\n";
+    printErrColor(Color.red, msg);
+    return error.GitNotFound;
+}
+
 /// Record `pkg` in the install cycle/dedup guard. Returns true if it was newly
 /// inserted, false if already present.
 ///
@@ -661,6 +679,7 @@ fn doInstall(
                     writeStderr(msg);
                     return error.GitFailed;
                 },
+                .git_not_found => return missingGit("install packages"),
             }
         }
     }
@@ -745,13 +764,7 @@ fn doInstall(
         const url_copy = try allocator.dupe(u8, clone_url);
         defer allocator.free(url_copy);
         runGit(allocator, &.{ "clone", "--quiet", "--", url_copy, pkg_dir }) catch |err| switch (err) {
-            error.GitNotFound => {
-                // Distinguish a missing git binary from a clone failure: the
-                // old silent 127 made every /usr/bin/git-less platform report
-                // "Failed to clone repository" with no cause (#2152).
-                printErrColor(Color.red, "  git not found in PATH — thottam requires git to install packages\n");
-                return error.GitNotFound;
-            },
+            error.GitNotFound => return missingGit("install packages"),
             else => {
                 printErrColor(Color.red, "  Failed to clone repository\n");
                 return error.GitFailed;
@@ -762,9 +775,12 @@ fn doInstall(
     if (install_version) |v| {
         printBuf(&buf, "  Checking out {s}...\n", .{v});
         runGit(allocator, &.{ "-C", pkg_dir, "fetch", "--quiet", "--tags" }) catch {};
-        checkoutVersion(allocator, pkg_dir, v) catch {
-            printErrColor(Color.red, "  Failed to checkout version\n");
-            return error.GitFailed;
+        checkoutVersion(allocator, pkg_dir, v) catch |err| switch (err) {
+            error.GitNotFound => return missingGit("install packages"),
+            else => {
+                printErrColor(Color.red, "  Failed to checkout version\n");
+                return error.GitFailed;
+            },
         };
     }
 
@@ -954,10 +970,14 @@ fn doUpdate(allocator: std.mem.Allocator, config: Config, pkg: ?[]const u8) !voi
         // package, so one pin no longer fails a whole-tree update. To move
         // the pin, install at the new version — `thottam install pkg@<ver>`
         // re-pins an installed package (issue #2134).
-        if (runGitCapture(allocator, &.{ "-C", pkg_dir, "symbolic-ref", "-q", "HEAD" })) |branch| {
+        const symref = runGitCapture(allocator, &.{ "-C", pkg_dir, "symbolic-ref", "-q", "HEAD" }) catch |err| switch (err) {
+            error.GitNotFound => return missingGit("update packages"),
+            else => null,
+        };
+        if (symref) |branch| {
             defer allocator.free(branch);
             // On a branch: ordinary update below.
-        } else |_| {
+        } else {
             var ref_buf: [64]u8 = undefined;
             const describe = runGitCapture(allocator, &.{ "-C", pkg_dir, "describe", "--tags", "--exact-match", "HEAD" }) catch null;
             defer if (describe) |d| allocator.free(d);
@@ -970,10 +990,7 @@ fn doUpdate(allocator: std.mem.Allocator, config: Config, pkg: ?[]const u8) !voi
         }
 
         runGit(allocator, &.{ "-C", pkg_dir, "pull", "--quiet" }) catch |err| switch (err) {
-            error.GitNotFound => {
-                printErrColor(Color.red, "  git not found in PATH — thottam requires git to update packages\n");
-                return error.GitNotFound;
-            },
+            error.GitNotFound => return missingGit("update packages"),
             else => {
                 printErrColor(Color.red, "  Failed to pull\n");
                 return error.GitFailed;

--- a/src/thottam_proc.zig
+++ b/src/thottam_proc.zig
@@ -1,6 +1,28 @@
 const std = @import("std");
 const platform = @import("platform.zig");
 
+/// execve in the forked child; the only "return" is failure, where it reports
+/// why to `err_fd` and exits 127. Shared by runPassthrough (err_fd = the
+/// inherited stderr) and runCapture (err_fd = the saved real stderr, since
+/// capture silences fd 2) so a missing or unexecutable git is distinguishable
+/// from a genuine failure in the logs (#2152).
+fn execveOrReport(argv_z: []?[*:0]const u8, err_fd: platform.fd_t) noreturn {
+    _ = std.posix.system.execve(
+        @ptrCast(argv_z[0].?),
+        @ptrCast(argv_z.ptr),
+        @ptrCast(std.c.environ),
+    );
+    // execve only returns on failure.
+    var exec_err: [256]u8 = undefined;
+    const exec_msg = std.fmt.bufPrint(&exec_err, "thottam: cannot execute {s}: {s}\n", .{ argv_z[0].?, @tagName(platform.errno(-1)) }) catch {
+        const fallback = "thottam: cannot execute child process\n";
+        _ = platform.write(err_fd, fallback.ptr, fallback.len);
+        std.process.exit(127);
+    };
+    _ = platform.write(err_fd, exec_msg.ptr, exec_msg.len);
+    std.process.exit(127);
+}
+
 pub fn runCapture(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8) ![]u8 {
     if (comptime platform.is_windows) {
         const raw = platform.winSpawnCapture(allocator, argv, cwd) catch |err| switch (err) {
@@ -45,6 +67,10 @@ pub fn runCapture(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?
         _ = std.c.close(pipe[0]);
         _ = std.c.dup2(pipe[1], 1);
         _ = std.c.close(pipe[1]);
+        // Save the real stderr so an execve failure stays audible; the
+        // /dev/null dup2 silences only git's own stderr, which is the point
+        // of capture (#2152).
+        const real_stderr = std.c.dup(2);
         const devnull = std.c.open("/dev/null", .{ .ACCMODE = .WRONLY }, @as(c_uint, 0));
         if (devnull >= 0) {
             _ = std.c.dup2(devnull, 2);
@@ -54,12 +80,7 @@ pub fn runCapture(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?
         if (cwd_z) |c| {
             _ = std.posix.system.chdir(c);
         }
-        _ = std.posix.system.execve(
-            @ptrCast(argv_z[0].?),
-            @ptrCast(argv_z.ptr),
-            @ptrCast(std.c.environ),
-        );
-        std.process.exit(127);
+        execveOrReport(argv_z, real_stderr);
     }
 
     // Parent
@@ -125,23 +146,8 @@ pub fn runPassthrough(allocator: std.mem.Allocator, argv: []const []const u8, cw
         if (cwd_z) |c| {
             _ = std.posix.system.chdir(c);
         }
-        _ = std.posix.system.execve(
-            @ptrCast(argv_z[0].?),
-            @ptrCast(argv_z.ptr),
-            @ptrCast(std.c.environ),
-        );
-        // execve only returns on failure. Passthrough inherits the child's
-        // stderr, so say why instead of exiting 127 silently: a missing or
-        // unexecutable git used to surface as "Failed to clone repository"
-        // with no cause, indistinguishable from a real clone failure (#2152).
-        var exec_err: [256]u8 = undefined;
-        const exec_msg = std.fmt.bufPrint(&exec_err, "thottam: cannot execute {s}: {s}\n", .{ argv_z[0].?, @tagName(platform.errno(-1)) }) catch {
-            const fallback = "thottam: cannot execute child process\n";
-            _ = platform.write(2, fallback.ptr, fallback.len);
-            std.process.exit(127);
-        };
-        _ = platform.write(2, exec_msg.ptr, exec_msg.len);
-        std.process.exit(127);
+        // Passthrough inherits stderr, so the diagnostic goes there directly.
+        execveOrReport(argv_z, 2);
     }
 
     var status: c_int = 0;
@@ -158,7 +164,7 @@ pub fn runPassthrough(allocator: std.mem.Allocator, argv: []const []const u8, cw
 /// BSD — FreeBSD and OpenBSD install git in /usr/local/bin, NetBSD in
 /// /usr/pkg/bin — so every git-backed thottam operation failed there (#2152).
 /// Returns a caller-owned absolute path, or null when git is not on PATH.
-/// The path is dupeZ'd: free with `path[0 .. path.len + 1]`.
+/// The path is dupeZ'd: free the `[:0]` slice with `allocator.free(path)`.
 fn findGit(allocator: std.mem.Allocator) ?[:0]const u8 {
     const path_env = platform.getenv("PATH") orelse return null;
     return findInPath(allocator, std.mem.span(path_env), "git");
@@ -168,8 +174,8 @@ fn findGit(allocator: std.mem.Allocator) ?[:0]const u8 {
 /// executable named `name` (with the platform suffix, so `git.exe` on
 /// Windows, where the resolved absolute path is what CreateProcessW is
 /// handed). An explicit path containing '/' is returned as-is. Returns a
-/// caller-owned dupeZ'd absolute path, or null when not found — free with
-/// `path[0 .. path.len + 1]`.
+/// caller-owned dupeZ'd absolute path, or null when not found — free the
+/// `[:0]` slice with `allocator.free(path)`.
 fn findInPath(allocator: std.mem.Allocator, path_str: []const u8, name: []const u8) ?[:0]const u8 {
     if (std.mem.indexOfScalar(u8, name, '/') != null) {
         return allocator.dupeZ(u8, name) catch null;
@@ -183,14 +189,29 @@ fn findInPath(allocator: std.mem.Allocator, path_str: []const u8, name: []const 
             continue;
         };
         allocator.free(full);
-        const fd = platform.openRead(full_z) catch {
-            allocator.free(full_z[0 .. full_z.len + 1]);
+        if (!isExecutableFile(full_z)) {
+            allocator.free(full_z);
             continue;
-        };
-        _ = platform.close(fd);
+        }
         return full_z;
     }
     return null;
+}
+
+/// Is `path` an executable regular file? The pre-#2152 resolver checked only
+/// `openRead`, which accepts a non-executable file or a directory named `git` —
+/// either would shadow a later real git and then fail at execve instead of
+/// falling through to the next PATH entry the way execvp would. X_OK (not
+/// R_OK) also keeps an execute-only git, which openRead would reject. Windows
+/// has no execute bit: a regular file (already .exe-suffixed) is executable.
+fn isExecutableFile(path: [:0]const u8) bool {
+    if (comptime platform.is_windows) {
+        const st = platform.statPath(path) orelse return false;
+        return st.is_file;
+    }
+    if (std.c.access(path, std.posix.X_OK) != 0) return false;
+    const st = platform.statPath(path) orelse return false;
+    return st.is_file;
 }
 
 pub fn runGit(allocator: std.mem.Allocator, args: []const []const u8) !void {
@@ -198,7 +219,7 @@ pub fn runGit(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer argv.deinit(allocator);
 
     const git = findGit(allocator) orelse return error.GitNotFound;
-    defer allocator.free(git[0 .. git.len + 1]);
+    defer allocator.free(git);
     argv.append(allocator, git) catch return error.OutOfMemory;
     for (args) |a| {
         argv.append(allocator, a) catch return error.OutOfMemory;
@@ -212,7 +233,7 @@ pub fn runGitCapture(allocator: std.mem.Allocator, args: []const []const u8) ![]
     defer argv.deinit(allocator);
 
     const git = findGit(allocator) orelse return error.GitNotFound;
-    defer allocator.free(git[0 .. git.len + 1]);
+    defer allocator.free(git);
     argv.append(allocator, git) catch return error.OutOfMemory;
     for (args) |a| {
         argv.append(allocator, a) catch return error.OutOfMemory;
@@ -242,7 +263,7 @@ test "checkoutVersion resolves a pinned tag as a ref, not a pathspec (issue #780
     // The precondition probe is now PATH-based (was: /usr/bin/git), matching
     // how runGit resolves the binary after #2152.
     if (findGit(allocator)) |git_path| {
-        allocator.free(git_path[0 .. git_path.len + 1]);
+        allocator.free(git_path);
     } else return error.SkipZigTest;
 
     const repo = try std.fmt.allocPrint(allocator, "{s}/kaappi-thottam-780-{d}", .{ platform.tempDir(), platform.getPid() });
@@ -288,20 +309,38 @@ test "findInPath resolves an executable through PATH, not a fixed location (issu
     // writeFile does not create parent directories (and cannot run git init
     // the way the #780 test does), so make the fixture dir by hand.
     const dir_z = try allocator.dupeZ(u8, dir);
-    defer allocator.free(dir_z[0 .. dir_z.len + 1]);
+    defer allocator.free(dir_z);
     _ = platform.mkdir(dir_z, 0o755);
-    try thottam.writeFile(allocator, git_path, "#!/bin/sh\n");
+    try thottam.writeFile(allocator, git_path, "#!/bin/sh\nexit 0\n");
+
+    // A readable-but-non-executable file is not a usable git: findInPath must
+    // skip it rather than hand execve a path it will reject. POSIX encodes
+    // this as the execute bit; Windows has no such bit, so the fresh fixture
+    // is already "executable" there. Probe with only the fixture dir on the
+    // path, so a real git elsewhere cannot satisfy the search.
+    if (!platform.is_windows) {
+        try std.testing.expect(findInPath(allocator, dir, "git") == null);
+    }
+
+    // Make it executable.
+    const git_path_z = try allocator.dupeZ(u8, git_path);
+    defer allocator.free(git_path_z);
+    platform.makeWritable(git_path_z);
 
     // The fake git sits in a directory that precedes /usr/bin — the path the
     // pre-#2152 code hardcoded. First match wins, so a resolver that looks in
     // /usr/bin first (or at all) would find the real git or nothing; this
-    // resolver must find the fixture's.
-    const path_str = try std.fmt.allocPrint(allocator, "{s}:/usr/bin:/bin", .{dir});
+    // resolver must find the fixture's, which is now executable.
+    const path_str = try std.fmt.allocPrint(allocator, "{s}{c}{s}{c}{s}", .{ dir, platform.path_list_sep, "/usr/bin", platform.path_list_sep, "/bin" });
     defer allocator.free(path_str);
 
     const resolved = findInPath(allocator, path_str, "git") orelse return error.TestUnexpectedResult;
-    defer allocator.free(resolved[0 .. resolved.len + 1]);
+    defer allocator.free(resolved);
     try std.testing.expectEqualStrings(git_path, resolved);
+    if (!platform.is_windows) {
+        const argv = [_][]const u8{resolved};
+        try std.testing.expectEqual(@as(u8, 0), try runPassthrough(allocator, &argv, null));
+    }
 
     // A name that is nowhere on the path resolves to null.
     try std.testing.expect(findInPath(allocator, path_str, "kaappi-definitely-not-a-real-tool") == null);

--- a/src/thottam_proc.zig
+++ b/src/thottam_proc.zig
@@ -130,6 +130,17 @@ pub fn runPassthrough(allocator: std.mem.Allocator, argv: []const []const u8, cw
             @ptrCast(argv_z.ptr),
             @ptrCast(std.c.environ),
         );
+        // execve only returns on failure. Passthrough inherits the child's
+        // stderr, so say why instead of exiting 127 silently: a missing or
+        // unexecutable git used to surface as "Failed to clone repository"
+        // with no cause, indistinguishable from a real clone failure (#2152).
+        var exec_err: [256]u8 = undefined;
+        const exec_msg = std.fmt.bufPrint(&exec_err, "thottam: cannot execute {s}: {s}\n", .{ argv_z[0].?, @tagName(platform.errno(-1)) }) catch {
+            const fallback = "thottam: cannot execute child process\n";
+            _ = platform.write(2, fallback.ptr, fallback.len);
+            std.process.exit(127);
+        };
+        _ = platform.write(2, exec_msg.ptr, exec_msg.len);
         std.process.exit(127);
     }
 
@@ -141,11 +152,54 @@ pub fn runPassthrough(allocator: std.mem.Allocator, argv: []const []const u8, cw
     return @intCast((raw >> 8) & 0xff);
 }
 
+/// Resolve the `git` executable through PATH, like `kaappi compile` does for
+/// a C compiler (native_compiler.zig) and test_selection does for its git
+/// invocations. The old `/usr/bin/git` hardcode was false on every supported
+/// BSD — FreeBSD and OpenBSD install git in /usr/local/bin, NetBSD in
+/// /usr/pkg/bin — so every git-backed thottam operation failed there (#2152).
+/// Returns a caller-owned absolute path, or null when git is not on PATH.
+/// The path is dupeZ'd: free with `path[0 .. path.len + 1]`.
+fn findGit(allocator: std.mem.Allocator) ?[:0]const u8 {
+    const path_env = platform.getenv("PATH") orelse return null;
+    return findInPath(allocator, std.mem.span(path_env), "git");
+}
+
+/// Search `path_str` (a PATH-style list, `:` or `;` separated) for an
+/// executable named `name` (with the platform suffix, so `git.exe` on
+/// Windows, where the resolved absolute path is what CreateProcessW is
+/// handed). An explicit path containing '/' is returned as-is. Returns a
+/// caller-owned dupeZ'd absolute path, or null when not found — free with
+/// `path[0 .. path.len + 1]`.
+fn findInPath(allocator: std.mem.Allocator, path_str: []const u8, name: []const u8) ?[:0]const u8 {
+    if (std.mem.indexOfScalar(u8, name, '/') != null) {
+        return allocator.dupeZ(u8, name) catch null;
+    }
+    var iter = std.mem.splitScalar(u8, path_str, platform.path_list_sep);
+    while (iter.next()) |dir| {
+        if (dir.len == 0) continue;
+        const full = std.fmt.allocPrint(allocator, "{s}/{s}{s}", .{ dir, name, platform.exe_suffix }) catch continue;
+        const full_z = allocator.dupeZ(u8, full) catch {
+            allocator.free(full);
+            continue;
+        };
+        allocator.free(full);
+        const fd = platform.openRead(full_z) catch {
+            allocator.free(full_z[0 .. full_z.len + 1]);
+            continue;
+        };
+        _ = platform.close(fd);
+        return full_z;
+    }
+    return null;
+}
+
 pub fn runGit(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(allocator);
-    // Windows: no fixed install path; CreateProcessW searches PATH.
-    argv.append(allocator, if (platform.is_windows) "git" else "/usr/bin/git") catch return error.OutOfMemory;
+
+    const git = findGit(allocator) orelse return error.GitNotFound;
+    defer allocator.free(git[0 .. git.len + 1]);
+    argv.append(allocator, git) catch return error.OutOfMemory;
     for (args) |a| {
         argv.append(allocator, a) catch return error.OutOfMemory;
     }
@@ -156,7 +210,10 @@ pub fn runGit(allocator: std.mem.Allocator, args: []const []const u8) !void {
 pub fn runGitCapture(allocator: std.mem.Allocator, args: []const []const u8) ![]u8 {
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(allocator);
-    argv.append(allocator, if (platform.is_windows) "git" else "/usr/bin/git") catch return error.OutOfMemory;
+
+    const git = findGit(allocator) orelse return error.GitNotFound;
+    defer allocator.free(git[0 .. git.len + 1]);
+    argv.append(allocator, git) catch return error.OutOfMemory;
     for (args) |a| {
         argv.append(allocator, a) catch return error.OutOfMemory;
     }
@@ -182,7 +239,11 @@ test "checkoutVersion resolves a pinned tag as a ref, not a pathspec (issue #780
     const thottam = @import("thottam.zig");
     const allocator = std.testing.allocator;
 
-    if (!thottam.fileExists(allocator, "/usr/bin/git")) return error.SkipZigTest;
+    // The precondition probe is now PATH-based (was: /usr/bin/git), matching
+    // how runGit resolves the binary after #2152.
+    if (findGit(allocator)) |git_path| {
+        allocator.free(git_path[0 .. git_path.len + 1]);
+    } else return error.SkipZigTest;
 
     const repo = try std.fmt.allocPrint(allocator, "{s}/kaappi-thottam-780-{d}", .{ platform.tempDir(), platform.getPid() });
     defer allocator.free(repo);
@@ -210,6 +271,40 @@ test "checkoutVersion resolves a pinned tag as a ref, not a pathspec (issue #780
     const v11 = try runGitCapture(allocator, &.{ "-C", repo, "rev-parse", "v1.1.0^{commit}" });
     defer allocator.free(v11);
     try std.testing.expect(!std.mem.eql(u8, head, v11));
+}
+
+test "findInPath resolves an executable through PATH, not a fixed location (issue #2152)" {
+    const thottam = @import("thottam.zig");
+    const allocator = std.testing.allocator;
+    const dir = try std.fmt.allocPrint(allocator, "{s}/kaappi-thottam-2152-{d}", .{ platform.tempDir(), platform.getPid() });
+    defer allocator.free(dir);
+    defer thottam.removeDir(allocator, dir) catch {};
+    thottam.removeDir(allocator, dir) catch {};
+
+    const exe_name = try std.fmt.allocPrint(allocator, "git{s}", .{platform.exe_suffix});
+    defer allocator.free(exe_name);
+    const git_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir, exe_name });
+    defer allocator.free(git_path);
+    // writeFile does not create parent directories (and cannot run git init
+    // the way the #780 test does), so make the fixture dir by hand.
+    const dir_z = try allocator.dupeZ(u8, dir);
+    defer allocator.free(dir_z[0 .. dir_z.len + 1]);
+    _ = platform.mkdir(dir_z, 0o755);
+    try thottam.writeFile(allocator, git_path, "#!/bin/sh\n");
+
+    // The fake git sits in a directory that precedes /usr/bin — the path the
+    // pre-#2152 code hardcoded. First match wins, so a resolver that looks in
+    // /usr/bin first (or at all) would find the real git or nothing; this
+    // resolver must find the fixture's.
+    const path_str = try std.fmt.allocPrint(allocator, "{s}:/usr/bin:/bin", .{dir});
+    defer allocator.free(path_str);
+
+    const resolved = findInPath(allocator, path_str, "git") orelse return error.TestUnexpectedResult;
+    defer allocator.free(resolved[0 .. resolved.len + 1]);
+    try std.testing.expectEqualStrings(git_path, resolved);
+
+    // A name that is nowhere on the path resolves to null.
+    try std.testing.expect(findInPath(allocator, path_str, "kaappi-definitely-not-a-real-tool") == null);
 }
 
 test "checkoutVersion rejects option-like versions (issue #736)" {

--- a/tests/scheme/thottam/thottam-lifecycle.sh
+++ b/tests/scheme/thottam/thottam-lifecycle.sh
@@ -39,26 +39,19 @@ if ! command -v git > /dev/null 2>&1; then
     exit 77
 fi
 
-# thottam invokes git as the absolute path /usr/bin/git (thottam_proc.zig:148),
-# not through PATH. That path exists on macOS and on CI's Linux images, and on
-# none of the three BSDs -- FreeBSD and OpenBSD put git in /usr/local/bin,
-# NetBSD in /usr/pkg/bin -- so every git-backed thottam operation fails there
-# (kaappi#2152). This suite is entirely git-backed, so it cannot run.
+# thottam used to invoke git as the absolute path /usr/bin/git
+# (thottam_proc.zig:148), not through PATH. That path exists on macOS and on
+# CI's Linux images, and on none of the three BSDs -- FreeBSD and OpenBSD put
+# git in /usr/local/bin, NetBSD in /usr/pkg/bin -- so every git-backed thottam
+# operation failed there (kaappi#2152). Fixed by resolving git through PATH,
+# so the only precondition left is the `command -v git` probe above. This
+# suite is itself the regression test: on a box without /usr/bin/git it used
+# to skip (or fail on the BSD legs), and now it runs.
 #
-# Probe for the exact precondition rather than listing platforms: when #2152 is
-# fixed to search PATH, this check should be replaced by `command -v git`,
-# which is already asserted above. Until then, testing for the very path
-# thottam will execute is the honest gate -- it skips exactly where thottam is
-# broken and nowhere else.
-#
-# An earlier version of this probe created a bare repo and cloned it, on the
-# hypothesis that local-bare-clone was unsupported there. It PASSED on OpenBSD
-# while the suite still failed, because the probe used PATH and thottam does
-# not. That falsified hypothesis is what located #2152.
-if [[ ! -x /usr/bin/git ]]; then
-    echo "SKIP: thottam hardcodes /usr/bin/git, which does not exist here (kaappi#2152)"
-    exit 77
-fi
+# The original probe created a bare repo and cloned it, on the hypothesis that
+# local-bare-clone was unsupported on the BSDs. It PASSED on OpenBSD while the
+# suite still failed, because the probe used PATH and thottam did not. That
+# falsified hypothesis is what located #2152.
 
 PASS=0
 FAIL=0


### PR DESCRIPTION
## Summary

`thottam` hardcoded `/usr/bin/git` on every non-Windows platform, which exists on macOS and CI's Linux images but on **none of the three supported BSDs** — FreeBSD and OpenBSD install git in `/usr/local/bin`, NetBSD in `/usr/pkg/bin`. Every git-backed operation (`install`, `update`, `ls-remote` version resolution) therefore failed there, leaving the package manager non-functional on platforms Kaappi ships binaries for.

### The fix

- **Resolve `git` through `PATH`** (`findGit`/`findInPath` in `src/thottam_proc.zig`), the same way `kaappi compile` discovers a C compiler (`native_compiler.zig`) and `test_selection` locates its git. The resolved absolute path is handed to `execve`, so the child never depends on PATH resolution. The Windows branch's assumption — "no fixed install path; CreateProcessW searches PATH" — turns out to hold for POSIX too.
- **A missing git is now a distinct `error.GitNotFound`** that `install`/`update` report with a cause (`git not found in PATH — thottam requires git to …`), instead of the old silent 127 surfacing as the unhelpful `Failed to clone repository`.
- **Stop swallowing the spawn failure**: `runPassthrough`'s child now prints `cannot execute <argv[0]>: <errno>` before exiting 127, so a `FileNotFound` on the git binary and a genuine clone failure are no longer indistinguishable in the logs — the second defect that hid the first across three CI runs.

### Tests

- New Zig unit test `findInPath resolves an executable through PATH, not a fixed location` — asserts the resolver finds a fixture `git` in a directory preceding `/usr/bin` (first-match-wins), and returns `null` for an absent name.
- Updated the existing `checkoutVersion` precondition probe from `/usr/bin/git` to the PATH-based `findGit`.
- `tests/scheme/thottam/thottam-lifecycle.sh`: removed the `/usr/bin/git` skip-gate; the suite now runs wherever `command -v git` succeeds (which is the regression test for the BSD legs). **145 assertions, 0 failed**.

## Checklist

- [x] `zig build test` passes (1801/1808, 7 skipped)
- [x] `zig fmt --check src/` passes
- [x] `bash tests/scheme/thottam/thottam-lifecycle.sh` passes (145/145)
- [x] New tests added for new behavior
- [x] Documentation updated (not applicable — no doc referenced the git binary path)

Closes #2152.
