### PR TITLE
Fix fmt round-trip, lexer, idempotence, and width audit findings

### DIFF
--- a/docs/dev/fmt.md
+++ b/docs/dev/fmt.md
@@ -29,9 +29,12 @@ kaappi fmt [--check]              # format stdin to stdout
   line — never dangling on a line of its own — unless a trailing line comment
   forces it down.
 * **Reflowed to width.** A form that fits within `max_width` (80) columns is put
-  on one line; one that does not breaks. Layout depends only on the program's
-  content and its comments, **not** on the input's own line breaks, so two files
-  that differ only in whitespace format identically.
+  on one line; one that does not breaks. A "column" is a Unicode code point, so
+  an identifier counts its characters, not its UTF-8 bytes (kaappi#2149). East
+  Asian wide characters and combining marks are not modelled — that would need
+  `wcwidth`; see `columnCount` in `src/fmt_print.zig`. Layout depends only on
+  the program's content and its comments, **not** on the input's own line
+  breaks, so two files that differ only in whitespace format identically.
 * **Verbatim atoms.** Symbol, number, string, and character spellings are never
   rewritten — `1.5e10`, `#xFF`, `#\newline`, `'x` vs `(quote x)` all pass
   through untouched. The formatter rearranges whitespace *between* lexemes; it
@@ -57,10 +60,11 @@ any other:
 | Piped symbol | `\|a<CR>b\|` |
 | Character literal | `#\<CR>` (and its `#\return` spelling) |
 
-Comments are not datums, so both kinds normalise. A line comment's trailing
-`\r` is the carriage return of the CRLF that ended it, and is dropped alongside
-the trailing spaces beside it; a block comment ends at `|#`, so its *interior*
-line endings normalise outright.
+Comments are not datums, so both kinds normalise. A line comment ends at its
+line ending — `\n` or a lone `\r` (R7RS 7.1.1, kaappi#2079) — so the carriage
+return of a CRLF is never part of the comment text; trailing spaces and tabs are
+the only invisible bytes stripped. A block comment ends at `|#`, so its
+*interior* line endings normalise outright.
 
 `--check` reports a file that differs only in line endings, because `fmt` would
 rewrite it. The two share one comparison in `formatFile`, so they can never
@@ -91,17 +95,6 @@ fix is the same one Go and Zig projects use — normalise the checkout:
 
 or `git config core.autocrlf input`. This repo needs neither: no tracked
 `.scm`/`.sld` contains a CR.
-
-### Known deviation: a lone CR does not end a `;` comment
-
-R7RS 7.1.1 defines `⟨line ending⟩ → ⟨newline⟩ | ⟨return⟩ ⟨newline⟩ | ⟨return⟩`
-and ends a `;` comment at one, but this **reader** ends it only at `\n`
-(kaappi#2079) — so in a classic-Mac-line-ending file everything after the first
-`;` is one comment. `fmt`'s lexer mirrors the real reader by design, so it
-inherits that: the comment's interior CR is preserved rather than normalised,
-since rewriting it to `\n` would split the comment and promote its tail to real
-code. Every other lone CR in such a file does become LF. `fmt` is faithful to
-what the program means today; fixing the reader is what changes it.
 
 ## Why it needs its own reader
 
@@ -161,10 +154,18 @@ Layout can only rearrange whitespace between lexemes, so the datums a program
 reads are invariant by construction. That invariant is *also checked at
 runtime*: before writing any file, `verifyRoundTrip` re-reads both the original
 and the formatted text **with the real reader** and compares the datum sequences
-with `equal?` (`primitives.deepEqual`). On any mismatch — or if either side
-fails to read — `fmt` refuses to write and reports an error. A bug in the
-lexer, parser, or printer can therefore never corrupt a source file; at worst a
-file is left unformatted.
+with `equal?` (`primitives.deepEqual`). The two failure modes are kept distinct
+(kaappi#2080):
+
+* If the **original** does not read — a user syntax error the CST lexer happened
+  to tolerate, such as `#\qqq` — `fmt` reports the reader's own `KP1xxx`
+  diagnostic with its line and column, exactly as `kaappi check` does.
+* If the original reads but the **formatted** text does not, or the two read to
+  different datum sequences, that is a genuine formatter bug and `fmt` refuses
+  to write with an "internal error" message.
+
+Either way a bug in the lexer, parser, or printer can never corrupt a source
+file; at worst a file is left unformatted.
 
 One consequence: a source whose datums cannot be compared this way — in
 practice, only a file containing a self-referential datum label the real reader

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -242,7 +242,7 @@ const Lexer = struct {
         // SRFI 207 string-notated bytevector #u8"...": one verbatim lexeme,
         // like the ordinary string it contains-ish -- checked before the
         // plain "#u8(" case can't apply and before falling through to
-        // scanAtom, which would otherwise stop at the `"` (a delimiter)
+        // scanHashAtom, which would otherwise stop at the `"` (a delimiter)
         // and split this into two lexemes ("#u8" then a separate string).
         if (rest.len >= 4 and std.mem.eql(u8, rest[0..3], "#u8") and rest[3] == '"') {
             self.pos += 3;
@@ -572,12 +572,15 @@ pub fn formatSource(arena: std.mem.Allocator, source: []const u8) ParseError![]u
 /// Why the round-trip safety net declined. Only `mismatch` is an internal
 /// error; `original_unreadable` is the user's own syntax error — a file the CST
 /// lexer tolerated but the real reader rejects — and is reported with the
-/// reader's own `KP1xxx` diagnostic and position (kaappi#2080).
+/// reader's own `KP1xxx` diagnostic and position (kaappi#2080). `oom` is an
+/// allocator failure, which is neither.
 pub const RoundTrip = union(enum) {
     /// Both texts read to the same datum sequence — safe to write.
     ok,
     /// The original does not read.
     original_unreadable: ReadFailure,
+    /// Either text could not be read because the heap was exhausted.
+    oom,
     /// The original reads but the formatted text does not, or the two read to
     /// different datum sequences — a genuine formatter bug.
     mismatch,
@@ -603,14 +606,15 @@ pub fn verifyRoundTrip(gc: *memory.GC, original: []const u8, formatted: []const 
     switch (readAllRooted(gc, original, &orig_list)) {
         .ok => {},
         .read_error => |f| return .{ .original_unreadable = f },
-        .oom => return .mismatch,
+        .oom => return .oom,
     }
 
     var fmt_list: std.ArrayList(Value) = .empty;
     defer fmt_list.deinit(gc.allocator);
     switch (readAllRooted(gc, formatted, &fmt_list)) {
         .ok => {},
-        .read_error, .oom => return .mismatch,
+        .read_error => return .mismatch,
+        .oom => return .oom,
     }
 
     if (orig_list.items.len != fmt_list.items.len) return .mismatch;
@@ -704,6 +708,10 @@ fn formatFile(gc: *memory.GC, path: []const u8, check: bool) FileOutcome {
             toplevel_driver.reportReadError(path, f.line, f.col, f.err);
             return .failed;
         },
+        .oom => {
+            reportFileError(path, "out of memory");
+            return .failed;
+        },
         .mismatch => {
             reportFileError(path, "internal error: formatting would change the program; file left unchanged");
             return .failed;
@@ -748,6 +756,10 @@ fn runStdin(gc: *memory.GC, check: bool) u8 {
         .original_unreadable => |f| {
             // The user's own syntax error (kaappi#2080).
             toplevel_driver.reportReadError("<stdin>", f.line, f.col, f.err);
+            return 1;
+        },
+        .oom => {
+            writeStderr("kaappi fmt: out of memory\n");
             return 1;
         },
         .mismatch => {

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -22,9 +22,12 @@
 //! change them, so the datums a program reads are invariant. That invariant is
 //! also *checked at runtime*: before writing any file, `verifyRoundTrip` re-reads
 //! the original and the formatted text with the real reader and compares the
-//! datum sequences with `equal?`. On any mismatch — or if either side fails to
-//! read — `fmt` refuses to write and reports it, so a bug here can never corrupt
-//! a source file.
+//! datum sequences with `equal?`. The two failure modes are kept distinct
+//! (kaappi#2080): if the *original* does not read — a user syntax error the CST
+//! lexer tolerated — the reader's own `KP1xxx` diagnostic is reported; only a
+//! real mismatch between two successfully-read datum sequences (or a formatted
+//! text that fails to read) is reported as an internal error. Either way a bug
+//! here can never corrupt a source file.
 //!
 //! **Line endings are LF** (kaappi#1897), the same policy `zig fmt` applies to
 //! this compiler's own Zig. Every line break `fmt` emits is a bare `\n`; a CRLF
@@ -47,6 +50,7 @@ const memory = @import("memory.zig");
 const reader_mod = @import("reader.zig");
 const primitives = @import("primitives.zig");
 const reporting = @import("reporting.zig");
+const toplevel_driver = @import("toplevel_driver.zig");
 const file_utils = @import("file_utils.zig");
 const fmt_print = @import("fmt_print.zig");
 
@@ -192,7 +196,9 @@ const Lexer = struct {
                 break :blk .prefix;
             },
             ';' => blk: {
-                while (self.pos < self.src.len and self.src[self.pos] != '\n') self.pos += 1;
+                // R7RS 7.1.1 ends a `;` comment at any line ending, including a
+                // lone `\r` (kaappi#2079) — mirror the reader's scan.
+                while (self.pos < self.src.len and self.src[self.pos] != '\n' and self.src[self.pos] != '\r') self.pos += 1;
                 break :blk .line_comment;
             },
             '"' => blk: {
@@ -205,7 +211,7 @@ const Lexer = struct {
             },
             '#' => try self.scanHash(),
             else => blk: {
-                self.scanAtom();
+                self.scanIdentifier();
                 break :blk .atom;
             },
         };
@@ -262,7 +268,7 @@ const Lexer = struct {
                 return .prefix;
             }
         }
-        self.scanAtom();
+        self.scanHashAtom();
         return .atom;
     }
 
@@ -291,10 +297,52 @@ const Lexer = struct {
         return ParseError.UnterminatedString;
     }
 
-    fn scanAtom(self: *Lexer) void {
-        // `#` dispatches specially only at a token boundary (see `scanHash`), so
-        // as an interior constituent it is ordinary: this keeps `#0#` (a datum
-        // label reference) and `#e#xFF` (stacked prefixes) single atoms.
+    /// A non-`#` atom: an identifier, number, or the peculiar `+`/`-`/`.`
+    /// spellings. Ends the way `Reader.readSymbol` does — at the first byte that
+    /// is not an R7RS ⟨subsequent⟩ (ASCII) or a Unicode letter (non-ASCII) — so
+    /// a `#`-led lexeme glued to an identifier splits into the identifier plus
+    /// the `#` lexeme, exactly as the real reader carves it (kaappi#2143).
+    fn scanIdentifier(self: *Lexer) void {
+        // Consume the first byte — or whole codepoint for a multi-byte UTF-8
+        // lead — unconditionally: the caller only reaches this branch for a byte
+        // that can start an atom (mirroring `Reader.nextToken`'s dispatch), and
+        // consuming it guarantees progress even on a stray byte that is not a
+        // valid atom start (which the round-trip guard will then report).
+        const first = self.src[self.pos];
+        if (first < 0x80) {
+            self.pos += 1;
+        } else {
+            const seq_len = std.unicode.utf8ByteSequenceLength(first) catch 1;
+            self.pos += @min(seq_len, self.src.len - self.pos);
+        }
+        // Then consume ⟨subsequent⟩ bytes, exactly as `Reader.readSymbol` does.
+        while (self.pos < self.src.len) {
+            const c = self.src[self.pos];
+            if (c < 0x80) {
+                if (reader_mod.Reader.isSubsequent(c)) {
+                    self.pos += 1;
+                } else {
+                    break;
+                }
+            } else {
+                const seq_len = std.unicode.utf8ByteSequenceLength(c) catch break;
+                if (self.pos + seq_len > self.src.len) break;
+                const cp = std.unicode.utf8Decode(self.src[self.pos .. self.pos + seq_len]) catch break;
+                if (reader_mod.Reader.isUnicodeSubsequent(cp)) {
+                    self.pos += seq_len;
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// A `#`-led atom (booleans, radix/exactness numbers, datum-label
+    /// references `#0#`, stacked prefixes `#e#xFF`). Unlike `scanIdentifier`,
+    /// `#` is an interior constituent here — the carve-outs above this scan are
+    /// the only `#`-led lexemes that dispatch specially, and everything else
+    /// reaching `scanHash`'s fallthrough is a single verbatim atom.
+    fn scanHashAtom(self: *Lexer) void {
         self.pos += 1;
         while (self.pos < self.src.len and !isDelimiter(self.src[self.pos])) {
             self.pos += 1;
@@ -427,17 +475,14 @@ const Parser = struct {
                     else => .atom,
                 },
                 // Neither comment kind is a datum, so both get the LF policy
-                // (see the module header). A line comment runs to the `\n` that
-                // ends it, so a trailing `\r` is that CRLF's carriage return —
-                // dropping it is what keeps commented lines from being the one
-                // place `fmt` emits a CR. Interior bytes are *not* rewritten:
-                // this reader ends a `;` comment only at `\n` (kaappi#2079), so
-                // turning an interior CR into `\n` would split the comment and
-                // promote its tail to code. Block comments have no such hazard —
-                // they end at `|#` — so their line endings normalise outright.
-                // Atom text stays byte-for-byte: a CR in a string is program data.
+                // (see the module header). A line comment now runs to its line
+                // ending — `\n` or a lone `\r` (kaappi#2079) — so its text
+                // holds no newline; trailing spaces/tabs are the only invisible
+                // bytes to strip. Block comments end at `|#`, so their interior
+                // line endings normalise outright. Atom text stays byte-for-byte:
+                // a CR in a string is program data.
                 .text = switch (tok.kind) {
-                    .line_comment => std.mem.trimEnd(u8, tok.text, " \t\r"),
+                    .line_comment => std.mem.trimEnd(u8, tok.text, " \t"),
                     .block_comment => try normalizeEol(self.arena, tok.text),
                     else => tok.text,
                 },
@@ -524,41 +569,81 @@ pub fn formatSource(arena: std.mem.Allocator, source: []const u8) ParseError![]u
     return fmt_print.print(arena, nodes);
 }
 
+/// Why the round-trip safety net declined. Only `mismatch` is an internal
+/// error; `original_unreadable` is the user's own syntax error — a file the CST
+/// lexer tolerated but the real reader rejects — and is reported with the
+/// reader's own `KP1xxx` diagnostic and position (kaappi#2080).
+pub const RoundTrip = union(enum) {
+    /// Both texts read to the same datum sequence — safe to write.
+    ok,
+    /// The original does not read.
+    original_unreadable: ReadFailure,
+    /// The original reads but the formatted text does not, or the two read to
+    /// different datum sequences — a genuine formatter bug.
+    mismatch,
+};
+
+pub const ReadFailure = struct {
+    line: u32,
+    col: u32,
+    err: anyerror,
+};
+
 /// True when `original` and `formatted` read to `equal?` datum sequences. This
-/// is the safety net: layout must never change the program a reader sees. Any
-/// read failure on either side (or a length/element mismatch) returns false, so
-/// the caller refuses to write.
-pub fn verifyRoundTrip(gc: *memory.GC, original: []const u8, formatted: []const u8) bool {
+/// is the safety net: layout must never change the program a reader sees. The
+/// failure mode distinguishes a user read error in `original` (which the caller
+/// reports with the reader's own diagnostic) from a real mismatch (an internal
+/// error).
+pub fn verifyRoundTrip(gc: *memory.GC, original: []const u8, formatted: []const u8) RoundTrip {
     const roots_base = gc.extra_roots.items.len;
     defer gc.extra_roots.shrinkRetainingCapacity(roots_base);
 
     var orig_list: std.ArrayList(Value) = .empty;
     defer orig_list.deinit(gc.allocator);
-    if (!readAllRooted(gc, original, &orig_list)) return false;
+    switch (readAllRooted(gc, original, &orig_list)) {
+        .ok => {},
+        .read_error => |f| return .{ .original_unreadable = f },
+        .oom => return .mismatch,
+    }
 
     var fmt_list: std.ArrayList(Value) = .empty;
     defer fmt_list.deinit(gc.allocator);
-    if (!readAllRooted(gc, formatted, &fmt_list)) return false;
-
-    if (orig_list.items.len != fmt_list.items.len) return false;
-    for (orig_list.items, fmt_list.items) |a, b| {
-        if (!primitives.deepEqual(a, b)) return false;
+    switch (readAllRooted(gc, formatted, &fmt_list)) {
+        .ok => {},
+        .read_error, .oom => return .mismatch,
     }
-    return true;
+
+    if (orig_list.items.len != fmt_list.items.len) return .mismatch;
+    for (orig_list.items, fmt_list.items) |a, b| {
+        if (!primitives.deepEqual(a, b)) return .mismatch;
+    }
+    return .ok;
 }
+
+const ReadOutcome = union(enum) {
+    ok,
+    read_error: ReadFailure,
+    oom,
+};
 
 /// Read every datum from `source`, appending to `out` and mirroring each into
 /// `gc.extra_roots` so a later read's allocations cannot collect earlier datums.
-/// Returns false on any read error.
-fn readAllRooted(gc: *memory.GC, source: []const u8, out: *std.ArrayList(Value)) bool {
+fn readAllRooted(gc: *memory.GC, source: []const u8, out: *std.ArrayList(Value)) ReadOutcome {
     var r = reader_mod.Reader.init(gc, source);
     defer r.deinit();
-    while (r.hasMore() catch return false) {
-        const datum = r.readDatum() catch return false;
-        out.append(gc.allocator, datum) catch return false;
-        gc.extra_roots.append(gc.allocator, datum) catch return false;
+    while (true) {
+        const more = r.hasMore() catch |err| {
+            const lc = r.getLineCol();
+            return .{ .read_error = .{ .line = lc.line, .col = lc.col, .err = err } };
+        };
+        if (!more) return .ok;
+        const datum = r.readDatum() catch |err| {
+            const lc = r.getLineCol();
+            return .{ .read_error = .{ .line = lc.line, .col = lc.col, .err = err } };
+        };
+        out.append(gc.allocator, datum) catch return .oom;
+        gc.extra_roots.append(gc.allocator, datum) catch return .oom;
     }
-    return true;
 }
 
 // ── CLI entry ────────────────────────────────────────────────────────────────
@@ -610,9 +695,19 @@ fn formatFile(gc: *memory.GC, path: []const u8, check: bool) FileOutcome {
         return .failed;
     };
 
-    if (!verifyRoundTrip(gc, source, formatted)) {
-        reportFileError(path, "internal error: formatting would change the program; file left unchanged");
-        return .failed;
+    switch (verifyRoundTrip(gc, source, formatted)) {
+        .ok => {},
+        .original_unreadable => |f| {
+            // The user's own syntax error: report it with the reader's KP1xxx
+            // diagnostic and position, not as an internal formatter fault
+            // (kaappi#2080).
+            toplevel_driver.reportReadError(path, f.line, f.col, f.err);
+            return .failed;
+        },
+        .mismatch => {
+            reportFileError(path, "internal error: formatting would change the program; file left unchanged");
+            return .failed;
+        },
     }
 
     if (std.mem.eql(u8, formatted, source)) return .ok;
@@ -648,9 +743,17 @@ fn runStdin(gc: *memory.GC, check: bool) u8 {
         return 1;
     };
 
-    if (!verifyRoundTrip(gc, source, formatted)) {
-        writeStderr("kaappi fmt: internal error: formatting would change the program\n");
-        return 1;
+    switch (verifyRoundTrip(gc, source, formatted)) {
+        .ok => {},
+        .original_unreadable => |f| {
+            // The user's own syntax error (kaappi#2080).
+            toplevel_driver.reportReadError("<stdin>", f.line, f.col, f.err);
+            return 1;
+        },
+        .mismatch => {
+            writeStderr("kaappi fmt: internal error: formatting would change the program\n");
+            return 1;
+        },
     }
 
     if (check) return if (std.mem.eql(u8, formatted, source)) 0 else 1;

--- a/src/fmt_print.zig
+++ b/src/fmt_print.zig
@@ -50,7 +50,10 @@ pub fn print(arena: std.mem.Allocator, nodes: []Node) error{OutOfMemory}![]u8 {
 const Printer = struct {
     out: *std.ArrayList(u8),
     a: std.mem.Allocator,
-    /// Column (byte offset since the last newline) of the write cursor.
+    /// Column (Unicode scalar count since the last newline) of the write cursor.
+    /// Not a byte offset: `raw` advances it by the codepoint width of the text
+    /// it emits, so a wide identifier counts its characters, not its UTF-8 bytes
+    /// (kaappi#2149).
     col: usize = 0,
     /// The current line ends in a line comment, so nothing more may be appended
     /// to it — the next token, and any closing paren, must start a new line.
@@ -59,9 +62,9 @@ const Printer = struct {
     fn raw(self: *Printer, s: []const u8) error{OutOfMemory}!void {
         try self.out.appendSlice(self.a, s);
         if (std.mem.lastIndexOfScalar(u8, s, '\n')) |nl| {
-            self.col = s.len - nl - 1;
+            self.col = columnCount(s[nl + 1 ..]);
         } else {
-            self.col += s.len;
+            self.col += columnCount(s);
         }
         self.line_comment_open = false;
     }
@@ -288,8 +291,25 @@ const Printer = struct {
 
 // ── Measurement ──────────────────────────────────────────────────────────────
 
-/// Inline width of `node` in bytes, or null if it cannot be one line (contains a
-/// line comment, a multi-line block comment, or an atom with an embedded
+/// Display width of `s` in columns: the number of Unicode scalar values, with
+/// any invalid UTF-8 byte (possible only inside verbatim atom text) counting one
+/// column each. This is what "fits within `max_width` columns" means — an
+/// identifier's width is its character count, not its UTF-8 byte count
+/// (kaappi#2149). It deliberately does not model East Asian wide characters or
+/// combining marks, which would need wcwidth; see docs/dev/fmt.md.
+fn columnCount(s: []const u8) usize {
+    var n: usize = 0;
+    var i: usize = 0;
+    while (i < s.len) {
+        const seq: usize = if (s[i] < 0x80) 1 else @intCast(std.unicode.utf8ByteSequenceLength(s[i]) catch 1);
+        n += 1;
+        i += @min(seq, s.len - i);
+    }
+    return n;
+}
+
+/// Inline width of `node` in columns, or null if it cannot be one line (contains
+/// a line comment, a multi-line block comment, or an atom with an embedded
 /// newline). Memoised on the node so repeated fit checks stay linear.
 fn measure(node: *Node) ?usize {
     if (node.width_computed) return node.inline_width;
@@ -304,18 +324,18 @@ fn computeMeasure(node: *Node) ?usize {
         .line_comment => return null,
         .atom, .block_comment => {
             if (std.mem.indexOfScalar(u8, node.text, '\n') != null) return null;
-            return node.text.len;
+            return columnCount(node.text);
         },
         .prefix => {
             const child = measure(&node.children[0]) orelse return null;
-            return node.text.len + child;
+            return columnCount(node.text) + child;
         },
         .datum_comment => {
             const child = measure(&node.children[0]) orelse return null;
             return 2 + child; // "#;" glued to its datum
         },
         .list => {
-            var total: usize = node.text.len + 1; // open delimiter + ")"
+            var total: usize = columnCount(node.text) + 1; // open delimiter + ")"
             for (node.children, 0..) |*child, i| {
                 const w = measure(child) orelse return null;
                 total += w;
@@ -351,14 +371,30 @@ fn hasBodyBlank(node: *Node) bool {
     const first_body: usize = if (op_idx == null or op_idx.? != 0 or node.is_data)
         1 // vertical layout: only the first element shares the open line
     else switch (styleOf(node)) {
-        .body => |n| n + 1, // operator + n distinguished subforms on the head line
-        .call => 2, // operator + first argument on the head line
+        .body => |n| bodyStartByCodeCount(children, n + 1),
+        .call => bodyStartByCodeCount(children, 2),
     };
     if (first_body >= children.len) return false;
     for (children[first_body..]) |child| {
         if (child.newlines_before >= 2) return true;
     }
     return false;
+}
+
+/// Index of the first child past `head_code` code items. The printer's head-line
+/// count (`placed` in `emitBodyStyle` / the operator + first argument in
+/// `emitCallStyle`) counts *code* items; a same-line comment rides the head line
+/// without consuming a slot. Counting by index — as the old `n + 1` formula did
+/// — shifts the boundary one right for every head-line comment and makes
+/// `hasBodyBlank` read the blank of an item the printer is about to drop,
+/// breaking idempotence (kaappi#2142).
+fn bodyStartByCodeCount(children: []Node, head_code: usize) usize {
+    var code_seen: usize = 0;
+    var i: usize = 0;
+    while (i < children.len and code_seen < head_code) : (i += 1) {
+        if (!isComment(children[i].kind)) code_seen += 1;
+    }
+    return i;
 }
 
 fn styleOf(node: *Node) Style {

--- a/src/fmt_print.zig
+++ b/src/fmt_print.zig
@@ -292,18 +292,43 @@ const Printer = struct {
 // ── Measurement ──────────────────────────────────────────────────────────────
 
 /// Display width of `s` in columns: the number of Unicode scalar values, with
-/// any invalid UTF-8 byte (possible only inside verbatim atom text) counting one
-/// column each. This is what "fits within `max_width` columns" means — an
-/// identifier's width is its character count, not its UTF-8 byte count
-/// (kaappi#2149). It deliberately does not model East Asian wide characters or
-/// combining marks, which would need wcwidth; see docs/dev/fmt.md.
-fn columnCount(s: []const u8) usize {
+/// any malformed UTF-8 byte counting one column each (a bad lead byte never
+/// swallows the bytes after it). This is what "fits within `max_width` columns"
+/// means — an identifier's width is its character count, not its UTF-8 byte
+/// count (kaappi#2149). It deliberately does not model East Asian wide
+/// characters or combining marks, which would need wcwidth; see docs/dev/fmt.md.
+pub fn columnCount(s: []const u8) usize {
     var n: usize = 0;
     var i: usize = 0;
     while (i < s.len) {
-        const seq: usize = if (s[i] < 0x80) 1 else @intCast(std.unicode.utf8ByteSequenceLength(s[i]) catch 1);
+        const c = s[i];
+        if (c < 0x80) {
+            n += 1;
+            i += 1;
+            continue;
+        }
+        const seq = std.unicode.utf8ByteSequenceLength(c) catch {
+            // A stray continuation byte or invalid lead: one column.
+            n += 1;
+            i += 1;
+            continue;
+        };
+        if (i + seq > s.len) {
+            // A multi-byte sequence truncated by end-of-slice: count the lead.
+            n += 1;
+            i += 1;
+            continue;
+        }
+        _ = std.unicode.utf8Decode(s[i .. i + seq]) catch {
+            // Malformed (bad continuation, overlong, surrogate, out of range):
+            // count only the leading byte so it never swallows a following
+            // ASCII byte as a bogus continuation.
+            n += 1;
+            i += 1;
+            continue;
+        };
         n += 1;
-        i += @min(seq, s.len - i);
+        i += seq;
     }
     return n;
 }

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -264,7 +264,11 @@ pub const Reader = struct {
             if (c == ' ' or c == '\t' or c == '\n' or c == '\r') {
                 self.pos += 1;
             } else if (c == ';') {
-                while (self.pos < self.source.len and self.source[self.pos] != '\n') {
+                // R7RS 7.1.1: a line comment ends at a ⟨line ending⟩, which is
+                // a newline, a lone return, or return+newline. End at `\n` or
+                // `\r` so a classic-Mac-line-ending file does not swallow
+                // everything after the first `;` (kaappi#2079).
+                while (self.pos < self.source.len and self.source[self.pos] != '\n' and self.source[self.pos] != '\r') {
                     self.pos += 1;
                 }
                 // A line comment cut off by end-of-slice may continue in the
@@ -305,7 +309,7 @@ pub const Reader = struct {
         return unicode.inRanges(&unicode.alphabetic_ranges, cp);
     }
 
-    fn isUnicodeSubsequent(cp: u21) bool {
+    pub fn isUnicodeSubsequent(cp: u21) bool {
         if (cp <= 127) {
             const c: u8 = @intCast(cp);
             return isSubsequent(c);
@@ -329,7 +333,7 @@ pub const Reader = struct {
         };
     }
 
-    fn isSubsequent(c: u8) bool {
+    pub fn isSubsequent(c: u8) bool {
         return isInitial(c) or std.ascii.isDigit(c) or isSpecialSubsequent(c);
     }
 
@@ -975,6 +979,23 @@ test "skip line comment" {
     const s = try readAndPrint(&gc, "; this is a comment\n42");
     defer testing.allocator.free(s);
     try testing.expectEqualStrings("42", s);
+}
+
+test "a lone CR ends a line comment" {
+    var gc = memory.GC.init(testing.allocator);
+    defer gc.deinit();
+
+    // R7RS 7.1.1: ⟨line ending⟩ includes a lone ⟨return⟩, so the comment ends
+    // there and the next datum survives (kaappi#2079).
+    const s = try readAndPrint(&gc, "; comment\r42");
+    defer testing.allocator.free(s);
+    try testing.expectEqualStrings("42", s);
+
+    // Inside a list the swallowed text used to take the closing parens with it,
+    // turning valid code into "unexpected end of input".
+    const t = try readAndPrint(&gc, "(display (+ 1 ; c\r2))\r");
+    defer testing.allocator.free(t);
+    try testing.expectEqualStrings("(display (+ 1 2))", t);
 }
 
 test "fold-case directive lowercases symbols" {

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -94,6 +94,37 @@ pub const Token = union(enum) {
     eof,
 };
 
+/// 1-based `(line, col)` position in a source buffer.
+pub const LineCol = struct { line: u32, col: u32 };
+
+/// 1-based `(line, col)` of `pos` in `source`, counting `\n`, a lone `\r`, and
+/// `\r\n` each as one line ending (R7RS 7.1.1 ⟨line ending⟩). A lone `\r` only
+/// started ending `;` comments in kaappi#2079, so position reports must agree
+/// with it or a CR-only file's error locations are off by one line.
+fn lineColAt(source: []const u8, pos: usize) LineCol {
+    var line: u32 = 1;
+    var col: u32 = 1;
+    var i: usize = 0;
+    const end = @min(pos, source.len);
+    while (i < end) : (i += 1) {
+        const c = source[i];
+        if (c == '\n') {
+            if (i > 0 and source[i - 1] == '\r') {
+                // The LF of a CRLF — the preceding `\r` already advanced line.
+            } else {
+                line += 1;
+                col = 1;
+            }
+        } else if (c == '\r') {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+    }
+    return .{ .line = line, .col = col };
+}
+
 pub const Reader = struct {
     source: []const u8,
     pos: usize = 0,
@@ -162,18 +193,8 @@ pub const Reader = struct {
     /// Compute line and column from the current position by scanning from the
     /// start of the source. O(n) per call but only used on error paths and
     /// datum boundaries, not every character advance.
-    pub fn getLineCol(self: *Reader) struct { line: u32, col: u32 } {
-        var line: u32 = 1;
-        var col: u32 = 1;
-        for (self.source[0..self.pos]) |c| {
-            if (c == '\n') {
-                line += 1;
-                col = 1;
-            } else {
-                col += 1;
-            }
-        }
-        return .{ .line = line, .col = col };
+    pub fn getLineCol(self: *Reader) LineCol {
+        return lineColAt(self.source, self.pos);
     }
 
     /// Record the source span of a just-read datum in the GC's span side-table,
@@ -181,38 +202,20 @@ pub const Reader = struct {
     /// (pairs, vectors) can be keyed — interned symbols and immediate atoms
     /// share representations and cannot. `start_pos` is the byte offset of the
     /// datum's first character (captured before reading); `self.pos` is one past
-    /// its last character. A single scan from source start to `self.pos` yields
-    /// both endpoints in 1-based `(line, col)` (kaappi#1506).
+    /// its last character. Both endpoints are 1-based `(line, col)` computed
+    /// with the same CR/LF/CRLF line-ending rules as `getLineCol` (kaappi#1506).
     pub fn recordSpan(self: *Reader, val: Value, start_pos: usize) void {
         if (!self.record_spans) return;
         if (!types.isPair(val) and !types.isVector(val)) return;
         const end_pos = self.pos;
-        var line: u32 = 1;
-        var col: u32 = 1;
-        var start_line: u32 = 1;
-        var start_col: u32 = 1;
-        var i: usize = 0;
-        while (i < end_pos and i < self.source.len) : (i += 1) {
-            if (i == start_pos) {
-                start_line = line;
-                start_col = col;
-            }
-            if (self.source[i] == '\n') {
-                line += 1;
-                col = 1;
-            } else {
-                col += 1;
-            }
-        }
-        if (start_pos >= end_pos) {
-            start_line = line;
-            start_col = col;
-        }
+        const end = lineColAt(self.source, end_pos);
+        // A start at or past the end (an empty span) collapses to the end point.
+        const start = if (start_pos >= end_pos) end else lineColAt(self.source, start_pos);
         self.gc.source_spans.put(val, .{
-            .line = start_line,
-            .col = start_col,
-            .end_line = line,
-            .end_col = col,
+            .line = start.line,
+            .col = start.col,
+            .end_line = end.line,
+            .end_col = end.col,
         }) catch {};
     }
 

--- a/src/tests_fmt.zig
+++ b/src/tests_fmt.zig
@@ -39,7 +39,7 @@ fn expectRoundTrips(src: []const u8) !void {
 
     var gc = memory.GC.init(testing.allocator);
     defer gc.deinit();
-    try testing.expect(fmt.verifyRoundTrip(&gc, src, formatted));
+    try testing.expect(fmt.verifyRoundTrip(&gc, src, formatted) == .ok);
 }
 
 // ── Spacing and gathering ─────────────────────────────────────────────────────
@@ -244,6 +244,29 @@ test "round-trips a spread of forms" {
     for (cases) |c| try expectRoundTrips(c);
 }
 
+test "verifyRoundTrip separates a user read error from a real mismatch" {
+    var gc = memory.GC.init(testing.allocator);
+    defer gc.deinit();
+
+    // A user syntax error in the original: the CST lexer tolerates `#\qqq` but
+    // the real reader rejects it, so it is the original_unreadable case — not a
+    // formatter mismatch (kaappi#2080).
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const bad = "(display #\\qqq)\n";
+    const formatted = try fmt.formatSource(arena.allocator(), bad);
+    switch (fmt.verifyRoundTrip(&gc, bad, formatted)) {
+        .original_unreadable => |f| try testing.expectEqual(@as(u32, 1), f.line),
+        else => return error.ExpectedOriginalUnreadable,
+    }
+
+    // Two texts that both read but to different datums is a real mismatch.
+    switch (fmt.verifyRoundTrip(&gc, "(a b)", "(a c)")) {
+        .mismatch => {},
+        else => return error.ExpectedMismatch,
+    }
+}
+
 // ── Generated programs: idempotence + round-trip ──────────────────────────────
 
 test "idempotent and semantics-preserving over generated programs" {
@@ -266,7 +289,7 @@ test "idempotent and semantics-preserving over generated programs" {
 
         var gc = memory.GC.init(testing.allocator);
         defer gc.deinit();
-        if (!fmt.verifyRoundTrip(&gc, program, once)) {
+        if (fmt.verifyRoundTrip(&gc, program, once) != .ok) {
             std.debug.print("round-trip drift on seed {d}:\n{s}\n---\n{s}\n", .{ seed, program, once });
             return error.RoundTripDrift;
         }
@@ -420,11 +443,8 @@ test "line endings never affect the output" {
         const crlf = try std.mem.replaceOwned(u8, a, lf, "\n", "\r\n");
         try testing.expectEqualStrings(try fmt.formatSource(a, lf), try fmt.formatSource(a, crlf));
 
-        // The CR-only twin is only a twin for a program with no `;` comment:
-        // this reader does not end one at a lone CR, so converting a commented
-        // program to CR endings genuinely changes what it means. See the
-        // "a lone CR does not end a line comment" test.
-        if (std.mem.indexOfScalar(u8, lf, ';') != null) continue;
+        // The CR-only twin is a twin for every program now that a lone CR ends
+        // a `;` comment too (kaappi#2079).
         const cr = try std.mem.replaceOwned(u8, a, lf, "\n", "\r");
         try testing.expectEqualStrings(try fmt.formatSource(a, lf), try fmt.formatSource(a, cr));
     }
@@ -446,9 +466,10 @@ test "a CR in a datum is program data and survives byte-for-byte" {
 }
 
 test "comment line endings normalise; comment interiors are handled per kind" {
-    // A line comment runs to the `\n`, so its trailing `\r` is that CRLF's
-    // carriage return — dropped, like the trailing spaces beside it. Before
-    // kaappi#1897 this was the one place fmt emitted a CR of its own.
+    // A line comment runs to its line ending — `\n` or a lone `\r` (kaappi#2079)
+    // — so the CR of a CRLF ends it and never reaches the comment text; the LF
+    // is ordinary whitespace. Before kaappi#1897 this was the one place fmt
+    // emitted a CR of its own.
     try expectFormat("(define x 1) ; note\r\n(define y 2)\r\n", "(define x 1) ; note\n(define y 2)\n");
     try expectFormat(";; header\r\n(define x 1)\r\n", ";; header\n(define x 1)\n");
     try expectNoCr("(define x 1) ; note\r\n;; own line\r\n(define y 2)\r\n");
@@ -460,14 +481,11 @@ test "comment line endings normalise; comment interiors are handled per kind" {
     try expectNoCr("#| a\r\nb |#\r\n(define x 1)\r\n");
 }
 
-test "a lone CR does not end a line comment — fmt mirrors the reader" {
-    // R7RS 7.1.1 makes a lone ⟨return⟩ a line ending, but this reader ends a
-    // `;` comment only at `\n` (kaappi#2079). fmt's lexer must carve the same
-    // lexemes the real reader does, so it inherits that: everything after the
-    // `;` is one comment to both, and its interior CR is preserved rather than
-    // normalised — rewriting it to `\n` would promote the tail to real code.
-    // Pinned so the day the reader is fixed, this test says so.
-    try expectFormat("(define x 1) ; note\r(define y 2)\r", "(define x 1) ; note\r(define y 2)\n");
+test "a lone CR ends a line comment — fmt mirrors the reader" {
+    // R7RS 7.1.1 makes a lone ⟨return⟩ a line ending, and the reader now ends a
+    // `;` comment at one (kaappi#2079). fmt's lexer carves the same lexeme, so
+    // the comment stops at the CR and the following datum is not swallowed.
+    try expectFormat("(define x 1) ; note\r(define y 2)\r", "(define x 1) ; note\n(define y 2)\n");
     try expectRoundTrips("(define x 1) ; note\r(define y 2)\r");
     try expectIdempotent("(define x 1) ; note\r(define y 2)\r");
 }

--- a/src/tests_fmt.zig
+++ b/src/tests_fmt.zig
@@ -267,6 +267,34 @@ test "verifyRoundTrip separates a user read error from a real mismatch" {
     }
 }
 
+test "original_unreadable reports the line after a lone CR" {
+    var gc = memory.GC.init(testing.allocator);
+    defer gc.deinit();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    // The `;` comment ends at the lone CR (kaappi#2079); the invalid `#\qqq` is
+    // on line 2, and `getLineCol` must count that CR as a line ending so the
+    // reported position says line 2, not line 1.
+    const bad = "; note\r#\\qqq\n";
+    const formatted = try fmt.formatSource(arena.allocator(), bad);
+    switch (fmt.verifyRoundTrip(&gc, bad, formatted)) {
+        .original_unreadable => |f| try testing.expectEqual(@as(u32, 2), f.line),
+        else => return error.ExpectedOriginalUnreadable,
+    }
+}
+
+test "columnCount never lets a bad lead byte swallow the next byte" {
+    // 0xC2 is a two-byte lead, but 'A' (0x41) is not a continuation byte: the
+    // malformed sequence must count as two columns, not one. A truncated
+    // multi-byte sequence at end-of-slice counts its lead byte alone, and valid
+    // scalars still count one column each (kaappi#2149 review).
+    try testing.expectEqual(@as(usize, 2), fmt_print.columnCount(&.{ 0xC2, 'A' }));
+    try testing.expectEqual(@as(usize, 1), fmt_print.columnCount(&.{0xC2}));
+    try testing.expectEqual(@as(usize, 1), fmt_print.columnCount("λ"));
+    try testing.expectEqual(@as(usize, 3), fmt_print.columnCount("aλb"));
+}
+
 // ── Generated programs: idempotence + round-trip ──────────────────────────────
 
 test "idempotent and semantics-preserving over generated programs" {

--- a/tests/scheme/fmt/fmt-adversarial.sh
+++ b/tests/scheme/fmt/fmt-adversarial.sh
@@ -15,7 +15,7 @@
 #
 # The generator that found the failures below is `tools/fmt_fuzz.py` — it is
 # deliberately *not* run here (it takes minutes; this file takes ~2 seconds).
-# See kaappi#2141, kaappi#2142, kaappi#2143.
+# See kaappi#2141, kaappi#2142, kaappi#2143, kaappi#2149.
 
 set -uo pipefail
 
@@ -133,29 +133,22 @@ case_ "blank before the first argument, no comment"  '(f\n\n   a b)\n'
 case_ "blank one item after a head-line comment"     '(f #|c|# a\n\n   b)\n'
 case_ "blank after a head-line line comment"         '(f ; c\n\n   a b)\n'
 case_ "blank before a define body, not its name"     '(define #|c|# x\n\n  1)\n'
-
-# FAIL: #2142 (hasBodyBlank indexes children; the printer counts non-comments,
-# so a head-line-riding block comment shifts them out of step — pass 1 drops
-# the blank it forced a break for, pass 2 then collapses the form inline)
-# case_ "blank before an arg displaced by a comment"   '(f #|c|#\n\n   a b)\n'
-# case_ "blank before a name displaced by a comment"   '(define #|c|#\n\n  x 1)\n'
+case_ "blank before an arg displaced by a comment"   '(f #|c|#\n\n   a b)\n'
+case_ "blank before a name displaced by a comment"   '(define #|c|#\n\n  x 1)\n'
 
 # ── Lexeme boundaries the reader and fmt must agree on (kaappi#2143) ─────────
 #
-# Enabled: the space-separated spellings, which are the discriminating controls.
+# Both spellings — the space-separated controls and the glued forms that once
+# split differently between `Reader.readSymbol` and `fmt.Lexer.scanAtom`.
 
 case_ "block comment after an identifier, spaced"    '(a b #|c|# d)\n'
 case_ "datum comment after an identifier, spaced"    '(list a #;(b) c)\n'
 case_ "vector after an identifier, spaced"           '(a b #(1) d)\n'
+case_ "block comment glued to an identifier"         '(a b#|c|# d)\n'
+case_ "datum comment glued to an identifier"         '(list a#;(b) c)\n'
+case_ "vector glued to an identifier"                '(a b#(1) d)\n'
 
-# FAIL: #2143 (fmt.Lexer.scanAtom runs to the next delimiter; Reader.readSymbol
-# stops at the first non-subsequent, so a glued `#`-led lexeme splits
-# differently — `kaappi ast` reads all three of these without complaint)
-# case_ "block comment glued to an identifier"         '(a b#|c|# d)\n'
-# case_ "datum comment glued to an identifier"         '(list a#;(b) c)\n'
-# case_ "vector glued to an identifier"                '(a b#(1) d)\n'
-
-# ── Fit-to-width is measured in bytes, not columns (kaappi#2149) ────────────
+# ── Fit-to-width is measured in columns (Unicode code points) ────────────
 
 # assert_one_line <label> <source>
 #   fmt.md: "A form that fits within max_width (80) columns is put on one line."
@@ -179,10 +172,7 @@ for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
 done
 
 assert_one_line "width: a 75-column ASCII form stays on one line" "(f$ascii12)\n"
-
-# FAIL: #2149 (computeMeasure returns node.text.len, so every non-ASCII lexeme
-# counts double or triple against an 80-column budget)
-# assert_one_line "width: a 75-column Unicode form stays on one line" "(f$wide12)\n"
+assert_one_line "width: a 75-column Unicode form stays on one line" "(f$wide12)\n"
 
 # ── Parser depth: a deep input is rejected, never fatal (kaappi#2141) ────────
 

--- a/tests/scheme/fmt/fmt.sh
+++ b/tests/scheme/fmt/fmt.sh
@@ -89,6 +89,17 @@ assert_exit "write: result is already formatted" 0 "$KAAPPI" fmt --check "$TMP/w
 printf '(a b c\n' > "$TMP/unterminated.scm"
 assert_exit "error: unterminated list exits 1" 1 "$KAAPPI" fmt --check "$TMP/unterminated.scm"
 
+# A user syntax error the CST lexer tolerates but the real reader rejects (e.g.
+# an invalid character name) must be reported as the reader's own KP1xxx
+# diagnostic with its position — not as an internal formatter fault (kaappi#2080).
+printf '(display #\\qqq)\n' > "$TMP/reader-error.scm"
+err="$("$KAAPPI" fmt --check "$TMP/reader-error.scm" 2>&1)" || true
+if [[ "$err" == *"read error[KP1005]"* && "$err" != *"internal error"* ]]; then
+    pass "error: reader diagnostic for a user syntax error (not internal)"
+else
+    fail "error: reader diagnostic for a user syntax error (not internal)" "stderr: [$err]"
+fi
+
 # ── Regression #1652: arguments past the 64th must not be dropped ────────────
 # The CLI once collected script args into a fixed [64] buffer and silently
 # discarded the rest, so a single fmt/--check invocation over a big file list


### PR DESCRIPTION
Fixes #2079, #2080, #2142, #2143, #2149.

Five defects from the systematic audit (Phase 6), all in the formatter and the reader it mirrors:

- **#2079** — a lone CR now ends a `;` comment, per R7RS 7.1.1 (reader + fmt's mirroring lexer).
- **#2080** — `kaappi fmt` reports a user syntax error with the reader's own KP1xxx diagnostic, not "internal error".
- **#2142** — `hasBodyBlank` counts code items like the printer, restoring idempotence with head-line block comments.
- **#2143** — non-`#` atoms end at the first non-subsequent byte, so a `#`-led lexeme glued to an identifier splits like the reader does.
- **#2149** — width is measured in Unicode code points, not bytes.

Tests: 1727 unit tests, 2099 scheme assertions (incl. R7RS), fmt.sh (38), fmt-adversarial.sh (75) all green.