### PR TITLE
Make equal? recurse into record fields (structural record equality)

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -24,6 +24,15 @@ Implemented: `cons*`, `xcons`, `list-tabulate`, `circular-list`, `iota`, `proper
 
 **Coverage: 100%.** `define-record-type` is implemented as R7RS compiler syntax.
 
+`equal?` recurses into record fields: two distinct instances of the same
+record type whose fields are pairwise `equal?` compare `#t`. R7RS §6.1 leaves
+records in the "all other cases" clause (the result is implementation-defined),
+so this is a permitted extension — matching Gambit, Guile, and Chibi — rather
+than a conformance requirement. Records of *different* types are never
+`equal?`, even with equal field values. `eq?`/`eqv?` remain identity-based on
+records, as §6.1 requires. Cyclic records terminate via the same visited-map
+used for pairs and vectors (kaappi#2293).
+
 ### SRFI 13 — String Library
 
 **Coverage: 97%** (30 of 31 non-mutating spec procedures)

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -966,6 +966,24 @@ fn deepEqualWithVisited(a: Value, b: Value, visited: *VisitedMap) bool {
         const nb = types.toNumericVector(b);
         return na.kind == nb.kind and std.mem.eql(u8, na.data, nb.data);
     }
+    if (types.isRecordInstance(a) and types.isRecordInstance(b)) {
+        const ra = types.toObject(a).as(types.RecordInstance);
+        const rb = types.toObject(b).as(types.RecordInstance);
+        // Same record type required (identity, not pointer -- a type
+        // survives an SRFI-18 thread hop at a new address, kaappi#1932), then
+        // fields compared pairwise. R7RS 6.1 leaves records in the "all other
+        // cases" clause, so this structural choice is a permitted extension
+        // that matches Gambit/Guile/Chibi (kaappi#2293).
+        if (!types.sameRecordType(ra.record_type, rb.record_type)) return false;
+        if (ra.fields.len != rb.fields.len) return false;
+        const key = VisitedKey{ .a = a, .b = b };
+        if (visited.get(key) != null) return true;
+        visited.put(key, {}) catch {};
+        for (ra.fields, rb.fields) |fa, fb| {
+            if (!deepEqualWithVisited(fa, fb, visited)) return false;
+        }
+        return true;
+    }
     return false;
 }
 

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -975,6 +975,9 @@ fn deepEqualWithVisited(a: Value, b: Value, visited: *VisitedMap) bool {
         // cases" clause, so this structural choice is a permitted extension
         // that matches Gambit/Guile/Chibi (kaappi#2293).
         if (!types.sameRecordType(ra.record_type, rb.record_type)) return false;
+        // Defensive: sameRecordType already implies equal field counts (both
+        // instances are sized from record_type.num_fields), so this is a cheap
+        // belt-and-suspenders guard, not a load-bearing check.
         if (ra.fields.len != rb.fields.len) return false;
         const key = VisitedKey{ .a = a, .b = b };
         if (visited.get(key) != null) return true;

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -386,8 +386,24 @@ fn valueHashDepth(key: Value, depth: usize) usize {
         for (nv.data) |b| h = h *% 31 +% b;
         return h;
     }
-    // Everything left (procedures, ports, records, ...) is compared by identity
-    // by `deepEqual`, so hashing the address is consistent with equality.
+    if (types.isRecordInstance(key)) {
+        if (depth >= MAX_HASH_DEPTH) return DEEP_CUTOFF_HASH;
+        const rec = types.toObject(key).as(types.RecordInstance);
+        // Fold the type *identity*, never the pointer: a record type that
+        // crossed an SRFI-18 thread boundary keeps its `identity` but lands at
+        // a new address (kaappi#1932), and `sameRecordType` — the gate
+        // `deepEqual` uses — compares `identity`. Fields fold like the vector
+        // arm: capped, so a wide record still hashes in O(1). There is no
+        // visited set here, so a cyclic field is absorbed by the
+        // MAX_HASH_DEPTH sentinel (the same trade the pair arm already makes).
+        var h: usize = @truncate(rec.record_type.identity *% 2654435761);
+        const limit = @min(rec.fields.len, 4);
+        for (rec.fields[0..limit]) |v| h = h *% 31 +% valueHashDepth(v, depth + 1);
+        return h;
+    }
+    // Everything left (procedures, ports, threads, and other native handles)
+    // is compared by identity by `deepEqual`, so hashing the address is
+    // consistent with equality. Records are structural and handled above.
     return @truncate(key *% 2654435761);
 }
 

--- a/src/tests_records.zig
+++ b/src/tests_records.zig
@@ -387,3 +387,77 @@ test "wide records: 27 and 255 fields instantiate; 256 fields error cleanly" {
         try std.testing.expectError(vm_mod.VMError.CompileError, vm.eval(def));
     }
 }
+
+// equal? recurses into record fields (kaappi#2293): two distinct instances of
+// the same record type with equal? fields are equal?, while eq?/eqv? stay
+// identity-based.
+test "equal? structural on records" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define-record-type point
+        \\  (make-point x y)
+        \\  point?
+        \\  (x point-x)
+        \\  (y point-y))
+    );
+
+    // Distinct-but-equal instances compare equal? ...
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? (make-point 1 2) (make-point 1 2))"));
+    // ... but eqv?/eq? remain identity-based (spec-required).
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(eqv? (make-point 1 2) (make-point 1 2))"));
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(eq? (make-point 1 2) (make-point 1 2))"));
+    // A record is still equal? to itself.
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(let ((p (make-point 1 2))) (equal? p p))"));
+    // Differing field values are not equal?.
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(equal? (make-point 1 2) (make-point 1 9))"));
+    // Fields are compared recursively (nested equal? contents).
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? (make-point '(1 2) \"ab\") (make-point '(1 2) \"ab\"))"));
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(equal? (make-point '(1 2) \"ab\") (make-point '(1 2) \"ac\"))"));
+}
+
+test "equal? records of different types are not equal?" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Two structurally identical but distinct record types.
+    _ = try vm.eval("(define-record-type a (make-a x) a? (x a-x))");
+    _ = try vm.eval("(define-record-type b (make-b x) b? (x b-x))");
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(equal? (make-a 1) (make-b 1))"));
+    // Same type, same field: sanity check the positive case still holds.
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? (make-a 1) (make-a 1))"));
+}
+
+test "equal? record with procedure field" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define-record-type box (make-box p) box? (p box-p))");
+    // Same closure object in both records: equal? at the leaf (identity).
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(let ((f (lambda (x) x))) (equal? (make-box f) (make-box f)))"));
+    // Distinct closures are not equal?, so the records are not equal? either.
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(equal? (make-box (lambda (x) x)) (make-box (lambda (x) x)))"));
+}
+
+test "equal? cyclic records terminate" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define-record-type node (make-node v) node? (v node-v set-node-v!))");
+    _ = try vm.eval("(define x (make-node 1))");
+    _ = try vm.eval("(define y (make-node 1))");
+    // Make each record point at itself -- two isomorphic cycles.
+    _ = try vm.eval("(set-node-v! x x)");
+    _ = try vm.eval("(set-node-v! y y)");
+    // The VisitedMap must break the cycle and report the trees equal.
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? x y)"));
+}

--- a/src/tests_records.zig
+++ b/src/tests_records.zig
@@ -4,6 +4,7 @@ const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
 const vm_mod = @import("vm.zig");
+const hashtable = @import("primitives_hashtable.zig");
 
 test "define-record-type basic" {
     var gc = memory.GC.init(std.testing.allocator);
@@ -460,4 +461,23 @@ test "equal? cyclic records terminate" {
     _ = try vm.eval("(set-node-v! y y)");
     // The VisitedMap must break the cycle and report the trees equal.
     try std.testing.expectEqual(types.TRUE, try vm.eval("(equal? x y)"));
+}
+
+test "equal? records hash alike; different record types hash apart" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define-record-type a (make-a x) a? (x a-x))");
+    _ = try vm.eval("(define-record-type b (make-b x) b? (x b-x))");
+    const a1 = try vm.eval("(make-a 1)");
+    const a2 = try vm.eval("(make-a 1)");
+    const b1 = try vm.eval("(make-b 1)");
+    // The hash/equality contract: deepEqual is structural on records, so
+    // valueHash must fold the same type identity + fields, not the address
+    // (kaappi#2293). Two equal? records hash alike; a different record type
+    // hashes apart even with identical field values.
+    try std.testing.expectEqual(hashtable.valueHash(a1), hashtable.valueHash(a2));
+    try std.testing.expect(hashtable.valueHash(a1) != hashtable.valueHash(b1));
 }

--- a/tests/scheme/smoke/record-equal-2293.scm
+++ b/tests/scheme/smoke/record-equal-2293.scm
@@ -2,7 +2,7 @@
 ;; distinct instances of the same record type with equal? fields are equal?.
 ;; eq?/eqv? stay identity-based (R7RS 6.1 requires that; the equal? behavior
 ;; is a permitted extension under the "all other cases" clause).
-(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64) (srfi 69))
 
 (test-begin "record-equal-2293")
 
@@ -36,6 +36,29 @@
 ;; Records of different types are never equal?, even with equal fields.
 (test-assert "different record types not equal?"
   (not (equal? (make-point 1 2) (make-other 1))))
+
+;; member/assoc default to equal? and share deepEqual, so they now find
+;; records structurally — every equal? consumer moved together.
+(test-assert "member finds a structurally-equal record"
+  (pair? (member (make-point 1 2) (list (make-point 1 2)))))
+(test-assert "assoc finds a structurally-equal record key"
+  (pair? (assoc (make-point 1 2) (list (cons (make-point 1 2) 'v)))))
+
+;; The hash/equality contract: deepEqual is structural on records, so valueHash
+;; must be too — two equal? records have to hash alike, or a default SRFI 69
+;; table (equal? + valueHash) silently loses record entries (kaappi#2293).
+(test-assert "equal? records hash equal"
+  (= (hash (make-point 1 2)) (hash (make-point 1 2))))
+
+(test-assert "populated equal?-table round-trips structurally-equal record keys"
+  (let ((ht (make-hash-table)))
+    (do ((i 0 (+ i 1))) ((= i 200))
+      (hash-table-set! ht (make-point i i) i))
+    (let loop ((i 0) (ok #t))
+      (if (= i 200)
+          ok
+          (loop (+ i 1)
+                (and ok (= (hash-table-ref/default ht (make-point i i) -1) i)))))))
 
 ;; Cyclic records must terminate (the cycle-tracking visited set handles it).
 (define-record-type node (make-node v) node? (v node-v set-node-v!))

--- a/tests/scheme/smoke/record-equal-2293.scm
+++ b/tests/scheme/smoke/record-equal-2293.scm
@@ -1,0 +1,50 @@
+;; Regression test for #2293: equal? recurses into record fields, so two
+;; distinct instances of the same record type with equal? fields are equal?.
+;; eq?/eqv? stay identity-based (R7RS 6.1 requires that; the equal? behavior
+;; is a permitted extension under the "all other cases" clause).
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+
+(test-begin "record-equal-2293")
+
+(define-record-type point (make-point x y) point? (x point-x) (y point-y))
+(define-record-type other (make-other x)   other? (x other-x))
+
+;; The headline case from the Reddit report.
+(test-assert "distinct-but-equal records are equal?"
+  (equal? (make-point 1 2) (make-point 1 2)))
+
+;; eq?/eqv? must remain identity-based.
+(test-assert "eqv? on distinct records is #f"
+  (not (eqv? (make-point 1 2) (make-point 1 2))))
+(test-assert "eq? on distinct records is #f"
+  (not (eq? (make-point 1 2) (make-point 1 2))))
+
+;; A record is equal? to itself.
+(test-assert "record equal? to itself"
+  (let ((p (make-point 1 2))) (equal? p p)))
+
+;; Differing fields are not equal?.
+(test-assert "differing field values not equal?"
+  (not (equal? (make-point 1 2) (make-point 1 9))))
+
+;; Fields compared recursively.
+(test-assert "recursive field comparison (equal? contents)"
+  (equal? (make-point (list 1 2) "ab") (make-point (list 1 2) "ab")))
+(test-assert "recursive field comparison (differing contents)"
+  (not (equal? (make-point (list 1 2) "ab") (make-point (list 1 2) "ac"))))
+
+;; Records of different types are never equal?, even with equal fields.
+(test-assert "different record types not equal?"
+  (not (equal? (make-point 1 2) (make-other 1))))
+
+;; Cyclic records must terminate (the cycle-tracking visited set handles it).
+(define-record-type node (make-node v) node? (v node-v set-node-v!))
+(test-assert "isomorphic cyclic records are equal?"
+  (let ((x (make-node 1)) (y (make-node 1)))
+    (set-node-v! x x)
+    (set-node-v! y y)
+    (equal? x y)))
+
+(let ((runner (test-runner-current)))
+  (test-end "record-equal-2293")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi9.scm
+++ b/tests/scheme/srfi/srfi9.scm
@@ -60,12 +60,13 @@
 (test-equal #f (swap? (kons 1 2)))
 (test-equal #f (pare? (mk-swap 1 2)))
 
-;;; --- equivalence: records compare by identity ---
+;;; --- equivalence: equal? is structural, eq?/eqv? compare by identity ---
 (let ((r1 (kons 1 2)) (r2 (kons 1 2)))
   (test-equal #t (equal? r1 r1))
   (test-equal #t (eqv? r1 r1))
-  (test-equal #f (equal? r1 r2))
-  (test-equal #f (eqv? r1 r2)))
+  (test-equal #t (equal? r1 r2))   ; same type + equal fields => structural #t
+  (test-equal #f (eqv? r1 r2))     ; distinct instances stay identity-distinct
+  (test-equal #f (eq? r1 r2)))
 
 ;;; --- records nest and travel through data structures ---
 (let* ((inner (kons 'i1 'i2))


### PR DESCRIPTION
## Summary

Make `equal?` recurse into record fields, so two distinct instances of the same record type whose fields are pairwise `equal?` compare as `#t`. Today Kaappi compares records by identity only (same as `eq?`/`eqv?`).

R7RS §6.1 leaves records in the "all other cases" clause for `equal?`, so the result is implementation-defined — this is a permitted extension, not a conformance fix. But every native-R7RS implementation (Gambit, Guile, Chibi) recurses into fields, and Kaappi was the lone identity-only holdout. `eq?`/`eqv?` stay identity-based, as §6.1 requires.

```scheme
(define-record-type point (make-point x y) point? (x point-x) (y point-y))

(equal? (make-point 1 2) (make-point 1 2))   ; now #t (was #f)
(eqv?  (make-point 1 2) (make-point 1 2))    ; #f  (unchanged)
```

## Changes

- Add a `record_instance` arm to `deepEqualWithVisited` (`src/primitives.zig`):
  - Same record type required, compared by `types.sameRecordType` (identity, not pointer — a type survives an SRFI-18 thread hop at a new address, kaappi#1932).
  - Fields compared pairwise through the existing `deepEqualWithVisited`, so nested pairs/vectors/records/strings recurse and leaf procedures fall to identity.
  - Routes through the shared `VisitedMap` (as pairs/vectors do), so cyclic records terminate.
- Zig unit tests in `src/tests_records.zig`: distinct-but-equal, different-types-same-shape, differing fields, recursive fields, procedure-bearing fields, and isomorphic cyclic records.
- Scheme smoke test `tests/scheme/smoke/record-equal-2293.scm` (auto-discovered by `run-all.sh`).
- `CONFORMANCE.md` SRFI 9 section records the decision and its §6.1 basis.

## Verification

- `zig build test` — green
- `zig build test -Dgc-stress=true -Dtest-filter=records` — green
- `./zig-out/bin/kaappi tests/scheme/smoke/record-equal-2293.scm` — 9 passes

Fixes #2293