### PR TITLE
Document non-portability of reusing one identifier as record type name and constructor name

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -33,6 +33,17 @@ than a conformance requirement. Records of *different* types are never
 records, as §6.1 requires. Cyclic records terminate via the same visited-map
 used for pairs and vectors (kaappi#2293).
 
+R7RS §5.5 is silent on whether `<name>` and `<constructor name>` may be the
+same identifier. Kaappi accepts the collision:
+`(define-record-type foo (foo x) foo? (x bar))` binds `foo` to the
+*constructor* — `(foo 1)` constructs a record, and the record type itself is
+not reachable under that name (it lives only behind the internal
+`__record_type_<name>` alias). Chibi and Guile reject the same form, so the
+outcome is implementation-dependent: code that reuses one identifier for both
+positions is not portable. Use distinct names —
+`(define-record-type foo (make-foo x) foo? (x bar))` — which every
+implementation accepts (kaappi#2294).
+
 ### SRFI 13 — String Library
 
 **Coverage: 97%** (30 of 31 non-mutating spec procedures)

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -34,15 +34,19 @@ records, as §6.1 requires. Cyclic records terminate via the same visited-map
 used for pairs and vectors (kaappi#2293).
 
 R7RS §5.5 is silent on whether `<name>` and `<constructor name>` may be the
-same identifier. Kaappi accepts the collision:
+same identifier. Kaappi accepts the collision on the R7RS form —
 `(define-record-type foo (foo x) foo? (x bar))` binds `foo` to the
-*constructor* — `(foo 1)` constructs a record, and the record type itself is
-not reachable under that name (it lives only behind the internal
-`__record_type_<name>` alias). Chibi and Guile reject the same form, so the
-outcome is implementation-dependent: code that reuses one identifier for both
-positions is not portable. Use distinct names —
+*constructor*, so `(foo 1)` constructs a record; the record type itself is
+not reachable under that name (on this path it is only ever bound behind the
+internal `__record_type_<name>` alias). Chibi and Guile reject the same form,
+so the outcome is implementation-dependent: code that reuses one identifier
+for both positions is not portable. Use distinct names —
 `(define-record-type foo (make-foo x) foo? (x bar))` — which every
-implementation accepts (kaappi#2294).
+implementation accepts. On the SRFI 237 clause form the collision is a
+deviation rather than an unspecified outcome: SRFI 237 specifies that the
+record name evaluates to the underlying record descriptor, and Kaappi's
+constructor-wins handling overwrites that name→descriptor binding
+(kaappi#2294).
 
 ### SRFI 13 — String Library
 

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -868,7 +868,15 @@ pub fn compileDefineRecordType(self: *Compiler, args: Value, dst: u16) CompileEr
         forms = gc.allocPair(gc.makeList(&[_]Value{ define_sym, np, body }) catch return CompileError.OutOfMemory, forms) catch return CompileError.OutOfMemory;
     }
 
-    // Constructor
+    // Constructor.
+    //
+    // Collision note (kaappi#2294): the R7RS grammar lets <name> and
+    // <constructor name> be the same identifier, and this path accepts it —
+    // the constructor's define below wins the name (the record type is only
+    // ever bound under the internal __record_type_<name> alias, so there is
+    // no user-visible type-name binding for the constructor to shadow). R7RS
+    // §5.5 leaves the collision unspecified; Chibi and Guile reject it, so
+    // such code is not portable. See vm_records.handleDefineRecordType.
     {
         const mr = globals_mod.baseBindingSymbol(gc, "%make-record") catch return CompileError.OutOfMemory;
         const rt_ref = gc.allocSymbol(internal_name) catch return CompileError.OutOfMemory;

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -651,6 +651,14 @@ pub fn handleDefineRecordTypeR6RS(vm: *VM, args: Value) VMError!Value {
         // SRFI 237: "As an expression, this keyword evaluates to the
         // underlying record descriptor" -- the declared name itself, not
         // just the hidden redefinition-stable alias above, must be bound.
+        //
+        // Collision note (kaappi#2294): when <name> also names the
+        // constructor, the constructor's alias define below overwrites
+        // this name->descriptor binding, so the identifier ends up the
+        // constructor and SRFI 237's name-as-expression guarantee is lost
+        // for it -- a documented deviation (CONFORMANCE.md SRFI 9). The
+        // ordering is load-bearing: this binding must stay BEFORE the
+        // constructor defines, or the rtd would silently win instead.
         lib_env.put(spec.type_name, rt_val) catch return VMError.OutOfMemory;
     } else {
         vm.defineGlobal(internal_name, rt_val) catch return VMError.OutOfMemory;
@@ -1044,6 +1052,9 @@ pub fn expandRecordTypeDefines(
     }
 
     // 2. (define ctor (let (( __rt __record_type_X)) (lambda (f1 f2) (%make-record  __rt ...))))
+    // Collision note (kaappi#2294): a <name>/<constructor name> collision is
+    // accepted here too — the ctor define wins the name. See
+    // handleDefineRecordType's constructor block for the full discussion.
     {
         const rt_local = gc.allocSymbol(" __rt") catch return CompileError.OutOfMemory;
         const lambda_sym = gc.allocSymbol("lambda") catch return CompileError.OutOfMemory;

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -48,6 +48,15 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
     // does not retarget previously created constructors (#1203):
     // (define ctor (let (( __rt __record_type_X))
     //               (lambda (f1 f2) (%make-record  __rt f_for_0 ...))))
+    //
+    // Collision note (kaappi#2294): the R7RS grammar lets <name> and
+    // <constructor name> be the same identifier, and this desugarer accepts
+    // it — the constructor's define below wins the name, so after
+    // (define-record-type foo (foo x) foo? (x bar)) the identifier `foo`
+    // names the constructor and the record type is reachable only through
+    // the internal __record_type_foo alias (never bound under `foo` itself
+    // on this R7RS path). R7RS §5.5 leaves the collision unspecified; Chibi
+    // and Guile reject it, so such code is not portable.
     {
         vm.gc.no_collect += 1;
         defer vm.gc.no_collect -= 1;

--- a/tests/scheme/smoke/record-name-ctor-collision-2294.scm
+++ b/tests/scheme/smoke/record-name-ctor-collision-2294.scm
@@ -1,0 +1,34 @@
+;; Behavior pin for kaappi#2294: R7RS §5.5 is silent on whether <name> and
+;; <constructor name> may be the same identifier. Kaappi accepts the
+;; collision, with the constructor winning the name — Chibi and Guile reject
+;; it, so the outcome is implementation-dependent and such code is not
+;; portable (documented in CONFORMANCE.md's SRFI 9 section). This test pins
+;; Kaappi's side of that contract so the documentation cannot drift.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64) (srfi 237))
+
+(test-begin "record-name-ctor-collision-2294")
+
+;; R7RS form: type name and constructor name are the same identifier.
+(define-record-type foo (foo x) foo? (x bar))
+
+(test-assert "constructor wins the name (foo is a procedure)"
+  (procedure? foo))
+(test-assert "foo constructs a record"
+  (foo? (foo 1)))
+(test-equal "accessor works on the colliding constructor's record"
+  1 (bar (foo 1)))
+
+;; R6RS clause-syntax (SRFI 237) name spec: same collision, same outcome —
+;; the constructor define rebinds the name over the rtd binding.
+(define-record-type (r6foo r6foo r6foo?) (fields (immutable v)))
+
+(test-assert "R6RS clause syntax: constructor wins the name too"
+  (procedure? r6foo))
+(test-assert "R6RS clause syntax: constructor builds a record"
+  (r6foo? (r6foo 7)))
+(test-equal "R6RS clause syntax: field accessor works"
+  7 (r6foo-v (r6foo 7)))
+
+(let ((runner (test-runner-current)))
+  (test-end "record-name-ctor-collision-2294")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/smoke/record-name-ctor-collision-2294.scm
+++ b/tests/scheme/smoke/record-name-ctor-collision-2294.scm
@@ -28,6 +28,11 @@
   (r6foo? (r6foo 7)))
 (test-equal "R6RS clause syntax: field accessor works"
   7 (r6foo-v (r6foo 7)))
+;; SRFI 237 specifies that the record name evaluates to the record
+;; descriptor; the collision means that binding does NOT survive — the name
+;; is the constructor, not the descriptor.
+(test-assert "R6RS clause syntax: colliding name is not the record descriptor"
+  (not (record-type-descriptor? r6foo)))
 
 (let ((runner (test-runner-current)))
   (test-end "record-name-ctor-collision-2294")


### PR DESCRIPTION
Fixes #2294

R7RS §5.5 is silent on whether `<name>` and `<constructor name>` may be the same identifier. Kaappi (like Gambit) accepts the collision, with the constructor winning the name; Chibi and Guile reject the same form. The outcome is implementation-dependent, so code that reuses one identifier for both positions is not portable.

## Changes

- **`CONFORMANCE.md`** — the SRFI 9 section now documents the collision and recommends the portable distinct-names form (following the precedent set by #2295 for the `equal?`-on-records decision).
- **`src/vm_records.zig`** — comment at the R7RS desugarer's constructor generation (`handleDefineRecordType`) recording the collision semantics.
- **`src/compiler_lambda.zig`** — matching comment at `compileDefineRecordType`, cross-referencing `vm_records`.
- **`tests/scheme/smoke/record-name-ctor-collision-2294.scm`** — SRFI-64 smoke test pinning Kaappi's side of the contract on both the R7RS and SRFI 237 clause-syntax paths, so the documentation cannot drift.

## Verification

- `zig fmt --check` and `zig build` clean
- Unit suite: exit 0
- R7RS suite: 1395 pass, 0 fail
- Full `tests/scheme/run-all.sh`: 2102 pass, 0 fail
- markdownlint: 0 issues