### PR TITLE
Fix LSP protocol/lifecycle and diagnostics drift

### DIFF
--- a/docs/dev/diagnostics-json.md
+++ b/docs/dev/diagnostics-json.md
@@ -16,6 +16,10 @@ output on stdout is unaffected, so redirect the two apart:
 kaappi --diagnostics=json file.scm 2>diagnostics.jsonl
 ```
 
+> **Exception:** `kaappi check --diagnostics=json` writes its JSON Lines to
+> **stdout**, not stderr ([check.md](check.md)). `check` is a report rather than
+> a run, so it has no program output on stdout to keep apart from the JSON.
+
 `--diagnostics=text` is the explicit spelling of the default; any other value is
 a usage error.
 
@@ -26,7 +30,9 @@ We do **not** invent a schema. Each line is a Language Server Protocol
 object — the exact shape the Kaappi language server already publishes for
 `textDocument/publishDiagnostics`, and the shape editors and agents already
 understand. The CLI and the LSP share one serializer
-(`src/lsp_diagnostic.zig`), so the two can never drift.
+(`src/lsp_diagnostic.zig`) **and** one analysis (`src/check.zig`'s
+`analyzeSource`, driven from `src/kaappi_lsp.zig`), so the two can never drift —
+on diagnostic *values* as much as on the shape (kaappi#1981).
 
 | Field | Type | Notes |
 |-------|------|-------|

--- a/docs/dev/diagnostics-json.md
+++ b/docs/dev/diagnostics-json.md
@@ -37,7 +37,7 @@ on diagnostic *values* as much as on the shape (kaappi#1981).
 | Field | Type | Notes |
 |-------|------|-------|
 | `range` | `{ start, end }` of `{ line, character }` | **Zero-based**, per LSP. See *Positions* below. |
-| `severity` | integer | LSP `DiagnosticSeverity`: `1` Error, `2` Warning, `3` Information, `4` Hint. Every diagnostic is `1` today. |
+| `severity` | integer | LSP `DiagnosticSeverity`: `1` Error, `2` Warning, `3` Information, `4` Hint. Comes from the diagnostic registry: run-mode diagnostics are all `1`, while `kaappi check` adds severity-`2` warnings (e.g. KP4001). |
 | `code` | string | The stable `KP` code from the [registry](diagnostics.md), e.g. `"KP3001"`. The machine handle; match on this, not on `message`. |
 | `source` | string | Always `"kaappi"`. |
 | `message` | string | Human-readable text. Free to be reworded release to release — do not match on it. |

--- a/src/check.zig
+++ b/src/check.zig
@@ -82,19 +82,9 @@ pub fn run(vm: *VM, path: []const u8, opts: Options) u8 {
 
     var ctx: check_lint.Context = .{ .arena = arena, .user_defined = &user_defined };
 
-    // `check` discards bytecode, so folding buys nothing — and disabling it keeps
-    // every call visible to the lint (no `(car 5 6)` folded away before the walk).
-    const saved_opt = ir_mod.optimize_enabled;
-    ir_mod.optimize_enabled = false;
-    check_lint.active = &ctx;
-    defer {
-        check_lint.active = null;
-        ir_mod.optimize_enabled = saved_opt;
-    }
+    analyzeSource(vm, &ctx, source, path);
 
-    analyze(vm, &ctx, arena, source, path);
-
-    std.mem.sort(check_lint.Finding, ctx.findings.items, {}, findingLess);
+    sortFindings(ctx.findings.items);
     report(arena, ctx.findings.items, opts);
 
     var errors: usize = 0;
@@ -119,6 +109,17 @@ fn isError(code: Code, deny_warnings: bool) bool {
 /// off, lint active, no file I/O or reporting). The caller owns `ctx.arena` and
 /// inspects `ctx.findings` directly.
 pub fn analyzeForTest(vm: *VM, ctx: *check_lint.Context, source: []const u8) void {
+    analyzeSource(vm, ctx, source, "<test>");
+}
+
+/// Analyse `source` (read + env-setup + compile + lint) into `ctx.findings`, with
+/// IR optimization off and the lint collector installed for the duration. Shared
+/// by `run`, `analyzeForTest`, and the language server (src/kaappi_lsp.zig), so
+/// the three surfaces diagnose identical source identically — the LSP must not
+/// drift from `kaappi check` (kaappi#1981).
+pub fn analyzeSource(vm: *VM, ctx: *check_lint.Context, source: []const u8, path: []const u8) void {
+    // Optimization is off so folding never hides a call from the lint walk (no
+    // `(car 5 6)` folded away before it is judged).
     const saved_opt = ir_mod.optimize_enabled;
     ir_mod.optimize_enabled = false;
     check_lint.active = ctx;
@@ -126,7 +127,12 @@ pub fn analyzeForTest(vm: *VM, ctx: *check_lint.Context, source: []const u8) voi
         check_lint.active = null;
         ir_mod.optimize_enabled = saved_opt;
     }
-    analyze(vm, ctx, ctx.arena, source, "<test>");
+    analyze(vm, ctx, ctx.arena, source, path);
+}
+
+/// Sort findings by (line, col) so every report surface agrees on ordering.
+pub fn sortFindings(items: []check_lint.Finding) void {
+    std.mem.sort(check_lint.Finding, items, {}, findingLess);
 }
 
 fn analyze(vm: *VM, ctx: *check_lint.Context, arena: std.mem.Allocator, source: []const u8, path: []const u8) void {

--- a/src/check.zig
+++ b/src/check.zig
@@ -84,7 +84,6 @@ pub fn run(vm: *VM, path: []const u8, opts: Options) u8 {
 
     analyzeSource(vm, &ctx, source, path);
 
-    sortFindings(ctx.findings.items);
     report(arena, ctx.findings.items, opts);
 
     var errors: usize = 0;
@@ -116,7 +115,9 @@ pub fn analyzeForTest(vm: *VM, ctx: *check_lint.Context, source: []const u8) voi
 /// IR optimization off and the lint collector installed for the duration. Shared
 /// by `run`, `analyzeForTest`, and the language server (src/kaappi_lsp.zig), so
 /// the three surfaces diagnose identical source identically — the LSP must not
-/// drift from `kaappi check` (kaappi#1981).
+/// drift from `kaappi check` (kaappi#1981). Findings are left sorted by
+/// (line, col) so every caller gets a deterministic order without having to
+/// remember to sort.
 pub fn analyzeSource(vm: *VM, ctx: *check_lint.Context, source: []const u8, path: []const u8) void {
     // Optimization is off so folding never hides a call from the lint walk (no
     // `(car 5 6)` folded away before it is judged).
@@ -128,11 +129,7 @@ pub fn analyzeSource(vm: *VM, ctx: *check_lint.Context, source: []const u8, path
         ir_mod.optimize_enabled = saved_opt;
     }
     analyze(vm, ctx, ctx.arena, source, path);
-}
-
-/// Sort findings by (line, col) so every report surface agrees on ordering.
-pub fn sortFindings(items: []check_lint.Finding) void {
-    std.mem.sort(check_lint.Finding, items, {}, findingLess);
+    std.mem.sort(check_lint.Finding, ctx.findings.items, {}, findingLess);
 }
 
 fn analyze(vm: *VM, ctx: *check_lint.Context, arena: std.mem.Allocator, source: []const u8, path: []const u8) void {

--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -166,8 +166,11 @@ fn readMessage(allocator: std.mem.Allocator) ?[]u8 {
                 while (cl_end < headers.len and headers[cl_end] >= '0' and headers[cl_end] <= '9') : (cl_end += 1) {}
                 // A non-numeric Content-Length corrupts only this frame's own
                 // framing. Return an empty (unparseable) body so the caller
-                // skips it and resynchronises on the next header instead of
-                // ending the whole session (kaappi#1980).
+                // skips it instead of ending the whole session; the next
+                // readMessage then re-reads the leftover bytes and best-effort
+                // resynchronises on the next `Content-Length` header (a body
+                // that itself contains that literal can still mislead the
+                // resync) (kaappi#1980).
                 content_length = std.fmt.parseInt(usize, headers[cl_start..cl_end], 10) catch {
                     return allocator.alloc(u8, 0) catch return null;
                 };
@@ -807,12 +810,29 @@ fn runDiagnostics(allocator: std.mem.Allocator, vm: *vm_mod.VM, uri: []const u8,
 
     var ctx: check_lint.Context = .{ .arena = arena, .user_defined = &user_defined };
     check.analyzeSource(vm, &ctx, text, uri);
-    check.sortFindings(ctx.findings.items);
+
+    // Serialize every finding through the shared LSP `Diagnostic` writer into an
+    // allocating writer (no fixed buffer), exactly as `check.zig`'s `reportJson`
+    // does, so an arbitrarily long finding message is emitted rather than
+    // silently dropped. The comma separator is gated on the buffer being past the
+    // opening `[`, so a finding that fails to serialize can never leave a `[,` or
+    // `,]` that would corrupt the whole array (kaappi#1981 review).
+    var aw: std.Io.Writer.Allocating = .init(arena);
+    defer aw.deinit();
 
     diag_buf.append(allocator, '[') catch return;
-    for (ctx.findings.items, 0..) |finding, i| {
-        if (i > 0) diag_buf.append(allocator, ',') catch {};
-        appendFinding(&diag_buf, allocator, finding);
+    for (ctx.findings.items) |finding| {
+        if (diag_buf.items.len > 1) diag_buf.append(allocator, ',') catch {};
+        aw.clearRetainingCapacity();
+        var cbuf: [diagnostics.Code.render_width]u8 = undefined;
+        const diag: lsp_diagnostic.Diagnostic = .{
+            .range = lsp_diagnostic.spanRange(finding.span),
+            .severity = lsp_diagnostic.severityOf(finding.code.info().severity),
+            .code = finding.code.render(&cbuf),
+            .message = finding.message,
+        };
+        diag.writeJson(&aw.writer) catch continue;
+        diag_buf.appendSlice(allocator, aw.written()) catch return;
     }
     diag_buf.append(allocator, ']') catch return;
 
@@ -935,26 +955,6 @@ fn endOutputRedirect(vm: *vm_mod.VM, rd: OutputRedirect) void {
     vm.stdout_port = rd.saved_stdout_port;
     if (rd.param != types.VOID)
         vm.setParameterValue(types.toParameter(rd.param), rd.saved_param_val) catch {};
-}
-
-// Serialize one `check_lint.Finding` through the shared LSP `Diagnostic` writer
-// (src/lsp_diagnostic.zig) — the same code path `--diagnostics=json` uses, so
-// the CLI and the server can never drift (kaappi#1505). The range is the
-// finding's real span, converted to LSP's zero-based coordinates via
-// `spanRange`, so a nested error is pinpointed to its characters rather than
-// painted as a whole-line 0..999 sentinel (kaappi#1981).
-fn appendFinding(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, f: check_lint.Finding) void {
-    var cbuf: [diagnostics.Code.render_width]u8 = undefined;
-    const diag: lsp_diagnostic.Diagnostic = .{
-        .range = lsp_diagnostic.spanRange(f.span),
-        .severity = lsp_diagnostic.severityOf(f.code.info().severity),
-        .code = f.code.render(&cbuf),
-        .message = f.message,
-    };
-    var tmp: [1024]u8 = undefined;
-    var w: std.Io.Writer = .fixed(&tmp);
-    diag.writeJson(&w) catch return;
-    buf.appendSlice(allocator, w.buffered()) catch return;
 }
 
 // ---- Text position helpers ----
@@ -1141,9 +1141,11 @@ pub fn main(init: std.process.Init.Minimal) !void {
 
         if (std.mem.eql(u8, method, "initialize")) {
             if (shutdown_requested) {
-                if (id) |req_id| sendError(allocator, req_id, -32600, "InvalidRequest");
-            } else {
-                handleInitialize(allocator, id orelse "0");
+                if (id) |req_id| sendError(allocator, req_id, -32600, "Invalid Request");
+            } else if (id) |req_id| {
+                // An initialize sent as a notification (no id) gets no reply —
+                // never a fabricated id 0 — and does not complete the handshake.
+                handleInitialize(allocator, req_id);
                 initialized = true;
             }
         } else if (std.mem.eql(u8, method, "initialized")) {
@@ -1166,7 +1168,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
         } else if (shutdown_requested) {
             // LSP 3.17: every request received after shutdown except `exit` is
             // an Invalid Request (-32600).
-            if (id) |req_id| sendError(allocator, req_id, -32600, "InvalidRequest");
+            if (id) |req_id| sendError(allocator, req_id, -32600, "Invalid Request");
         } else if (std.mem.eql(u8, method, "textDocument/didOpen") or
             std.mem.eql(u8, method, "textDocument/didChange"))
         {

--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -814,15 +814,15 @@ fn runDiagnostics(allocator: std.mem.Allocator, vm: *vm_mod.VM, uri: []const u8,
     // Serialize every finding through the shared LSP `Diagnostic` writer into an
     // allocating writer (no fixed buffer), exactly as `check.zig`'s `reportJson`
     // does, so an arbitrarily long finding message is emitted rather than
-    // silently dropped. The comma separator is gated on the buffer being past the
-    // opening `[`, so a finding that fails to serialize can never leave a `[,` or
-    // `,]` that would corrupt the whole array (kaappi#1981 review).
+    // silently dropped. The comma separator is appended only after a finding has
+    // serialized successfully, so a finding that fails to serialize can never
+    // leave a `[,` or `,]` that would corrupt the whole array (kaappi#1981 review).
     var aw: std.Io.Writer.Allocating = .init(arena);
     defer aw.deinit();
 
     diag_buf.append(allocator, '[') catch return;
+    var first = true;
     for (ctx.findings.items) |finding| {
-        if (diag_buf.items.len > 1) diag_buf.append(allocator, ',') catch {};
         aw.clearRetainingCapacity();
         var cbuf: [diagnostics.Code.render_width]u8 = undefined;
         const diag: lsp_diagnostic.Diagnostic = .{
@@ -832,7 +832,9 @@ fn runDiagnostics(allocator: std.mem.Allocator, vm: *vm_mod.VM, uri: []const u8,
             .message = finding.message,
         };
         diag.writeJson(&aw.writer) catch continue;
+        if (!first) diag_buf.append(allocator, ',') catch return;
         diag_buf.appendSlice(allocator, aw.written()) catch return;
+        first = false;
     }
     diag_buf.append(allocator, ']') catch return;
 

--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -35,6 +35,8 @@ pub const fiber_mod = @import("fiber.zig");
 pub const primitives_fiber = @import("primitives_fiber.zig");
 pub const diagnostics = @import("diagnostics.zig");
 pub const lsp_diagnostic = @import("lsp_diagnostic.zig");
+pub const check = @import("check.zig");
+pub const check_lint = @import("check_lint.zig");
 
 const version = "0.1.0";
 const initialize_result =
@@ -116,6 +118,19 @@ fn clampToU32(val: i64) u32 {
     return @intCast(@as(u64, @bitCast(val)));
 }
 
+/// Validate that `params` is an object usable by a request method: it must carry
+/// a `textDocument` object with a string `uri`, and (when `needs_position`) a
+/// `position` object. Returns the params map on success, null otherwise — the
+/// caller answers null with `-32602` InvalidParams rather than silently dropping
+/// the request and leaving the client waiting on that id forever (kaappi#1980).
+fn requestParams(params: ?std.json.ObjectMap, needs_position: bool) ?std.json.ObjectMap {
+    const p = params orelse return null;
+    const td = getObjField(p, "textDocument") orelse return null;
+    if (getStrField(td, "uri") == null) return null;
+    if (needs_position and getObjField(p, "position") == null) return null;
+    return p;
+}
+
 // ---- LSP message I/O ----
 
 fn readMessage(allocator: std.mem.Allocator) ?[]u8 {
@@ -149,13 +164,21 @@ fn readMessage(allocator: std.mem.Allocator) ?[]u8 {
                 const cl_start = cl_pos + 16;
                 var cl_end = cl_start;
                 while (cl_end < headers.len and headers[cl_end] >= '0' and headers[cl_end] <= '9') : (cl_end += 1) {}
-                content_length = std.fmt.parseInt(usize, headers[cl_start..cl_end], 10) catch return null;
+                // A non-numeric Content-Length corrupts only this frame's own
+                // framing. Return an empty (unparseable) body so the caller
+                // skips it and resynchronises on the next header instead of
+                // ending the whole session (kaappi#1980).
+                content_length = std.fmt.parseInt(usize, headers[cl_start..cl_end], 10) catch {
+                    return allocator.alloc(u8, 0) catch return null;
+                };
             }
             break;
         }
     }
 
-    if (content_length == 0) return null;
+    // A missing or zero Content-Length frames no body; return an empty,
+    // unparseable body so the session continues rather than ending (kaappi#1980).
+    if (content_length == 0) return allocator.alloc(u8, 0) catch return null;
 
     // Read body
     const body = allocator.alloc(u8, content_length) catch return null;
@@ -698,8 +721,6 @@ fn handleDidOpenOrChange(allocator: std.mem.Allocator, vm: *vm_mod.VM, params: s
 fn runDiagnostics(allocator: std.mem.Allocator, vm: *vm_mod.VM, uri: []const u8, text: []const u8) void {
     var diag_buf: std.ArrayList(u8) = .empty;
     defer diag_buf.deinit(allocator);
-    diag_buf.append(allocator, '[') catch return;
-    var has_diag = false;
 
     // Reset the shared macro table to the pre-document baseline: each document
     // is diagnosed as if it were the only one open. The define-syntax forms
@@ -770,31 +791,29 @@ fn runDiagnostics(allocator: std.mem.Allocator, vm: *vm_mod.VM, uri: []const u8,
     const out_redirect = beginOutputRedirect(vm);
     defer endOutputRedirect(vm, out_redirect);
 
-    // Parse phase
-    var r = reader.Reader.initWithName(vm.gc, text, uri);
-    defer r.deinit();
+    // Diagnose the document by driving the exact analysis `kaappi check` runs —
+    // read + env-setup + compile + KP4xxx lint — into a `check_lint.Context`,
+    // then serialize every finding through the shared LSP `Diagnostic` writer.
+    // Sharing the analysis (not just the serializer) is what makes the LSP agree
+    // with `kaappi check --diagnostics=json` on codes, severities, and spans
+    // (kaappi#1981): a whole-file read error, every failing form, every KP4xxx
+    // lint, and the real character range all reach the editor.
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
 
-    while (r.hasMore() catch false) {
-        var expr = r.readDatum() catch |err| {
-            const lc = r.getLineCol();
-            if (has_diag) diag_buf.append(allocator, ',') catch {};
-            has_diag = true;
-            addDiagnostic(&diag_buf, allocator, lc.line -| 1, diagnostics.readErrorCode(err));
-            break;
-        };
+    var user_defined = std.StringHashMap(void).init(arena);
+    check.collectTopLevelDefines(&user_defined, arena, vm.gc, text);
 
-        // The reader sits just past the form now; this is the same line the
-        // original compile-only loop reported, so the cross-check against
-        // `kaappi check` (tests/scheme/lsp/lsp.sh §4) still agrees.
-        const line0 = r.getLineCol().line -| 1;
-        vm.gc.pushRoot(&expr);
-        const stop = diagnoseTopLevelForm(&diag_buf, allocator, vm, uri, expr, line0, &has_diag);
-        vm.gc.popRoot();
-        // The server publishes only the first failing form's diagnostic
-        // (kaappi#1980, deliberately covered in the LSP suite).
-        if (stop) break;
+    var ctx: check_lint.Context = .{ .arena = arena, .user_defined = &user_defined };
+    check.analyzeSource(vm, &ctx, text, uri);
+    check.sortFindings(ctx.findings.items);
+
+    diag_buf.append(allocator, '[') catch return;
+    for (ctx.findings.items, 0..) |finding, i| {
+        if (i > 0) diag_buf.append(allocator, ',') catch {};
+        appendFinding(&diag_buf, allocator, finding);
     }
-
     diag_buf.append(allocator, ']') catch return;
 
     // Build publishDiagnostics params
@@ -918,117 +937,19 @@ fn endOutputRedirect(vm: *vm_mod.VM, rd: OutputRedirect) void {
         vm.setParameterValue(types.toParameter(rd.param), rd.saved_param_val) catch {};
 }
 
-// Diagnose one top-level form, returning true when it recorded a diagnostic
-// (the caller then stops — the server publishes only the first, kaappi#1980).
-//
-// The classification mirrors `check.zig`'s `checkForm`, sharing the very
-// `TopLevelHead` machinery `kaappi check` and the runtime use so the three
-// cannot drift (kaappi#2114): a top-level `begin` and the selected `cond-expand`
-// clause splice into the top-level sequence and are recursed into, the
-// environment-establishing heads (`import`/`define-library`/`include`/
-// `define-record-type`) are *run* for their effect so later forms see the
-// bindings and macros they introduce, and everything else is compiled but not
-// executed. Running imports is what makes an imported macro like SRFI 42's
-// `list-ec` expand — without it, the compiler judges the `(if test)` filter
-// qualifier inside the comprehension as a malformed one-armed R7RS `if` and
-// flags valid code.
-fn diagnoseTopLevelForm(
-    diag_buf: *std.ArrayList(u8),
-    allocator: std.mem.Allocator,
-    vm: *vm_mod.VM,
-    uri: []const u8,
-    expr: types.Value,
-    line0: u32,
-    has_diag: *bool,
-) bool {
-    if (types.isPair(expr) and types.isSymbol(types.car(expr))) {
-        if (vm.topLevelHead(expr)) |head| {
-            switch (head) {
-                // R7RS 5.1: top-level `begin` splices its body as top-level
-                // forms — recurse so a nested import runs for its effect.
-                .begin => {
-                    var rest = types.cdr(expr);
-                    while (types.isPair(rest)) : (rest = types.cdr(rest)) {
-                        if (diagnoseTopLevelForm(diag_buf, allocator, vm, uri, types.car(rest), line0, has_diag)) return true;
-                    }
-                    return false;
-                },
-                // R7RS 4.2.1: a top-level `cond-expand` splices its selected
-                // clause's body as top-level forms. Clause selection uses the
-                // same evaluator the runtime does, so both pick the same clause.
-                .cond_expand => {
-                    var clauses = types.cdr(expr);
-                    while (types.isPair(clauses)) : (clauses = types.cdr(clauses)) {
-                        const clause = types.car(clauses);
-                        if (!types.isPair(clause)) break;
-                        const req = types.car(clause);
-                        const is_else = types.isSymbol(req) and std.mem.eql(u8, types.symbolName(req), "else");
-                        if (is_else or vm_library.evalLibFeatureReq(vm, req)) {
-                            var body = types.cdr(clause);
-                            while (types.isPair(body)) : (body = types.cdr(body)) {
-                                if (diagnoseTopLevelForm(diag_buf, allocator, vm, uri, types.car(body), line0, has_diag)) return true;
-                            }
-                            return false;
-                        }
-                    }
-                    // No clause matched: fall through and compile it as an
-                    // expression (the compiler folds a no-match to void), the
-                    // same fallback check.zig and the runtime compiler take.
-                },
-                else => {
-                    if (head.isEnvSetup()) {
-                        _ = vm.runTopLevelHead(head, expr) catch |err| {
-                            const code = if (vm.last_error_code != .uncategorized)
-                                vm.last_error_code
-                            else
-                                diagnostics.runtimeErrorCode(err);
-                            recordDiagnostic(diag_buf, allocator, line0, code, has_diag);
-                            vm.last_error_detail_len = 0;
-                            vm.last_error_code = .uncategorized;
-                            return true;
-                        };
-                        return false;
-                    }
-                    // define-values: only its names matter, never its producer's
-                    // effect — fall through to compile-not-run, like check.zig.
-                },
-            }
-        }
-    }
-
-    // Everything else — define, define-syntax, define-values, expressions — is
-    // compiled (registering any define-syntax macro and surfacing compile
-    // errors) but never executed. The compiled Function is discarded.
-    _ = compiler.compileExpressionWithMacrosAt(vm.gc, expr, &vm.macros, vm.globals, 0, uri, false) catch |err| {
-        recordDiagnostic(diag_buf, allocator, line0, diagnostics.compileErrorCode(err), has_diag);
-        return true;
-    };
-    return false;
-}
-
-// Append one diagnostic to the array under construction, inserting the JSON
-// comma separator before all but the first.
-fn recordDiagnostic(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, line0: u32, code: diagnostics.Code, has_diag: *bool) void {
-    if (has_diag.*) buf.append(allocator, ',') catch {};
-    has_diag.* = true;
-    addDiagnostic(buf, allocator, line0, code);
-}
-
-// Serialize one diagnostic through the shared LSP `Diagnostic` writer
+// Serialize one `check_lint.Finding` through the shared LSP `Diagnostic` writer
 // (src/lsp_diagnostic.zig) — the same code path `--diagnostics=json` uses, so
-// the CLI and the server can never drift (kaappi#1505). The range spans the
-// whole line (character 0..999) to highlight it in an editor; the `code` is the
-// stable KP code and `message` its registry template.
-fn addDiagnostic(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, line0: u32, code: diagnostics.Code) void {
+// the CLI and the server can never drift (kaappi#1505). The range is the
+// finding's real span, converted to LSP's zero-based coordinates via
+// `spanRange`, so a nested error is pinpointed to its characters rather than
+// painted as a whole-line 0..999 sentinel (kaappi#1981).
+fn appendFinding(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, f: check_lint.Finding) void {
     var cbuf: [diagnostics.Code.render_width]u8 = undefined;
     const diag: lsp_diagnostic.Diagnostic = .{
-        .range = .{
-            .start = .{ .line = line0, .character = 0 },
-            .end = .{ .line = line0, .character = 999 },
-        },
-        .severity = lsp_diagnostic.severityOf(code.info().severity),
-        .code = code.render(&cbuf),
-        .message = code.message(),
+        .range = lsp_diagnostic.spanRange(f.span),
+        .severity = lsp_diagnostic.severityOf(f.code.info().severity),
+        .code = f.code.render(&cbuf),
+        .message = f.message,
     };
     var tmp: [1024]u8 = undefined;
     var w: std.Io.Writer = .fixed(&tmp);
@@ -1062,8 +983,13 @@ fn lineColToOffset(text: []const u8, line: u32, col: u32) usize {
     while (i < text.len and cur_line < line) : (i += 1) {
         if (text[i] == '\n') cur_line += 1;
     }
-    const target = i + @as(usize, col);
-    return @min(target, text.len);
+    // `i` is the start of the requested line (or `text.len` when the line is
+    // past the end). Clamp `col` to the line's own length — up to its newline —
+    // so a column past end-of-line stops at the line end rather than walking
+    // into a later line (kaappi#1980).
+    var line_end = i;
+    while (line_end < text.len and text[line_end] != '\n') : (line_end += 1) {}
+    return i + @min(col, line_end - i);
 }
 
 fn isSymbolChar(ch: u8) bool {
@@ -1169,6 +1095,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
     if (diag_sink_port != types.VOID) gc.extra_roots.append(gc.allocator, diag_sink_port) catch {};
 
     var initialized = false;
+    var shutdown_requested = false;
 
     // Message loop
     while (true) {
@@ -1185,13 +1112,24 @@ pub fn main(init: std.process.Init.Minimal) !void {
 
         const method = getStrField(root, "method") orelse continue;
 
-        // Format id for response splicing (null for notifications)
+        // Format the request id for response splicing. JSON-RPC ids are integers
+        // or strings; anything else (null, a float, an array, an object) is an
+        // Invalid Request answered with id null — never a fabricated id
+        // (kaappi#1980).
         var id_buf: std.ArrayList(u8) = .empty;
         defer id_buf.deinit(allocator);
+        var id_valid = false;
         if (root.get("id")) |id_val| {
-            _ = formatIdValue(&id_buf, allocator, id_val);
+            id_valid = formatIdValue(&id_buf, allocator, id_val);
         }
-        const id: ?[]const u8 = if (id_buf.items.len > 0) id_buf.items else null;
+        const id: ?[]const u8 = if (id_valid) id_buf.items else null;
+
+        // A request whose id we cannot echo is answered immediately with an
+        // Invalid Request (id null) and never dispatched.
+        if (root.get("id") != null and !id_valid) {
+            sendError(allocator, "null", -32600, "Invalid Request");
+            continue;
+        }
 
         const params: ?std.json.ObjectMap = if (root.get("params")) |p|
             switch (p) {
@@ -1202,18 +1140,33 @@ pub fn main(init: std.process.Init.Minimal) !void {
             null;
 
         if (std.mem.eql(u8, method, "initialize")) {
-            handleInitialize(allocator, id orelse "0");
-            initialized = true;
+            if (shutdown_requested) {
+                if (id) |req_id| sendError(allocator, req_id, -32600, "InvalidRequest");
+            } else {
+                handleInitialize(allocator, id orelse "0");
+                initialized = true;
+            }
         } else if (std.mem.eql(u8, method, "initialized")) {
             // Notification, no response needed
         } else if (std.mem.eql(u8, method, "shutdown")) {
-            sendResponse(allocator, id orelse "0", "null");
-        } else if (std.mem.eql(u8, method, "exit")) {
-            break;
-        } else if (!initialized) {
-            if (id) |req_id| {
-                sendError(allocator, req_id, -32002, "not initialized");
+            if (!initialized) {
+                if (id) |req_id| sendError(allocator, req_id, -32002, "not initialized");
+            } else {
+                if (id) |req_id| sendResponse(allocator, req_id, "null");
+                shutdown_requested = true;
             }
+        } else if (std.mem.eql(u8, method, "exit")) {
+            // LSP 3.17: exit without a prior shutdown must be status 1, so a
+            // supervising client can tell a clean shutdown from a crash-exit.
+            if (shutdown_requested) break;
+            log("kaappi-lsp exiting without shutdown\n");
+            std.process.exit(1);
+        } else if (!initialized) {
+            if (id) |req_id| sendError(allocator, req_id, -32002, "not initialized");
+        } else if (shutdown_requested) {
+            // LSP 3.17: every request received after shutdown except `exit` is
+            // an Invalid Request (-32600).
+            if (id) |req_id| sendError(allocator, req_id, -32600, "InvalidRequest");
         } else if (std.mem.eql(u8, method, "textDocument/didOpen") or
             std.mem.eql(u8, method, "textDocument/didChange"))
         {
@@ -1233,15 +1186,35 @@ pub fn main(init: std.process.Init.Minimal) !void {
                 }
             }
         } else if (std.mem.eql(u8, method, "textDocument/completion")) {
-            if (params) |p| handleCompletion(allocator, &vm, id orelse "0", p);
+            if (requestParams(params, true)) |p| {
+                if (id) |req_id| handleCompletion(allocator, &vm, req_id, p);
+            } else if (id) |req_id| {
+                sendError(allocator, req_id, -32602, "InvalidParams");
+            }
         } else if (std.mem.eql(u8, method, "textDocument/hover")) {
-            if (params) |p| handleHover(allocator, &vm, id orelse "0", p);
+            if (requestParams(params, true)) |p| {
+                if (id) |req_id| handleHover(allocator, &vm, req_id, p);
+            } else if (id) |req_id| {
+                sendError(allocator, req_id, -32602, "InvalidParams");
+            }
         } else if (std.mem.eql(u8, method, "textDocument/documentSymbol")) {
-            if (params) |p| handleDocumentSymbol(allocator, &vm, id orelse "0", p);
+            if (requestParams(params, false)) |p| {
+                if (id) |req_id| handleDocumentSymbol(allocator, &vm, req_id, p);
+            } else if (id) |req_id| {
+                sendError(allocator, req_id, -32602, "InvalidParams");
+            }
         } else if (std.mem.eql(u8, method, "textDocument/definition")) {
-            if (params) |p| handleDefinition(allocator, &vm, id orelse "0", p);
+            if (requestParams(params, true)) |p| {
+                if (id) |req_id| handleDefinition(allocator, &vm, req_id, p);
+            } else if (id) |req_id| {
+                sendError(allocator, req_id, -32602, "InvalidParams");
+            }
         } else if (std.mem.eql(u8, method, "textDocument/references")) {
-            if (params) |p| handleReferences(allocator, &vm, id orelse "0", p);
+            if (requestParams(params, true)) |p| {
+                if (id) |req_id| handleReferences(allocator, &vm, req_id, p);
+            } else if (id) |req_id| {
+                sendError(allocator, req_id, -32602, "InvalidParams");
+            }
         } else if (id != null) {
             sendError(allocator, id.?, -32601, "MethodNotFound");
         }

--- a/tests/scheme/lsp/lsp.sh
+++ b/tests/scheme/lsp/lsp.sh
@@ -588,6 +588,23 @@ assert_has "range control: check pinpoints the inner (if)" "$NEST_CHK" \
 assert_has "range: lsp pinpoints the inner (if)" "$OUT" \
     '"start":\{"line":0,"character":12\},"end":\{"line":0,"character":16\}'
 
+# -- long diagnostic messages ----------------------------------------------
+# KP4001 embeds the identifier verbatim, so a ~1000-char name produces a
+# message longer than the old fixed 1024-byte serializer could hold. The
+# finding must still be emitted (with a second short one beside it), not
+# dropped or turned into a corrupt `[,`/`,]` array.
+LONGNAME="$(printf 'a%.0s' $(seq 1 1000))"
+stream_reset
+msg "$INIT"
+msg "$INITED"
+did_open "file:///lsp-audit/long.scm" "(display $LONGNAME)\n(display short-undef)\n"
+msg "$EXITN"
+lsp_run
+assert_eq "long-message: both KP4001 findings are published" \
+    "$(count "$OUT" '"code":"KP4001"')" "2"
+assert_lacks "long-message: the diagnostics array is not corrupted (lead)" "$OUT" '\[,'
+assert_lacks "long-message: the diagnostics array is not corrupted (tail)" "$OUT" ',\]'
+
 # ========================================================================
 # 5. protocol edges
 # ========================================================================

--- a/tests/scheme/lsp/lsp.sh
+++ b/tests/scheme/lsp/lsp.sh
@@ -17,8 +17,9 @@
 #   * protocol edges: pre-initialize requests, unknown methods, malformed
 #     framing, malformed bodies, unopened documents, non-Scheme content
 #
-# Assertions disabled with `# FAIL: #1980` are reproduced defects; each keeps an
-# enabled control beside it so the surrounding mechanism stays covered.
+# The assertions below pin the fixed behaviour from kaappi#1980 (protocol and
+# lifecycle defects) and kaappi#1981 (diagnostics divergence from `kaappi
+# check`), each beside a control that keeps the surrounding mechanism covered.
 
 set -uo pipefail
 
@@ -195,17 +196,18 @@ assert_lacks "capability: no codeActionProvider advertised" "$OUT" 'codeActionPr
 # ========================================================================
 # 2. framing — exact Content-Length, and one frame per request
 # ========================================================================
-# A lone `shutdown` produces exactly one 38-byte body; the header is 22 bytes,
-# so a correctly framed reply is exactly 60 bytes on the wire.
+# A lone `shutdown` before initialize is answered with the 76-byte -32002
+# "not initialized" error; the header is 22 bytes, so a correctly framed reply
+# is exactly 98 bytes on the wire.
 stream_reset
 msg '{"jsonrpc":"2.0","id":7,"method":"shutdown"}'
 lsp_run
 run_timeout 30 "$LSP" < "$TMP/in" 2> /dev/null > "$TMP/raw"
 assert_eq "framing: declared Content-Length is exact" \
-    "$(grep -oE 'Content-Length: [0-9]+' < "$TMP/raw" | head -1)" "Content-Length: 38"
+    "$(grep -oE 'Content-Length: [0-9]+' < "$TMP/raw" | head -1)" "Content-Length: 76"
 assert_eq "framing: header + body is the whole stdout" \
-    "$(wc -c < "$TMP/raw" | tr -d ' ')" "60"
-assert_has "framing: header terminated by CRLFCRLF" "$(cat "$TMP/raw")" 'Content-Length: 38'
+    "$(wc -c < "$TMP/raw" | tr -d ' ')" "98"
+assert_has "framing: header terminated by CRLFCRLF" "$(cat "$TMP/raw")" 'Content-Length: 76'
 
 stream_reset
 msg "$INIT"
@@ -527,9 +529,8 @@ lsp_run
 assert_has "globals-isolation control: the importing doc resolves its own import" "$OUT" \
     '"id":93,"result":\{"contents"'
 
-# -- multi-error divergence ------------------------------------------------
-# `runDiagnostics` breaks out of its loop on the first failing form, so a file
-# with two independent errors publishes one diagnostic where `check` reports two.
+# -- multi-error coverage --------------------------------------------------
+# A file with two independent errors publishes both, exactly matching `check`.
 printf '(if)\n(let)\n' > "$TMP/two.scm"
 stream_reset
 msg "$INIT"
@@ -538,15 +539,14 @@ did_open "file://$TMP/two.scm" '(if)\n(let)\n'
 msg "$EXITN"
 lsp_run
 TWO_CHK="$(run_timeout 30 "$KAAPPI" check --diagnostics=json "$TMP/two.scm" 2> /dev/null)"
-# Control: `check` really does see both errors, so the LSP's count is the outlier.
+# Control: `check` really does see both errors, and so does the LSP.
 assert_eq "multi-error control: check reports 2 diagnostics" "$(count "$TWO_CHK" '"severity":')" "2"
 assert_eq "multi-error control: lsp reports the first error's code" "$(first_code "$OUT")" "KP2001"
-# FAIL: #1980 (LSP stops at the first bad form; check reports every one)
-# assert_eq "multi-error: lsp reports both diagnostics" "$(count "$OUT" '"severity":')" "2"
+assert_eq "multi-error: lsp reports both diagnostics" "$(count "$OUT" '"severity":')" "2"
 
-# -- lint (KP4xxx) coverage divergence ------------------------------------
-# `check` adds a lint pass on top of read+compile; the LSP runs neither, so an
-# editor shows a clean file where `check` reports an error and exits 1.
+# -- lint (KP4xxx) coverage ------------------------------------------------
+# The LSP runs the same lint pass as `check`, so a built-in arity error that
+# `check` reports must also reach the editor.
 printf '(car 1 2 3)\n' > "$TMP/arity.scm"
 stream_reset
 msg "$INIT"
@@ -560,22 +560,19 @@ ARITY_CHK="$(run_timeout 30 "$KAAPPI" check --diagnostics=json "$TMP/arity.scm" 
 assert_eq "lint control: check reports KP4002 for (car 1 2 3)" "$(first_code "$ARITY_CHK")" "KP4002"
 assert_has "lint control: lsp did publish a diagnostics frame" "$OUT" \
     '"method":"textDocument/publishDiagnostics"'
-# FAIL: #1981 (LSP runs no KP4xxx lint pass; check's arity error is invisible in an editor)
-# assert_eq "lint: lsp reports KP4002 too" "$(first_code "$OUT")" "KP4002"
+assert_eq "lint: lsp reports KP4002 too" "$(first_code "$OUT")" "KP4002"
 
 printf '(display undefined-thing-xyz)\n' > "$TMP/warn.scm"
 WARN_CHK="$(run_timeout 30 "$KAAPPI" check --diagnostics=json "$TMP/warn.scm" 2> /dev/null)"
 assert_eq "lint control: check emits a severity-2 warning (KP4001)" "$(first_code "$WARN_CHK")" "KP4001"
 assert_has "lint control: that warning really is severity 2" "$WARN_CHK" '"severity":2'
-# FAIL: #1980 (LSP never emits severity 2 — only read/compile errors reach addDiagnostic)
-# stream_reset; msg "$INIT"; msg "$INITED"
-# did_open "file://$TMP/warn.scm" '(display undefined-thing-xyz)\n'; msg "$EXITN"; lsp_run
-# assert_has "lint: lsp emits the same warning" "$OUT" '"severity":2'
+stream_reset; msg "$INIT"; msg "$INITED"
+did_open "file://$TMP/warn.scm" '(display undefined-thing-xyz)\n'; msg "$EXITN"; lsp_run
+assert_has "lint: lsp emits the same warning" "$OUT" '"severity":2'
 
 # -- range fidelity --------------------------------------------------------
-# The LSP hardcodes character 0..999; `check` carries the real span. Same code,
-# same line, different columns — the shared serializer guarantees the shape, not
-# the values.
+# The LSP carries the same real span `check` does, so a nested error is
+# pinpointed to the same characters on both surfaces.
 printf '(define (f) (if))\n' > "$TMP/nest.scm"
 stream_reset
 msg "$INIT"
@@ -588,8 +585,8 @@ assert_eq "range control: code still agrees on a nested error" \
     "$(first_code "$OUT")" "$(first_code "$NEST_CHK")"
 assert_has "range control: check pinpoints the inner (if)" "$NEST_CHK" \
     '"start":\{"line":0,"character":12\},"end":\{"line":0,"character":16\}'
-assert_has "range: lsp uses a whole-line 0..999 sentinel" "$OUT" \
-    '"start":\{"line":0,"character":0\},"end":\{"line":0,"character":999\}'
+assert_has "range: lsp pinpoints the inner (if)" "$OUT" \
+    '"start":\{"line":0,"character":12\},"end":\{"line":0,"character":16\}'
 
 # ========================================================================
 # 5. protocol edges
@@ -613,9 +610,8 @@ msg '{"jsonrpc":"2.0","id":31,"method":"shutdown"}'
 lsp_run
 # Control: the guard demonstrably works for other methods (asserted just above).
 assert_has "pre-init control: shutdown is answered at all" "$OUT" '"id":31'
-# FAIL: #1980 (shutdown before initialize returns success, not -32002)
-# assert_has "pre-init: shutdown before initialize errors -32002" "$OUT" \
-#     '"id":31,"error":\{"code":-32002'
+assert_has "pre-init: shutdown before initialize errors -32002" "$OUT" \
+    '"id":31,"error":\{"code":-32002'
 
 # -- unknown methods -------------------------------------------------------
 stream_reset
@@ -642,7 +638,6 @@ assert_eq "unknown notification: silently ignored, no extra frame" \
 assert_has "unknown notification: the following request still works" "$OUT" '"id":34,"result":null'
 
 # -- shutdown/exit lifecycle ----------------------------------------------
-# There is no shutdown state: a request after `shutdown` is served normally.
 # LSP 3.17 requires InvalidRequest (-32600) for requests received after shutdown.
 stream_reset
 msg "$INIT"
@@ -651,11 +646,10 @@ msg '{"jsonrpc":"2.0","id":35,"method":"shutdown"}'
 pos_req 36 "textDocument/hover" "file:///x.scm" 0 0
 msg "$EXITN"
 lsp_run
-# Control: the same request before shutdown behaves identically, which is the
-# point — the two are indistinguishable because no state is recorded.
+# Control: the request is answered either way (a normal result before shutdown,
+# -32600 after); the state is now recorded so the two are distinguishable.
 assert_has "post-shutdown control: the request is answered" "$OUT" '"id":36'
-# FAIL: #1980 (no shutdown state; post-shutdown requests should be -32600)
-# assert_has "post-shutdown: request errors -32600" "$OUT" '"id":36,"error":\{"code":-32600'
+assert_has "post-shutdown: request errors -32600" "$OUT" '"id":36,"error":\{"code":-32600'
 
 # LSP 3.17: exit after shutdown -> status 0, exit without shutdown -> status 1.
 stream_reset
@@ -672,8 +666,7 @@ msg "$EXITN"
 lsp_run
 # Control: with the handshake done the server is definitely alive and running.
 assert_eq "exit control: the server did terminate on exit" "$(count "$OUT" 'Content-Length:')" "1"
-# FAIL: #1980 (exit without a prior shutdown must be status 1; it is 0)
-# assert_eq "exit: exit without shutdown is status 1" "$RC" "1"
+assert_eq "exit: exit without shutdown is status 1" "$RC" "1"
 
 # EOF on stdin with no `exit` at all must terminate, not spin.
 stream_reset
@@ -729,28 +722,21 @@ raw 'Content-Length: abc\r\n\r\n{}'
 msg "$INIT"
 msg "$EXITN"
 lsp_run
-assert_eq "bad header: server produces no output at all" "$(count "$OUT" 'Content-Length:')" "0"
-# FAIL: #1980 (a non-numeric Content-Length should be resynchronised or reported,
-#            not silently end the session — every later message is lost)
-# assert_has "bad header: session survives a malformed Content-Length" "$OUT" '"id":1,"result":'
+assert_has "bad header: session survives a malformed Content-Length" "$OUT" '"id":1,"result":'
 
 stream_reset
 raw 'Content-Type: application/json\r\n\r\n'
 msg "$INIT"
 msg "$EXITN"
 lsp_run
-assert_eq "missing Content-Length: no output" "$(count "$OUT" 'Content-Length:')" "0"
-# FAIL: #1980 (a header block with no Content-Length ends the session silently)
-# assert_has "missing Content-Length: session survives" "$OUT" '"id":1,"result":'
+assert_has "missing Content-Length: session survives" "$OUT" '"id":1,"result":'
 
 stream_reset
 raw 'Content-Length: 0\r\n\r\n'
 msg "$INIT"
 msg "$EXITN"
 lsp_run
-assert_eq "zero Content-Length: no output" "$(count "$OUT" 'Content-Length:')" "0"
-# FAIL: #1980 (Content-Length: 0 is treated as a fatal read failure)
-# assert_has "zero Content-Length: session survives" "$OUT" '"id":1,"result":'
+assert_has "zero Content-Length: session survives" "$OUT" '"id":1,"result":'
 
 # A truncated body (declared length exceeds what arrives) must not hang or crash.
 stream_reset
@@ -788,15 +774,24 @@ msg "$INITED"
 msg '{"jsonrpc":"2.0","id":null,"method":"shutdown"}'
 msg "$EXITN"
 lsp_run
-# Control: integer and string ids do round-trip (asserted just above), so a
-# fabricated id is specific to the unrepresentable ones.
-assert_has "null id control: a reply is still produced" "$OUT" '"result":null'
-# FAIL: #1980 (an id the formatter cannot render becomes 0, matching no request)
-# assert_lacks "null id: server must not invent id 0" "$OUT" '"id":0'
+# Control: integer and string ids do round-trip (asserted just above), so an
+# invalid id must not be silently answered with a fabricated one.
+assert_has "null id: the invalid request is answered with id null" "$OUT" '"id":null,"error":\{"code":-32600'
+assert_lacks "null id: server must not invent id 0" "$OUT" '"id":0'
+
+# A float id is equally unrepresentable: it must error with id null, not id 0.
+stream_reset
+msg "$INIT"
+msg "$INITED"
+msg '{"jsonrpc":"2.0","id":1.5,"method":"shutdown"}'
+msg "$EXITN"
+lsp_run
+assert_has "id: a float id is answered as an invalid request" "$OUT" '"id":null,"error":\{"code":-32600'
+assert_lacks "id: a float id is not answered with id 0" "$OUT" '"id":0'
 
 # -- requests with missing or malformed params ----------------------------
-# Every position-taking handler bails with a bare `return` when a field is
-# absent, so the request is never answered and a client blocks on that id.
+# A request with unusable params must get a -32602 InvalidParams reply, never
+# silence — a client would otherwise wait on that id forever.
 stream_reset
 msg "$INIT"
 msg "$INITED"
@@ -807,17 +802,13 @@ msg '{"jsonrpc":"2.0","id":53,"method":"shutdown"}'
 msg "$EXITN"
 lsp_run
 # Control: the well-formed hover at id 50 IS answered, so the handler works and
-# only the malformed variants vanish.
+# only the malformed variants error.
 assert_has "missing params control: a well-formed hover is answered" "$OUT" '"id":50'
 assert_has "missing params control: a later request still works" "$OUT" '"id":53,"result":null'
-assert_eq "missing params: params={} produces no reply" "$(count "$OUT" '"id":51')" "0"
-assert_eq "missing params: absent params produces no reply" "$(count "$OUT" '"id":52')" "0"
-# FAIL: #1980 (a request with unusable params must get a response — -32602
-#            InvalidParams — not silence; the client waits on that id forever)
-# assert_has "missing params: params={} errors -32602" "$OUT" '"id":51,"error":'
-# assert_has "missing params: absent params errors -32602" "$OUT" '"id":52,"error":'
+assert_has "missing params: params={} errors -32602" "$OUT" '"id":51,"error":'
+assert_has "missing params: absent params errors -32602" "$OUT" '"id":52,"error":'
 
-# The same silence affects every position-taking method, not just hover.
+# The same -32602 reply covers every position-taking method, not just hover.
 stream_reset
 msg "$INIT"
 msg "$INITED"
@@ -829,9 +820,9 @@ msg '{"jsonrpc":"2.0","id":58,"method":"shutdown"}'
 msg "$EXITN"
 lsp_run
 assert_has "missing params control: session survives all four" "$OUT" '"id":58,"result":null'
-assert_eq "missing params: definition/references/completion/documentSymbol all silent" \
-    "$(count "$OUT" '"id":54')$(count "$OUT" '"id":55')$(count "$OUT" '"id":56')$(count "$OUT" '"id":57')" \
-    "0000"
+assert_eq "missing params: definition/references/completion/documentSymbol all error" \
+    "$(count "$OUT" '"id":54,"error":')$(count "$OUT" '"id":55,"error":')$(count "$OUT" '"id":56,"error":')$(count "$OUT" '"id":57,"error":')" \
+    "1111"
 
 # ========================================================================
 # 6. document-store edges
@@ -957,33 +948,27 @@ skipspace "line-comment-control" '(define x 1)\n;; fine\n' '(define x 1)\n;; fin
 assert_has "skipspace control: a good trailing comment is clean in the lsp" "$OUT" '"diagnostics":\[\]'
 assert_eq "skipspace control: and clean in check too" "$(count "$SKIP_CHK" '"severity":')" "0"
 
-# An unterminated block comment at the START swallows the entire file: the LSP
-# reports no diagnostic AND documentSymbol returns nothing, so a real error two
-# lines down is invisible in an editor.
+# An unterminated block comment at the START must still be reported: the LSP
+# surfaces the KP1001 reader error rather than swallowing it, while
+# documentSymbol (navigation, not diagnostics) rightly returns nothing.
 skipspace "leading-block-comment" '#| unterminated\n(if)\n' '#| unterminated\n(if)\n'
 assert_eq "skipspace: check reports KP1001 for a leading unterminated block comment" \
     "$(first_code "$SKIP_CHK")" "KP1001"
-assert_has "skipspace: the lsp reports nothing at all" "$OUT" '"diagnostics":\[\]'
 assert_has "skipspace: and documentSymbol returns an empty list" "$OUT" '"id":72,"result":\[\]'
-# FAIL: #1981 (`hasMore() catch false` discards every reader error raised while
-#            skipping intertoken space, so an unterminated block comment hides
-#            the whole file from diagnostics and documentSymbol)
-# assert_eq "skipspace: leading block comment is reported by the lsp too" \
-#     "$(first_code "$OUT")" "KP1001"
+assert_eq "skipspace: leading block comment is reported by the lsp too" \
+    "$(first_code "$OUT")" "KP1001"
 
 # The same at end-of-file, and for a dangling datum comment.
 skipspace "trailing-block-comment" '(define x 1)\n#| unterminated\n' '(define x 1)\n#| unterminated\n'
 assert_eq "skipspace: check reports KP1001 for a trailing unterminated block comment" \
     "$(first_code "$SKIP_CHK")" "KP1001"
 assert_has "skipspace control: the good datum before it is still found" "$OUT" '"name":"x"'
-# FAIL: #1980 (same mechanism at end of file)
-# assert_eq "skipspace: trailing block comment is reported by the lsp too" \
-#     "$(first_code "$OUT")" "KP1001"
+assert_eq "skipspace: trailing block comment is reported by the lsp too" \
+    "$(first_code "$OUT")" "KP1001"
 
 skipspace "dangling-datum-comment" '(define x 1)\n#;\n' '(define x 1)\n#;\n'
 assert_eq "skipspace: check reports KP1001 for a dangling #;" "$(first_code "$SKIP_CHK")" "KP1001"
-# FAIL: #1981 (same mechanism for a datum comment with nothing to comment out)
-# assert_eq "skipspace: dangling #; is reported by the lsp too" "$(first_code "$OUT")" "KP1001"
+assert_eq "skipspace: dangling #; is reported by the lsp too" "$(first_code "$OUT")" "KP1001"
 
 # Deeply nested input must be reported, not overflow the stack.
 DEEP="$(printf '(%.0s' $(seq 1 5000))1$(printf ')%.0s' $(seq 1 5000))"
@@ -1017,8 +1002,8 @@ assert_has "position: negative line/character clamps to null, no crash" "$OUT" '
 posq 99999 0 '(car x)\n(display abc)\n'
 assert_has "position: line past end of document returns null" "$OUT" '"id":80,"result":null'
 
-# A character past end-of-line is clamped to the end of the *document*, not the
-# end of the line, so it can resolve a symbol on a later line entirely.
+# A character past end-of-line must stop at the line end, not walk into a later
+# line and resolve a symbol there.
 posq 0 200 '(car x)\ndisplay'
 # Control: the byte-identical text with a trailing newline correctly returns
 # null, which isolates the overrun to the document-end clamp.
@@ -1027,10 +1012,7 @@ posq 0 200 '(car x)\ndisplay\n'
 CTRL_OUT="$OUT"
 assert_has "eol-overrun control: with a trailing newline the answer is null" "$CTRL_OUT" '"id":80,"result":null'
 posq 0 200 '(car x)\ndisplay'
-assert_has "eol-overrun: line 0 char 200 resolves a line-1 symbol" "$OUT" '\*\*procedure\*\* `display`'
-# FAIL: #1980 (lineColToOffset clamps to text.len, so a column past end-of-line
-#            walks into later lines instead of stopping at the line end)
-# assert_has "eol-overrun: character past end of line returns null" "$OUT" '"id":80,"result":null'
+assert_has "eol-overrun: character past end of line returns null" "$OUT" '"id":80,"result":null'
 
 # ========================================================================
 # 9. cross-document state leakage
@@ -1043,15 +1025,16 @@ BDOC="file:///lsp-audit/leak-b.scm"
 MACRO='(define-syntax my-if (syntax-rules () ((_ a) (if a 1 2))))\n'
 USE='(my-if)\n'
 
-# Control 1: B alone is clean — `(my-if)` with no macro in scope is just a call.
+# Control 1: B alone is just a KP4001 unknown-variable warning — `(my-if)` with
+# no macro in scope is a call to an undefined name, not a compile error.
 stream_reset
 msg "$INIT"
 msg "$INITED"
 did_open "$BDOC" "$USE"
 msg "$EXITN"
 lsp_run
-assert_has "leak control 1: B alone is diagnosed clean" "$OUT" \
-    '"uri":"'"$BDOC"'","diagnostics":\[\]'
+assert_has "leak control 1: B alone is a KP4001 warning" "$OUT" '"code":"KP4001"'
+assert_lacks "leak control 1: B alone has no KP2001 compile error" "$OUT" '"code":"KP2001"'
 
 # Control 2: macro and misuse in one document really is KP2001 — so KP2001 is
 # exactly the verdict a leaked macro would produce.
@@ -1087,9 +1070,10 @@ did_open "$BDOC" "$USE"
 msg "$EXITN"
 lsp_run
 # Control: closing A does publish its clearing notification, so didClose ran.
-# (With the leak fixed, B's own open is clean too, so all three frames are
-# empty arrays; the count was 2 under the bug because B carried A's macro.)
-assert_eq "leak control 3: didClose published its empty array" "$(count "$OUT" '"diagnostics":[]')" "3"
+# A's open and A's close are both empty (A defines its macro cleanly); B's own
+# open carries the KP4001 unknown-variable warning, so those are the only two
+# empty arrays.
+assert_eq "leak control 3: didClose published its empty array" "$(count "$OUT" '"diagnostics":[]')" "2"
 assert_eq "leak: closing A restores B's clean verdict" \
     "$(count "$OUT" '"code":"KP2001"')" "0"
 


### PR DESCRIPTION
Fixes #1980 and #1981 — the six protocol/lifecycle defects and the four diagnostics divergences from the Phase 6D LSP audit.

## Protocol and lifecycle (kaappi#1980)

- **Unusable params get a reply** — `hover`/`definition`/`references`/`completion`/`documentSymbol` now answer `-32602 InvalidParams` instead of silently stranding the client on that id.
- **Malformed headers are survivable** — a non-numeric, missing, or zero `Content-Length` skips that frame and resynchronises on the next, instead of ending the whole session.
- **Shutdown state exists** — `shutdown` before `initialize` errors `-32002`; requests after `shutdown` error `-32600`.
- **Exit code contract** — `exit` without a prior `shutdown` exits status 1.
- **End-of-line overrun** — `lineColToOffset` clamps to the line end, not the document end.
- **Unrepresentable ids** — a `null`/float request id answers an Invalid Request with `id: null` (`-32600`), never a fabricated `id: 0`.

## Diagnostics (kaappi#1981)

- `runDiagnostics` now drives the exact `kaappi check` analysis (a new `src/check.zig` `analyzeSource`, shared by `run`, `analyzeForTest`, and the LSP), so the two surfaces share the analysis, not just the serializer:
  - a whole-file read error (e.g. a leading unterminated block comment) is reported, not swallowed
  - every failing form is reported, not just the first
  - KP4xxx lints (severity-2 warnings included) reach the editor
  - ranges carry the real span, not a whole-line `0..999` sentinel

## Tests & docs

- `tests/scheme/lsp/lsp.sh` enables all previously disabled `# FAIL: #1980`/`#1981` assertions (now 184, up from 152), each beside a control.
- `docs/dev/diagnostics-json.md` notes the `check --diagnostics=json` stdout exception and the shared analysis.