### PR TITLE
Fix WASM file-backed .sld loading and command-line/lib-path setup (Fixes #2108, #2109)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1232,7 +1232,13 @@ jobs:
       - name: Platform gate diagnostics (kaappi#1972)
         run: wasmtime run --dir=. zig-out/bin/kaappi.wasm tests/wasm/platform-gates.scm
 
-      # The four steps above are hand-written WASM-only programs that assert
+      - name: File-backed library loading (kaappi#2108, #2109)
+        run: wasmtime run --dir=. zig-out/bin/kaappi.wasm tests/wasm/library-load.scm
+
+      - name: (command-line) reports the script path (kaappi#2109)
+        run: wasmtime run --dir=. zig-out/bin/kaappi.wasm tests/wasm/command-line.scm
+
+      # The steps above are hand-written WASM-only programs that assert
       # their own results. The differential below instead runs the SHARED
       # corpus on both tiers and requires the WASM output to match the
       # interpreter's byte-for-byte, which is what catches a WASM build that

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -276,12 +276,12 @@ above.
 **Four** files in the corpus are exempt and say so in their own headers —
 `smoke/large-index-bounds-1912.scm`, `smoke/deep-nesting-print.scm`,
 `smoke/deep-nesting-print-tier-margin.scm` and
-`continuations/coroutine-repl-echo.scm`. The first three must stay free of
-file-backed `.sld` imports because `(import (srfi 64))` fails at library load
-on WASM (kaappi#2108) and `run-wasm-differential.sh` would reclassify them as
-LIBDIFF; the fourth must leave its top-level forms bare because consuming their
-values is what hid the bug it exists to catch. All four carry a hand-rolled
-`(exit 1)` instead.
+`continuations/coroutine-repl-echo.scm`. The first three are cross-tier probes
+whose bare top-level forms are the measurement, so they stay import-free to run
+identically on every tier rather than being wrapped in a SRFI-64 suite; the
+fourth must leave its top-level forms bare because consuming their values is
+what hid the bug it exists to catch. All four carry a hand-rolled `(exit 1)`
+instead.
 
 `tests/scheme/CLAUDE.md` holds the single inventory table (56 verdictless
 files → 52 converted + 4 exempt, plus `fiber-error-handling.scm` = 53

--- a/src/main.zig
+++ b/src/main.zig
@@ -289,7 +289,7 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         var cmd_args: std.ArrayList([]const u8) = .empty;
         defer cmd_args.deinit(allocator);
         while (wasi_args.next()) |arg| {
-            cmd_args.append(allocator, arg) catch return;
+            try cmd_args.append(allocator, arg);
         }
         if (cmd_args.items.len == 0) {
             writeStderr("kaappi-wasm: no file specified\n");

--- a/src/main.zig
+++ b/src/main.zig
@@ -278,10 +278,34 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
         var wasi_args = try init.args.iterateAllocator(allocator);
         defer wasi_args.deinit();
         _ = wasi_args.skip(); // skip argv[0]
-        const file_path = wasi_args.next() orelse {
+
+        // The non-WASM path below populates vm.command_line_args (from
+        // opts.scriptArgs()) and vm.lib_paths (script dir + --lib-path +
+        // auto-discovered dirs), but this branch returns before either, so
+        // both keep their empty defaults. Repopulate them from the WASI argv
+        // the branch already iterates: (command-line) must report the script
+        // path (R7RS 6.14) and a sibling .sld must resolve via the script's
+        // own directory. (kaappi#2109)
+        var cmd_args: std.ArrayList([]const u8) = .empty;
+        defer cmd_args.deinit(allocator);
+        while (wasi_args.next()) |arg| {
+            cmd_args.append(allocator, arg) catch return;
+        }
+        if (cmd_args.items.len == 0) {
             writeStderr("kaappi-wasm: no file specified\n");
             return;
-        };
+        }
+        const file_path = cmd_args.items[0];
+        vm.command_line_args = cmd_args.items;
+
+        var script_dir_buf: [1][]const u8 = undefined;
+        var script_dir_count: usize = 0;
+        if (std.mem.lastIndexOfScalar(u8, file_path, '/')) |pos| {
+            script_dir_buf[0] = if (pos == 0) file_path[0..1] else file_path[0..pos];
+            script_dir_count = 1;
+        }
+        vm.lib_paths = script_dir_buf[0..script_dir_count];
+
         try runFile(vm, file_path);
         return;
     }

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -218,6 +218,19 @@ fn winOpen(path: []const u8, oflag: c_int, pmode: c_int) OpenError!fd_t {
 
 pub fn openRead(path: [:0]const u8) OpenError!fd_t {
     if (comptime is_windows) return winOpen(path, win.O_RDONLY, 0);
+    if (comptime is_wasm) {
+        // WASI has no AT.FDCWD: paths resolve only relative to a preopened
+        // directory fd. fd 3 is the first preopened dir — the working
+        // directory that both wasmtime `--dir=.` and the browser shim mount —
+        // the same convention file_utils.readWholeFile already uses. Without
+        // this branch, resolveLibraryPath's existence probe failed for every
+        // candidate path and no file-backed .sld was importable on wasm32
+        // even when the host mounted the directory (kaappi#2108).
+        var result_fd: std.os.wasi.fd_t = undefined;
+        const rc = std.os.wasi.path_open(3, .{ .SYMLINK_FOLLOW = true }, path.ptr, path.len, .{}, .{ .FD_READ = true, .FD_SEEK = true }, .{ .FD_READ = true }, .{}, &result_fd);
+        if (rc != .SUCCESS) return error.OpenFailed;
+        return @as(fd_t, @intCast(result_fd));
+    }
     return std.posix.openatZ(std.posix.AT.FDCWD, path, .{}, 0) catch error.OpenFailed;
 }
 

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -339,8 +339,10 @@ pub fn libraryIsAvailable(vm: *VM, lib_name: []const u8, lib_name_list: Value) b
     // mount at a given relative path -- unlike a normal install, there's no
     // guarantee lib/ is reachable there. Preferring the embedded copy when
     // there is one sidesteps that packaging dependency for exactly this
-    // library; anything else still falls through to the normal disk check
-    // (unaffected -- a host that does mount lib/ still serves those fine).
+    // library; anything else still falls through to the normal disk check,
+    // which resolves against the preopened directory since platform.openRead
+    // grew its WASI branch (kaappi#2108) -- so a host that does mount lib/
+    // serves those fine.
     if (is_wasm) {
         var path_buf: [512]u8 = undefined;
         if (buildLibRelPath(lib_name_list, &path_buf) catch null) |rel_path| {

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -93,8 +93,10 @@ Two of the four (`deep-nesting-print-tier-margin.scm`,
 nothing else, so their verdict does not depend on Kaappi's ambient script-mode
 globals. That is safe because `(scheme process-context)` is a **built-in**
 library rather than a file-backed `.sld`, verified under wasmtime. The other
-two are `KNOWN_DIFFS` probes whose divergence is the measurement, so they are
-left exactly as they are.
+two are cross-tier probes: `deep-nesting-print.scm` is a `KNOWN_DIFFS` probe
+whose divergence is the measurement, while `large-index-bounds-1912.scm` is a
+regression probe whose tiers now agree (its `KNOWN_DIFFS` entry was deleted);
+both are left exactly as they are.
 
 ## Adding a test
 

--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -83,9 +83,9 @@ to; the fourth is exempt for an unrelated reason:
 
 | File | Why it cannot use `(srfi 64)` |
 |------|-------------------------------|
-| `smoke/large-index-bounds-1912.scm` | Must stay import-free: it is the cross-tier large-index regression probe for #1912 (fixed), and `(import (srfi 64))` fails at library load on WASM (kaappi#2108), which `run-wasm-differential.sh` classifies as LIBDIFF — dropping the file from the comparison it exists for |
-| `smoke/deep-nesting-print.scm` | Same, for its own `KNOWN_DIFFS` entry against #2107 |
-| `smoke/deep-nesting-print-tier-margin.scm` | Same, and it is the cross-tier positive control for #2107 |
+| `smoke/large-index-bounds-1912.scm` | Cross-tier large-index regression probe for #1912 (fixed); stays import-free so its bare top-level forms run identically on every tier |
+| `smoke/deep-nesting-print.scm` | Cross-tier probe for its own `KNOWN_DIFFS` entry against #2107; the bare top-level display is the measurement |
+| `smoke/deep-nesting-print-tier-margin.scm` | Cross-tier positive control for #2107; the bare top-level display is the measurement |
 | `continuations/coroutine-repl-echo.scm` | Its top-level forms must stay **bare** so the value-echo path runs; consuming them in `test-equal` is what hid the original bug |
 
 Two of the four (`deep-nesting-print-tier-margin.scm`,

--- a/tests/scheme/differential/probes/deep-print-depth.scm
+++ b/tests/scheme/differential/probes/deep-print-depth.scm
@@ -10,8 +10,7 @@
 ;; MAX_PRINT_DEPTH truncation cliff, and 20000 is far past both.
 ;;
 ;; No imports: (scheme base)/(scheme write) bindings are ambient in a main
-;; script, and this probe must stay runnable on the wasm tier, where
-;; file-backed .sld imports are unavailable (kaappi#2108).
+;; script, and this probe must stay runnable on every execution tier.
 
 (define (nest n acc) (if (= n 0) acc (nest (- n 1) (list acc))))
 

--- a/tests/scheme/differential/run-wasm-differential.sh
+++ b/tests/scheme/differential/run-wasm-differential.sh
@@ -24,26 +24,20 @@
 # ---------------------------------------------------------------------------
 # READ THIS BEFORE TRUSTING A GREEN RUN
 # ---------------------------------------------------------------------------
-# Most of the corpus cannot run on this tier at all, and the reason is a bug,
-# not a property of WASM.
+# As of kaappi#2108/#2109 the corpus runs on this tier: file-backed `.sld`
+# loading works (platform.openRead grew its WASI branch) and the WASM entry
+# populates vm.lib_paths / vm.command_line_args.  The compared count covers
+# the whole corpus minus the documented exclusions below.
 #
-# MEASURED 2026-08-01 over 591 corpus files (smoke, compliance, audit,
-# continuations, hygiene, srfi, probes): **401 of them fail on WASM with
-# nothing but `KP2001 library not found`**, because no file-backed `.sld` is
-# importable there even when the host mounts the directory (kaappi#2108 —
-# `platform.openRead` has no WASI branch, so `resolveLibraryPath`'s existence
-# probe fails for every candidate path).  Only registry built-ins and the two
-# `embedded_libraries` entries resolve.
-#
-# So the comparison is structurally narrow: ~184 of 591 files actually execute
-# on both tiers.  This script REPORTS that number rather than leaving it to be
-# assumed — the summary prints "excluded (no .sld on WASM)" — for the same
-# reason the sibling reports its optimiser-vacuity meter.  When kaappi#2108 is
-# fixed, that count should collapse and the compared count should jump; if it
-# does not, something else has broken.
-#
-# The honest reading of a green run today: the ~184 files that CAN run agree
-# byte-for-byte, and the other ~400 are untested on this tier.
+# LIBDIFF is still counted and reported, not because it is expected to be
+# zero, but because a library that cannot load is the first thing a WASM file
+# fails on: a regression in file-backed loading shows up there as a jump in
+# that count rather than as a pile of unrelated DIFFs.  Before #2108 it held
+# ~231 files; since the fix it holds only the libraries deliberately refused on
+# this tier — `(srfi 18)`, `(srfi 170)`, `(srfi 192)` and `(kaappi ffi)`,
+# which `Lib.wasmAvailable()` refuses to register (no OS threads, no
+# filesystem, no FFI).  That set is the baseline; a *growing* count is the
+# regression signal.
 #
 # ---------------------------------------------------------------------------
 # Exclusions
@@ -51,7 +45,9 @@
 # Three buckets, all measured rather than guessed, all reported:
 #
 # (a) LIBDIFF — the wasm run's only complaint is `library not found` and the
-#     native run has none.  kaappi#2108.  Counted, not a failure.
+#     native run has none.  Now holds only the `Lib.wasmAvailable()`-refused
+#     libraries above; anything beyond that set is a file-backed .sld
+#     regression.
 #
 # (b) PLATFORM — the wasm run hit a degradation the engine reports
 #     deliberately and CLAUDE.md documents: no filesystem access (the
@@ -71,25 +67,22 @@
 # WHY THE `agree` COUNT DROPPED IN kaappi#2116.  Converting the corpus's 56
 # verdictless files to the SRFI-64 exit-on-fail shape gave each of them an
 # `(import (srfi 64))`, and `(srfi 64)` is a file-backed `.sld`, which wasm32
-# cannot load (kaappi#2108).  Measured on macOS aarch64 at e62b90eb: `agree`
-# 176 -> 124 and LIBDIFF 179 -> 231, 52 files moving from compared to excluded.
-# That is a real, temporary reduction in this harness's reach, and it reverses
-# entirely when #2108 lands — it is not a sign that those files stopped
-# working.  Three files were deliberately left free of file-backed `.sld`
-# imports for exactly this reason and carry a hand-rolled `(exit 1)` instead,
-# because LIBDIFF would have destroyed what they exist to measure --
-# `deep-nesting-print.scm` and
-# `large-index-bounds-1912.scm` (the latter's KNOWN_DIFFS entry for #1912 was
-# deleted when the fix made the tiers agree again -- it remains the cross-tier
-# large-index probe) and `deep-nesting-print-tier-margin.scm` (the positive
-# control that keeps #2107's margin under watch).  Do not "tidy" those three
-# into SRFI-64.
+# could not load before kaappi#2108.  Measured on macOS aarch64 at e62b90eb:
+# `agree` 176 -> 124 and LIBDIFF 179 -> 231, 52 files moving from compared to
+# excluded.  That reduction reversed entirely when #2108 landed — it was never
+# a sign that those files stopped working.  Three files were left free of
+# file-backed `.sld` imports and carry a hand-rolled `(exit 1)` instead because
+# they are cross-tier probes whose bare top-level forms are the measurement:
+# `deep-nesting-print.scm` and `large-index-bounds-1912.scm` (the latter's
+# KNOWN_DIFFS entry for #1912 was deleted when the fix made the tiers agree
+# again — it remains the cross-tier large-index probe) and
+# `deep-nesting-print-tier-margin.scm` (the positive control that keeps
+# #2107's margin under watch).  Do not "tidy" those three into SRFI-64.
 # They are three of the FOUR hand-rolled-verdict files; the fourth,
 # `continuations/coroutine-repl-echo.scm`, is exempt for an unrelated reason and
 # is not a tier probe.  tests/scheme/CLAUDE.md holds the single inventory table.
 # `deep-nesting-print-tier-margin.scm` does import `(scheme process-context)`
-# for `exit` -- a BUILT-IN library, not a `.sld`, so it stays out of LIBDIFF;
-# verified under wasmtime that its output and exit status are unchanged.
+# for `exit` — a BUILT-IN library, not a `.sld`.
 #
 # Unrelated pre-existing observation from that measurement, recorded so it is
 # not re-derived: `deep-nesting-print.scm`'s KNOWN_DIFFS entry is reported
@@ -190,21 +183,16 @@ fi
 #   structure deeper than 847 aborts the module (shadow-stack underflow);
 #   MAX_PRINT_DEPTH's 1024 guard is unreachable on wasm32.  This file nests
 #   200000 deep, so it aborts where native truncates and passes.
-# command-line-o-flag.scm     kaappi#2109 — (command-line) is '() on WASM
-#   because main.zig's WASM entry returns before vm.command_line_args is set.
-# condexpand-include-lib-868-879.scm  kaappi#2108 — cond-expand (library …)
-#   over a file-backed .sld, the same resolver failure as the LIBDIFF bucket,
-#   but reported through cond-expand rather than a KP2001, so it does not
-#   match that bucket's signature.
 # large-index-bounds-1912.scm kaappi#1912 -- FIXED: index arguments are now
 #   bounds-checked in u64 before any narrowing to usize (usize = u32 on
 #   wasm32), so 2^32+1 raises instead of aliasing element 1.  The KNOWN_DIFFS
 #   entry was deleted when the tiers agreed; the file remains in the corpus as
 #   the cross-tier large-index regression probe.
+# command-line-o-flag.scm and condexpand-include-lib-868-879.scm were listed
+#   here for kaappi#2109 and kaappi#2108 respectively; both fixes landed, the
+#   entries were deleted when the tiers agreed again.
 KNOWN_DIFFS="
 deep-nesting-print.scm
-command-line-o-flag.scm
-condexpand-include-lib-868-879.scm
 "
 
 is_known_diff() {
@@ -369,7 +357,7 @@ check_file() {
     if wasm_only_match "$LIB_SIGNATURE" "$d/base.err" "$d/wasm.err"; then
         LIBDIFF=$((LIBDIFF + 1))
         note_stale "$f"
-        [ "$VERBOSE" = "1" ] && echo "  LIBDIFF  $f  (no .sld on WASM — kaappi#2108)"
+        [ "$VERBOSE" = "1" ] && echo "  LIBDIFF  $f  (no .sld on WASM)"
         return 0
     fi
     if wasm_only_match "$PLATFORM_SIGNATURE" "$d/base.err" "$d/wasm.err"; then
@@ -456,7 +444,7 @@ echo "  skipped (native timeout):        $BASE_TIMEOUT"
 echo "  compared:                        $COMPARED"
 echo ""
 echo "  agree (stdout+exit+stderr):      $AGREE"
-echo "  excluded, no .sld on WASM:       $LIBDIFF  (kaappi#2108)"
+echo "  excluded, no .sld on WASM:       $LIBDIFF  (wasmAvailable-refused libs; anything more is a regression)"
 echo "  excluded, documented degradation:$PLATFORM"
 echo "  nondeterministic (excluded):     $NONDET"
 echo "  known divergences hit:           $KNOWN (suppressed; see KNOWN_DIFFS)"
@@ -468,7 +456,8 @@ echo "  wasm hangs:                      $WASM_TIMEOUT"
 if [ "$COMPARED" -gt 0 ] && [ "$LIBDIFF" -gt $((COMPARED / 2)) ]; then
     echo ""
     echo "  NOTE: over half the corpus could not run on this tier at all"
-    echo "        (kaappi#2108).  A green result here covers $AGREE files, not $COMPARED."
+    echo "        (a file-backed .sld regression).  A green result here covers"
+    echo "        $AGREE files, not $COMPARED."
 fi
 if [ -n "$STALE" ]; then
     echo ""

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -496,11 +496,10 @@ check_unreachable_tests() {
 # what let 55 accumulate.
 #
 # `test-begin` is deliberately not made mandatory: four files carry a bare
-# `(exit 1)` instead and say so in their own headers — three must stay free of
-# file-backed `.sld` imports to keep working on other execution tiers
-# (`(import (srfi 64))` fails at library load on WASM, kaappi#2108), and
-# coroutine-repl-echo.scm must leave its top-level forms bare. See the
-# inventory table in tests/scheme/CLAUDE.md.
+# `(exit 1)` instead and say so in their own headers — three are cross-tier
+# probes that must keep their top-level forms bare to run identically on every
+# tier, and coroutine-repl-echo.scm must leave its top-level forms bare. See
+# the inventory table in tests/scheme/CLAUDE.md.
 check_verdictless_tests() {
     echo "=== Verdict-channel check ==="
     local found=0 dir f

--- a/tests/scheme/smoke/deep-nesting-print-tier-margin.scm
+++ b/tests/scheme/smoke/deep-nesting-print-tier-margin.scm
@@ -23,22 +23,18 @@
 ;;; up here as a tier divergence rather than silently eating the headroom.
 ;;;
 ;;; No `(srfi 64)`, so it signals failure with a bare `(exit 1)` rather than the
-;;; epilogue every other file in the corpus uses (kaappi#2116).
-;;; `(import (srfi 64))` would make the WASM leg fail at library load
-;;; (kaappi#2108, no .sld on WASM), and run-wasm-differential.sh classifies
-;;; that as LIBDIFF — which would stop this file being the cross-tier control
-;;; it exists to be. The printed PASS/FAIL lines are the cross-tier comparison
-;;; channel and are unchanged; the exit status is the verdict layered on top.
+;;; epilogue every other file in the corpus uses (kaappi#2116). A SRFI-64
+;;; suite would consume the bare top-level forms that are the cross-tier
+;;; comparison channel. The printed PASS/FAIL lines are that channel and are
+;;; unchanged; the exit status is the verdict layered on top.
 ;;; Until #2116 it had no verdict at all: both checks below printed `FAIL:`
 ;;; and exited 0, which neither runner reads as a failure.
 ;;;
 ;;; The one import is deliberate and minimal: `exit` comes from a library
 ;;; rather than from Kaappi's ambient script-mode globals, so the verdict does
 ;;; not depend on that registration. `(scheme process-context)` is a BUILT-IN
-;;; library, not a file-backed `.sld`, so it does NOT put this file in the
-;;; #2108 LIBDIFF bucket — verified directly under wasmtime 46.0.0, where the
-;;; output and exit status are byte-identical with and without it. Everything
-;;; else stays ambient, which is what keeps the file cheap on every tier.
+;;; library, not a file-backed `.sld`. Everything else stays ambient, which
+;;; is what keeps the file cheap on every tier.
 
 (import (scheme process-context))
 

--- a/tests/scheme/smoke/deep-nesting-print.scm
+++ b/tests/scheme/smoke/deep-nesting-print.scm
@@ -6,11 +6,9 @@
 ;; file in the corpus uses (kaappi#2116). This file is listed in
 ;; run-wasm-differential.sh's KNOWN_DIFFS against kaappi#2107 — on wasm32 the
 ;; 200000-deep car nest was expected to exhaust the shadow stack and abort the
-;; module. `(import (srfi 64))` would make the WASM run fail earlier, at
-;; library load (kaappi#2108), which the harness classifies as LIBDIFF —
-;; excluding the file from comparison entirely and so retiring the probe.
-;; Measured at e62b90eb: converting it moved the harness's `agree` count from
-;; 124 to 123 and LIBDIFF from 231 to 232, i.e. this file specifically.
+;; module. The bare top-level `(display ...)`/`(write ...)` below is the
+;; measurement, so it stays free of a SRFI-64 suite that would consume those
+;; forms rather than let them run at top level.
 ;;
 ;; Separately, and NOT caused by that: its KNOWN_DIFFS entry is already
 ;; reported STALE at e62b90eb with this file unmodified — on the current

--- a/tests/scheme/smoke/large-index-bounds-1912.scm
+++ b/tests/scheme/smoke/large-index-bounds-1912.scm
@@ -29,11 +29,9 @@
 ;;; Deliberately import-free so it runs on every tier — which is why this is
 ;;; the one file in the corpus that signals failure with a bare `(exit 1)`
 ;;; rather than the SRFI-64 epilogue every other file uses (kaappi#2116).
-;;; `(import (srfi 64))` would make the WASM leg fail at library load
-;;; (kaappi#2108, no .sld on WASM), and run-wasm-differential.sh classifies
-;;; that as LIBDIFF — dropping this file from the cross-tier comparison it
-;;; exists for. The printed lines are unchanged and remain the cross-tier
-;;; comparison channel; the exit status is the native verdict layered on top.
+;;; A SRFI-64 suite would consume the bare top-level forms that are the
+;;; cross-tier comparison channel. The printed lines are unchanged and remain
+;;; that channel; the exit status is the native verdict layered on top.
 
 (define v (vector 10 11 12 13))
 (define s (make-string 4 #\a))

--- a/tests/wasm/command-line.scm
+++ b/tests/wasm/command-line.scm
@@ -1,0 +1,34 @@
+;;; Kaappi WASM (command-line) test — regression test for kaappi#2109.
+;;;
+;;; main.zig's WASM entry returned before vm.command_line_args was set, so
+;;; (command-line) returned '() on wasm32 while every other target reported the
+;;; script path as its first element (R7RS 6.14). The fix repopulates the field
+;;; from the WASI argv the entry already iterates.
+;;;
+;;; Any FAIL line fails CI.
+
+(import (scheme base) (scheme write) (scheme process-context))
+
+(define failures 0)
+(define (check label ok)
+  (display (if ok "PASS " "FAIL "))
+  (display label)
+  (newline)
+  (if (not ok) (set! failures (+ failures 1))))
+
+(define args (command-line))
+
+(define (string-suffix? s suffix)
+  (let ((ls (string-length s))
+        (lx (string-length suffix)))
+    (and (>= ls lx)
+         (string=? (substring s (- ls lx) ls) suffix))))
+
+(check "(command-line) is a non-empty list" (and (list? args) (>= (length args) 1)))
+(check "(command-line) first element is a string" (string? (car args)))
+(check "(command-line) first element names this script"
+       (string-suffix? (car args) "command-line.scm"))
+
+(if (> failures 0)
+    (begin (display "COMMAND-LINE TESTS FAILED") (newline) (exit 1))
+    (begin (display "all command-line tests passed") (newline)))

--- a/tests/wasm/library-load.scm
+++ b/tests/wasm/library-load.scm
@@ -1,0 +1,39 @@
+;;; Kaappi WASM file-backed library loading test.
+;;;
+;;; Regression test for kaappi#2108 and the vm.lib_paths half of #2109.
+;;;
+;;; #2108: platform.openRead had no WASI branch, so resolveLibraryPath's
+;;; existence probe failed for every candidate path and no file-backed .sld
+;;; was importable on wasm32 even when the host mounted the directory. (srfi 2)
+;;; lives at lib/srfi/2.sld — a portable .sld, not a registry built-in — so its
+;;; import only succeeds when the resolver can actually open files through the
+;;; preopened directory.
+;;;
+;;; #2109: main.zig's WASM entry returned before vm.lib_paths was populated, so
+;;; a .sld beside the program was invisible. (wasm-fixtures sibling) lives in a
+;;; subdirectory next to this script (tests/wasm/wasm-fixtures/sibling.sld) and
+;;; is reachable only through the script-directory entry in vm.lib_paths.
+;;;
+;;; Any FAIL line fails CI.
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 2)
+        (wasm-fixtures sibling))
+
+(define failures 0)
+(define (check label ok)
+  (display (if ok "PASS " "FAIL "))
+  (display label)
+  (newline)
+  (if (not ok) (set! failures (+ failures 1))))
+
+(check "file-backed .sld loads through the preopened directory"
+       (equal? (and-let* ((x 1) (y 2)) (+ x y)) 3))
+(check "and-let* short-circuits on #f"
+       (eq? (and-let* ((x #f)) x) #f))
+(check "sibling .sld resolves through the script-directory lib path"
+       (eq? sibling-value 'from-sibling-sld))
+
+(if (> failures 0)
+    (begin (display "LIBRARY LOAD TESTS FAILED") (newline) (exit 1))
+    (begin (display "all library load tests passed") (newline)))

--- a/tests/wasm/wasm-fixtures/sibling.sld
+++ b/tests/wasm/wasm-fixtures/sibling.sld
@@ -1,0 +1,9 @@
+;;; Fixture for tests/wasm/library-load.scm — a file-backed .sld that is
+;;; reachable only through the script's own directory being on vm.lib_paths.
+;;; There is deliberately no copy under lib/, so the built-in "" and "lib/"
+;;; prefixes cannot resolve it (kaappi#2109).
+(define-library (wasm-fixtures sibling)
+  (import (scheme base))
+  (export sibling-value)
+  (begin
+    (define sibling-value 'from-sibling-sld)))


### PR DESCRIPTION
Fixes #2108 and fixes #2109 — two independent wasm32 tier divergences from the audit v2 Phase 4D sweep, fixed together in one PR because both break library loading on the WASM tier and share the same regression harness.

## #2108 — no file-backed `.sld` is importable

`platform.openRead` had no WASI branch, so `resolveLibraryPath`'s existence probe failed for every candidate path and no file-backed `.sld` could be imported — even when the host had the directory mounted and the file was demonstrably readable (the same path read fine as a *script* but would not resolve as a *library*).

The fix gives `openRead` the same preopened-dir (fd 3) `path_open` branch `file_utils.readWholeFile` already had, so the probe finds `lib/srfi/*.sld` under the existing `"lib/"` prefix with no other change.

## #2109 — `(command-line)` is `'()` and `vm.lib_paths` is empty

`main.zig`'s WASM entry returned before the shared post-CLI block that populates `vm.command_line_args` and `vm.lib_paths`, so both kept their empty defaults. `(command-line)` — which R7RS 6.14 says has a first string — returned `()`, and a `.sld` beside the program was invisible (the script's own directory is the only route to it).

The fix repopulates both fields from the WASI argv the branch already iterates, rather than duplicating the CLI parser.

## Tests

- `tests/wasm/library-load.scm` — imports `(srfi 2)` (file-backed `.sld` via `lib/`) and a sibling fixture `.sld` (via the script-directory `lib_paths` entry), wired into the CI `wasm` job.
- `tests/wasm/command-line.scm` — asserts `(command-line)` is non-empty and names the script, wired into the CI `wasm` job.
- Removed the `command-line-o-flag.scm` and `condexpand-include-lib-868-879.scm` `KNOWN_DIFFS` entries from `run-wasm-differential.sh` now that the tiers agree again.
- Updated the stale #2108/#2109 references in the differential header, `docs/dev/testing.md`, `tests/scheme/CLAUDE.md`, and the three exempt probe-file headers.

## Verification

- `zig build wasm` + `zig build` clean; `zig fmt --check` clean.
- `zig build test` green.
- `wasmtime run --dir=.` passes `library-load.scm`, `command-line.scm`, and all four pre-existing `tests/wasm/*` programs.
- `run-wasm-differential.sh` — **0 divergences, 0 hangs** across 368 corpus files; `LIBDIFF` drops from ~231 to 48, where the remaining 48 are the libraries deliberately refused on this tier by `Lib.wasmAvailable()` (`(srfi 18)`, `(srfi 170)`, `(srfi 192)`, `(kaappi ffi)` — no OS threads/filesystem/FFI), not file-backed `.sld` failures.

