### PR TITLE
Bound default-hash recursion depth in SRFI 128 (fixes #2235)

### DIFF
--- a/lib/srfi/128.sld
+++ b/lib/srfi/128.sld
@@ -97,7 +97,20 @@
                 (car cmps)
                 (loop (cdr cmps))))))
 
-    (define (default-hash obj)
+    ;; Structural hashing is depth-bounded so a *cyclic* key (which is "an
+    ;; error" under SRFI 128, but must not abort the process) folds in a fixed
+    ;; sentinel past the cutoff instead of recursing forever into the KP3008
+    ;; stack cap. This mirrors the native equal? hash's MAX_HASH_DEPTH /
+    ;; DEEP_CUTOFF_HASH (src/primitives_hashtable.zig): the cutoff is a fixed
+    ;; constant, never derived from the object, so two equal? keys still hash
+    ;; alike. Acyclic values nesting less than max-hash-depth deep are
+    ;; unaffected. (kaappi#2235)
+    (define max-hash-depth 8)
+    (define (hash-cutoff) (modulo 668265261 (hash-bound)))
+
+    (define (default-hash obj) (default-hash-at obj 0))
+
+    (define (default-hash-at obj depth)
       (let ((reg (find-registered-hash obj)))
         (if reg
             (comparator-hash reg obj)
@@ -109,15 +122,20 @@
               ((symbol? obj) (symbol-hash obj))
               ((null? obj) 0)
               ((pair? obj)
-               (modulo (+ (default-hash (car obj))
-                          (* 31 (default-hash (cdr obj))))
-                       (hash-bound)))
+               (if (>= depth max-hash-depth)
+                   (hash-cutoff)
+                   (modulo (+ (default-hash-at (car obj) (+ depth 1))
+                              (* 31 (default-hash-at (cdr obj) (+ depth 1))))
+                           (hash-bound))))
               ((vector? obj)
-               (let loop ((i 0) (h 0))
-                 (if (= i (vector-length obj))
-                     (modulo h (hash-bound))
-                     (loop (+ i 1)
-                           (+ (* h 31) (default-hash (vector-ref obj i)))))))
+               (if (>= depth max-hash-depth)
+                   (hash-cutoff)
+                   (let loop ((i 0) (h 0))
+                     (if (= i (vector-length obj))
+                         (modulo h (hash-bound))
+                         (loop (+ i 1)
+                               (+ (* h 31)
+                                  (default-hash-at (vector-ref obj i) (+ depth 1))))))))
               ((bytevector? obj)
                (let loop ((i 0) (h 0))
                  (if (= i (bytevector-length obj))

--- a/tests/scheme/srfi/srfi128-audit.scm
+++ b/tests/scheme/srfi/srfi128-audit.scm
@@ -1,0 +1,54 @@
+;; SRFI 128 audit: default-hash must be depth-bounded (kaappi#2235).
+;;
+;; A cyclic key is "an error" under SRFI 128 / SRFI 146, but the failure mode
+;; must stay bounded (no uncatchable KP3008 stack overflow). Before the depth
+;; budget was added, a make-default-comparator hashmap keyed on a cyclic key
+;; recursed default-hash into the stack cap and aborted the process.
+
+(import (scheme base)
+        (scheme write)
+        (srfi 128)
+        (srfi 146 hash))
+
+(define failures 0)
+(define (check name got want)
+  (if (equal? got want)
+      (begin (display "ok   ") (display name) (newline))
+      (begin (set! failures (+ failures 1))
+             (display "FAIL ") (display name)
+             (display " got=") (write got)
+             (display " want=") (write want) (newline))))
+
+(define (ok-hash? h)
+  (and (exact-integer? h) (<= 0 h)))
+
+;; --- ordinary (acyclic) values still hash to stable non-negative integers ---
+(check "hash-number"   (ok-hash? (default-hash 42)) #t)
+(check "hash-negnum"   (ok-hash? (default-hash -7)) #t)
+(check "hash-string"   (ok-hash? (default-hash "hello")) #t)
+(check "hash-list"     (ok-hash? (default-hash '(1 2 3))) #t)
+(check "hash-nested"   (ok-hash? (default-hash '(1 (2 . 3) #(4) "five"))) #t)
+(check "hash-vector"   (ok-hash? (default-hash #(1 2 3))) #t)
+
+;; default-hash is a pure function of value: equal inputs hash equal, and the
+;; same input hashes the same twice.
+(check "hash-stable"   (= (default-hash '(1 2 3)) (default-hash '(1 2 3))) #t)
+(check "hash-equal-eq" (= (default-hash '(1 2)) (default-hash (list 1 2))) #t)
+
+;; --- the regression: a cyclic key must TERMINATE, not abort the process ---
+(define cyc (list 1 2 3))
+(set-cdr! (cddr cyc) cyc)          ; cyc is now a cyclic list
+
+;; default-hash on the cycle returns a bounded integer instead of overflowing.
+(check "cyclic-hash-terminates" (ok-hash? (default-hash cyc)) #t)
+
+;; and inserting the cyclic key into a make-default-comparator hashmap
+;; completes (this is the exact repro from the issue).
+(define hm (hashmap (make-default-comparator) cyc 'v))
+(check "cyclic-hashmap-insert" (hashmap-contains? hm cyc) #t)
+
+(newline)
+(if (= failures 0)
+    (begin (display "All SRFI 128 audit checks passed.") (newline))
+    (begin (display "FAILURES: ") (display failures) (newline)
+           (error "srfi128-audit failed")))


### PR DESCRIPTION
## Problem

`default-hash` in `lib/srfi/128.sld` recursed over pairs and vectors with **no depth limit**. Since #2044 threaded the comparator through `(srfi 146 hash)`, a `make-default-comparator` hashmap keys its table via `default-hash`, so a *cyclic* key ran the recursion into the `KP3008` stack cap — an **uncatchable process abort**:

```scheme
(import (scheme base) (srfi 128) (srfi 146 hash))
(define k (list 1 2 3)) (set-cdr! (cddr k) k)
(hashmap (make-default-comparator) k 'v)   ; was: KP3008 stack overflow
```

Before #2044 the table was keyed by the native `equal?` hash, whose depth cap (`MAX_HASH_DEPTH = 8`) silently absorbed the cycle. Cyclic keys are "an error" under both SRFI 128 and SRFI 146, so no *legal* program is affected — but the failure mode regressed from "silently accepted" to "uncatchable process abort".

## Fix

Thread a `depth` argument through the pair/vector recursion. Past a cutoff, fold in a fixed sentinel constant instead of recursing further. This mirrors the native precedent in `src/primitives_hashtable.zig` (`MAX_HASH_DEPTH = 8`, a fixed `DEEP_CUTOFF_HASH`):

- The cutoff is a **fixed constant, never derived from the object**, so two `equal?` keys still hash alike (the comparator-hash contract holds).
- **Acyclic values nesting less than the cutoff deep hash exactly as before** — the recurrence is byte-identical below the depth limit.
- Cyclic keys now produce a bounded, terminating hash instead of aborting the process.

## Tests

New `tests/scheme/srfi/srfi128-audit.scm`: asserts the exact issue repro (cyclic key hashed and inserted into a `make-default-comparator` hashmap) **terminates**, and that `default-hash` on ordinary numbers/strings/lists/vectors still returns stable non-negative integers with equal inputs hashing equal. The existing `tests/scheme/srfi/srfi128.scm` suite (94 checks) still passes.

Closes #2235

🤖 Generated with [Claude Code](https://claude.com/claude-code)