### PR TITLE
Subtract custom-port read-ahead from port-position (#1996)

### DIFF
--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -1061,7 +1061,7 @@ fn portPosition(args: []const Value) PrimitiveError!Value {
         return types.makeFixnum(@intCast(port.string_out_pos));
     }
     if (port.custom_backend) |cb| {
-        return portPositionFromCustomPort(cb);
+        return portPositionFromCustomPort(port, cb);
     }
     const os_pos = platform.seek(port.fd, 0, platform.SEEK_CUR);
     if (os_pos < 0) return primitives.argError("port-position", "port does not support positioning", .{});
@@ -1185,13 +1185,23 @@ fn setPortPositionBang(args: []const Value) PrimitiveError!Value {
 /// offset to the result. The spec's alternative "implementation-dependent
 /// object" case is available directly from get-position for code that
 /// calls it itself; it just isn't threaded through port-position.
-fn portPositionFromCustomPort(cb: *types.CustomBacking) PrimitiveError!Value {
+fn portPositionFromCustomPort(port: *types.Port, cb: *types.CustomBacking) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     if (cb.get_position_proc == types.FALSE)
         return primitives.argError("port-position", "port does not support positioning", .{});
     const result = try callCustomPortProc(vm, cb.get_position_proc, &[_]Value{});
     if (!types.isFixnum(result)) return raiseCustomPortBadReturn(vm, "get-position");
-    return result;
+    // get-position reports the SOURCE position, but the port holds its own
+    // lookahead the program has not consumed: the tail of the last read!
+    // burst (read_buf), a pushed-back peek_byte, and peek_extra. Subtract it,
+    // and add any pending write-buffer bytes -- the identical adjustment the
+    // fd path in portPosition applies to its os_pos (#1996).
+    const base: i64 = types.toFixnum(result);
+    const ahead: i64 = @as(i64, @intCast(port.read_buf_len)) +
+        @as(i64, if (port.peek_byte != null) 1 else 0) +
+        @as(i64, port.peek_extra_len);
+    const behind: i64 = @intCast(port.write_buf_len - port.write_buf_start);
+    return types.makeFixnum(base - ahead + behind);
 }
 
 /// SRFI 181: (set-port-position! custom-port pos). Flushes first via

--- a/tests/scheme/audit/primitives_srfi181-audit.scm
+++ b/tests/scheme/audit/primitives_srfi181-audit.scm
@@ -739,30 +739,32 @@
             (read-u8 p)
             (list a b c (port-position p))))))))
 
-;; FAIL: #1996 (port-position ignores port.read_buf: a burst read! over-reports)
-;; (test-equal "port-position subtracts the unconsumed remainder of a burst read!"
-;;   '(1 2 3)
-;;   (call-with-values (lambda () (byte-source (bytevector 10 20 30 40 50 60) 3))
-;;     (lambda (p src-pos)
-;;       (read-u8 p)
-;;       (let ((a (port-position p)))
-;;         (read-u8 p)
-;;         (let ((b (port-position p)))
-;;           (read-u8 p)
-;;           (list a b (port-position p)))))))
+;; #1996 (fixed): port-position subtracts the unconsumed remainder of a burst
+;; read! (port.read_buf) instead of returning the raw get-position result.
+(test-equal "port-position subtracts the unconsumed remainder of a burst read!"
+  '(1 2 3)
+  (call-with-values (lambda () (byte-source (bytevector 10 20 30 40 50 60) 3))
+    (lambda (p src-pos)
+      (read-u8 p)
+      (let ((a (port-position p)))
+        (read-u8 p)
+        (let ((b (port-position p)))
+          (read-u8 p)
+          (list a b (port-position p)))))))
 
 ;; SRFI 181 § Port positioning and peeking: "But if port-position is called
 ;; before the peeked character is read, the port must return its cached
 ;; position rather than calling the get-position procedure."
-;; FAIL: #1996 (peek is not position-cached: port-position reports the post-peek source position)
-;; (test-equal "port-position after a peek returns the cached pre-peek position"
-;;   '(0 1)
-;;   (call-with-values (lambda () (byte-source (bytevector 10 20 30) 1))
-;;     (lambda (p src-pos)
-;;       (peek-u8 p)
-;;       (let ((a (port-position p)))
-;;         (read-u8 p)
-;;         (list a (port-position p))))))
+;; #1996 (fixed): the peeked byte is unconsumed lookahead, so port-position
+;; subtracts it rather than reporting the post-peek source position.
+(test-equal "port-position after a peek returns the cached pre-peek position"
+  '(0 1)
+  (call-with-values (lambda () (byte-source (bytevector 10 20 30) 1))
+    (lambda (p src-pos)
+      (peek-u8 p)
+      (let ((a (port-position p)))
+        (read-u8 p)
+        (list a (port-position p))))))
 
 ;; #1942 (fixed): the setter predicate is its own function inspecting
 ;; set_position_proc, no longer an alias of the getter predicate.


### PR DESCRIPTION
## Problem

`portPositionFromCustomPort` (`src/primitives_io.zig`) called the custom port's
`get-position` and returned the result verbatim. But a custom port holds its
own unconsumed lookahead the program has not yet read:

- the tail of the last `read!` burst, in `port.read_buf` (`read_buf_len`),
- a pushed-back `port.peek_byte`,
- and `port.peek_extra` (`peek_extra_len`).

`get-position` reports the **source** position; `port-position` must report the
**port** position. So after a burst `read!` that fetched several bytes, or after
any peek, `port-position` over-reported. The fd-backed branch in the same
`portPosition` function already applies the correct adjustment — the custom-port
branch returned before reaching it.

## Fix

Pass the `Port` into `portPositionFromCustomPort` and apply the identical
ahead/behind arithmetic the fd path uses, with the `get-position` result as the
base: subtract unconsumed read-ahead, add any pending write-buffer bytes.

This also satisfies SRFI 181 §*Port positioning and peeking*: "if `port-position`
is called before the peeked character is read, the port must return its cached
position rather than calling the `get-position` procedure."

## Before / after

Repro from the issue (a `read!` that hands over 3 bytes per call):

```
(read-u8 p)        ; 10  — one byte consumed
(port-position p)  ; before: 4   after: 1
(read-u8 p)        ; 20  — two bytes consumed
(port-position p)  ; before: 4   after: 2
```

A peek no longer advances the reported position (was 1, now 0).

## Tests

Enabled the two `;; FAIL: #1996` assertions already present (and disabled) in
`tests/scheme/audit/primitives_srfi181-audit.scm`: burst-`read!` position
accounting, and cached position after a peek. The existing one-byte-per-call
control (no lookahead ⇒ source and port position coincide) stays green.
`zig build test` passes.

Closes #1996

🤖 Generated with [Claude Code](https://claude.com/claude-code)
