### PR TITLE
Route top-level import through load's evaluator and attribute errors to the loaded file

### DIFF
--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -335,8 +335,11 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
         contents.appendSlice(gc.allocator, tmp[0..n]) catch return PrimitiveError.OutOfMemory;
     }
 
-    // Parse and eval each expression
-    var reader = reader_mod.Reader.init(gc, contents.items);
+    // Parse and eval each expression. Name the reader with the loaded file's
+    // path so a diagnostic raised while evaluating a loaded form cites that
+    // file, not the loader (#2005): the compiled thunk carries `path` as its
+    // source_name, and `captureErrorLocation` reads it off the raising frame.
+    var reader = reader_mod.Reader.initWithName(gc, contents.items, path);
     defer reader.deinit();
 
     // Custom environments get an isolated macro table so define-syntax
@@ -356,7 +359,16 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
 
     var last_result: Value = types.VOID;
     while (reader.hasMore() catch return PrimitiveError.TypeError) { // bare-ok: reader error in load
-        const expr = reader.readDatum() catch return primitives.typeError("load", "valid datum", args[0]);
+        // The datum's start line, so the compiled thunk (and thus any
+        // diagnostic raised from it) is attributed to the right line of the
+        // loaded file (#2005).
+        const datum_line = reader.getLineCol().line;
+        var expr = reader.readDatum() catch return primitives.typeError("load", "valid datum", args[0]);
+        // Root the form: evaluating it (e.g. an import that loads a library, or
+        // a compile that collects) can trigger GC, which would otherwise
+        // reclaim the AST mid-walk.
+        gc.pushRoot(&expr);
+        defer gc.popRoot();
 
         if (env) |e| {
             const func = compiler_mod.compileExpressionInEnv(gc, expr, macro_target, e, env_val, false, .restricted) catch return primitives.typeError("load", "valid expression", args[0]);
@@ -368,12 +380,24 @@ fn loadFn(args: []const Value) PrimitiveError!Value {
                 return err;
             };
         } else {
-            const func = compiler_mod.compileExpressionWithMacros(gc, expr, &vm.macros, vm.globals) catch return primitives.typeError("load", "valid expression", args[0]);
-            var closure_val = gc.allocClosure(func) catch return PrimitiveError.OutOfMemory;
-            compiler_mod.Compiler.unrootFunction(gc, func);
-            gc.pushRoot(&closure_val);
+            // Route top-level declarations (import/define-library/begin/…)
+            // through the same machinery a file/REPL uses, so an `import` in a
+            // loaded file is handled instead of being evaluated as an ordinary
+            // application (#2005). handleTopLevelForm returns null for plain
+            // expressions, which fall through to compilation below.
+            if (vm.handleTopLevelForm(expr)) |top_result| {
+                last_result = top_result catch |err| return err;
+                continue;
+            }
+            const func = compiler_mod.compileExpressionWithMacrosAt(gc, expr, &vm.macros, vm.globals, datum_line, path, false) catch return primitives.typeError("load", "valid expression", args[0]);
+            var func_val = types.makePointer(&func.header);
+            gc.pushRoot(&func_val);
             defer gc.popRoot();
-            last_result = vm.callWithArgs(closure_val, &[_]Value{}) catch |err| {
+            compiler_mod.Compiler.unrootFunction(gc, func);
+            // runTopLevelFunction, not vm.execute (#2012): `load` runs
+            // re-entrantly under the caller's still-suspended frame; a bare
+            // vm.execute would resetExecutionState and abandon it.
+            last_result = vm.runTopLevelFunction(func) catch |err| {
                 return err;
             };
         }

--- a/tests/scheme/smoke/load-import-2005.sh
+++ b/tests/scheme/smoke/load-import-2005.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# kaappi#2005: `(load "file.scm")` where file.scm begins with a top-level
+# `import` must route that import through the same machinery a script or the
+# REPL uses — not evaluate it as an ordinary application.
+#
+# Before the fix, the loaded `(import (scheme base) ...)` was compiled as a
+# call: `(scheme base)` was applied and `base` looked up as a variable, so the
+# load failed with an "undefined variable 'base'" error — and the error was
+# attributed to the LOADER's file and line, because the loaded thunk carried no
+# source name of its own. Both halves are checked here: that the import-bearing
+# file loads and runs (prints "inner ok", exit 0), and that a genuinely broken
+# loaded file reports the error against the LOADED file, not the loader.
+
+set -euo pipefail
+
+KAAPPI="${KAAPPI:-${1:-zig-out/bin/kaappi}}"
+
+. "$(dirname "$0")/../shell-common.sh"
+
+# `load` opens a relative path against the current working directory, so the
+# test runs kaappi from inside the fixture directory. Resolve the binary to an
+# absolute path first, since KAAPPI is typically relative to the repo root.
+case "$KAAPPI" in
+    */*) kaappi_abs="$(cd "$(dirname "$KAAPPI")" 2>/dev/null && pwd)/$(basename "$KAAPPI")" ;;
+    *)   kaappi_abs="$(command -v "$KAAPPI" || true)" ;;
+esac
+if [ ! -x "$kaappi_abs" ]; then
+    echo "FAIL: $KAAPPI is not an executable file (build first: zig build)"
+    exit 1
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+PASS=0
+FAIL=0
+
+# --- Case 1: a loaded file whose first form is a top-level import ----------
+cat > "$work/inner.scm" <<'SCM'
+(import (scheme base) (scheme write))
+(display "inner ok")
+(newline)
+SCM
+cat > "$work/loader.scm" <<'SCM'
+(import (scheme base) (scheme load))
+(load "inner.scm")
+SCM
+
+set +e
+out=$(cd "$work" && "$kaappi_abs" loader.scm 2>&1)
+status=$?
+set -e
+
+if [ "$status" -eq 0 ] && printf '%s' "$out" | grep -q 'inner ok'; then
+    echo "PASS: load of an import-bearing file runs it"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: expected 'inner ok' and exit 0, got exit $status:"
+    printf '%s\n' "$out"
+    FAIL=$((FAIL + 1))
+fi
+
+# --- Case 2: a genuinely broken loaded file — error names the loaded file --
+# The loaded file is named so that its basename is NOT a substring of the
+# driver's ("bad.scm" vs "driver.scm"): before the attribution fix the error
+# was reported against the driver, and a grep that also matched the driver's
+# name would pass vacuously. The `(car 7)` on line 2 is the error; its import
+# on line 1 must itself succeed (the same fix), so the reported line is 2.
+cat > "$work/bad.scm" <<'SCM'
+(import (scheme base))
+(car 7)
+SCM
+cat > "$work/driver.scm" <<'SCM'
+(import (scheme base) (scheme load))
+(load "bad.scm")
+SCM
+
+set +e
+berr=$(cd "$work" && "$kaappi_abs" driver.scm 2>&1)
+bstatus=$?
+set -e
+
+if [ "$bstatus" -ne 0 ] && printf '%s' "$berr" | grep -q 'bad.scm:2:'; then
+    echo "PASS: a broken loaded file reports its own file:line"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: expected an error naming bad.scm:2 and non-zero exit, got exit $bstatus:"
+    printf '%s\n' "$berr"
+    FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "Passed: $PASS / $((PASS + FAIL))"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
`(load "file.scm")` where the loaded file begins with a top-level `import`
failed, and the error was blamed on the loader.

## Two defects

1. **The import wasn't handled.** `load` compiled every form of the loaded file
   as an ordinary expression, so a top-level `(import (scheme base) ...)` was
   evaluated as an application: `(scheme base)` was applied and `base` looked up
   as a variable, failing with `KP3001 undefined variable 'base'`. A `load` of a
   file *without* an import worked, which is what made this specific to `import`.

2. **The error named the wrong file.** The loaded thunk carried no source name,
   so the diagnostic was attributed to the loader's file and line
   (`loader.scm:1:9`) — column 9 happens to line up with `(scheme base)` in both
   files, which is easy to misread as a bug in the loader.

## Fix

For the default (global-env) case, `load` now routes each form through
`vm.handleTopLevelForm` first — the same dispatch a script or the REPL uses — so
`import`/`define-library`/`begin`/`cond-expand`/etc. are handled by the
import/library machinery, and only plain expressions fall through to
compilation. Those are compiled with `compileExpressionWithMacrosAt`, naming the
reader and the compiled thunk with the loaded file's path so
`captureErrorLocation` attributes any raised diagnostic to the loaded
`file:line`, and run via `runTopLevelFunction` so a `load` nested under a
suspended caller frame stays re-entrant (#2012). The custom-environment branch
of `load` is unchanged.

## Before / after

```console
# before
$ kaappi loader.scm
loader.scm:1:9: error[KP3001]: undefined variable 'base'. Did you mean 'take'?
    (import (scheme base) (scheme load))

# after
$ kaappi loader.scm
inner ok
```

A genuinely broken loaded file is now attributed correctly:

```console
$ kaappi driver.scm          # driver.scm loads bad.scm, whose line 2 is (car 7)
bad.scm:2:1: error[KP3002]: type error in 'car': expected pair, got 7
```

## Test

`tests/scheme/smoke/load-import-2005.sh` covers both halves: an import-bearing
loaded file runs (prints `inner ok`, exit 0), and a broken loaded file reports
the error against its own `file:line` (not the driver's). Verified failing
before the fix and passing after; `zig build test` passes.

Closes #2005

🤖 Generated with [Claude Code](https://claude.com/claude-code)
