### PR TITLE
Dedup reactor ceil-to-ms rule: Windows backend calls msFromNs

### DIFF
--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -1104,12 +1104,16 @@ const WindowsEventBackend = struct {
     }
 
     fn wait(self: *WindowsEventBackend, timeout_ns: ?u64) ![]const ReadyEvent {
-        var ms: u32 = if (timeout_ns) |ns| blk: {
-            // Ceil so a timer may fire slightly late but never early
-            // (resolved KEP-0001 question 2, epoll's msFromNs discipline).
-            const ceil_ms = (ns +| 999_999) / 1_000_000;
-            break :blk @intCast(@min(ceil_ms, platform.win.INFINITE - 1));
-        } else platform.win.INFINITE;
+        // One ceil-to-ms rule for every backend: call msFromNs (resolved
+        // KEP-0001 question 2 — a timer may fire slightly late but never
+        // early) and translate its i32/-1 convention into the Windows
+        // u32/INFINITE one. -1 ("no bound") becomes INFINITE; a positive
+        // result is clamped to INFINITE-1.
+        const ms_i32 = msFromNs(timeout_ns);
+        var ms: u32 = if (ms_i32 < 0)
+            platform.win.INFINITE
+        else
+            @min(@as(u32, @intCast(ms_i32)), platform.win.INFINITE - 1);
         // Armed pipe interest has no kernel wakeup — bound the block at
         // the poll quantum so the sweep below re-checks it (#1608 stage 2).
         if (self.pipes.count() > 0) ms = @min(ms, pipe_poll_quantum_ms);

--- a/src/tests_reactor_parity.zig
+++ b/src/tests_reactor_parity.zig
@@ -534,8 +534,10 @@ test "parity: a cross-thread notify interrupts the wait without consuming a time
 // ---------------------------------------------------------------------------
 // epoll's nanoseconds→milliseconds conversion, verified from any host.
 //
-// `msFromNs` is epoll-only (`epoll_wait` takes `int` milliseconds) but it is
-// a pure function at file scope in reactor.zig, so it compiles and runs on
+// `msFromNs` began epoll-only (`epoll_wait` takes `int` milliseconds) but is
+// now the single ceil-to-ms rule for both millisecond backends: the Windows
+// backend calls it too (kaappi#2154) rather than restating the arithmetic. It
+// is a pure function at file scope in reactor.zig, so it compiles and runs on
 // every target. That makes it the one piece of a *foreign* backend a kqueue
 // host can verify directly — and its rule is a documented KEP-0001
 // resolution, not an implementation detail: "Rounds up (ceil) so a timer may
@@ -599,4 +601,16 @@ test "parity: msFromNs saturates instead of overflowing into a negative timeout"
         try std.testing.expect(ms > 0);
         try std.testing.expectEqual(std.math.maxInt(i32), ms);
     }
+}
+
+test "parity: msFromNs pins the exact ceil mapping the Windows backend now shares" {
+    // The Windows backend calls msFromNs (kaappi#2154) instead of restating
+    // the ceil, so these exact mappings are the contract both millisecond
+    // backends observe. Each row is a value from the issue's own table.
+    try std.testing.expectEqual(@as(i32, -1), reactor_mod.msFromNs(null)); // no bound
+    try std.testing.expectEqual(@as(i32, 0), reactor_mod.msFromNs(0)); // do not block
+    try std.testing.expectEqual(@as(i32, 1), reactor_mod.msFromNs(1)); // 1 ns ceils to 1 ms
+    try std.testing.expectEqual(@as(i32, 1), reactor_mod.msFromNs(1_000_000)); // exact 1 ms
+    try std.testing.expectEqual(@as(i32, 2), reactor_mod.msFromNs(1_500_000)); // ceils to 2 ms
+    try std.testing.expectEqual(std.math.maxInt(i32), reactor_mod.msFromNs(std.math.maxInt(u64))); // clamp
 }


### PR DESCRIPTION
## What

The nanoseconds→milliseconds ceil-to-ms timeout rule in `src/reactor.zig` was implemented twice by hand. Only the epoll copy — the pure, file-scope `msFromNs` — was named, reachable from a test, and compiled on every target. The Windows backend (`WindowsEventBackend.wait`) restated the exact same arithmetic inline, with a comment that even cited `msFromNs` by name as the authority.

This is the fourth instance in the tree of a hand-maintained copy running alongside the thing it claims to follow; the previous three had each already drifted (#1896, #2089, #2099).

## The fix

`WindowsEventBackend.wait` now **calls** `msFromNs` instead of restating the ceil. The two representational differences are handled cleanly at the one call site:

- **msFromNs** returns `i32` milliseconds with `-1` meaning "no bound".
- **Windows** wants `u32` milliseconds with `INFINITE` for "no bound", clamped to `INFINITE - 1`.

The conversion: `-1` → `INFINITE`; otherwise `@min(result, INFINITE - 1)`. `msFromNs` was already at platform-neutral file scope, so no move was needed to make it referenceable from the Windows backend.

Observable behavior is unchanged on every reachable input (the sole disagreement in the old copies — the >24.9-day vs >49.7-day saturation ceiling — is benign and unreachable; an early return from the backend wait is always safe).

## Test

Added an exact-mapping unit test in `tests_reactor_parity.zig` pinning the rows from the issue's table: `null → -1`, `0 → 0`, `1 ns → 1`, `1_000_000 ns → 1`, `1_500_000 ns → 2` (ceil), `u64 max → i32 max` (clamp). Since both millisecond backends now route through `msFromNs`, the existing parity suite covers both.

## Verification

- `zig build` — passed
- `zig build test` — passed
- `zig build -Dtarget=x86_64-windows` — passed (cross-compile exercises the Windows-gated branch, per repo rule)

Closes #2154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
