### PR TITLE
Deduplicate GC remembered set to keep minor collections linear

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -81,6 +81,12 @@ fn pruneRememberedSet(gc: *GC) void {
         if (referencesYoung(gc, obj)) {
             gc.remembered_set.items[write_idx] = obj;
             write_idx += 1;
+        } else {
+            // #2196: dropped from the set, so clear the dedup flag — a later
+            // old->young write to this container must be free to re-queue it.
+            // Only touch the flag on containers we own (foreign containers are
+            // appended without the flag; see writeBarrier).
+            if (obj.owner == gc.id) obj.flags.in_remembered_set = false;
         }
     }
     gc.remembered_set.shrinkRetainingCapacity(write_idx);
@@ -323,6 +329,13 @@ fn isYoungPointer(gc: *GC, val: Value) bool {
 }
 
 fn fullCollect(gc: *GC) void {
+    // #2196: drain the remembered_set up front. A full collect marks from
+    // roots over both generations, so it never consults the set — and doing
+    // this before sweepOld frees any old object means every entry is still
+    // live when we clear its dedup flag (clearing after the sweep would be a
+    // use-after-free). Every surviving old container is then free to re-queue
+    // itself on its next old->young write.
+    drainRememberedSet(gc);
     clearOldMarks(gc);
     markRoots(gc);
     processWeakRefs(gc);
@@ -330,6 +343,14 @@ fn fullCollect(gc: *GC) void {
     gc.quarantineReleaseToCap();
     sweep(gc);
     sweepOld(gc);
+}
+
+fn drainRememberedSet(gc: *GC) void {
+    // Only clear the flag on containers we own (foreign containers never had it
+    // set by this GC; see writeBarrier).
+    for (gc.remembered_set.items) |obj| {
+        if (obj.owner == gc.id) obj.flags.in_remembered_set = false;
+    }
     gc.remembered_set.clearRetainingCapacity();
 }
 

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -355,7 +355,25 @@ pub const GC = struct {
             // GC, so it needs no remembered-set entry — and reading its
             // generation bit would race the owner's collection cycle.
             if (child.owner == self.id and child.flags.generation == 0) {
-                self.remembered_set.append(self.allocator, container) catch @panic("GC writeBarrier: remembered set OOM");
+                // #2196: dedup. A container mutated n times must appear in the
+                // remembered_set at most once — otherwise the minor mark phase
+                // marks it n times, and marking a large container is O(capacity),
+                // making a fill quadratic in writes. The in_remembered_set flag
+                // is cleared when the container leaves the set (pruneRememberedSet
+                // or a full-collect drain), so a container re-added after being
+                // dropped queues exactly one fresh entry.
+                //
+                // The flag belongs to the container's *owning* GC. Only dedup a
+                // container we own; a foreign container (a shared global mutated
+                // across threads — the #1924 hazard) keeps the pre-#2196
+                // unconditional append, so its owner's flag is never observed or
+                // written here and no reference this GC must track is dropped.
+                if (container.owner != self.id) {
+                    self.remembered_set.append(self.allocator, container) catch @panic("GC writeBarrier: remembered set OOM");
+                } else if (!container.flags.in_remembered_set) {
+                    self.remembered_set.append(self.allocator, container) catch @panic("GC writeBarrier: remembered set OOM");
+                    container.flags.in_remembered_set = true;
+                }
             }
         }
     }

--- a/src/tests_gc_tracing.zig
+++ b/src/tests_gc_tracing.zig
@@ -1758,3 +1758,126 @@ test "gc tracing (remembered set): a port carrying both satellites" {
     // Test B: markObjectContents plus referencesYoung, via the remembered set.
     try expectRememberedTrace(&gc, port, &.{ ref(rd, 1), ref(wrapped, 2) });
 }
+
+// ---------------------------------------------------------------------------
+// #2196 — remembered-set deduplication
+//
+// A container mutated n times must appear in the remembered_set at most once,
+// or the minor mark phase marks it n times (and marking a large container is
+// O(capacity), making a fill quadratic in writes). These assert the count is
+// bounded by the number of *distinct* containers, not the number of writes,
+// while every distinct container still gets tracked.
+// ---------------------------------------------------------------------------
+
+test "gc remembered set (#2196): repeated writes to one container queue a single entry" {
+    var gc = newGc();
+    defer gc.deinit();
+    const c = try gc.allocVectorFill(4, types.NIL);
+    try promoteToOld(&gc, c);
+    const vec = types.toObject(c).as(types.Vector);
+
+    // Fire the barrier many times, as a container mutated in a loop does
+    // (hash-table-set! fires it twice per insert). Each iteration repoints a
+    // slot at a fresh young object. gc.enabled is false, so no collection --
+    // and no prune -- runs underneath the loop.
+    var i: usize = 0;
+    while (i < 500) : (i += 1) {
+        const a = try young(&gc, @intCast(i));
+        vec.data[i % 4] = a;
+        gc.writeBarrier(&vec.header, a);
+    }
+
+    // Pre-fix: 500 identical entries. Post-fix: exactly one.
+    try std.testing.expectEqual(@as(usize, 1), gc.remembered_set.items.len);
+    try std.testing.expect(inRemembered(&gc, &vec.header));
+    try std.testing.expect(vec.header.flags.in_remembered_set);
+}
+
+test "gc remembered set (#2196): writes to N distinct containers queue N entries" {
+    var gc = newGc();
+    defer gc.deinit();
+    const N = 16;
+    var containers: [N]*Object = undefined;
+    var i: usize = 0;
+    while (i < N) : (i += 1) {
+        const c = try gc.allocPair(types.NIL, types.NIL);
+        try promoteToOld(&gc, c);
+        containers[i] = types.toObject(c);
+    }
+
+    // One old->young write per distinct container. Dedup must never suppress a
+    // *different* container -- every reference still has to be tracked.
+    for (containers) |cobj| {
+        const a = try young(&gc, 0);
+        cobj.as(types.Pair).car = a;
+        gc.writeBarrier(cobj, a);
+    }
+
+    try std.testing.expectEqual(@as(usize, N), gc.remembered_set.items.len);
+    for (containers) |cobj| {
+        try std.testing.expect(inRemembered(&gc, cobj));
+        try std.testing.expect(cobj.flags.in_remembered_set);
+    }
+}
+
+test "gc remembered set (#2196): a container re-queues after the set drops it" {
+    var gc = newGc();
+    defer gc.deinit();
+    const c = try gc.allocVectorFill(1, types.NIL);
+    try promoteToOld(&gc, c);
+    const vec = types.toObject(c).as(types.Vector);
+
+    // First old->young write: one entry, dedup flag set.
+    const a = try young(&gc, 1);
+    vec.data[0] = a;
+    gc.writeBarrier(&vec.header, a);
+    try std.testing.expectEqual(@as(usize, 1), gc.remembered_set.items.len);
+    try std.testing.expect(vec.header.flags.in_remembered_set);
+
+    // Overwrite the slot with an immediate, then collect. The container no
+    // longer references young, so pruneRememberedSet drops it and must clear
+    // the dedup flag.
+    vec.data[0] = types.makeFixnum(0);
+    forceMinor(&gc);
+    try std.testing.expectEqual(@as(usize, 0), gc.remembered_set.items.len);
+    try std.testing.expect(!vec.header.flags.in_remembered_set);
+
+    // A fresh old->young write must re-queue exactly one entry -- proving the
+    // flag was reset, so no old->young reference is ever silently dropped.
+    const b = try young(&gc, 2);
+    vec.data[0] = b;
+    gc.writeBarrier(&vec.header, b);
+    try std.testing.expectEqual(@as(usize, 1), gc.remembered_set.items.len);
+    try std.testing.expect(vec.header.flags.in_remembered_set);
+}
+
+test "gc remembered set (#2196): a full collect drain resets every dedup flag" {
+    var gc = newGc();
+    defer gc.deinit();
+    const c = try gc.allocVectorFill(1, types.NIL);
+    try promoteToOld(&gc, c);
+    const vec = types.toObject(c).as(types.Vector);
+
+    const a = try young(&gc, 1);
+    vec.data[0] = a;
+    gc.writeBarrier(&vec.header, a);
+    try std.testing.expect(vec.header.flags.in_remembered_set);
+
+    // fullCollect drains the whole remembered_set. The flag must be cleared
+    // there too -- otherwise a surviving container that keeps its stale flag
+    // would refuse to re-queue, silently dropping a later old->young write.
+    // Root the container so the full collect keeps it.
+    var root = c;
+    gc.pushRoot(&root);
+    forceFull(&gc);
+    gc.popRoot();
+    try std.testing.expectEqual(@as(usize, 0), gc.remembered_set.items.len);
+    try std.testing.expect(!vec.header.flags.in_remembered_set);
+
+    // And it can be tracked again.
+    const b = try young(&gc, 2);
+    vec.data[0] = b;
+    gc.writeBarrier(&vec.header, b);
+    try std.testing.expectEqual(@as(usize, 1), gc.remembered_set.items.len);
+    try std.testing.expect(vec.header.flags.in_remembered_set);
+}

--- a/src/types.zig
+++ b/src/types.zig
@@ -234,7 +234,14 @@ pub const Object = struct {
         generation: u1 = 0,
         survive_count: u2 = 0,
         immutable: bool = false,
-        _pad: u3 = 0,
+        // #2196: set while this object is present in its owning GC's
+        // remembered_set, so writeBarrier can dedup and append each mutated
+        // old-gen container at most once per collection cycle. Cleared when
+        // the container leaves the set (pruneRememberedSet drops it, or a
+        // full collect drains the whole set). Keeps the barrier O(1) and the
+        // minor mark phase O(distinct containers) instead of O(writes).
+        in_remembered_set: bool = false,
+        _pad: u2 = 0,
     };
     const Align = if (@alignOf(?*Object) < 8) struct { _: u64 align(8) = 0 } else struct {};
 


### PR DESCRIPTION
## Problem

`GC.writeBarrier` appended a mutated old-gen container to `remembered_set` on
every old→young write with no membership check. A container mutated *n* times
queued up to *n* identical entries. The minor mark phase (`gc_collect.zig`)
then marked **every** entry, and marking a large container is O(capacity) — so
a minor collection cost O(barrier_count × capacity) instead of
O(distinct_containers × capacity).

`hash-table-set!` fires the barrier twice per insert, so filling one
150k-entry table queued ~300k entries for a 262144-capacity table. Filling a
hash table exhibited multi-second stalls with per-size cliffs (2491 ms, 3113 ms
in the issue's trace) — all of it in the mark phase.

## Fix

Deduplicate: each container appears in `remembered_set` at most once per
collection cycle.

- Add an `in_remembered_set` flag bit to `Object.Flags`, taken from the
  struct's spare `_pad` bits (no size change).
- `writeBarrier` sets the flag and appends only if it is not already set;
  the barrier stays O(1).
- The flag is cleared wherever a container leaves the set:
  `pruneRememberedSet` (entry dropped after a minor collection) and a new
  `drainRememberedSet` used at the top of `fullCollect` (draining up front,
  while every entry is still live, so clearing the flag can't touch a
  swept-out object).
- Foreign containers (a shared global mutated across threads — the #1924
  hazard) keep the pre-existing unconditional append, and the flag is only
  ever read/written for containers this GC owns, so no cross-thread flag race
  is introduced and every old→young reference is still tracked.

## Before / after

Repro from the issue (`hash-table-set!` over a fresh table, warm process):

| n       | before      | after   |
|---------|-------------|---------|
| 50000   | 67 ms       | 88 ms   |
| 55000   | **2491 ms** | 93 ms   |
| 70000   | **3113 ms** | 108 ms  |
| 150000  | 159 ms      | 184 ms  |

The cliffs are gone; cost is linear in entries.

## Tests

New Zig unit tests in `src/tests_gc_tracing.zig` assert:
- repeated writes to one container queue a single `remembered_set` entry
  (bounded by distinct containers, not writes);
- writes to N distinct containers still queue all N;
- a container re-queues after the set drops it (prune path clears the flag);
- a full-collect drain resets every flag so containers can be tracked again.

`zig build`, `zig build test`, and `zig build test -Dgc-stress=true` all pass.

Closes #2196

🤖 Generated with [Claude Code](https://claude.com/claude-code)
