### PR TITLE
Correct SRFI 260 rationale: generated symbols intern deliberately

### DIFF
--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -194,12 +194,14 @@ preserves uninterned-ness across SRFI-18 thread boundaries.
 ### SRFI 260 — generated symbols
 
 SRFI 260 (generated symbols) is built-in but needs no engine integration
-beyond one primitive (`generate-symbol` in `primitives_srfi260.zig`): because
-Kaappi interns every symbol by name (no uninterned symbols), write/read
-invariance is automatic, so the primitive just interns a fresh
-`"<pretty>.<counter>.<128-bit-OS-entropy-hex>"` name — a process-global atomic
-counter guarantees in-process uniqueness and `platform.osRandomBytes` supplies
-the unpredictability.
+beyond one primitive (`generate-symbol` in `primitives_srfi260.zig`).
+Kaappi *does* have uninterned symbols (SRFI 258, above), so write/read
+invariance is not automatic: `generate-symbol` gets it by deliberately
+interning through `GC.allocSymbol` — the opposite choice from SRFI 258's
+`generate-uninterned-symbol`, which uses `GC.allocUninternedSymbol`. The
+primitive interns a fresh `"<pretty>.<counter>.<128-bit-OS-entropy-hex>"`
+name — a process-global atomic counter guarantees in-process uniqueness and
+`platform.osRandomBytes` supplies the unpredictability.
 
 ### SRFI 120 — Timer APIs
 

--- a/src/primitives_srfi260.zig
+++ b/src/primitives_srfi260.zig
@@ -5,12 +5,16 @@
 //! (SRFI 258), a generated symbol keeps write/read invariance and the classic
 //! rule that two symbols are identical iff their names are equal.
 //!
-//! Kaappi has no uninterned symbols — every symbol is interned by name in the
-//! one symbol table (`GC.allocSymbol`) — so those two properties fall out for
-//! free: any symbol we mint round-trips through `write`/`read` back to an `eq?`
-//! symbol (the printer bar-quotes names that need it). The whole SRFI therefore
-//! reduces to "intern a symbol under a fresh, unpredictable, collision-free
-//! name."
+//! Kaappi *does* have uninterned symbols (SRFI 258, `GC.allocUninternedSymbol`,
+//! which bypasses the intern table), so those two properties are a deliberate
+//! choice here, not a free consequence of the engine: `generate-symbol` mints
+//! its symbol through `GC.allocSymbol`, interning it by name in the one symbol
+//! table. That is what makes it round-trip through `write`/`read` back to an
+//! `eq?` symbol (the printer bar-quotes names that need it) — and it is why the
+//! primitive must *not* be "simplified" onto `GC.allocUninternedSymbol`, which
+//! would produce a symbol never `eq?` to its own re-read. The whole SRFI
+//! therefore reduces to "intern a symbol under a fresh, unpredictable,
+//! collision-free name."
 //!
 //! The generated name is `"<pretty>.<counter>.<128-bit-random-hex>"`:
 //!   * a process-global atomic counter gives a hard in-process uniqueness


### PR DESCRIPTION
## Problem (doc-truth, #2009)

Both the `primitives_srfi260.zig` header and the SRFI 260 entry in
`docs/dev/srfi-implementation-notes.md` justified `generate-symbol`'s write/read
invariance by claiming *"Kaappi has no uninterned symbols"*. That is false: SRFI
258 shipped uninterned symbols 51 minutes after SRFI 260 on the same day, and the
same doc paragraph documents them two sentences earlier. The invariance is a
**deliberate choice** by `generate-symbol` (it interns via `GC.allocSymbol`), not
an automatic consequence of the engine.

## Fix (wording only — no behavioral change)

`src/primitives_srfi260.zig` header, old:

> Kaappi has no uninterned symbols — every symbol is interned by name in the one symbol table (`GC.allocSymbol`) — so those two properties fall out for free …

corrected:

> Kaappi *does* have uninterned symbols (SRFI 258, `GC.allocUninternedSymbol`, which bypasses the intern table), so those two properties are a deliberate choice here … `generate-symbol` mints its symbol through `GC.allocSymbol` … it is why the primitive must *not* be "simplified" onto `GC.allocUninternedSymbol`, which would produce a symbol never `eq?` to its own re-read.

`docs/dev/srfi-implementation-notes.md` corrected the parallel clause the same way:
write/read invariance holds because SRFI 260 deliberately interns, the opposite
choice from SRFI 258's `generate-uninterned-symbol`.

Verified against `src/gc_alloc.zig`: `allocSymbol` (line 72) interns; `allocUninternedSymbol` (line 126) bypasses the intern table.

## Verification (fresh `zig build`)

```
$ kaappi -- '(import (scheme base) (srfi 258)) (display (symbol-interned? (string->uninterned-symbol "x")))'
#f

$ kaappi chk260.scm   ; write a generated symbol, read it back
(interned? #t eq-roundtrip? #t)
```

`tests/scheme/audit/primitives_smallbatch-audit.scm` (which pins "a generated
symbol is INTERNED, unlike SRFI 258's"): **235 expected passes, 0 failures.**

Closes #2009

🤖 Generated with [Claude Code](https://claude.com/claude-code)