### PR TITLE
Doc-truth: name the copy route's aliased class; fix the ffi-callback row (#2028)

### DIFF
--- a/docs/dev/thread-value-sharing.md
+++ b/docs/dev/thread-value-sharing.md
@@ -42,6 +42,24 @@ that name through the shared globals map at run time, so the value never
 enters the copy at all. This is the whole reason the two routes exist as
 separate things.
 
+The copy route's tag switch is not a two-way sort into *copied* or
+*refused*. It has a distinct middle class — **aliased** — where the arm
+returns the source object to the destination heap **by pointer** instead of
+duplicating it. Soundness in that class is not automatic: an aliased object
+outlives its source heap's collector only if the arm first promotes it to a
+shared, refcounted representation and checks that the running thread is
+entitled to share it. Exactly one tag earns the class — `channel` — and its
+arm does all three. An arm that aliases *without* them hands the receiver a
+pointer neither collector accounts for; that was the FFI bug #2027 removed by
+moving `ffi-library`/`ffi-function` out of the aliased class and into the
+*copied* one (below). So the switch has three outcomes, not two:
+
+| class | what the arm returns | members |
+|---|---|---|
+| **copied** | a fresh object in the destination heap | pairs, vectors, strings, records, `native-fn`, `ffi-library`, `ffi-function`, `file-info`/`user-info`/`group-info`, `srfi18-time`, `random-source`, … |
+| **aliased** | the source object, by pointer, after promotion + refcount + an ownership check | `channel` only |
+| **refused** | `error.UncopyableType` | the eleven below |
+
 `gc_deep_copy.zig` refuses eleven tags outright:
 
 ```text
@@ -55,9 +73,12 @@ and have copied by value since kaappi#1978, so a `file-info` can be the
 join result of a child thread. `directory_object` among the SRFI-170 types
 is still genuinely uncopyable — it owns a live `DIR*`.
 
-Channels are **not** on that list. Their arm promotes the channel to a
-shared representation and aliases it, which is what makes a lexically
-captured channel the supported way to share one (KEP-0002 §2).
+Channels are the sole **aliased** tag, and so **not** on that refusal list.
+Their arm promotes the channel to a shared, refcounted representation and
+aliases it — the promotion, the refcount, and the ownership check (next
+paragraph) together are what make aliasing sound here, and what make a
+lexically captured channel the supported way to share one (KEP-0002 §2). No
+other tag may alias, because no other arm carries those three safeguards.
 
 That arm carries the globals-route check too, in the one direction where
 it means something. A copy **out of** the running thread's heap — into
@@ -71,8 +92,9 @@ its unpromoted twin failed, so a thread that read one out of a shared
 global could still hand it down to a child, and that child got a working
 stub for a channel nobody gave it.
 
-FFI handles are not on that list either — `ffi-library` and `ffi-function`
-are **copied**, and only the callback is refused. The dlopen handle and the
+FFI handles are not on that list either, and — since #2027 — no longer in
+the aliased class: `ffi-library` and `ffi-function` are **copied**, and only
+the callback is refused. The dlopen handle and the
 symbol address are process-global and are shared by value; it is the
 wrapper object that gets duplicated into the receiving heap, exactly as
 `native-fn` duplicates the object around a static function pointer. Until
@@ -164,7 +186,7 @@ with a top-level `define` and named by the thunk.
 | guardian | refused | refused (kaappi#2008) | **coherent** — the raw-container mutation made a check mandatory |
 | ephemeron | refused | works | unchecked — bound to one GC's collection cycle, but nothing mutates a raw container through it |
 | transport cell | refused | — | unreachable from Scheme: on this non-moving collector a transport-cell guardian always yields `#f` |
-| ffi-callback | refused | not probed | needs a loaded FFI library to construct |
+| ffi-callback | refused | works | unchecked — the copy refusal is now pinned both directions (`srfi18-deepcopy-matrix-audit.scm`, two-pointer signature); a global runs the parent-heap closure, like a custom port |
 
 Two rows deserve their own note.
 
@@ -333,8 +355,11 @@ enforcement shape the nine already cover. (The three *copyable* ones —
 `file-info`, `user-info`, `group-info` — have their own cross-boundary
 coverage in `tests/scheme/audit/srfi18-deepcopy-matrix-audit.scm` and
 `tests/scheme/audit/primitives_filesystem-audit.scm` section H since
-kaappi#1978.) `ffi-callback` needs a loaded
-FFI library; the transport cell is unreachable, as above.
+kaappi#1978.) `ffi-callback` is exercised instead in
+`tests/scheme/audit/srfi18-deepcopy-matrix-audit.scm` — a *callback* needs no
+loaded library, only a supported signature (the two-pointer shape from
+`callback-error.scm`), and that suite pins both copy-route directions as
+refused; the transport cell is unreachable, as above.
 
 Two smaller checks live elsewhere and are worth knowing about rather than
 duplicating: `src/tests_deepcopy.zig` asserts the port and continuation


### PR DESCRIPTION
`docs/dev/thread-value-sharing.md` framed the deep-copy tag switch as a two-way sort — *copied* or *refused* — with the channel arm as a prose-only exception. That left the **aliased** class unnamed and its soundness contract invisible, which is issue #2028's finding.

## What changed

1. **Explicit aliased class.** Added a three-outcome table (copied / aliased / refused) and a paragraph stating that aliasing (returning the source object by pointer) is sound *only* when the arm promotes the object to a shared, refcounted representation and checks the running thread's entitlement. `channel` is the sole member; the paragraph names all three safeguards. The channel and FFI paragraphs now reference this class by name.

2. **Fixed the `ffi-callback` matrix row.** Was `refused / not probed / needs a loaded FFI library to construct`. Now `refused / works / unchecked …`. The copy route is pinned in both directions by `srfi18-deepcopy-matrix-audit.scm` (a callback needs no loaded library, only a supported two-pointer signature), and the globals cell is `works` — matching the intro's own "eight of the eleven tags … freely reachable" count and the code, which gives `ffi_callback` no owner check. Corrected the matching "Keeping it honest" note.

## Discrepancy with the issue's premise (followed the code)

Issue #2028 (filed against v0.22.1, `d0d03deb`) describes `ffi-library`/`ffi-function` as an **unsound alias** (`.ffi_library, .ffi_function => src`). That is no longer the code. **#2027/#2229 (v0.22.2) already landed** the fix *and* the doc update: the FFI arms now allocate fresh wrappers (`allocFfiLibrary`/`allocFfiFunction`), i.e. they are **copied**, and the doc already documented that. So this PR does not resurrect an unsound-alias class — it names the aliased class correctly (channel-only, sound) and records that #2027 moved the FFI arms *out* of it into *copied*.

## Tags verified against `src/gc_deep_copy.zig` (current `main`)

- **aliased (1):** `channel` — promote + refcount + ownership check (lines ~585-636)
- **copied (FFI):** `ffi_library` (allocFfiLibrary), `ffi_function` (allocFfiFunction) — lines ~502-523; plus `native-fn`, `srfi18-time`, `file-info`/`user-info`/`group-info`, `random-source`, and all ordinary heap types
- **refused (11):** `port` `continuation` `fiber` `mutex` `condition_variable` `ffi_callback` `directory_object` `scheme_environment` `ephemeron` `guardian` `transport_cell` — lines ~658-670, `=> error.UncopyableType`

`ffi_callback` copy-route refusal pinned both directions in `tests/scheme/audit/srfi18-deepcopy-matrix-audit.scm` (lines ~681-694). The verbatim refusal message and the two-route model are unchanged.

Closes #2028

🤖 Generated with [Claude Code](https://claude.com/claude-code)