### PR TITLE
Render offending value's identity in type errors (#1899)

### DIFF
--- a/docs/audit-strategy.md
+++ b/docs/audit-strategy.md
@@ -553,7 +553,7 @@ Phase 2 session:
 |---|---|---|
 | D1 | **Internal-primitive direct-call surface** | The `%`-prefix convention and the `INTERNAL`/`INTERNAL_PUBLIC` split postdate v1 (#1856). ~53 procedures are callable from a plain script with no import and have zero test mention |
 | D2 | **Error-taxonomy correctness** | `typeError`/`indexError`/`argError` now carry distinct codes (KP3002/3006/3007). `indexError` appears in 6 files, `argError` in 3 — bounds failures are likely still reported as type errors elsewhere |
-| D3 | **Diagnostic fidelity** | `safeValueDescription` renders symbols, strings, vectors, bytevectors, rationals and bignums opaquely — see F10 |
+| D3 | **Diagnostic fidelity** | F10's opaque rendering was fixed (#1899): `safeValueDescription` now names a symbol/string/char/rational/small-bignum value. The dimension stays live — the `else` arm still renders unlisted tags opaquely, and every new heap type must decide what its `got` field says |
 | D4 | **Registration-table invariants** | `specs` arity vs. what the body indexes; `libs` tags vs. the SRFI's export list; the comptime `%`-vs-`scheme.*` check. Pure table-vs-body audit, no runtime needed |
 | D5 | **Re-entrancy and parking discipline** | Fibers, the reactor, custom-port callbacks and guardian invocation are all post-v1. Which callbacks may block, and does the rejection stay catchable? |
 | D6 | **Cross-heap deep-copy closure** | Every new heap type must round-trip both SRFI-18 boundaries or fail cleanly |

--- a/docs/dev/adding-features.md
+++ b/docs/dev/adding-features.md
@@ -73,8 +73,10 @@ procedure name itself: `argError("%make-record-type-descriptor", "record type
 "expected X, got Y" would misdescribe the failure -- a symbol that is not one of
 three accepted symbols, an rtd that refuses to be extended, a uid already
 claimed. It also sidesteps a limit of `typeError`: `safeValueDescription`
-deliberately does not dereference heap payloads, so `got` renders every symbol
-as a bare `#<symbol>`, and `argError`'s own format string can name it.
+renders a bounded, non-recursive summary by contract (kaappi#1899) — a pair
+stays `#<pair>`, a vector reports only its length, a bignum past u128 stays
+`#<bignum>` — so when the diagnostic needs more than that summary,
+`argError`'s own format string can name the value.
 
 ### 2. Register the procedure and its libraries
 

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -601,16 +601,48 @@ pub fn parseOptionalRange(args: []const Value, arg_offset: usize, max_len: usize
     return .{ .start = start, .end = end };
 }
 
+/// Render `value` for a type-error message: enough of its identity that a user
+/// can tell *which* value was wrong (kaappi#1899), not just its type.
+///
+/// This is on the error path of ~700 type-error sites, potentially holding a
+/// half-constructed or foreign-owned value, so it stays deliberately
+/// conservative — the same properties the flonum note below relied on:
+///   (a) **No allocation and no VM callback.** Everything is read directly out
+///       of the value or its object header; nothing calls the GC or the
+///       interpreter. Bignum/rational rendering therefore only covers what
+///       fits in a stack `u128` (`writeExactInteger`); a larger magnitude,
+///       which would need heap scratch to stringify, falls back to `#<bignum>`
+///       / `#<rational>`.
+///   (b) **Bounded output.** Writing through a fixed 128-byte `Io.Writer`,
+///       every write is capped by the buffer; strings and symbols are
+///       additionally truncated with `...` before they get there, so a
+///       megabyte string or million-element vector can never be dumped into a
+///       diagnostic.
+///   (c) **No recursion into heap structure.** Compound types render a
+///       one-level summary (a vector/bytevector reports its length; a rational
+///       renders its two exact-integer components), never a recursive print —
+///       so a cyclic structure cannot make this loop.
 fn safeValueDescription(buf: *[128]u8, value: Value) []const u8 {
+    var w: std.Io.Writer = .fixed(buf);
+    describeValue(&w, value);
+    const out = w.buffered();
+    return if (out.len == 0) "?" else out;
+}
+
+/// Best-effort renderer for `safeValueDescription`. All writes are `catch {}`:
+/// a full buffer just truncates the description rather than propagating an
+/// error out of the error path.
+fn describeValue(w: *std.Io.Writer, value: Value) void {
     if (types.isFixnum(value)) {
-        return std.fmt.bufPrint(buf, "{d}", .{types.toFixnum(value)}) catch "?";
+        w.print("{d}", .{types.toFixnum(value)}) catch {};
+        return;
     }
-    if (value == types.NIL) return "()";
-    if (value == types.TRUE) return "#t";
-    if (value == types.FALSE) return "#f";
-    if (value == types.VOID) return "#<void>";
-    if (value == types.EOF) return "#<eof>";
-    if (types.isChar(value)) return "#<char>";
+    if (value == types.NIL) return w.writeAll("()") catch {};
+    if (value == types.TRUE) return w.writeAll("#t") catch {};
+    if (value == types.FALSE) return w.writeAll("#f") catch {};
+    if (value == types.VOID) return w.writeAll("#<void>") catch {};
+    if (value == types.EOF) return w.writeAll("#<eof>") catch {};
+    if (types.isChar(value)) return describeChar(w, types.toChar(value));
     if (types.isFlonum(value)) {
         // Via the printer, not a bare `{d}`, so an integral flonum keeps its
         // `.0`. Without it `(… 1.0)` reported "expected exact integer, got 1",
@@ -618,26 +650,141 @@ fn safeValueDescription(buf: *[128]u8, value: Value) []const u8 {
         // (kaappi#1916). Safe in this deliberately-defensive helper: a flonum
         // is inline under NaN-boxing, so `formatFlonum` reads no heap and
         // handles NaN/Inf itself.
-        return printer.formatFlonum(buf, types.toFlonum(value));
+        var fbuf: [64]u8 = undefined;
+        w.writeAll(printer.formatFlonum(&fbuf, types.toFlonum(value))) catch {};
+        return;
     }
     if (types.isPointer(value)) {
         const addr = @as(usize, @truncate(value));
-        if (addr == 0 or addr < 4096) return "#<invalid-pointer>";
+        if (addr == 0 or addr < 4096) return w.writeAll("#<invalid-pointer>") catch {};
         const obj = types.toObject(value);
         const tag = @intFromEnum(obj.tag);
         if (tag >= @typeInfo(types.ObjectTag).@"enum".fields.len)
-            return std.fmt.bufPrint(buf, "#<corrupt tag={d}>", .{tag}) catch "#<corrupt>";
-        return switch (obj.tag) {
-            .pair => "#<pair>",
-            .symbol => "#<symbol>",
-            .string => "#<string>",
-            .closure, .native_fn, .function, .native_closure => "#<procedure>",
-            .vector => "#<vector>",
-            .hash_table => "#<hash-table>",
-            else => std.fmt.bufPrint(buf, "#<{s}>", .{@tagName(obj.tag)}) catch "#<object>",
-        };
+            return w.print("#<corrupt tag={d}>", .{tag}) catch {};
+        switch (obj.tag) {
+            // Symbol name is inline in the object (interned, no allocation);
+            // print it so `(string-length 'foo)` says `got foo`, not `#<symbol>`.
+            .symbol => describeBounded(w, obj.as(types.Symbol).name, 96),
+            .string => {
+                const s = obj.as(types.SchemeString);
+                describeString(w, s.data[0..s.len]);
+            },
+            // Length, not contents: cheap, cycle-safe, and far more useful than
+            // a bare tag (kaappi#1899). A one-level element preview would have
+            // to guard against cyclic vectors; length needs no such guard.
+            .vector => w.print("#<vector length {d}>", .{obj.as(types.Vector).data.len}) catch {},
+            .bytevector => w.print("#<bytevector length {d}>", .{obj.as(types.Bytevector).data.len}) catch {},
+            .bignum => if (!writeExactInteger(w, value)) {
+                w.writeAll("#<bignum>") catch {};
+            },
+            .rational => {
+                const r = obj.as(types.Rational);
+                // Numerator and denominator are each a fixnum or bignum -- never
+                // a pointer to a compound, so this cannot recurse or cycle.
+                if (writeExactInteger(w, r.numerator)) {
+                    w.writeByte('/') catch {};
+                    if (!writeExactInteger(w, r.denominator)) w.writeAll("...") catch {};
+                } else {
+                    w.writeAll("#<rational>") catch {};
+                }
+            },
+            .pair => w.writeAll("#<pair>") catch {},
+            .closure, .native_fn, .function, .native_closure => w.writeAll("#<procedure>") catch {},
+            .hash_table => w.writeAll("#<hash-table>") catch {},
+            else => w.print("#<{s}>", .{@tagName(obj.tag)}) catch {},
+        }
+        return;
     }
-    return std.fmt.bufPrint(buf, "0x{x}", .{value}) catch "?";
+    w.print("0x{x}", .{value}) catch {};
+}
+
+/// Write an exact integer (fixnum or a bignum small enough to fit a `u128`)
+/// in decimal. Returns false, having written nothing, for a bignum too large
+/// to stringify without heap scratch -- the caller renders `#<bignum>` then.
+fn writeExactInteger(w: *std.Io.Writer, value: Value) bool {
+    if (types.isFixnum(value)) {
+        w.print("{d}", .{types.toFixnum(value)}) catch return false;
+        return true;
+    }
+    if (types.isPointer(value) and types.toObject(value).tag == .bignum) {
+        const bn = types.toObject(value).as(types.Bignum);
+        if (bn.len == 0) {
+            w.writeAll("0") catch return false;
+            return true;
+        }
+        if (bn.len > 2) return false; // magnitude exceeds u128 -- needs allocation
+        var mag: u128 = 0;
+        var i: usize = bn.len;
+        while (i > 0) {
+            i -= 1;
+            mag = (mag << 64) | bn.limbs[i];
+        }
+        if (!bn.positive) w.writeByte('-') catch return false;
+        w.print("{d}", .{mag}) catch return false;
+        return true;
+    }
+    return false;
+}
+
+/// Render a character in its `#\` external representation (kaappi#1899: chars
+/// are immediates and were rendering as the opaque `#<char>`). Mirrors the
+/// named/hex forms of `printer.printValueOnce`, but self-contained so it reads
+/// no heap.
+fn describeChar(w: *std.Io.Writer, cp: u21) void {
+    w.writeAll("#\\") catch {};
+    switch (cp) {
+        0x00 => return w.writeAll("null") catch {},
+        0x07 => return w.writeAll("alarm") catch {},
+        0x08 => return w.writeAll("backspace") catch {},
+        0x09 => return w.writeAll("tab") catch {},
+        0x0A => return w.writeAll("newline") catch {},
+        0x0D => return w.writeAll("return") catch {},
+        0x1B => return w.writeAll("escape") catch {},
+        0x20 => return w.writeAll("space") catch {},
+        0x7F => return w.writeAll("delete") catch {},
+        else => {},
+    }
+    if (cp < 0x20 or (cp >= 0x7F and cp <= 0x9F)) {
+        w.print("x{x}", .{cp}) catch {};
+    } else {
+        var cbuf: [4]u8 = undefined;
+        const len = std.unicode.utf8Encode(cp, &cbuf) catch 0;
+        w.writeAll(cbuf[0..len]) catch {};
+    }
+}
+
+/// Write `s` truncated to at most `cap` bytes, with a trailing `...` when cut.
+/// Truncation backs off to a UTF-8 boundary so a diagnostic never emits a
+/// split multibyte sequence.
+fn describeBounded(w: *std.Io.Writer, s: []const u8, cap: usize) void {
+    if (s.len <= cap) {
+        w.writeAll(s) catch {};
+        return;
+    }
+    var end = cap;
+    while (end > 0 and (s[end] & 0xC0) == 0x80) end -= 1; // don't split a codepoint
+    w.writeAll(s[0..end]) catch {};
+    w.writeAll("...") catch {};
+}
+
+/// Write a bounded, quoted, escaped prefix of a string value.
+fn describeString(w: *std.Io.Writer, s: []const u8) void {
+    const cap: usize = 32;
+    w.writeByte('"') catch {};
+    var n = @min(s.len, cap);
+    while (n > 0 and n < s.len and (s[n] & 0xC0) == 0x80) n -= 1; // don't split a codepoint
+    for (s[0..n]) |c| {
+        switch (c) {
+            '"' => w.writeAll("\\\"") catch {},
+            '\\' => w.writeAll("\\\\") catch {},
+            '\n' => w.writeAll("\\n") catch {},
+            '\t' => w.writeAll("\\t") catch {},
+            '\r' => w.writeAll("\\r") catch {},
+            else => w.writeByte(c) catch {},
+        }
+    }
+    w.writeByte('"') catch {};
+    if (n < s.len) w.writeAll("...") catch {};
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/scheme/audit/error-taxonomy-audit.scm
+++ b/tests/scheme/audit/error-taxonomy-audit.scm
@@ -488,59 +488,65 @@
 (test-assert "fidelity: the empty list renders as ()"
              (contains? (msg-of (lambda () (car '()))) "()"))
 
-;; -- Values that do NOT render (the finding) ---------------------------------
-(test-assert "TODAY (#1899): a symbol renders as an opaque #<symbol>"
-             (contains? (msg-of (lambda () (vector-ref (vector 1) 'the-key))) "#<symbol>"))
-(test-assert "TODAY (#1899): the symbol's name is absent from the message"
+;; -- Values that now render their identity (#1899 fixed) ---------------------
+;; safeValueDescription renders identifying content for heap types while
+;; staying no-allocation, bounded, and cycle-safe (a compound value gets a
+;; one-level summary, never a recursive print).
+(test-assert "#1899 FIXED: a symbol renders its name"
+             (contains? (msg-of (lambda () (vector-ref (vector 1) 'the-key))) "the-key"))
+(test-assert "#1899 FIXED: the opaque #<symbol> tag is gone"
              (not (contains? (msg-of (lambda () (vector-ref (vector 1) 'the-key)))
-                             "the-key")))
-(test-assert "TODAY (#1899): a string renders as an opaque #<string>"
-             (contains? (msg-of (lambda () (vector-ref (vector 1) "needle"))) "#<string>"))
-(test-assert "TODAY (#1899): a vector renders as an opaque #<vector>"
-             (contains? (msg-of (lambda () (vector-ref (vector 1) (vector 9)))) "#<vector>"))
-(test-assert "TODAY (#1899): a pair renders as an opaque #<pair>"
+                             "#<symbol>")))
+(test-assert "#1899 FIXED: a string renders a quoted prefix"
+             (contains? (msg-of (lambda () (vector-ref (vector 1) "needle"))) "\"needle\""))
+;; Compound types get a one-level length summary -- cheap, and cycle-safe by
+;; construction (no recursion into the contents).
+(test-assert "#1899 FIXED: a vector renders its length, not #<vector>"
+             (contains? (msg-of (lambda () (vector-ref (vector 1) (vector 9))))
+                        "#<vector length 1>"))
+(test-assert "#1899 FIXED: a bytevector renders its length"
+             (contains? (msg-of (lambda () (vector-ref (vector 1) (bytevector 1 2 3))))
+                        "#<bytevector length 3>"))
+(test-assert "#1899 FIXED: a rational renders as num/den"
+             (contains? (msg-of (lambda () (vector-ref (vector 1) 3/2))) "3/2"))
+;; A pair stays a summary (rendering its spine would need cycle detection).
+(test-assert "a pair still renders conservatively as #<pair>"
              (contains? (msg-of (lambda () (vector-ref (vector 1) (list 9)))) "#<pair>"))
-(test-assert "TODAY (#1899): a bytevector renders as an opaque #<bytevector>"
-             (contains? (msg-of (lambda () (vector-ref (vector 1) (bytevector 1))))
-                        "#<bytevector>"))
-(test-assert "TODAY (#1899): a rational renders as an opaque #<rational>"
-             (contains? (msg-of (lambda () (vector-ref (vector 1) 3/2))) "#<rational>"))
 
-;; A character is an IMMEDIATE under NaN-boxing -- rendering it needs no heap
-;; access at all, so the documented "does not dereference heap payloads"
-;; rationale cannot apply. #1899 says this could not be reproduced; it does.
-(test-assert "TODAY (#1899): a character renders as #<char> despite being immediate"
-             (contains? (msg-of (lambda () (vector-ref (vector 1) #\a))) "#<char>"))
-(test-assert "TODAY (#1899): the character's own value is absent"
-             (not (contains? (msg-of (lambda () (vector-ref (vector 1) #\a))) "#\\a")))
+;; A character is an IMMEDIATE under NaN-boxing -- #1899 noted an unverified
+;; report that it rendered as #<char>; that was real, and it now renders in its
+;; #\ external form.
+(test-assert "#1899 FIXED: a character renders in its #\\ form"
+             (contains? (msg-of (lambda () (vector-ref (vector 1) #\a))) "#\\a"))
+(test-assert "#1899 FIXED: the opaque #<char> tag is gone"
+             (not (contains? (msg-of (lambda () (vector-ref (vector 1) #\a))) "#<char>")))
 
-;; -- The self-contradiction: a bignum IS an exact integer --------------------
-;; This is #1916's exact shape ("expected exact integer, got 1", where 1 is an
-;; exact integer), still live for bignums and rationals. It is also a Part 2
-;; instance: the value satisfies the claimed type and is merely out of range.
-(test-assert "TODAY (#1899): a bignum index says 'expected exact integer'"
+;; -- A bignum in u128 range now renders its exact value ----------------------
+;; #1916's shape ("expected exact integer, got <the integer>") no longer argues
+;; against itself for bignums that fit a u128; the value is shown in full.
+(test-assert "#1899 FIXED: a bignum index says 'expected exact integer'"
              (contains? (msg-of (lambda () (vector-ref (vector 1 2) 99999999999999999999)))
                         "expected exact integer"))
-(test-assert "TODAY (#1899): ...and reports the value as #<bignum>"
+(test-assert "#1899 FIXED: ...and reports the bignum's value"
              (contains? (msg-of (lambda () (vector-ref (vector 1 2) 99999999999999999999)))
-                        "#<bignum>"))
-(test-assert "control: the value really is an exact integer, so the message is self-contradictory"
+                        "99999999999999999999"))
+(test-assert "control: the value really is an exact integer"
              (exact-integer? 99999999999999999999))
+;; A magnitude beyond u128 needs heap scratch to stringify, which the error
+;; path must not allocate, so it falls back to a bounded #<bignum>.
+(test-assert "a bignum past u128 falls back conservatively to #<bignum>"
+             (contains? (msg-of (lambda () (vector-ref (vector 1 2)
+                                                       999999999999999999999999999999999999999999)))
+                        "#<bignum>"))
 
-;; -- The decisive control: the "unsafe" path renders BETTER ------------------
-;; `vm_calls.mapNativeError:383` runs the FULL allocating printer
-;; (printer.valueToString) when a primitive returns a bare TypeError with no
-;; detail set. So the path CI's gate exists to eliminate produces a strictly
-;; more informative value than primitives.typeError does -- same error class,
-;; same VM state, same file. This is why the documented rationale for the
-;; opacity ("deliberately does not dereference heap payloads",
-;; docs/dev/adding-features.md:75-77) cannot be the real constraint.
+;; -- Parity with the "unsafe" bare-return path -------------------------------
+;; `vm_calls.mapNativeError` runs the full allocating printer for a primitive
+;; that returns a bare TypeError with no detail. The typeError path used to
+;; render strictly worse than that; now both name the value.
 (test-assert "control: sqrt (bare-return path) renders the symbol's name"
              (contains? (msg-of (lambda () (sqrt 'the-key))) "the-key"))
-(test-assert "TODAY (#1899): magnitude (typeError path) renders #<symbol> instead"
-             (contains? (msg-of (lambda () (magnitude 'the-key))) "#<symbol>"))
-(test-assert "TODAY (#1899): ...and loses the name the other path kept"
-             (not (contains? (msg-of (lambda () (magnitude 'the-key))) "the-key")))
+(test-assert "#1899 FIXED: magnitude (typeError path) also renders the name"
+             (contains? (msg-of (lambda () (magnitude 'the-key))) "the-key"))
 
 ;; FAIL: #1899 (the helper path is less informative than the fallback path)
 ;; (test-assert "the typeError path is at least as informative as the fallback"

--- a/tests/scheme/audit/internal-primitives-audit.scm
+++ b/tests/scheme/audit/internal-primitives-audit.scm
@@ -681,8 +681,11 @@
 ;;; ==================================================================
 ;;; D3 -- diagnostic fidelity
 ;;; ==================================================================
-;;; #1899 (heap values render opaquely as `#<symbol>` etc.) is already
-;;; filed and is NOT re-asserted here. These two are distinct from it.
+;;; #1899 (heap values rendering opaquely as `#<symbol>` etc.) was fixed
+;;; separately; its regression coverage lives in
+;;; tests/scheme/audit/error-taxonomy-audit.scm and
+;;; tests/scheme/errors/type-error-value-identity-1899.sh, not here. These two
+;;; are distinct from it.
 ;;;
 ;;; All three defects below were found by this audit and fixed in #1916; the
 ;;; assertions are kept alongside their original controls, which is what makes

--- a/tests/scheme/audit/primitives_io-audit.scm
+++ b/tests/scheme/audit/primitives_io-audit.scm
@@ -719,7 +719,7 @@
 ;; CONTROL: a genuinely wrong type — and a right-type/wrong-direction port —
 ;; must still be a type error, or the fix above would have flattened the
 ;; distinction instead of drawing it.
-(test-equal "type error in 'write-string': expected output port, got #<symbol>"
+(test-equal "type error in 'write-string': expected output port, got not-a-port"
   (err-message (lambda () (write-string "x" 'not-a-port))))
 (test-equal "type error in 'write-string': expected output port, got #<port>"
   (err-message (lambda () (write-string "x" (open-input-string "y")))))
@@ -766,7 +766,7 @@
   (err-message (lambda () (fd->port 999999999999))))
 ;; CONTROL: a genuinely wrong type is still a type error, so the fix drew the
 ;; distinction rather than flattening every rejection into one kind.
-(test-equal "type error in 'fd->port': expected file descriptor, got #<symbol>"
+(test-equal "type error in 'fd->port': expected file descriptor, got nope"
   (err-message (lambda () (fd->port 'nope))))
 (test-equal "type error in 'fd->port': expected file descriptor, got 3.0"
   (err-message (lambda () (fd->port 3.0))))

--- a/tests/scheme/errors/type-error-value-identity-1899.sh
+++ b/tests/scheme/errors/type-error-value-identity-1899.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Regression test for kaappi#1899: a type-error message must name the offending
+# value's identity, not render it as an opaque tag.
+#
+# `primitives.safeValueDescription` (src/primitives.zig) used to print symbol,
+# string, vector, bytevector, rational and bignum as `#<symbol>`/`#<string>`/…
+# and characters (which are immediates) as `#<char>`. The one thing the user
+# needs — WHICH value was wrong — was exactly what got dropped. It now renders
+# the identifying content, while staying bounded (long strings/vectors are
+# summarised, never dumped) and cycle-safe (a compound value gets a one-level
+# summary, never a recursive print).
+
+set -euo pipefail
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+PASS=0
+FAIL=0
+
+assert_output_contains() {
+    local label="$1"
+    local input="$2"
+    local expected="$3"
+    local output
+    output=$(echo "$input" | "$KAAPPI" 2>&1 || true)
+    if grep -qF "$expected" <<< "$output"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — expected '$expected' in output; got:"
+        echo "    $output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_output_lacks() {
+    local label="$1"
+    local input="$2"
+    local forbidden="$3"
+    local output
+    output=$(echo "$input" | "$KAAPPI" 2>&1 || true)
+    if grep -qF "$forbidden" <<< "$output"; then
+        echo "FAIL: $label — output still contains '$forbidden'"
+        FAIL=$((FAIL + 1))
+    else
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# The length of a bounded description must stay small no matter how big the
+# value is: assert the `got ...` field of the message is under a cap.
+assert_got_field_bounded() {
+    local label="$1"
+    local input="$2"
+    local cap="$3"
+    local output got_field
+    output=$(echo "$input" | "$KAAPPI" 2>&1 || true)
+    # Everything after the last "got " on the error line.
+    got_field=$(grep -oE 'got .*$' <<< "$output" | tail -1 || true)
+    if [ -z "$got_field" ]; then
+        echo "FAIL: $label — no 'got ...' field in output; got: $output"
+        FAIL=$((FAIL + 1))
+    elif [ "${#got_field}" -le "$cap" ]; then
+        echo "PASS: $label (${#got_field} <= $cap bytes)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — 'got' field is ${#got_field} bytes, over $cap: $got_field"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== Type-error value identity (kaappi#1899) ==="
+echo
+
+# --- Symbols: name, not #<symbol> ---
+echo "-- Symbols --"
+assert_output_contains "vector-ref names the symbol argument" \
+    "(vector-ref (vector 1 2) 'somesym)" "got somesym"
+assert_output_contains "string-length names the symbol argument" \
+    "(string-length 'foo)" "got foo"
+assert_output_lacks "symbol no longer renders as an opaque tag" \
+    "(string-length 'foo)" "#<symbol>"
+
+# --- Strings: bounded, quoted prefix, not #<string> ---
+echo
+echo "-- Strings --"
+assert_output_contains "type error quotes a short string value" \
+    '(vector-ref (make-vector 3 0) "hello")' 'got "hello"'
+assert_output_lacks "string no longer renders as an opaque tag" \
+    '(vector-ref (make-vector 3 0) "hello")' "#<string>"
+# A long string is truncated with a trailing ellipsis and stays bounded.
+assert_output_contains "a long string is truncated with ..." \
+    '(char-upcase "0123456789012345678901234567890123456789 and more")' '...'
+assert_got_field_bounded "the rendered long string stays bounded" \
+    '(char-upcase "0123456789012345678901234567890123456789 and more")' 50
+
+# --- Vectors / bytevectors: one-level length summary, not #<vector> ---
+echo
+echo "-- Vectors and bytevectors --"
+assert_output_contains "vector renders as a length summary" \
+    '(char-upcase (vector 1 2 3 4 5))' "got #<vector length 5>"
+assert_output_contains "bytevector renders as a length summary" \
+    '(char-upcase (bytevector 1 2 3))' "got #<bytevector length 3>"
+# A large vector must be summarised, never dumped element by element.
+assert_got_field_bounded "a large vector stays bounded" \
+    '(char-upcase (make-vector 100000 0))' 40
+
+# --- Characters: literal #\a form, not #<char> ---
+echo
+echo "-- Characters (unverified #<char> claim — confirmed real) --"
+assert_output_contains "a character renders in its #\\ form" \
+    '(+ 1 (integer->char 97))' 'got #\a'
+assert_output_lacks "character no longer renders as an opaque tag" \
+    '(+ 1 (integer->char 97))' "#<char>"
+assert_output_contains "a named character renders by name" \
+    '(+ 1 #\newline)' 'got #\newline'
+
+# --- Exact numbers: bignum and rational render their value ---
+echo
+echo "-- Bignum and rational --"
+assert_output_contains "a bignum in u128 range renders its value" \
+    '(char-upcase 99999999999999999999)' "got 99999999999999999999"
+assert_output_contains "a negative bignum keeps its sign" \
+    '(char-upcase -12345678901234567890)' "got -12345678901234567890"
+# A bignum beyond u128 falls back conservatively (no heap scratch on the
+# error path) but stays bounded and self-describing.
+assert_output_contains "a huge bignum falls back to #<bignum>" \
+    '(char-upcase 999999999999999999999999999999999999999999999999999999)' "got #<bignum>"
+assert_output_contains "a rational renders as num/den" \
+    '(char-upcase 1/3)' "got 1/3"
+
+# --- No regression for values that already rendered ---
+echo
+echo "-- No regression for inline values --"
+assert_output_contains "fixnum still renders as its value" \
+    '(string-length 42)' "got 42"
+assert_output_contains "flonum keeps its .0 (kaappi#1916)" \
+    '(vector-ref (vector 1 2) 1.0)' "got 1.0"
+assert_output_contains "empty list still renders as ()" \
+    "(vector-ref (vector 1 2) '())" "got ()"
+assert_output_contains "boolean still renders as #f" \
+    '(vector-ref (vector 1 2) #f)' "got #f"
+
+echo
+echo "=== Results ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo "TYPE-ERROR VALUE IDENTITY REGRESSION DETECTED"
+    exit 1
+fi
+
+echo "All type-error value identity tests pass."
+exit 0

--- a/tests/wasm/platform-gates.scm
+++ b/tests/wasm/platform-gates.scm
@@ -88,7 +88,7 @@
 
 (check "CONTROL: fd->port still type-checks its argument first"
        (equal? (classify (lambda () (fd->port 'not-a-fixnum)))
-               '(error "type error in 'fd->port': expected file descriptor, got #<symbol>" ())))
+               '(error "type error in 'fd->port': expected file descriptor, got not-a-fixnum" ())))
 
 ;; file-exists? is the one filesystem procedure with a value to degrade to, so
 ;; it answers #f rather than raising anything at all — deliberately unlike the


### PR DESCRIPTION
## Problem

A type error rendered the offending value through `primitives.safeValueDescription`, which printed most heap types as an opaque tag — so the one piece of information a user needs, *which* value was wrong, was exactly what got dropped:

```
$ echo "(vector-ref (vector 1 2) 'x)" | kaappi
error[KP3002]: type error in 'vector-ref': expected exact integer, got #<symbol>   # was
error[KP3002]: type error in 'vector-ref': expected exact integer, got x           # now
```

The issue also carried an unverified report that `#\a` rendered as `#<char>`. **Confirmed real** — characters are immediates, so `safeValueDescription` had a literal `if (types.isChar(value)) return "#<char>";` arm. Fixed here.

## What each type now renders as

| Type | Before | After |
|------|--------|-------|
| symbol | `#<symbol>` | `foo` (the name) |
| string | `#<string>` | `"needle"` (quoted, escaped, 32-byte cap + `...`) |
| character | `#<char>` | `#\a`, `#\newline`, `#\x1b` |
| vector | `#<vector>` | `#<vector length 5>` |
| bytevector | `#<bytevector>` | `#<bytevector length 3>` |
| rational | `#<rational>` | `1/3` |
| bignum (≤ u128) | `#<bignum>` | `99999999999999999999` |
| bignum (> u128) | `#<bignum>` | `#<bignum>` (conservative — see below) |

Inline values (fixnum, flonum, `#t`/`#f`/`()`, procedures, pairs, hash-tables) are unchanged, including the `1.0`-keeps-its-`.0` fix from #1916.

## Safety properties preserved

`safeValueDescription` runs on the error path of ~700 type-error sites, possibly holding a half-constructed or foreign-owned value. All three constraints in its own contract are kept:

- **No allocation, no VM callback.** Everything is read directly from the value or its object header. A bignum whose magnitude exceeds `u128` would need heap scratch to stringify, so it falls back to `#<bignum>` rather than allocate on the error path. A rational whose numerator or denominator is such a bignum falls back to `#<rational>`.
- **Bounded output.** All writing goes through a fixed 128-byte `std.Io.Writer`, so every write is capped by the buffer; strings and symbols are additionally truncated (with a trailing `...`, backing off to a UTF-8 boundary) before they reach it. A million-element vector reports its length, never its contents.
- **No recursion into heap structure.** Compound types get a one-level summary — a vector/bytevector reports its length; a rational renders its two exact-integer components (each necessarily a fixnum or bignum, never a pointer to a compound). Nothing recurses, so a cyclic value cannot loop. Pairs stay a conservative `#<pair>` for the same reason.

## Tests

- New `tests/scheme/errors/type-error-value-identity-1899.sh` (21 assertions): symbol/string/vector/bytevector/char/bignum/rational identity, long-string truncation and large-vector bounding (asserts the `got` field stays under a byte cap), and no-regression checks for fixnum/flonum/`()`/`#f`.
- Updated `tests/scheme/audit/error-taxonomy-audit.scm` — its Part 5 "diagnostic fidelity" block was a characterization of this bug as `TODAY (#1899)`; it now asserts the fixed behavior (including the u128 fallback boundary).
- Updated two `got #<symbol>` golden strings in `tests/scheme/audit/primitives_io-audit.scm` and one in `tests/wasm/platform-gates.scm`.

`zig build test` passes; the existing `tests/scheme/errors/error-format.sh` (144 assertions) and both affected audit suites pass.

Closes #1899

🤖 Generated with [Claude Code](https://claude.com/claude-code)
