### PR TITLE
Compile top-level define-values in program order, not the preamble

### DIFF
--- a/docs/dev/cache.md
+++ b/docs/dev/cache.md
@@ -179,34 +179,37 @@ to* the source as `file.sbc`. A central store is what makes `cache status` /
   `define-library`, `define-record-type`) — and records them in the artifact's
   preamble for replay. `begin` and `cond-expand` are spliced into the form
   stream so their bodies are compiled (only a `cond-expand`'s branch
-  *selection* is a compile-time question), and a `define-values` is recorded
-  without its producer expression being evaluated. Until
-  [#2156](https://github.com/kaappi/kaappi/issues/2156) all three were
-  evaluated for real, so `(begin (delete-file "x"))` deleted the file while
-  producing the `.sbc` and again at run time from the preamble.
-  `--disassemble` follows the same discipline.
+  *selection* is a compile-time question). Until
+  [#2156](https://github.com/kaappi/kaappi/issues/2156) those bodies — and a
+  `define-values` producer — were evaluated for real, so
+  `(begin (delete-file "x"))` deleted the file while producing the `.sbc` and
+  again at run time from the preamble. `--disassemble` follows the same
+  discipline.
 
   **The preamble replays in full before any compiled form**, so a recorded
-  declaration does not keep its position in the program. Splicing puts `begin`
-  and `cond-expand` bodies into the compiled stream, which is what restores
-  their order; the other six heads still replay first. For `import`,
-  `include`, `include-ci`, `define-library` and `define-record-type` that is
-  harmless — they are declarations, and hoisting them is what a preamble is
-  for. For `define-values` it is not, because its producer is arbitrary
-  program code that can depend on earlier forms:
+  declaration does not keep its position in the program. That is harmless for
+  the five env-setup heads — they are declarations, and hoisting them ahead of
+  the compiled stream is what a preamble is for.
+
+  `define-values` is **not** hoisted
+  ([#2200](https://github.com/kaappi/kaappi/issues/2200)): its producer is
+  arbitrary program code that can depend on an earlier top-level form, so
+  reordering it would fail where the interpreter succeeds. It has a compilable
+  lowering (`compileDefineValues` desugars it to `define` + `call-with-values` +
+  `set!`), so `--compile` routes it through ordinary compilation and it keeps
+  its position in the compiled stream, exactly like `begin`/`cond-expand`
+  splicing does for their bodies.
 
   ```scheme
   (define x 1)
-  (define-values (a b) (values x 2))   ; replayed first, with x unbound
+  (define-values (a b) (values x 2))   ; compiled in order, sees x = 1
   (display (list a b))
   ```
 
-  The interpreter prints `(1 2)`; the standalone binary fails with
-  `preamble error[KP3001]: undefined variable 'x'` and exits 1. This
-  pre-dates #2156 and is unchanged by it — tracked separately as
-  [#2200](https://github.com/kaappi/kaappi/issues/2200), since fixing it needs
-  either an order-preserving preamble in the `.sbc` format or a compilable
-  `define-values`.
+  Both the interpreter and the standalone binary print `(1 2)`. Before #2200
+  the `define-values` was recorded in the preamble and replayed first, with `x`
+  still unbound, so the binary failed with
+  `preamble error[KP3001]: undefined variable 'x'` and exited 1.
 - `.sld` library loads are never cached in either direction.
 
 ## Inspect, clear, bypass

--- a/src/main.zig
+++ b/src/main.zig
@@ -1230,29 +1230,38 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
             };
 
             if (vm.topLevelHead(form)) |head| {
-                // Record every declaration for replay when the artifact runs.
-                // Propagate an allocation failure rather than dropping the
-                // form: silently continuing here writes an artifact missing an
-                // `import`, then prints `Compiled ... -> ...` and exits 0.
-                // `runFile`'s equivalent site returns error.OutOfMemory too.
-                const form_src = try printer.valueToString(allocator, form, .write);
-                preamble.append(allocator, form_src) catch {
-                    allocator.free(form_src);
-                    return error.OutOfMemory;
-                };
-                // ...but evaluate only those the *compiler* depends on. A
-                // `define-values` needs nothing at compile time, and evaluating
-                // it ran its producer expression's side effects for real while
-                // writing the `.sbc`, on top of the replay just recorded — so
-                // `(define-values (a) (values (delete-file "x")))` deleted the
-                // file twice (#2156). `begin` and `cond-expand` never reach
-                // here; TopLevelForms already spliced them.
-                if (!head.isEnvSetup()) continue;
-                _ = vm.runTopLevelHead(head, form) catch |err| {
-                    script_had_error = true;
-                    toplevel_driver.reportRuntimeError(vm, err, .{ .source = path, .line = datum_lc.line });
-                };
-                continue;
+                // Only the env-setup declarations belong in the preamble, which
+                // the artifact replays *before* any compiled form. `import` /
+                // `include` / `include-ci` / `define-library` /
+                // `define-record-type` establish the environment later forms
+                // are compiled against, so hoisting them ahead of the compiled
+                // stream is exactly what a preamble is for.
+                //
+                // `define-values` is NOT env setup: its producer is arbitrary
+                // program code that can depend on earlier forms, so hoisting it
+                // into the preamble reorders execution and can fail where the
+                // interpreter succeeds (#2200). It has a compilable lowering
+                // (`compileDefineValues`), so let it fall through to ordinary
+                // compilation and keep its position in the compiled stream.
+                // `begin` and `cond-expand` never reach here; TopLevelForms
+                // already spliced them.
+                if (head.isEnvSetup()) {
+                    // Record the declaration for replay when the artifact runs.
+                    // Propagate an allocation failure rather than dropping the
+                    // form: silently continuing here writes an artifact missing
+                    // an `import`, then prints `Compiled ... -> ...` and exits 0.
+                    // `runFile`'s equivalent site returns error.OutOfMemory too.
+                    const form_src = try printer.valueToString(allocator, form, .write);
+                    preamble.append(allocator, form_src) catch {
+                        allocator.free(form_src);
+                        return error.OutOfMemory;
+                    };
+                    _ = vm.runTopLevelHead(head, form) catch |err| {
+                        script_had_error = true;
+                        toplevel_driver.reportRuntimeError(vm, err, .{ .source = path, .line = datum_lc.line });
+                    };
+                    continue;
+                }
             }
 
             const func = compiler.compileExpressionWithMacrosAt(vm.gc, form, &vm.macros, vm.globals, datum_lc.line, path, false) catch |err| {

--- a/tests/scheme/compile/compile-define-values-order-2200.sh
+++ b/tests/scheme/compile/compile-define-values-order-2200.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Regression test for #2200: a compiled artifact must run a top-level
+# `define-values` in program order, not hoist it into the preamble.
+#
+# `kaappi --compile` records every top-level form `vm_eval.handleTopLevelForm`
+# claims into the artifact's PREAMBLE, and the bundle runner replays the whole
+# preamble *before* any compiled form. For the five `TopLevelHead.isEnvSetup()`
+# declarations (import/include/include-ci/define-library/define-record-type)
+# that hoisting is correct — they establish the environment later forms compile
+# against. `define-values` is NOT env setup: its producer is arbitrary program
+# code that can depend on an earlier top-level form, so hoisting it reorders
+# execution and can fail where the interpreter succeeds.
+#
+# Repro: `(define x 1) (define-values (a b) (values x 2))` — hoisting the
+# `define-values` ahead of `(define x 1)` made the artifact die with
+# `preamble error[KP3001]: undefined variable 'x'`.
+#
+# The fix routes `define-values` through ordinary compilation (it has a
+# compilable lowering, `compileDefineValues`), so it keeps its position in the
+# compiled stream instead of reaching the preamble at all.
+#
+# The interpreter is this tier's oracle (tests/scheme/CLAUDE.md): the standalone
+# binary's stdout and exit status must match the interpreter's.
+#
+# Usage: bash tests/scheme/compile/compile-define-values-order-2200.sh [path-to-kaappi]
+
+set -euo pipefail
+
+. "$(dirname "$0")/../shell-common.sh"
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+if [ ! -x "$KAAPPI" ]; then
+    echo "FAIL: no kaappi binary at '$KAAPPI' — build it first (zig build)"
+    exit 1
+fi
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+PASS=0
+FAIL=0
+
+HOMEDIR="$(mktemp -d)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$HOMEDIR" "$WORK"' EXIT
+export KAAPPI_HOME="$HOMEDIR"
+
+ok() {
+    echo "PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+bad() {
+    echo "FAIL: $1"
+    shift
+    for line in "$@"; do echo "  $line"; done
+    FAIL=$((FAIL + 1))
+}
+
+# The producer of the define-values depends on an earlier top-level define, so
+# any hoisting into the preamble breaks it.
+cat > "$WORK/prog.scm" <<'SCM'
+(define x 1)
+(define-values (a b) (values x 2))
+(display (list a b))
+(newline)
+SCM
+
+echo "=== interpreter (the tier oracle) ==="
+interp_status=0
+interp_out="$(interp_stdout "$KAAPPI_ABS" "$WORK" "$WORK/prog.scm")" || interp_status=$?
+if [ "$interp_out" == "(1 2)" ] && [ "$interp_status" -eq 0 ]; then
+    ok "interpreted run prints (1 2) and exits 0"
+else
+    bad "interpreted run prints (1 2) and exits 0" \
+        "stdout: $interp_out" "exit: $interp_status"
+fi
+
+echo "=== standalone binary matches the interpreter ==="
+skip_without_zig "the standalone-binary check needs a Zig toolchain"
+
+# The .sbc's compiler hash folds in the producing binary's git build id
+# (docs/dev/cache.md), so a .sbc made by a stale zig-out/bin/kaappi goes stale
+# against a bundler rebuilt from current source (kaappi#1930). Build the
+# interpreter into an isolated prefix from the same source the bundler uses, and
+# produce the .sbc with THAT binary. -p keeps zig-out/ and the caller's binary
+# untouched.
+(cd "$REPO_ROOT" && zig build -p "$WORK/interp" > /dev/null 2>&1)
+"$WORK/interp/bin/kaappi" --compile -o "$WORK/prog.sbc" "$WORK/prog.scm" > /dev/null
+
+(cd "$REPO_ROOT" && zig build -Dbundle="$WORK/prog.sbc" -p "$WORK/bundle" > /dev/null 2>&1)
+native_status=0
+native_out="$("$WORK/bundle/bin/kaappi" 2> /dev/null)" || native_status=$?
+
+if [ "$native_out" == "(1 2)" ] && [ "$native_status" -eq 0 ]; then
+    ok "standalone binary prints (1 2) and exits 0"
+else
+    bad "standalone binary prints (1 2) and exits 0" \
+        "stdout: $native_out" "exit: $native_status"
+fi
+
+if assert_tiers_agree "standalone binary vs interpreter" \
+    "$interp_out" "$interp_status" "$native_out" "$native_status"; then
+    ok "the standalone binary agrees with the interpreter on stdout and exit status"
+else
+    FAIL=$((FAIL + 1))
+fi
+
+echo "=== control: an env-setup declaration is still hoisted and works ==="
+# A top-level `import` must still reach the preamble and be replayed before the
+# compiled forms — that is what a preamble is for. Proving it still works
+# compiled guards against over-restricting the hoisting.
+cat > "$WORK/env.scm" <<'SCM'
+(import (scheme base) (scheme write))
+(define-values (p q) (values 10 20))
+(display (+ p q))
+(newline)
+SCM
+env_interp_status=0
+env_interp_out="$(interp_stdout "$KAAPPI_ABS" "$WORK" "$WORK/env.scm")" || env_interp_status=$?
+
+"$WORK/interp/bin/kaappi" --compile -o "$WORK/env.sbc" "$WORK/env.scm" > /dev/null
+(cd "$REPO_ROOT" && zig build -Dbundle="$WORK/env.sbc" -p "$WORK/envbundle" > /dev/null 2>&1)
+env_native_status=0
+env_native_out="$("$WORK/envbundle/bin/kaappi" 2> /dev/null)" || env_native_status=$?
+
+if assert_tiers_agree "env-setup import + define-values compiled" \
+    "$env_interp_out" "$env_interp_status" "$env_native_out" "$env_native_status"; then
+    ok "an import is still hoisted and the compiled artifact prints 30"
+else
+    FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "Passed: $PASS, Failed: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Problem

`kaappi --compile` records every top-level form `vm_eval.handleTopLevelForm`
claims into the `.sbc` artifact's **preamble**, and the bundle runner replays
the whole preamble *before* any compiled form. Hoisting is correct for the five
`TopLevelHead.isEnvSetup()` declarations (`import` / `include` / `include-ci` /
`define-library` / `define-record-type`) — they establish the environment later
forms compile against.

`define-values` is **not** env setup: its producer is arbitrary program code
that can depend on an earlier top-level form, so hoisting it reorders execution
and can fail where the interpreter succeeds.

```scheme
(define x 1)
(define-values (a b) (values x 2))
(display (list a b))
(newline)
```

| | before |
|---|---|
| `kaappi dvdep.scm` | `(1 2)`, exit 0 |
| bundled `.sbc` | `preamble error[KP3001]: undefined variable 'x'`, exit 1 |

The `define-values` was replayed from the preamble first, with `x` still
unbound.

## Fix

Restrict preamble hoisting in `compileFile` (`src/main.zig`) to `isEnvSetup()`
heads only. `define-values` already has a compilable lowering
(`compileDefineValues` desugars it to `define` + `call-with-values` + `set!`),
so it now falls through to ordinary compilation and keeps its position in the
compiled stream — exactly like the `begin`/`cond-expand` splicing from #2156.
Its producer is still never executed at compile time (the #2156 double-effect
guarantee is preserved).

| | after |
|---|---|
| `kaappi dvdep.scm` | `(1 2)`, exit 0 |
| bundled `.sbc` | `(1 2)`, exit 0 |

## Tests

`tests/scheme/compile/compile-define-values-order-2200.sh` — native/artifact
tier (a `.scm` regression is not sufficient evidence per repo rule). Compiles
the repro, bundles it with `zig build -Dbundle`, runs the standalone binary, and
asserts stdout `(1 2)` / exit 0 against the interpreter oracle. Includes an
env-setup control (a top-level `import`) that must stay hoisted and still
compile. Verified to fail before the fix (standalone binary errored, exit 1) and
pass after.

Existing `compile-toplevel-side-effects-2156.sh` still passes (the
`define-values` producer is still unrun at compile time). `docs/dev/cache.md`,
which had documented #2200 as an open limitation, is updated.

Closes #2200

🤖 Generated with [Claude Code](https://claude.com/claude-code)