### PR TITLE
Validate SRFI 231 entry-point arguments to match the reference (#2312 #2313 #2315 #2316 #2317 #2318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **SRFI 231 argument validation now matches the reference implementation at
+  six entry points** (#2312, #2313, #2315, #2316, #2317, #2318), found by
+  running the reference test suite's 330 error-expectation tests against
+  Kaappi (all 330 now pass; 322 did before).
+  `interval-contains-multi-index?` signaled nothing when the number of
+  indices differed from the interval's dimension, silently returning `#f`
+  (#2312); every built-in storage class's `data->body` was the unvalidated
+  identity, handing wrong-typed data back as a would-be body (#2313);
+  `make-array` accepted a non-procedure setter, so `mutable-array?` and
+  `array-setter` then misreported the object (#2315); non-boolean
+  `safe?`/`mutable?` values were accepted by both specialized constructors
+  and both default parameters — the parameter case installing garbage as a
+  process-wide default every later array would inherit (#2316);
+  `specialized-array-share` accepted a non-procedure mapper, undetectable
+  for empty domains where the mapper is never invoked (#2317); and
+  `array-tile` accepted a scalar slice-width on a zero-width axis, where the
+  spec permits only the explicit-vector form (#2318).
+
 ## [0.23.0] - 2026-08-23
 
 ### Added

--- a/lib/srfi/231/arrays.sld
+++ b/lib/srfi/231/arrays.sld
@@ -94,10 +94,24 @@
       (unless (interval? interval) (error "make-array: not an interval" interval))
       (unless (procedure? getter) (error "make-array: getter must be a procedure" getter))
       (let ((setter (if (null? maybe-setter) #f (car maybe-setter))))
+        (unless (or (not setter) (procedure? setter))
+          (error "make-array: setter must be a procedure or #f" setter))
         (%make-array interval getter setter #f #f #f #f)))
 
-    (define specialized-array-default-safe? (make-parameter #f))
-    (define specialized-array-default-mutable? (make-parameter #t))
+    ;; safe?/mutable? are booleans everywhere they appear (the two default
+    ;; parameters and both specialized constructors' options) -- the
+    ;; reference implementation rejects non-booleans at each site rather
+    ;; than letting a truthy wrong-typed value silently flip a mode.
+    (define (%check-boolean! x who)
+      (unless (boolean? x) (error (string-append who ": argument must be a boolean") x)))
+
+    (define (%boolean-parameter default name)
+      (make-parameter default (lambda (x) (%check-boolean! x name) x)))
+
+    (define specialized-array-default-safe?
+      (%boolean-parameter #f "specialized-array-default-safe?"))
+    (define specialized-array-default-mutable?
+      (%boolean-parameter #t "specialized-array-default-mutable?"))
 
     ;; The lexicographical mapping of interval onto [0, interval-volume) --
     ;; per spec, a specialized array's own indexer. Subtracts each axis's
@@ -134,6 +148,8 @@
 
     (define (make-specialized-array interval . opts)
       (unless (interval? interval) (error "make-specialized-array: not an interval" interval))
+      (%check-boolean! (%opt opts 2 (specialized-array-default-safe?))
+                       "make-specialized-array: safe?")
       (let* ((storage-class (%opt opts 0 generic-storage-class))
              (initial-value (%opt opts 1 (storage-class-default storage-class)))
              (safe? (%opt opts 2 (specialized-array-default-safe?)))
@@ -152,6 +168,10 @@
     ;; new 1-D array WITHOUT copying -- data must already be exactly
     ;; body-shaped for storage-class (per storage-class-data?).
     (define (make-specialized-array-from-data data . opts)
+      (%check-boolean! (%opt opts 1 (specialized-array-default-mutable?))
+                       "make-specialized-array-from-data: mutable?")
+      (%check-boolean! (%opt opts 2 (specialized-array-default-safe?))
+                       "make-specialized-array-from-data: safe?")
       (let* ((storage-class (%opt opts 0 generic-storage-class))
              (mutable? (%opt opts 1 (specialized-array-default-mutable?)))
              (safe? (%opt opts 2 (specialized-array-default-safe?))))

--- a/lib/srfi/231/intervals.sld
+++ b/lib/srfi/231/intervals.sld
@@ -125,16 +125,22 @@
                  (<= (interval-upper-bound i1 k) (interval-upper-bound i2 k))
                  (loop (+ k 1))))))
 
+    ;; Per spec, the multi-index must have exactly the interval's
+    ;; dimension -- a mismatch is an error, not a normal #f result (#f is
+    ;; reserved for a well-formed multi-index that fails the bound check),
+    ;; mirroring interval-subset? above.
     (define (interval-contains-multi-index? interval . multi-index)
+      (unless (= (length multi-index) (interval-dimension interval))
+        (error "interval-contains-multi-index?: the dimension of the interval does not match the number of indices"
+               interval multi-index))
       (let ((lo (interval-lower-vec interval)) (up (interval-upper-vec interval)))
-        (and (= (length multi-index) (vector-length lo))
-             (let loop ((i 0) (xs multi-index))
-               (or (null? xs)
-                   (begin
-                     (unless (and (integer? (car xs)) (exact? (car xs)))
-                       (error "interval-contains-multi-index?: multi-index entries must be exact integers" (car xs)))
-                     (and (<= (vector-ref lo i) (car xs)) (< (car xs) (vector-ref up i))
-                          (loop (+ i 1) (cdr xs)))))))))
+        (let loop ((i 0) (xs multi-index))
+          (or (null? xs)
+              (begin
+                (unless (and (integer? (car xs)) (exact? (car xs)))
+                  (error "interval-contains-multi-index?: multi-index entries must be exact integers" (car xs)))
+                (and (<= (vector-ref lo i) (car xs)) (< (car xs) (vector-ref up i))
+                     (loop (+ i 1) (cdr xs))))))))
 
     ;; General d-dimensional nested traversal in lexicographic order. proc
     ;; receives each multi-index as a LIST; public callers apply it to their

--- a/lib/srfi/231/storage-classes.sld
+++ b/lib/srfi/231/storage-classes.sld
@@ -57,6 +57,20 @@
       (data? storage-class-data?)
       (data->body storage-class-data->body))
 
+    ;; data->body: the body IS the data for every built-in class (no
+    ;; offset/scale to install), but the contract still requires rejecting
+    ;; wrong-typed data instead of handing it back as a would-be body
+    ;; (reference implementation: "converts data to a body, raising an
+    ;; exception if needed").
+    (define (%checked-data->body pred class-name type-name)
+      (lambda (data)
+        (if (pred data)
+            data
+            (error (string-append "Expecting a " type-name
+                                  " passed to (storage-class-data->body "
+                                  class-name "): ")
+                   data))))
+
     ;; Reference definitions from the spec text itself, reused verbatim --
     ;; Kaappi's native vector/string already satisfy every one of
     ;; make-storage-class's operational contracts (O(1) getter/setter,
@@ -65,52 +79,52 @@
     (define generic-storage-class
       (make-storage-class vector-ref vector-set! (lambda (arg) #t)
                            make-vector vector-copy! vector-length
-                           #f vector? values))
+                           #f vector? (%checked-data->body vector? "generic-storage-class" "vector")))
 
     (define char-storage-class
       (make-storage-class string-ref string-set! char?
                            make-string string-copy! string-length
-                           #\0 string? values))
+                           #\0 string? (%checked-data->body string? "char-storage-class" "string")))
 
     (define (%exact-int-range-checker lo hi)
       (lambda (x) (and (exact-integer? x) (<= lo x hi))))
 
     (define s8-storage-class
       (make-storage-class s8vector-ref s8vector-set! (%exact-int-range-checker -128 127)
-                           make-s8vector s8vector-copy! s8vector-length 0 s8vector? values))
+                           make-s8vector s8vector-copy! s8vector-length 0 s8vector? (%checked-data->body s8vector? "s8-storage-class" "s8vector")))
     (define s16-storage-class
       (make-storage-class s16vector-ref s16vector-set! (%exact-int-range-checker -32768 32767)
-                           make-s16vector s16vector-copy! s16vector-length 0 s16vector? values))
+                           make-s16vector s16vector-copy! s16vector-length 0 s16vector? (%checked-data->body s16vector? "s16-storage-class" "s16vector")))
     (define s32-storage-class
       (make-storage-class s32vector-ref s32vector-set! (%exact-int-range-checker -2147483648 2147483647)
-                           make-s32vector s32vector-copy! s32vector-length 0 s32vector? values))
+                           make-s32vector s32vector-copy! s32vector-length 0 s32vector? (%checked-data->body s32vector? "s32-storage-class" "s32vector")))
     (define s64-storage-class
       (make-storage-class s64vector-ref s64vector-set!
                            (%exact-int-range-checker -9223372036854775808 9223372036854775807)
-                           make-s64vector s64vector-copy! s64vector-length 0 s64vector? values))
+                           make-s64vector s64vector-copy! s64vector-length 0 s64vector? (%checked-data->body s64vector? "s64-storage-class" "s64vector")))
 
     ;; u8 is a plain R7RS bytevector alias throughout this codebase (per
     ;; SRFI 160's own design), so its storage class is built directly on
     ;; (scheme base)'s bytevector procedures, not a (srfi 160 u8) import.
     (define u8-storage-class
       (make-storage-class bytevector-u8-ref bytevector-u8-set! (%exact-int-range-checker 0 255)
-                           make-bytevector bytevector-copy! bytevector-length 0 bytevector? values))
+                           make-bytevector bytevector-copy! bytevector-length 0 bytevector? (%checked-data->body bytevector? "u8-storage-class" "bytevector")))
     (define u16-storage-class
       (make-storage-class u16vector-ref u16vector-set! (%exact-int-range-checker 0 65535)
-                           make-u16vector u16vector-copy! u16vector-length 0 u16vector? values))
+                           make-u16vector u16vector-copy! u16vector-length 0 u16vector? (%checked-data->body u16vector? "u16-storage-class" "u16vector")))
     (define u32-storage-class
       (make-storage-class u32vector-ref u32vector-set! (%exact-int-range-checker 0 4294967295)
-                           make-u32vector u32vector-copy! u32vector-length 0 u32vector? values))
+                           make-u32vector u32vector-copy! u32vector-length 0 u32vector? (%checked-data->body u32vector? "u32-storage-class" "u32vector")))
     (define u64-storage-class
       (make-storage-class u64vector-ref u64vector-set! (%exact-int-range-checker 0 18446744073709551615)
-                           make-u64vector u64vector-copy! u64vector-length 0 u64vector? values))
+                           make-u64vector u64vector-copy! u64vector-length 0 u64vector? (%checked-data->body u64vector? "u64-storage-class" "u64vector")))
 
     (define f32-storage-class
       (make-storage-class f32vector-ref f32vector-set! real?
-                           make-f32vector f32vector-copy! f32vector-length 0.0 f32vector? values))
+                           make-f32vector f32vector-copy! f32vector-length 0.0 f32vector? (%checked-data->body f32vector? "f32-storage-class" "f32vector")))
     (define f64-storage-class
       (make-storage-class f64vector-ref f64vector-set! real?
-                           make-f64vector f64vector-copy! f64vector-length 0.0 f64vector? values))
+                           make-f64vector f64vector-copy! f64vector-length 0.0 f64vector? (%checked-data->body f64vector? "f64-storage-class" "f64vector")))
 
     ;; complex? is true of every number in Scheme's numeric tower
     ;; (real/rational/integer are all complex), matching the spec's own
@@ -118,11 +132,11 @@
     (define c64-storage-class
       (make-storage-class c64vector-ref c64vector-set! complex?
                            make-c64vector c64vector-copy! c64vector-length
-                           (make-rectangular 0.0 0.0) c64vector? values))
+                           (make-rectangular 0.0 0.0) c64vector? (%checked-data->body c64vector? "c64-storage-class" "c64vector")))
     (define c128-storage-class
       (make-storage-class c128vector-ref c128vector-set! complex?
                            make-c128vector c128vector-copy! c128vector-length
-                           (make-rectangular 0.0 0.0) c128vector? values))
+                           (make-rectangular 0.0 0.0) c128vector? (%checked-data->body c128vector? "c128-storage-class" "c128vector")))
 
     (define u1-storage-class #f)
     (define f8-storage-class #f)

--- a/lib/srfi/231/views.sld
+++ b/lib/srfi/231/views.sld
@@ -69,6 +69,8 @@
     (define (specialized-array-share array new-domain new-domain->old-domain)
       (unless (specialized-array? array) (error "specialized-array-share: not a specialized array" array))
       (unless (interval? new-domain) (error "specialized-array-share: not an interval" new-domain))
+      (unless (procedure? new-domain->old-domain)
+        (error "specialized-array-share: new-domain->old-domain must be a procedure" new-domain->old-domain))
       (when (> (interval-volume new-domain) (interval-volume (array-domain array)))
         (error "specialized-array-share: new-domain has more elements than array" new-domain array))
       (let* ((storage-class (array-storage-class array))
@@ -243,16 +245,22 @@
     ;; confirmed spec-sanctioned, not an error) or a nonempty vector of
     ;; nonnegative exact integers summing to the axis's width (custom
     ;; per-slice widths, exact prefix sums).
-    (define (%tile-cut-offsets width lower Sk)
+    (define (%tile-cut-offsets width lower k Sk)
       (cond
        ((and (integer? Sk) (exact? Sk) (positive? Sk))
-        (let* ((n (quotient (+ width (- Sk 1)) Sk))
-               (offsets (make-vector (+ n 1) lower)))
-          (let loop ((i 1))
-            (when (<= i n)
-              (vector-set! offsets i (min (+ lower (* i Sk)) (+ lower width)))
-              (loop (+ i 1))))
-          offsets))
+        ;; A scalar slice-width is legal only on a positive-width axis; a
+        ;; zero-width axis must use the explicit-vector form (e.g. #(0)),
+        ;; whose entries sum to the width -- the reference implementation's
+        ;; own rule.
+        (if (eqv? width 0)
+            (error "array-tile: a scalar slice-width is allowed only on an axis of positive width" k Sk width)
+            (let* ((n (quotient (+ width (- Sk 1)) Sk))
+                   (offsets (make-vector (+ n 1) lower)))
+              (let loop ((i 1))
+                (when (<= i n)
+                  (vector-set! offsets i (min (+ lower (* i Sk)) (+ lower width)))
+                  (loop (+ i 1))))
+              offsets)))
        ((and (vector? Sk) (> (vector-length Sk) 0)
              (%vector-every (lambda (x) (and (integer? x) (exact? x) (>= x 0))) Sk)
              (= (let loop ((i 0) (acc 0)) (if (= i (vector-length Sk)) acc (loop (+ i 1) (+ acc (vector-ref Sk i))))) width))
@@ -275,7 +283,7 @@
         (let ((cuts (make-vector d #f)))
           (let loop ((k 0))
             (when (< k d)
-              (vector-set! cuts k (%tile-cut-offsets (vector-ref widths k) (vector-ref lowers k) (vector-ref S k)))
+              (vector-set! cuts k (%tile-cut-offsets (vector-ref widths k) (vector-ref lowers k) k (vector-ref S k)))
               (loop (+ k 1))))
           (let ((out-dims (list->vector (map (lambda (c) (- (vector-length c) 1)) (vector->list cuts)))))
             (make-array

--- a/tests/scheme/srfi/srfi231-arrays.scm
+++ b/tests/scheme/srfi/srfi231-arrays.scm
@@ -141,6 +141,31 @@
   (let ((safe-ea (make-specialized-array e s8-storage-class 0 #t)))
     (test-equal #t (guard (exn (#t #t)) (array-ref safe-ea 3 3) #f))))
 
+;;; --- reference-parity argument validation: a setter must be a procedure
+;;; or #f, and safe?/mutable? must be booleans at every site they appear
+;;; (both constructors' options and the two default parameters) ---
+(test-equal #t (guard (e (#t #t))
+                  (make-array (make-interval (vector 3)) list 1)
+                  #f))
+(test-equal #t (guard (e (#t #t))
+                  (make-specialized-array (make-interval (vector 10)) generic-storage-class 0 'a)
+                  #f))
+(test-equal #t (guard (e (#t #t))
+                  (make-specialized-array-from-data (vector 1 2 3) generic-storage-class 'a)
+                  #f))
+(test-equal #t (guard (e (#t #t))
+                  (make-specialized-array-from-data (vector 1 2 3) generic-storage-class #t 'a)
+                  #f))
+(test-equal #t (guard (e (#t #t))
+                  (specialized-array-default-safe? 'a)
+                  #f))
+(test-equal #t (guard (e (#t #t))
+                  (specialized-array-default-mutable? 'a)
+                  #f))
+;; the rejected sets must not have changed the defaults
+(test-equal #f (specialized-array-default-safe?))
+(test-equal #t (specialized-array-default-mutable?))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-231-arrays")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi231-intervals.scm
+++ b/tests/scheme/srfi/srfi231-intervals.scm
@@ -93,7 +93,14 @@
   (test-equal #f (interval-contains-multi-index? b 2 0))
   (test-equal #t (interval-contains-multi-index? b 0 0))
   ;; a multi-index must consist of exact integers
-  (test-equal #t (guard (e (#t #t)) (interval-contains-multi-index? b 1.5 0) #f)))
+  (test-equal #t (guard (e (#t #t)) (interval-contains-multi-index? b 1.5 0) #f))
+  ;; a multi-index whose length differs from the interval's dimension is an
+  ;; error (reference-parity), not a normal #f answer
+  (test-equal #t (guard (e (#t #t)) (interval-contains-multi-index? b 1) #f))
+  (test-equal #t (guard (e (#t #t)) (interval-contains-multi-index? b 0 0 0) #f))
+  (test-equal #t (guard (e (#t #t))
+                  (interval-contains-multi-index? (make-interval '#(1 2 3) '#(4 5 6)) 1)
+                  #f)))
 
 ;;; --- interval-for-each: lexicographic order, separate positional args ---
 (let ((visits '()))

--- a/tests/scheme/srfi/srfi231-storage-classes.scm
+++ b/tests/scheme/srfi/srfi231-storage-classes.scm
@@ -87,6 +87,22 @@
   (test-equal #t ((storage-class-checker sc) 'a-symbol))
   (test-equal #f ((storage-class-checker sc) 42)))
 
+;;; --- storage-class-data->body: rejects wrong-typed data (raising, like
+;;; the reference implementation) and hands correct data back unchanged
+;;; (the body IS the data -- zero-copy) ---
+(test-equal #t (guard (e (#t #t))
+                  ((storage-class-data->body u8-storage-class) 'a)
+                  #f))
+(test-equal #t (guard (e (#t #t))
+                  ((storage-class-data->body generic-storage-class) 'a)
+                  #f))
+(test-equal #t (guard (e (#t #t))
+                  ((storage-class-data->body f64-storage-class) "not an f64vector")
+                  #f))
+(let ((v (vector 1 2 3)) (u #u8(9 8)))
+  (test-equal #t (eq? v ((storage-class-data->body generic-storage-class) v)))
+  (test-equal #t (eq? u ((storage-class-data->body u8-storage-class) u))))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-231-storage-classes")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi231-views.scm
+++ b/tests/scheme/srfi/srfi231-views.scm
@@ -191,6 +191,26 @@
                                               (make-interval (vector 5)))
                   #f))  ;; volume mismatch
 
+;;; --- reference-parity argument validation: the sharing mapper must be a
+;;; procedure (checked even for empty new-domains, where it would never be
+;;; invoked), and a scalar slice-width is legal only on a positive-width
+;;; axis (an empty axis takes the explicit-vector form) ---
+(test-equal #t (guard (e (#t #t))
+                  (specialized-array-share (array-copy (make-array (make-interval (vector 1)) list))
+                                           (make-interval (vector 1)) 1)
+                  #f))
+(test-equal #t (guard (e (#t #t))
+                  (specialized-array-share (array-copy (make-array (make-interval (vector 1)) list))
+                                           (make-interval (vector 0)) 5)
+                  #f))
+(test-equal #t (guard (e (#t #t))
+                  (array-tile (make-array (make-interval (vector 0)) list) (vector 2))
+                  #f))
+(test-equal 1 (interval-volume
+               (array-domain
+                (array-tile (make-array (make-interval (vector 0)) list)
+                            (vector (vector 0))))))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-231-views")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Group A of the SRFI 231 audit fixes — six reference-parity argument-validation guards, one per issue, each with a guarded regression test in its per-module suite. Found by extracting every `(test expr "expected-error-message")` form from the [SRFI 231 reference test suite](https://github.com/scheme-requests-for-implementation/srfi-231) (330 of them — the message means the reference *raises*) and running each against kaappi.

**Method note:** these are all error situations per the SRFI ("It is an error to call … if the arguments do not satisfy this condition"), so any behavior is spec-permitted — but the reference implementation raises explicitly at each site, and half of these expressions are literal error tests in its suite. The port's own neighbors already treated the sibling cases as errors (e.g. `interval-subset?` on dimension mismatch, non-exact-integer multi-index components); these six were the gaps.

| Issue | Site | Fix |
|---|---|---|
| #2312 | `interval-contains-multi-index?` | dimension mismatch now errors instead of silently returning `#f` |
| #2313 | built-in storage classes | `data->body` validates the data type instead of being the identity (`values`) |
| #2315 | `make-array` | setter must be a procedure or `#f`, checked at construction |
| #2316 | both specialized constructors + both default parameters | non-boolean `safe?`/`mutable?` rejected; parameters get boolean converters |
| #2317 | `specialized-array-share` | mapper must be a procedure — checked even for empty new-domains where it is never invoked |
| #2318 | `array-tile` | scalar slice-width only on a positive-width axis (reference's own rule); explicit-vector form unchanged |

**Verification**

- Reference error-test sweep: 322/330 before → **330/330 after** (no flags, no hangs).
- All seven `tests/scheme/srfi/srfi231-*.scm` suites pass (arrays 71, assembly 63, combinators 56, intervals 82, storage-classes 142, views 79, hub 17).
- The three Reddit-reported repros: the two covered here now raise with reference-shaped messages; the third (`array-packed?` on an extracted view) is unchanged as intended.

**Out of scope:** #2314 (`array-packed?` zero-offset semantics, priority: high) is a behavior change with `specialized-array-reshape` fallout and a dev-notes update — it ships as its own PR (group B of the audit plan), rebranching trivially off this one.

Closes #2312
Closes #2313
Closes #2315
Closes #2316
Closes #2317
Closes #2318
