### PR TITLE
Fix array-packed?: consecutive increasing indices from any body base (#2314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`array-packed?` now follows the spec's definition: consecutive increasing
+  body indices from any base, not from zero** (#2314). It previously required
+  the lexicographic traversal to start at body index 0, so any view with a
+  non-zero offset — `(array-extract A interval)` being the common one —
+  wrongly reported `#f` (the spec says "increasing and consecutive indices";
+  the reference checks only stride-1 between neighbors). Side effect:
+  `specialized-array-reshape` now reshapes such offset views in place,
+  sharing the body like the reference, instead of erroring or copying.
+
 - **SRFI 231 argument validation now matches the reference implementation at
   six entry points** (#2312, #2313, #2315, #2316, #2317, #2318), found by
   running the reference test suite's 330 error-expectation tests against

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -828,7 +828,10 @@ pre-materialized before the fill, a distinction observable only under
 multi-shot-continuation re-entry, which the spec itself declares undefined).
 `specialized-array-reshape` uses a deliberate packed-check-based
 affine-detection simplification instead of the reference's full multi-group
-algorithm, verified identical on the spec's own worked examples. `array-block`
+algorithm, verified identical on the spec's own worked examples. (`array-packed?`
+itself means consecutive-increasing from any body base — not a zero base —
+per #2314; an `array-extract` view with a non-zero offset is packed and
+reshapes in place through this same fast path, like the reference.) `array-block`
 needed a genuinely two-phase algorithm unlike everything else in the SRFI:
 full per-axis width-consistency validation (reusing
 `array-curry`+`array-permute`+`index-first`) followed by cheap

--- a/lib/srfi/231/arrays.sld
+++ b/lib/srfi/231/arrays.sld
@@ -188,22 +188,29 @@
                             (if safe? (%safe-setter interval (storage-class-checker storage-class) raw-setter) raw-setter))))
           (%make-array interval getter setter body indexer storage-class safe?))))
 
-    ;; #t iff lexicographic traversal order visits body positions
-    ;; 0,1,2,...,volume-1 consecutively -- always true immediately after
-    ;; make-specialized-array/make-specialized-array-from-data (their own
-    ;; indexer IS that exact lexicographic mapping); becomes meaningful
-    ;; once a later phase's view/share/reverse procedures install a
-    ;; different (non-consecutive) indexer over the same body. Escapes via
-    ;; call/cc on the first mismatch rather than scanning the full domain,
-    ;; since a later phase's non-packed arrays could otherwise pay a full
+    ;; #t iff lexicographic traversal order visits CONSECUTIVE, INCREASING
+    ;; body positions -- per spec, "the elements of array, taken in
+    ;; lexicographical order, are stored in (array-body array) with
+    ;; increasing and consecutive indices". The first visited position may
+    ;; be ANY base (a non-zero offset view such as array-extract's is still
+    ;; packed), matching the reference implementation, which checks only
+    ;; stride-1 differences between lexicographic neighbors and treats a
+    ;; length-1 axis as trivially packed. Always true immediately after
+    ;; make-specialized-array/make-specialized-array-from-data; becomes
+    ;; meaningful once a later phase's view/share/reverse procedures
+    ;; install a different indexer over the same body. Escapes via call/cc
+    ;; on the first mismatch rather than scanning the full domain, since a
+    ;; later phase's non-packed arrays could otherwise pay a full
     ;; interval-volume traversal just to report "not packed" at index 0.
     (define (array-packed? a)
       (unless (specialized-array? a) (error "array-packed?: not a specialized array" a))
       (call/cc
        (lambda (return)
-         (let ((expected 0) (indexer (array-indexer a)))
+         (let ((expected #f) (indexer (array-indexer a)))
            (interval-for-each (lambda multi-index
-                                 (unless (= (apply indexer multi-index) expected) (return #f))
-                                 (set! expected (+ expected 1)))
+                                (let ((idx (apply indexer multi-index)))
+                                  (cond ((not expected) (set! expected (+ idx 1)))
+                                        ((= idx expected) (set! expected (+ expected 1)))
+                                        (else (return #f)))))
                                (array-domain a))
            #t))))))

--- a/tests/scheme/srfi/srfi231-arrays.scm
+++ b/tests/scheme/srfi/srfi231-arrays.scm
@@ -126,6 +126,15 @@
   (test-equal 9 (array-ref zs))
   (test-equal #t (array-packed? zs)))
 
+;;; --- array-packed?: consecutive-from-any-base per spec -- the first
+;;; visited body position may have ANY offset; only stride-1 increasing
+;;; order matters (#2314). View-based cases (extract/translate/reverse/
+;;; sample) live in srfi231-views.scm, which imports the views module. ---
+(test-equal #t (array-packed? (make-specialized-array (make-interval (vector 2) (vector 4)))))
+(test-equal #t (array-packed? (make-specialized-array-from-data (vector 0 1 2 3))))
+;; vacuously packed: no elements at all
+(test-equal #t (array-packed? (make-specialized-array (make-interval (vector 0)))))
+
 ;;; --- empty-domain arrays (some axis has lower = upper): array-empty? is
 ;;; #t, and no multi-index can ever be valid since that axis's range is
 ;;; unsatisfiable, so any access is rejected -- via the explicit domain

--- a/tests/scheme/srfi/srfi231-views.scm
+++ b/tests/scheme/srfi/srfi231-views.scm
@@ -182,6 +182,28 @@
   (let ((forced (specialized-array-reshape b (make-interval (vector 8)) #t)))
     (test-equal #t (interval= (array-domain forced) (make-interval (vector 8))))))
 
+;;; --- an offset view (non-zero body base) IS packed (#2314), so reshape
+;;; flattens it in place -- sharing the body, not copying ---
+(let* ((base (make-specialized-array (make-interval (vector 2) (vector 4))))
+       (view (array-extract base (make-interval (vector 3) (vector 4))))
+       (r (specialized-array-reshape view (make-interval (vector 1)))))
+  (array-set! base 'x 3)
+  (test-equal 'x (array-ref r 0))
+  (array-set! r 'y 0)  ;; write-through proves body sharing
+  (test-equal 'y (array-ref base 3)))
+
+;;; --- array-packed? on views: consecutive-from-any-base per spec (#2314);
+;;; the first visited body position may have ANY offset, only stride-1
+;;; increasing order matters ---
+(let* ((a (make-specialized-array (make-interval (vector 2) (vector 4))))
+       (A (make-specialized-array-from-data (vector 0 1 2 3))))
+  (test-equal #t (array-packed? (array-extract a (make-interval (vector 3) (vector 4)))))
+  (test-equal #t (array-packed? (array-extract a (make-interval (vector 2) (vector 4)))))
+  (test-equal #t (array-packed? (array-translate a (vector 1))))
+  ;; the spec's own example: decreasing order and stride-2 are not packed
+  (test-equal #f (array-packed? (array-reverse A)))
+  (test-equal #f (array-packed? (array-sample A (vector 2)))))
+
 (test-equal #t (guard (e (#t #t))
                   (specialized-array-reshape (make-array (make-interval (vector 3)) (lambda (i) i)) (make-interval (vector 3)))
                   #f))  ;; not specialized


### PR DESCRIPTION
Group B of the SRFI 231 audit: the semantic fix for `array-packed?` (#2314, priority: high — the one audit finding where a *legal* program got a silently wrong answer), plus its behavioral ripple into `specialized-array-reshape`.

**The fix.** The spec: "`#t` if the elements of array, taken in lexicographical order, are stored in `(array-body array)` with **increasing and consecutive indices**" — any base offset qualifies. The port demanded the traversal start at body index 0. The new implementation captures the first visited index as the base and requires base+1, base+2, … thereafter (same single-pass `call/cc` early exit). Empty arrays remain vacuously `#t`, matching the reference.

```scheme
(define a (make-specialized-array (make-interval '#(2) '#(4))))
(array-packed? (array-extract a (make-interval '#(3) '#(4))))   ; was #f, now #t
```

**The ripple.** `specialized-array-reshape`'s fast path already computed its `base` from the first indexer value (`views.sld`) — it was written for the correct semantics. With `array-packed?` fixed, an offset view now reshapes **in place, sharing the body** (write-through verified in tests), exactly like the reference, instead of erroring "not affinely representable" or forcing a copy.

**Also in line with the reference, verified:** `array-reverse` → `#f` (decreasing), `array-sample` → `#f` (stride ≠ 1), empty and zero-dimensional → `#t` — the spec's own `array-packed?` example block passes unchanged.

**Verification:** all seven `tests/scheme/srfi/srfi231-*.scm` suites pass (the packed-view cases live in the views suite, which imports the view constructors); the spec document's full worked-example corpus still passes (66 automated checks); the reference test suite's 330 error-expectation tests remain 330/330. Docs: the reshape-simplification note in `srfi-implementation-notes.md` now records the corrected semantics.

Follow-ups from the same audit still open: #2320 (`array-copy` option booleans) and #2321 (combinator function-argument validation) — a small same-class PR like #2319 whenever wanted.

Closes #2314
