### PR TITLE
Let --lib-path shadow a bundled (srfi N)

### DIFF
--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -271,24 +271,25 @@ fn loadLibrarySource(vm: *VM, source: []const u8) !void {
 /// Resolve the full path for a library .sld file.
 /// Returns a heap-allocated path string, or null if not found.
 pub fn resolveLibraryPath(allocator: std.mem.Allocator, rel_path: []const u8, lib_paths: []const []const u8) ?[]u8 {
-    // Built-in search prefixes (relative to cwd)
+    // Search the explicit --lib-path entries (and the auto-added script dir /
+    // ~/.kaappi/lib / exe-relative lib that follow them in vm.lib_paths)
+    // BEFORE the cwd-relative "" and "lib/" fallbacks. Otherwise a bundled
+    // library found under ./lib silently wins over a --lib-path entry meant to
+    // shadow it — e.g. running from the source checkout, ./lib/srfi/N.sld beat
+    // `--lib-path shadow`, so an A/B comparison measured the bundled copy
+    // (kaappi#1927). This preserves the documented ordering: explicit
+    // --lib-path first, then the auto-added dirs, with the cwd fallbacks last.
     const builtin_prefixes = [_][]const u8{ "", "lib/" };
 
-    const total_candidates = builtin_prefixes.len + lib_paths.len;
+    const total_candidates = lib_paths.len + builtin_prefixes.len;
     var candidate_idx: usize = 0;
 
     while (candidate_idx < total_candidates) : (candidate_idx += 1) {
         var full_path_buf: [600]u8 = undefined;
         var full_len: usize = 0;
 
-        if (candidate_idx < builtin_prefixes.len) {
-            const prefix = builtin_prefixes[candidate_idx];
-            full_len = prefix.len + rel_path.len;
-            if (full_len >= full_path_buf.len) continue;
-            @memcpy(full_path_buf[0..prefix.len], prefix);
-            @memcpy(full_path_buf[prefix.len .. prefix.len + rel_path.len], rel_path);
-        } else {
-            const lp = lib_paths[candidate_idx - builtin_prefixes.len];
+        if (candidate_idx < lib_paths.len) {
+            const lp = lib_paths[candidate_idx];
             const needs_sep: usize = if (lp.len > 0 and lp[lp.len - 1] != '/') 1 else 0;
             full_len = lp.len + needs_sep + rel_path.len;
             if (full_len >= full_path_buf.len) continue;
@@ -297,6 +298,12 @@ pub fn resolveLibraryPath(allocator: std.mem.Allocator, rel_path: []const u8, li
                 full_path_buf[lp.len] = '/';
             }
             @memcpy(full_path_buf[lp.len + needs_sep .. lp.len + needs_sep + rel_path.len], rel_path);
+        } else {
+            const prefix = builtin_prefixes[candidate_idx - lib_paths.len];
+            full_len = prefix.len + rel_path.len;
+            if (full_len >= full_path_buf.len) continue;
+            @memcpy(full_path_buf[0..prefix.len], prefix);
+            @memcpy(full_path_buf[prefix.len .. prefix.len + rel_path.len], rel_path);
         }
 
         const full_path = full_path_buf[0..full_len];
@@ -401,15 +408,8 @@ pub fn libraryFileExists(vm: *VM, name_list: Value) bool {
 /// Try to find a library's .sld source in bundled files, using the same
 /// search order as resolveLibraryPath.
 fn findBundledSource(bf: *std.StringHashMap([]const u8), rel_path: []const u8, lib_paths: []const []const u8) ?struct { path: []const u8, source: []const u8 } {
-    const prefixes = [_][]const u8{ "", "lib/" };
-    for (prefixes) |prefix| {
-        var buf: [600]u8 = undefined;
-        const full = std.fmt.bufPrint(&buf, "{s}{s}", .{ prefix, rel_path }) catch continue;
-        if (bf.get(full)) |src| {
-            const key = bf.getKey(full) orelse continue;
-            return .{ .path = key, .source = src };
-        }
-    }
+    // Same precedence as resolveLibraryPath (kaappi#1927): --lib-path entries
+    // (and the auto-added dirs after them) before the cwd-relative fallbacks.
     for (lib_paths) |lp| {
         var buf: [600]u8 = undefined;
         const needs_sep: usize = if (lp.len > 0 and lp[lp.len - 1] != '/') 1 else 0;
@@ -418,6 +418,15 @@ fn findBundledSource(bf: *std.StringHashMap([]const u8), rel_path: []const u8, l
             if (needs_sep == 1) "/" else "",
             rel_path,
         }) catch continue;
+        if (bf.get(full)) |src| {
+            const key = bf.getKey(full) orelse continue;
+            return .{ .path = key, .source = src };
+        }
+    }
+    const prefixes = [_][]const u8{ "", "lib/" };
+    for (prefixes) |prefix| {
+        var buf: [600]u8 = undefined;
+        const full = std.fmt.bufPrint(&buf, "{s}{s}", .{ prefix, rel_path }) catch continue;
         if (bf.get(full)) |src| {
             const key = bf.getKey(full) orelse continue;
             return .{ .path = key, .source = src };
@@ -454,8 +463,10 @@ fn recordFileForBundle(vm: *VM, path: []const u8, content: []const u8) void {
 }
 
 /// Try to load a library from a .sld file on disk.
-/// Search order: ./rel_path, ./lib/rel_path, then each vm.lib_paths entry
-/// (--lib-path flags, the script's directory, ~/.kaappi/lib).
+/// Search order: each vm.lib_paths entry (--lib-path flags first, then the
+/// script's directory, ~/.kaappi/lib, and the exe-relative lib), then the
+/// cwd-relative ./rel_path and ./lib/rel_path fallbacks. --lib-path therefore
+/// takes precedence over a bundled ./lib copy (kaappi#1927).
 fn loadEmbeddedLibrary(vm: *VM, rel_path: []const u8, source: []const u8) !void {
     loadLibrarySource(vm, source) catch |err| {
         if (vm.last_error_detail_len == 0) {

--- a/tests/scheme/smoke/lib-path-shadow-bundled-srfi-1927.sh
+++ b/tests/scheme/smoke/lib-path-shadow-bundled-srfi-1927.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Regression test for #1927: --lib-path could not shadow a bundled (srfi N).
+#
+# resolveLibraryPath probed the cwd-relative "" and "lib/" prefixes BEFORE any
+# --lib-path entry, so running from a checkout that ships ./lib/srfi/N.sld, a
+# `--lib-path shadow` meant to override (srfi N) lost silently to the bundled
+# copy — an A/B comparison then measured the bundled library while looking like
+# it ran. `kaappi --help` and CLAUDE.md both promise --lib-path takes
+# precedence (auto-added dirs come *after* it), so the loader now searches every
+# lib_paths entry before the cwd fallbacks.
+#
+# Case 1 (the fix): with a synthetic ./lib/srfi/14.sld present in the run cwd —
+# exactly what beat --lib-path before — a `--lib-path shadow` entry must win.
+# Before the fix this printed the BUNDLED sentinel; after it prints SHADOWED.
+#
+# Case 2 (no regression): an *unshadowed* bundled SRFI (here the real, shipped
+# (srfi 151)) must still load even while --lib-path points at the shadow dir.
+
+set -euo pipefail
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+PASS=0
+FAIL=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# A synthetic "bundled" (srfi 14) reachable via the cwd "lib/" prefix — this is
+# the copy that used to beat --lib-path.
+mkdir -p "$TMP/lib/srfi"
+cat > "$TMP/lib/srfi/14.sld" <<'EOF'
+(define-library (srfi 14)
+  (export char-set?)
+  (import (scheme base))
+  (begin (define (char-set? x) 'BUNDLED)))
+EOF
+
+# The shadow the user passes with --lib-path, overriding (srfi 14).
+mkdir -p "$TMP/shadow/srfi"
+cat > "$TMP/shadow/srfi/14.sld" <<'EOF'
+(define-library (srfi 14)
+  (export char-set?)
+  (import (scheme base))
+  (begin (define (char-set? x) 'SHADOWED)))
+EOF
+
+cat > "$TMP/prog14.scm" <<'EOF'
+(import (scheme base) (scheme write) (srfi 14))
+(write (char-set? 1))
+(newline)
+EOF
+
+# An unshadowed, genuinely-shipped portable SRFI. (bitwise-and 12 10) = 8.
+cat > "$TMP/prog151.scm" <<'EOF'
+(import (scheme base) (scheme write) (srfi 151))
+(write (bitwise-and 12 10))
+(newline)
+EOF
+
+check() { # $1 = label; $2 = expected stdout substring; rest = argv
+    local label="$1" want_out="$2"
+    shift 2
+    local status=0
+    # Run from $TMP so its ./lib/srfi/14.sld is the cwd-relative bundled copy.
+    (cd "$TMP" && env -u KAAPPI_LIB_DIR "$KAAPPI_ABS" "$@") > "$TMP/out.txt" 2>&1 || status=$?
+    if [[ "$status" -ne 0 ]]; then
+        echo "FAIL: $label — exited $status"
+        cat "$TMP/out.txt"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if ! grep -q "$want_out" "$TMP/out.txt"; then
+        echo "FAIL: $label — output missing '$want_out'"
+        cat "$TMP/out.txt"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    echo "PASS: $label"
+    PASS=$((PASS + 1))
+}
+
+# Case 1: --lib-path shadows the bundled (srfi 14) that ./lib would otherwise
+# win. The synthetic ./lib/srfi/14.sld is the trap: before the fix the loader
+# probed it before --lib-path and printed BUNDLED; after, --lib-path wins.
+check "--lib-path shadows bundled (srfi 14)" "SHADOWED" \
+    --lib-path shadow prog14.scm
+
+# Case 2: an unshadowed bundled SRFI still loads with --lib-path in play (the
+# reorder must not break normal resolution of names the shadow dir lacks).
+check "unshadowed bundled (srfi 151) still loads under --lib-path" "8" \
+    --lib-path shadow prog151.scm
+
+echo ""
+echo "$PASS pass, $FAIL fail"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Problem

`--lib-path` resolved a *new* library correctly but could not shadow a bundled `(srfi N)` — the bundled copy won silently, with no diagnostic. An A/B comparison against a modified SRFI therefore appeared to run while measuring the unmodified bundled library.

```bash
mkdir -p shadow/srfi
echo '(define-library (srfi 14) (export char-set?)
        (begin (define (char-set? x) (quote SHADOWED))))' > shadow/srfi/14.sld
echo '(import (scheme base) (scheme write) (srfi 14)) (write (char-set? 1))' > p.scm
kaappi --lib-path shadow p.scm     # expected SHADOWED, was #f
```

## Fix

`src/vm_library.zig` now consults `--lib-path` directories **before** the bundled library set when resolving every library name, including `(srfi N)` — not only names absent from the bundle. The documented ordering (explicit `--lib-path` entries first, auto-added directories after) is preserved.

## Test

`tests/scheme/smoke/lib-path-shadow-bundled-srfi-1927.sh` asserts a shadow `srfi/14.sld` under `--lib-path` wins, and that an unshadowed bundled SRFI (151) still loads under the same `--lib-path`. `zig build test` passes.

Closes #1927

🤖 Generated with [Claude Code](https://claude.com/claude-code)