### PR TITLE
Reclaim descriptors on EMFILE before failing an open (#1993)

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -328,7 +328,7 @@ fn isYoungPointer(gc: *GC, val: Value) bool {
     return obj.flags.generation == 0;
 }
 
-fn fullCollect(gc: *GC) void {
+pub fn fullCollect(gc: *GC) void {
     // #2196: drain the remembered_set up front. A full collect marks from
     // roots over both generations, so it never consults the set — and doing
     // this before sweepOld frees any old object means every entry is still

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -534,6 +534,17 @@ pub const GC = struct {
         gc_collect.collect(self);
     }
 
+    /// Force a full (both-generation) collection regardless of the
+    /// minor-cycle schedule. Used to reclaim OS descriptors held by
+    /// unreachable objects — abandoned file ports and directory streams —
+    /// before reporting descriptor exhaustion to a program (kaappi#1993).
+    /// A plain `collect()` usually runs a minor sweep, which misses any
+    /// fd-holder already promoted to the old generation.
+    pub fn collectFull(self: *GC) void {
+        self.stats.collections += 1;
+        gc_collect.fullCollect(self);
+    }
+
     pub fn markValue(self: *GC, v: Value) void {
         gc_collect.markValue(self, v);
     }

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -206,13 +206,41 @@ pub const sockPollReady = win_sock.sockPollReady;
 // is platform-specific and the runtime only ever uses these five shapes.
 // ---------------------------------------------------------------------------
 
-pub const OpenError = error{OpenFailed};
+/// `FdExhausted` singles out EMFILE (per-process) / ENFILE (system-wide)
+/// descriptor exhaustion so a caller can force a GC — reclaiming descriptors
+/// held by unreachable ports / directory streams — and retry the open before
+/// raising (kaappi#1993). Every other open failure stays `OpenFailed`.
+pub const OpenError = error{ OpenFailed, FdExhausted };
+
+/// Fold std.posix's open error set onto OpenError, mapping the two
+/// descriptor-exhaustion errnos (EMFILE → ProcessFdQuotaExceeded,
+/// ENFILE → SystemFdQuotaExceeded) to `FdExhausted`.
+fn classifyOpenError(e: anytype) OpenError {
+    return switch (e) {
+        error.ProcessFdQuotaExceeded, error.SystemFdQuotaExceeded => error.FdExhausted,
+        else => error.OpenFailed,
+    };
+}
+
+/// True when libc's current errno is EMFILE/ENFILE. POSIX-only: on Windows
+/// FindFirstFileW reports via GetLastError rather than errno, so this reads
+/// false there and the caller simply skips the retry. Read it immediately
+/// after the failing call, before any intervening libc call can clobber errno.
+pub fn errnoIsFdExhausted() bool {
+    if (comptime is_windows) return false;
+    const ev = std.c._errno().*;
+    return ev == @intFromEnum(E.MFILE) or ev == @intFromEnum(E.NFILE);
+}
 
 fn winOpen(path: []const u8, oflag: c_int, pmode: c_int) OpenError!fd_t {
     var wbuf: WPathBuf = undefined;
     const wpath = widen(&wbuf, path) orelse return error.OpenFailed;
     const fd = win._wopen(wpath.ptr, oflag | win.O_BINARY, pmode);
-    if (fd < 0) return error.OpenFailed;
+    if (fd < 0) {
+        const ev = win._errno().*;
+        if (ev == @intFromEnum(E.MFILE) or ev == @intFromEnum(E.NFILE)) return error.FdExhausted;
+        return error.OpenFailed;
+    }
     return fd;
 }
 
@@ -231,12 +259,12 @@ pub fn openRead(path: [:0]const u8) OpenError!fd_t {
         if (rc != .SUCCESS) return error.OpenFailed;
         return @as(fd_t, @intCast(result_fd));
     }
-    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{}, 0) catch error.OpenFailed;
+    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{}, 0) catch |e| classifyOpenError(e);
 }
 
 pub fn openWriteTrunc(path: [:0]const u8, mode: u16) OpenError!fd_t {
     if (comptime is_windows) return winOpen(path, win.O_WRONLY | win.O_CREAT | win.O_TRUNC, 0o600);
-    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true }, mode) catch error.OpenFailed;
+    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true }, mode) catch |e| classifyOpenError(e);
 }
 
 pub fn openWriteTruncExcl(path: [:0]const u8, mode: u16) OpenError!fd_t {
@@ -621,13 +649,17 @@ pub const DirIter = struct {
 /// GC-managed object (SRFI-170 directory streams): allocated from the
 /// c allocator so the GC finalizer can destroy it without allocator
 /// plumbing.
-pub fn dirIterCreate(path: [:0]const u8) ?*DirIter {
-    const it = std.heap.c_allocator.create(DirIter) catch return null;
-    it.* = DirIter.open(path) orelse {
-        std.heap.c_allocator.destroy(it);
-        return null;
-    };
-    return it;
+pub fn dirIterCreate(path: [:0]const u8) OpenError!*DirIter {
+    const it = std.heap.c_allocator.create(DirIter) catch return error.OpenFailed;
+    if (DirIter.open(path)) |opened| {
+        it.* = opened;
+        return it;
+    }
+    // opendir failed — read errno before destroy() can clobber it, so an
+    // EMFILE/ENFILE surfaces as FdExhausted and the caller can retry (#1993).
+    const err: OpenError = if (errnoIsFdExhausted()) error.FdExhausted else error.OpenFailed;
+    std.heap.c_allocator.destroy(it);
+    return err;
 }
 
 pub fn dirIterDestroy(it: *DirIter) void {

--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -287,6 +287,35 @@ fn raiseFileError(gc: *GC, msg_text: []const u8, irritant: Value) PrimitiveError
     return raiseFileErrorCode(gc, msg_text, irritant, std.c._errno().*);
 }
 
+/// Open a directory iterator, forcing a full GC and retrying once on
+/// descriptor exhaustion (EMFILE/ENFILE). Directory streams hold an fd that
+/// their finalizer closes, so when the process is out of descriptors but the
+/// stream objects are unreachable a collection frees table slots the retry can
+/// reuse — the SRFI-170 `open-directory` no longer spuriously fails at a
+/// normal `ulimit -n` (kaappi#1993). Any other failure propagates unchanged so
+/// the caller still raises the correct file error.
+fn openDirWithFdRetry(gc: *GC, path_z: [:0]const u8) platform.OpenError!*platform.DirIter {
+    return platform.dirIterCreate(path_z) catch |e| switch (e) {
+        error.FdExhausted => blk: {
+            gc.collectFull();
+            break :blk platform.dirIterCreate(path_z);
+        },
+        else => e,
+    };
+}
+
+/// `DirIter.open` counterpart of `openDirWithFdRetry` for the `directory-files`
+/// path, which opens and immediately closes an iterator rather than handing it
+/// to a GC-managed stream. Reads errno straight after the failing `opendir`
+/// (before any other libc call) to distinguish EMFILE/ENFILE from a real
+/// failure worth raising (kaappi#1993).
+fn openDirIterWithFdRetry(gc: *GC, path_z: [:0]const u8) ?platform.DirIter {
+    if (platform.DirIter.open(path_z)) |d| return d;
+    if (!platform.errnoIsFdExhausted()) return null;
+    gc.collectFull();
+    return platform.DirIter.open(path_z);
+}
+
 /// `raiseFileError` with an explicit errno — 0 for an error that did not
 /// come from a syscall (a pre-check like the embedded-NUL guard, or a
 /// semantic failure like "symlink target too long"), so `posix-error?`
@@ -408,7 +437,7 @@ fn directoryFiles(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    var dir = platform.DirIter.open(path_z) orelse {
+    var dir = openDirIterWithFdRetry(gc, path_z) orelse {
         return raiseFileError(gc, "cannot open directory", args[0]);
     };
     defer dir.close();
@@ -1155,7 +1184,7 @@ fn openDirectoryFn(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    const dir = platform.dirIterCreate(path_z) orelse {
+    const dir = openDirWithFdRetry(gc, path_z) catch {
         return raiseFileError(gc, "cannot open directory", args[0]);
     };
 

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -779,6 +779,34 @@ fn raiseFileError(gc: *@import("memory.zig").GC, msg_text: []const u8, irritant:
 /// native target fell through to its caller on the playground.
 const wasm_no_fs = ": this WebAssembly build has no filesystem access";
 
+/// Open a file, forcing a full GC and retrying once on descriptor exhaustion
+/// (EMFILE/ENFILE). The fd-holding objects (ports) are ordinarily unreachable
+/// and their finalizers close the descriptor, so a collection frees table
+/// slots the retry can reuse — a legal program that abandons ports faster than
+/// the GC's allocation-count threshold trips no longer spuriously fails at a
+/// normal `ulimit -n` (kaappi#1993). Only `FdExhausted` triggers the retry;
+/// every other failure (ENOENT, EACCES, …) propagates unchanged so the caller
+/// still raises the correct file error.
+fn openFileWithFdRetry(
+    gc: *memory.GC,
+    comptime openFn: fn ([:0]const u8) platform.OpenError!platform.fd_t,
+    path_z: [:0]const u8,
+) platform.OpenError!platform.fd_t {
+    return openFn(path_z) catch |e| switch (e) {
+        error.FdExhausted => blk: {
+            gc.collectFull();
+            break :blk openFn(path_z);
+        },
+        else => e,
+    };
+}
+
+/// `openWriteTrunc` with the 0o644 mode `open-output-file` uses fixed, so it
+/// matches `openFileWithFdRetry`'s single-argument `openFn` shape.
+fn openOutputTrunc(path_z: [:0]const u8) platform.OpenError!platform.fd_t {
+    return platform.openWriteTrunc(path_z, 0o644);
+}
+
 fn openInputFile(args: []const Value) PrimitiveError!Value {
     // The type check runs first even on WASM: a non-string argument is a type
     // error on every target, and only a well-formed call reaches the gate.
@@ -791,7 +819,7 @@ fn openInputFile(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    const fd = platform.openRead(path_z) catch {
+    const fd = openFileWithFdRetry(gc, platform.openRead, path_z) catch {
         return raiseFileError(gc, "cannot open input file", args[0]);
     };
     errdefer _ = platform.close(fd);
@@ -813,7 +841,7 @@ fn openOutputFile(args: []const Value) PrimitiveError!Value {
     const path_z = gc.allocator.dupeZ(u8, path) catch return PrimitiveError.OutOfMemory;
     defer gc.allocator.free(path_z);
 
-    const fd = platform.openWriteTrunc(path_z, 0o644) catch {
+    const fd = openFileWithFdRetry(gc, openOutputTrunc, path_z) catch {
         return raiseFileError(gc, "cannot open output file", args[0]);
     };
     errdefer _ = platform.close(fd);

--- a/tests/scheme/audit/primitives_filesystem-audit.scm
+++ b/tests/scheme/audit/primitives_filesystem-audit.scm
@@ -669,19 +669,21 @@
                               ((string? e) (loop (+ n 1)))
                               (else #f)))))
      (close-directory ds))
-   ;; FAIL: #1993 (an abandoned stream is reclaimed only when the GC's
-   ;; allocation-count threshold happens to trip, never on descriptor
-   ;; pressure: at `ulimit -n 256` exactly 253 unclosed opens succeed, i.e.
-   ;; no collection runs before EMFILE.  This passed on macOS and Linux CI
-   ;; only because their limit is 1048576, and it exhausted the fd table on
-   ;; the openbsd-test and netbsd-test legs -- taking down the *next* block,
-   ;; which could no longer create its own scratch files.  Re-enable with
-   ;; the collect-and-retry fix.)
-   ;; (test-equal "(let loop ((i 0)) (if (= i 3000) #t (let ((ds (open-direc..." #t (let loop ((i 0))
-   ;;                  (if (= i 3000) #t
-   ;;                      (let ((ds (open-directory dir)))
-   ;;                        (read-directory ds)
-   ;;                        (loop (+ i 1))))))
+   ;; #1993: an abandoned stream must be reclaimed under descriptor pressure,
+   ;; not only when the GC's allocation-count threshold happens to trip. Before
+   ;; the fix this exhausted the fd table at `ulimit -n 256` (exactly 253
+   ;; unclosed opens succeeded, i.e. no collection ran before EMFILE) and so
+   ;; took down the *next* block on the low-limit openbsd-test/netbsd-test legs.
+   ;; open-directory now forces a full collection and retries on EMFILE/ENFILE,
+   ;; so 3000 opens with no close complete at every limit. (A hermetic trigger
+   ;; that fails without the fix regardless of the ambient limit lives in
+   ;; smoke/fd-reclaim-emfile-1993.sh, which caps `ulimit -n`.)
+   (test-equal "(let loop ((i 0)) (if (= i 3000) #t (let ((ds (open-directory dir))) (read-directory ds) (loop (+ i 1)))))" #t
+     (let loop ((i 0))
+       (if (= i 3000) #t
+           (let ((ds (open-directory dir)))
+             (read-directory ds)
+             (loop (+ i 1))))))
    ;; The reclamation-independent half of that check: closing is what the
    ;; program controls, and 3000 open/close cycles must not accumulate fds.
    (test-equal "(let loop ((i 0)) (if (= i 3000) #t (let ((ds (open-directory dir))) (read-directory ds) (close-directory ds) ...)))" #t

--- a/tests/scheme/smoke/fd-reclaim-emfile-1993.sh
+++ b/tests/scheme/smoke/fd-reclaim-emfile-1993.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Regression test for kaappi#1993: open-input-file, open-output-file and
+# open-directory must force a full GC and retry on EMFILE/ENFILE before
+# raising. The fd-holding objects (ports, directory streams) are ordinarily
+# unreachable and their finalizers close the descriptor, so a legal program
+# that abandons them faster than the GC's allocation-count threshold trips
+# should not spuriously fail at a normal `ulimit -n`.
+#
+# Hermetic trigger: cap the soft descriptor limit low, then open-and-abandon
+# far more fd-holders than the cap, one at a time, in a loop. Each open's
+# value is discarded, so every object is immediately unreachable.
+#
+#   * WITHOUT the fix, the fd table fills within ~cap iterations — long before
+#     the 8192-object allocation-count threshold trips a collection — so the
+#     next open raises EMFILE, the uncaught error aborts the program, and
+#     kaappi exits nonzero. This test then FAILS (which is how it was verified
+#     to actually exercise the fix).
+#   * WITH the fix, the open on a full table forces a full collection that
+#     reclaims the abandoned fd-holders' descriptors and the retry succeeds, so
+#     the loop runs to completion, prints OK, and kaappi exits 0.
+#
+# The loop count (4000) is ~30x the 128-fd cap, well beyond anything a single
+# object-count-driven collection could paper over, and each of the three
+# primitives is exercised in turn.
+set -u
+
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "ulimit -n / EMFILE retry is POSIX-only; Windows opens use HANDLEs, not the fd table"
+
+KAAPPI="${KAAPPI:-${1:-zig-out/bin/kaappi}}"
+
+# Lower the per-process descriptor cap. 128 clears the handful of fds the
+# runtime itself holds (std streams, bytecode cache, history, ...) yet sits far
+# below the loop count, so the table fills quickly and the retry path is what
+# carries the loop to completion.
+if ! ulimit -n 128 2> /dev/null; then
+    echo "SKIP: cannot lower ulimit -n on this host"
+    exit 77
+fi
+
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/kaappi-fd1993.XXXXXX")" || exit 1
+trap 'rm -rf "$workdir"' EXIT
+
+seed="$workdir/seed"
+: > "$seed"
+prog="$workdir/prog.scm"
+
+cat > "$prog" << EOF
+(import (scheme base) (scheme write) (scheme file) (srfi 170))
+
+(define dir "$workdir")
+(define seed "$seed")
+
+;; Open N fd-holders, discarding each — every value is unreachable the moment
+;; the next iteration begins, so only on-demand reclamation can keep the fd
+;; table from overflowing under the low cap.
+(define (spin n thunk)
+  (let loop ((i 0))
+    (if (= i n) #t (begin (thunk) (loop (+ i 1))))))
+
+(spin 4000 (lambda () (open-directory dir)))
+(spin 4000 (lambda () (open-input-file seed)))
+(spin 4000 (lambda () (open-output-file (string-append dir "/out"))))
+
+(display "OK")
+(newline)
+EOF
+
+out="$("$KAAPPI" "$prog" 2>&1)"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+    echo "FAIL: kaappi exited $rc under ulimit -n 128 (descriptors not reclaimed on EMFILE)"
+    echo "$out"
+    exit 1
+fi
+
+case "$out" in
+    *OK*) ;;
+    *)
+        echo "FAIL: expected OK marker, got:"
+        echo "$out"
+        exit 1
+        ;;
+esac
+
+echo "PASS: fd-holders reclaimed and reopened under a low descriptor cap"
+exit 0


### PR DESCRIPTION
## Problem

`open-input-file`, `open-output-file`, and `open-directory` raised as soon as the OS reported `EMFILE` (per-process) / `ENFILE` (system-wide), without forcing a collection and retrying. The fd-holding objects (ports, SRFI-170 directory streams) are ordinarily unreachable and their finalizers close the descriptor — so a collection would free table slots and the retry would succeed. A program that abandons fd-holders faster than the GC's allocation-count threshold trips fails at a normal `ulimit -n` and succeeds at a larger one; nothing about the program changes, only the descriptor limit.

At `ulimit -n 256` the reproduction fit only 253 opens (the descriptor limit itself), proving no collection ran before failing.

## Fix

- `src/platform.zig`: new `OpenError.FdExhausted` distinguishes EMFILE/ENFILE from every other open failure (`ProcessFdQuotaExceeded`/`SystemFdQuotaExceeded` on POSIX, `_errno` on the Windows `_wopen` path; `errnoIsFdExhausted()` for the `opendir` path, read immediately after the failing call). `dirIterCreate` now returns `OpenError!*DirIter`.
- `src/memory.zig`: `GC.collectFull()` forces a full (both-generation) collection — a plain `collect()` runs a minor sweep, which misses an fd-holder already promoted to the old generation.
- `src/primitives_io.zig` / `src/primitives_filesystem.zig`: `open{Input,Output}File`, `open-directory`, and `directory-files` now force a `collectFull()` and retry **once** on `FdExhausted`. Any other failure propagates unchanged.

## Tests

`tests/scheme/smoke/fd-reclaim-emfile-1993.sh` opens-and-abandons fd-holders past a low descriptor cap and asserts the loop completes (the GC reclaims fds) rather than failing. `zig build test` passes; `zig build -Dtarget=x86_64-windows` cross-compiles (platform.zig touched); gc-stress running.

Closes #1993

🤖 Generated with [Claude Code](https://claude.com/claude-code)