### PR TITLE
Validate array-copy options and combinator function arguments (#2320 #2321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`array-copy`/`array-copy!` reject non-boolean `mutable?`/`safe?` options, and
+  every SRFI 231 combinator rejects a non-procedure function argument**
+  (#2320, #2321), closing the two gaps surfaced by the SRFI author's follow-up
+  report. `array-copy`'s `mutable?` never flowed through a validating
+  constructor, so a truthy wrong-typed value silently yielded an unfrozen
+  array; `array-map`, `array-for-each`, both folds, `array-any`, `array-every`,
+  `array-outer-product`, and `array-inner-product` now check at call time —
+  previously the lazy combinators deferred the failure to first element access
+  (possibly never) and the eager ones could succeed silently over an empty
+  domain.
+
 - **`array-packed?` now follows the spec's definition: consecutive increasing
   body indices from any base, not from zero** (#2314). It previously required
   the lexicographic traversal to start at body index 0, so any view with a

--- a/lib/srfi/231/arrays.sld
+++ b/lib/srfi/231/arrays.sld
@@ -40,7 +40,7 @@
           ;; and later phases) to build genuinely specialized arrays with
           ;; custom indexers, the same way (srfi 160 base)'s %uvec-* helpers
           ;; exist only for that package's own per-tag files to consume.
-          %make-array %safe-getter %safe-setter %make-lex-indexer)
+          %make-array %safe-getter %safe-setter %make-lex-indexer %check-boolean!)
   (begin
 
     (define-record-type <array>

--- a/lib/srfi/231/combinators.sld
+++ b/lib/srfi/231/combinators.sld
@@ -64,6 +64,15 @@
 
     (define (%opt lst i default) (if (> (length lst) i) (list-ref lst i) default))
 
+    ;; The reference implementation validates the function argument of
+    ;; every combinator at call time -- without this, the lazy ones
+    ;; (array-map, array-outer-product) would defer the failure to the
+    ;; first element access (possibly never), and the eager ones would
+    ;; fail with a generic apply error -- or succeed silently over an
+    ;; empty domain, where f is never invoked at all.
+    (define (%check-procedure! x who)
+      (unless (procedure? x) (error (string-append who ": the function argument must be a procedure") x)))
+
     (define (%check-same-domain! all who)
       (let ((domain (array-domain (car all))))
         (for-each (lambda (a)
@@ -78,6 +87,7 @@
     ;; definition, which builds an ordinary (immutable, non-specialized)
     ;; make-array rather than a specialized/precomputed one.
     (define (array-map f array . arrays)
+      (%check-procedure! f "array-map")
       (let ((all (cons array arrays)))
         (%check-same-domain! all "array-map")
         (make-array (array-domain array)
@@ -85,12 +95,14 @@
                       (apply f (map (lambda (a) (apply (array-getter a) multi-index)) all))))))
 
     (define (array-for-each f array . arrays)
+      (%check-procedure! f "array-for-each")
       (let ((all (cons array arrays)))
         (%check-same-domain! all "array-for-each")
         (interval-for-each (lambda multi-index (apply f (map (lambda (a) (apply (array-getter a) multi-index)) all)))
                             (array-domain array))))
 
     (define (array-fold-left operator identity array . arrays)
+      (%check-procedure! operator "array-fold-left")
       (let ((all (cons array arrays)) (acc identity))
         (%check-same-domain! all "array-fold-left")
         (interval-for-each (lambda multi-index
@@ -104,6 +116,7 @@
     ;; plain left-walk applying (operator e0 e1 ... acc), matching
     ;; interval-fold-right's own already-verified technique.
     (define (array-fold-right operator identity array . arrays)
+      (%check-procedure! operator "array-fold-right")
       (let ((all (cons array arrays)) (results '()))
         (%check-same-domain! all "array-fold-right")
         (interval-for-each (lambda multi-index
@@ -135,6 +148,7 @@
     ;; that ACTUAL result (not just #t) -- matching the spec's own
     ;; "returns that result" wording, not a forced boolean.
     (define (array-any predicate array . arrays)
+      (%check-procedure! predicate "array-any")
       (let ((all (cons array arrays)))
         (%check-same-domain! all "array-any")
         (call/cc
@@ -148,6 +162,7 @@
     ;; Short-circuits (returning #f) on the first #f result; otherwise
     ;; returns the LAST nonfalse result, not just #t.
     (define (array-every predicate array . arrays)
+      (%check-procedure! predicate "array-every")
       (let ((all (cons array arrays)) (last-result #t))
         (%check-same-domain! all "array-every")
         (call/cc
@@ -161,6 +176,7 @@
     ;; --- products ---
 
     (define (array-outer-product operator array1 array2)
+      (%check-procedure! operator "array-outer-product")
       (let ((domain (interval-cartesian-product (array-domain array1) (array-domain array2)))
             (d1 (array-dimension array1)))
         (make-array domain
@@ -169,6 +185,8 @@
                                 (apply (array-getter array2) (drop multi-index d1)))))))
 
     (define (array-inner-product A f g B)
+      (%check-procedure! f "array-inner-product")
+      (%check-procedure! g "array-inner-product")
       (unless (and (>= (array-dimension A) 1) (>= (array-dimension B) 1))
         (error "array-inner-product: both arrays must have dimension at least 1" A B))
       (let ((a-last (- (array-dimension A) 1)))

--- a/lib/srfi/231/views.sld
+++ b/lib/srfi/231/views.sld
@@ -315,6 +315,8 @@
     ;; and complexity isn't justified for this phase.
     (define (%array-copy-impl array opts)
       (unless (array? array) (error "array-copy: not an array" array))
+      (%check-boolean! (%opt opts 1 (specialized-array-default-mutable?)) "array-copy: mutable?")
+      (%check-boolean! (%opt opts 2 (specialized-array-default-safe?)) "array-copy: safe?")
       (let* ((specialized? (specialized-array? array))
              (storage-class (%opt opts 0 (if specialized? (array-storage-class array) generic-storage-class)))
              (mutable? (%opt opts 1 (if specialized? (mutable-array? array) (specialized-array-default-mutable?))))

--- a/tests/scheme/srfi/srfi231-combinators.scm
+++ b/tests/scheme/srfi/srfi231-combinators.scm
@@ -152,6 +152,26 @@
 ;; own %check-nested-list validation, rather than a raw vector->list crash
 (test-equal #t (guard (e (#t #t)) (vector*->array 2 (vector 1 2)) #f))
 
+;;; --- every combinator validates its function argument at call time
+;;; (#2321): the lazy ones (array-map, array-outer-product) would
+;;; otherwise defer the failure to first access, and eager ones would
+;;; succeed silently over an empty domain, where f is never invoked ---
+(let ((t (make-array (make-interval (vector 2)) (lambda (i) i)))
+      (empty (make-array (make-interval (vector 0)) list)))
+  (test-equal #t (guard (e (#t #t)) (array-map 'a t) #f))
+  (test-equal #t (guard (e (#t #t)) (array-for-each 'a t) #f))
+  ;; the silent case: empty domain, f never invoked -- still an error
+  (test-equal #t (guard (e (#t #t)) (array-for-each 'a empty) #f))
+  (test-equal #t (guard (e (#t #t)) (array-fold-left 'a 0 t) #f))
+  (test-equal #t (guard (e (#t #t)) (array-fold-right 'a 0 t) #f))
+  (test-equal #t (guard (e (#t #t)) (array-any 'a t) #f))
+  (test-equal #t (guard (e (#t #t)) (array-every 'a t) #f))
+  (test-equal #t (guard (e (#t #t)) (array-outer-product 'a t t) #f))
+  (test-equal #t (guard (e (#t #t)) (array-inner-product t 'a + t) #f))
+  (test-equal #t (guard (e (#t #t)) (array-inner-product t + 'a t) #f))
+  ;; sanity: proper calls still work (- negates: 0 -> 0, 1 -> -1)
+  (test-equal '(0 -1) (array->list (array-map - t))))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-231-combinators")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi231-views.scm
+++ b/tests/scheme/srfi/srfi231-views.scm
@@ -140,6 +140,16 @@
 ;; array-tile's outer array is always immutable/non-specialized
 (test-equal #f (specialized-array? (array-tile (make-specialized-array (make-interval (vector 4)) s8-storage-class) (vector 2))))
 
+;;; --- array-copy/array-copy! validate their own boolean options (#2320):
+;;; mutable? never flows through a validating constructor, so a truthy
+;;; wrong-typed value would silently yield an unfrozen array; safe? now
+;;; errors attributed to array-copy itself, not the inner constructor ---
+(let ((plain (make-array (make-interval (vector 3)) list)))
+  (test-equal #t (guard (e (#t #t)) (array-copy plain generic-storage-class 'a) #f))
+  (test-equal #t (guard (e (#t #t)) (array-copy plain generic-storage-class #f 'a) #f))
+  (test-equal #t (guard (e (#t #t)) (array-copy! plain generic-storage-class 'a) #f))
+  (test-equal #t (array-safe? (array-copy plain generic-storage-class #f #t))))
+
 ;;; --- array-copy / array-copy!: default-inheritance rule ---
 (let* ((plain (make-array (make-interval (vector 2 2)) list))
        (copied (array-copy plain)))


### PR DESCRIPTION
The final PR of the SRFI 231 audit: the two remaining findings from the SRFI author's follow-up report, both the same guard-clause shape as #2319.

**#2320 — `array-copy`/`array-copy!` validate their own boolean options.** `array-copy` parses its options separately from the constructors; its `mutable?` only gates the final `array-freeze!`, so a truthy wrong-typed value silently produced an unfrozen (mutable) array — and `safe?` errors were attributed to the inner `make-specialized-array` rather than to `array-copy`. Both options are now checked up front with the `array-copy:` prefix (the reference validates all four arguments through an explicit chain). `%check-boolean!` moved to `arrays.sld`'s internal `%`-helper exports so `views.sld` can reuse it — the hub's public 118-binding surface is unchanged.

**#2321 — every combinator rejects a non-procedure function argument at call time.** `array-map`, `array-for-each`, `array-fold-left`, `array-fold-right`, `array-any`, `array-every`, `array-outer-product`, and `array-inner-product` (both `f` and `g`) now guard their function argument like `array-reduce` already did. Previously the lazy combinators (`array-map`, `array-outer-product`) deferred the failure to the first element access — possibly never — and the eager ones could **succeed silently over an empty domain**, where `f` is never invoked at all (covered by a dedicated test).

**Verification:** all seven `tests/scheme/srfi/srfi231-*.scm` suites pass; the spec document's full worked-example corpus still passes (66 automated checks); the reference test suite's 330 error-expectation tests remain 330/330.

With this and the merged #2319/#2322, every finding from the audit — the Reddit post, the author's follow-up comment, the reference-suite sweep, and the spec-document example run — is resolved except the deliberately deferred `u1`/`f8`/`f16` storage classes (documented in `docs/dev/srfi-implementation-notes.md`).

Closes #2320
Closes #2321
