### PR TITLE
Preserve local-macro forms in expand so the dump round-trips (#1894)

### DIFF
--- a/docs/dev/observing-the-pipeline.md
+++ b/docs/dev/observing-the-pipeline.md
@@ -105,11 +105,26 @@ expanded again when the program is compiled:
 
 - **`quote` / `quasiquote` data** is never touched — a macro-named list inside
   `'(...)` stays literal.
-- **`let-syntax` / `letrec-syntax` local macros** are not built; uses of a
-  locally-bound syntax are left in place (the transformer spec is still shown).
+- **`let-syntax` / `letrec-syntax` forms** are left entirely unexpanded —
+  bindings *and* body. Their local transformers are never built here, so the
+  body is not walked at all; the whole form is printed as read and re-expanded
+  on a real compile. Expanding the body would be unsound: a use of a shadowed
+  keyword would resolve against the *outer* binding of that name, not the local
+  one (kaappi#1894). Leaving the form intact round-trips because re-reading
+  re-establishes the inner binding.
 - **Macros that capture use-site locals** (only reachable inside a `lambda` /
   `let` body) may not expand identically to a real compile — the dump uses the
   same best-effort expansion the compiler's own pre-scan does.
+
+A subtlety behind the round-trip guarantee: leaving a *use* of a locally-bound
+keyword in place is only sound if the **binder keeps the same spelling**, so the
+use still matches it after re-reading. When a macro expands *into* a
+`let-syntax` (a SRFI 139 syntax parameter does exactly this), hygiene would
+rename the binder and leave the body's use bare, severing them. The dump avoids
+that by registering every `define-syntax` a top-level macro expands into — just
+as a real compile does after evaluating it — so the shared keyword is known, and
+therefore kept bare rather than renamed, when the later macro's template
+mentions it (kaappi#1894, second shape).
 
 Environment forms (`import`, `define-syntax`, `define-record-type`, …) are shown
 unchanged; their effect is applied so later forms expand against it.

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -124,15 +124,24 @@ fn expandTopLevel(vm: *VM, expr: Value, path: []const u8) void {
     var rooted = expanded;
     vm.gc.pushRoot(&rooted);
     printDatum(vm.gc.allocator, rooted);
+    // Register from the EXPANDED form, not the original: a `define-syntax`
+    // produced by expanding a macro (a SRFI 139 syntax parameter's
+    // `define-syntax-parameter`, say) must register its transformer just as a
+    // real compile does after evaluating it — otherwise the shared keyword is
+    // unknown when a later macro's template mentions it, and hygiene renames a
+    // `let-syntax` binder away from the body's use of it (kaappi#1894, second
+    // shape). `import`/`define-library`/`define-syntax` are opaque to the
+    // expander, so for them the expanded form equals the original.
+    registerEnvForExpand(vm, rooted, path);
     vm.gc.popRoot();
-
-    registerEnvForExpand(vm, expr, path);
 }
 
 /// Establish the environment effects `expand` needs from a top-level form so
 /// later forms expand correctly: run macro-importing forms, and register a
 /// `define-syntax` transformer by compiling (never executing) the form. Ordinary
 /// `define`s / expressions and value-defining forms are deliberately left alone.
+/// Called with the form AFTER macro expansion so a macro-generated
+/// `define-syntax` (SRFI 139 syntax parameters) is registered too (kaappi#1894).
 fn registerEnvForExpand(vm: *VM, expr: Value, path: []const u8) void {
     if (!types.isPair(expr) or !types.isSymbol(types.car(expr))) return;
     const name = types.symbolName(types.car(expr));
@@ -277,14 +286,25 @@ fn expandLet(vm: *VM, expr: Value, depth: u16) error{OutOfMemory}!Value {
     return cons3Tail(vm, types.car(expr), bindings, body);
 }
 
-/// `let-syntax` / `letrec-syntax`: the transformer bindings are left in place
-/// (they are `syntax-rules` specs), and the body is expanded against the global
-/// macro set — uses of the locally-bound syntax stay unexpanded and round-trip.
+/// `let-syntax` / `letrec-syntax`: left entirely unexpanded — form, bindings
+/// and body. The local transformers are never built here, so expanding the body
+/// would resolve a use of a locally-bound keyword against the OUTER binding of
+/// that name, silently changing the program (kaappi#1894: a shadowed
+/// `(let-syntax ((c ...)) (c))` came out as the outer `c`'s expansion with the
+/// inner binding re-emitted but never applied). Leaving the whole form intact is
+/// sound — the compiler builds the local macros and expands the body on a real
+/// run — and round-trips, because re-reading re-establishes the inner binding.
+///
+/// Round-trip fidelity depends on the binder keeping its spelling so a use left
+/// in the body still matches it. That holds because a shared keyword introduced
+/// by a `define-syntax` — including one a macro generated, e.g. a SRFI 139
+/// syntax parameter — is registered by `registerEnvForExpand`, so a later macro
+/// whose template mentions it keeps it bare rather than hygiene-renaming the
+/// binder away from the body's use of it.
 fn expandSyntaxLet(vm: *VM, expr: Value, depth: u16) error{OutOfMemory}!Value {
-    const rest = types.cdr(expr);
-    if (!types.isPair(rest)) return expr;
-    const body = try mapExpand(vm, types.cdr(rest), depth);
-    return cons3Tail(vm, types.car(expr), types.car(rest), body);
+    _ = vm;
+    _ = depth;
+    return expr;
 }
 
 /// `(define x init)` or `(define (f . args) body...)` — keep the target, expand

--- a/tests/scheme/pipeline/pipeline.sh
+++ b/tests/scheme/pipeline/pipeline.sh
@@ -94,6 +94,43 @@ assert_roundtrip "roundtrip: quoted data untouched" '
 (display (quote (dbl 1 2))) (newline)
 (display (dbl 4)) (newline)'
 
+# kaappi#1894: expand expanded a let-syntax/letrec-syntax body with the OUTER
+# binding of a shadowed keyword, then re-emitted the never-applied inner
+# binding — so the dump printed 42 where the program yields 99. The body of a
+# local-macro form is now left unexpanded (its local transformers are never
+# built here), so re-reading re-establishes the inner binding and round-trips.
+assert_roundtrip "roundtrip: let-syntax shadowing an outer keyword (#1894)" '
+(import (scheme base) (scheme write))
+(define-syntax c (syntax-rules () ((c) 42)))
+(display (let-syntax ((c (syntax-rules () ((c) 99)))) (c))) (newline)'
+
+assert_roundtrip "roundtrip: letrec-syntax shadowing an outer keyword (#1894)" '
+(import (scheme base) (scheme write))
+(define-syntax c (syntax-rules () ((c) 42)))
+(display (letrec-syntax ((c (syntax-rules () ((c) 99)))) (c))) (newline)'
+
+# kaappi#1894 second shape: a macro (here a SRFI 139 syntax parameter) expands
+# into a let-syntax whose binder is hygiene-renamed while the body use keeps its
+# original spelling — severing the link, so the re-read dump raised
+# "abort used outside of a loop" instead of yielding 4. registerEnvForExpand now
+# registers the macro-generated define-syntax, so the shared keyword stays bare
+# through the later expansion.
+assert_roundtrip "roundtrip: syntax-parameter through let-syntax (#1894)" '
+(import (scheme base) (scheme write) (srfi 139))
+(define-syntax-parameter abort
+  (syntax-rules () ((_ . _) (syntax-error "abort used outside of a loop"))))
+(define-syntax forever
+  (syntax-rules ()
+    ((forever body1 body2 ...)
+     (call-with-current-continuation
+      (lambda (escape)
+        (syntax-parameterize
+            ((abort (syntax-rules () ((abort v (... ...)) (escape v (... ...))))))
+          (let loop () body1 body2 ... (loop))))))))
+(display
+  (let ((n 0))
+    (forever (set! n (+ n 1)) (when (> n 3) (abort n))))) (newline)'
+
 # ── ast: the reader view ────────────────────────────────────────────────────
 
 printf "%s\n" "'(a b c)" > "$TMP/ast.scm"


### PR DESCRIPTION
## Problem

`docs/dev/observing-the-pipeline.md` guarantees that feeding `kaappi expand` output back through `kaappi` preserves behavior. It did not, for `let-syntax`/`letrec-syntax`:

```scheme
(define-syntax c (syntax-rules () ((c) 42)))
(display (let-syntax ((c (syntax-rules () ((c) 99)))) (c))) (newline)
# kaappi f.scm        -> 99
# kaappi expand f.scm -> (display (let-syntax ((c ...)) 42))   ; body already 42, using the OUTER c
# round-tripped       -> 42   (answer changed)
```

The dump expanded the body against the global macro set — resolving the shadowed `(c)` to the *outer* `c` — then re-emitted the inner binding it never applied. A second shape (a SRFI 139 syntax parameter expanding into a `let-syntax`) emitted a hygienically renamed binder while leaving the body use under its original spelling, severing the link and raising on re-read.

## Fix

- `src/pipeline.zig` `expandSyntaxLet`: leave `let-syntax`/`letrec-syntax` **entirely unexpanded** (form, bindings, body). The local transformers are never built in the expand path, so expanding the body could only resolve against the wrong binding. Leaving the form intact is sound — the compiler builds the local macros and expands the body on a real run — and round-trips, because re-reading re-establishes the inner binding.
- `registerEnvForExpand` now runs on the **expanded** form, so a macro-generated `define-syntax` (e.g. a SRFI 139 syntax parameter) registers its transformer and the shared keyword stays bare through a later expansion instead of being hygiene-renamed away from its use.
- `docs/dev/observing-the-pipeline.md` updated to match.

## Test

`tests/scheme/pipeline/pipeline.sh` gains three `assert_roundtrip` cases (let-syntax shadowing, letrec-syntax shadowing, and the syntax-parameter-through-let-syntax second shape). All 16 pipeline assertions pass; `zig build test` and the hygiene suite (22/22) pass.

Closes #1894

🤖 Generated with [Claude Code](https://claude.com/claude-code)