### PR TITLE
Guard the WASM differential against a stale kaappi.wasm

### DIFF
--- a/tests/scheme/differential/run-wasm-differential.sh
+++ b/tests/scheme/differential/run-wasm-differential.sh
@@ -168,7 +168,13 @@ for p in src build.zig build.zig.zon vendor; do
 done
 if [ -n "$FRESH_INPUTS" ]; then
     # shellcheck disable=SC2086  # deliberate word splitting over the path list
-    NEWER_SRC="$(find $FRESH_INPUTS -type f -newer "$WASM" 2> /dev/null)"
+    # Fail closed: if the scan itself fails (an input vanished mid-scan or is
+    # unreadable), freshness cannot be established — SKIP rather than proceed
+    # on an empty NEWER_SRC and measure a module of unknown provenance.
+    if ! NEWER_SRC="$(find $FRESH_INPUTS -type f -newer "$WASM" 2> /dev/null)"; then
+        echo "SKIP: cannot verify freshness of wasm module $WASM"
+        exit 77
+    fi
     if [ -n "$NEWER_SRC" ]; then
         NEWER_ONE="$(printf '%s\n' "$NEWER_SRC" | head -1)"
         echo "SKIP: wasm module $WASM is stale — interpreter sources are newer"
@@ -461,7 +467,7 @@ echo "=== differential: WASM tier vs interpreter oracle ==="
 echo "native:  $KAAPPI ($("$KAAPPI" --version 2> /dev/null | head -1))"
 # Size is a cheap staleness tell in a transcript; the freshness gate above has
 # already refused to run against a module older than the sources (kaappi#2197).
-echo "wasm:    $WASM ($(wc -c < "$WASM" 2> /dev/null | tr -d ' ') bytes, verified newer than src/)"
+echo "wasm:    $WASM ($(wc -c < "$WASM" 2> /dev/null | tr -d ' ') bytes, verified newer than interpreter build inputs)"
 echo "runtime: $(wasmtime --version 2> /dev/null | head -1)"
 printf 'corpus: '
 # shellcheck disable=SC2086  # deliberate word splitting over the dir list

--- a/tests/scheme/differential/run-wasm-differential.sh
+++ b/tests/scheme/differential/run-wasm-differential.sh
@@ -18,8 +18,10 @@
 #   KAAPPI_WASM_DIFF_VERBOSE=1 print a line per file instead of only diffs
 #   KAAPPI_WASM_DIFF_KEEP=1    keep the temp tree of captured outputs
 #
-# Exits 77 (SKIP) when there is no WASM runtime or no module to run — most
-# dev boxes have neither, and CI's `wasm` job has both.
+# Exits 77 (SKIP) when there is no WASM runtime, no module to run, or the module
+# predates the interpreter sources (i.e. was not built from this tree — see the
+# freshness gate below, kaappi#2197). Most dev boxes have neither runtime nor a
+# fresh module; CI's `wasm` job has both.
 #
 # ---------------------------------------------------------------------------
 # READ THIS BEFORE TRUSTING A GREEN RUN
@@ -136,6 +138,46 @@ fi
 if [ ! -f "$WASM" ]; then
     echo "SKIP: no wasm module at $WASM (run 'zig build wasm' first)"
     exit 77
+fi
+
+# ---------------------------------------------------------------------------
+# Freshness — refuse to measure a module not built from this tree (kaappi#2197)
+# ---------------------------------------------------------------------------
+# This harness compares TODAY's interpreter against whatever `.wasm` is sitting
+# in zig-out/, and nothing on the run-all.sh path rebuilds it (that script has
+# no `zig build wasm` step).  A module from an earlier commit still runs, and
+# every message-text match then measures the OLD engine: the pre-#2016
+# file-error wording, a probe newer than the module, and so on all surface as
+# confident, specific FALSE divergences naming real corpus files, with nothing
+# in the output hinting the module is old.  The silent direction is worse — a
+# stale module that still agrees yields a clean PASS while testing nothing about
+# this tree, exactly the "green while testing nothing" class the v2 audit put
+# first.
+#
+# So establish that the module postdates the sources compiled INTO it before
+# comparing anything.  If any such source is newer than the module, the module
+# cannot reflect this tree: SKIP, never FAIL.  Only the binary's inputs are
+# checked (src/, build.zig{,.zon}, vendor/) — editing a test or a doc does not
+# trip it, since both tiers read those live from disk.  `find -newer` is plain
+# POSIX (no GNU-only predicate); the strict OpenBSD grep leg never sees a regex
+# here.  CI is unaffected: its `wasm` job builds the module before the native
+# oracle, so no source ever outdates it.
+FRESH_INPUTS=""
+for p in src build.zig build.zig.zon vendor; do
+    [ -e "$p" ] && FRESH_INPUTS="$FRESH_INPUTS $p"
+done
+if [ -n "$FRESH_INPUTS" ]; then
+    # shellcheck disable=SC2086  # deliberate word splitting over the path list
+    NEWER_SRC="$(find $FRESH_INPUTS -type f -newer "$WASM" 2> /dev/null)"
+    if [ -n "$NEWER_SRC" ]; then
+        NEWER_ONE="$(printf '%s\n' "$NEWER_SRC" | head -1)"
+        echo "SKIP: wasm module $WASM is stale — interpreter sources are newer"
+        echo "      than it (e.g. $NEWER_ONE), so it was not built from this tree."
+        echo "      Run 'zig build wasm' to refresh it.  Refusing to report WASM"
+        echo "      tier divergences against a module of unknown provenance"
+        echo "      (kaappi#2197)."
+        exit 77
+    fi
 fi
 
 TIMEOUT="${KAAPPI_WASM_DIFF_TIMEOUT:-60}"
@@ -417,7 +459,9 @@ check_file() {
 
 echo "=== differential: WASM tier vs interpreter oracle ==="
 echo "native:  $KAAPPI ($("$KAAPPI" --version 2> /dev/null | head -1))"
-echo "wasm:    $WASM"
+# Size is a cheap staleness tell in a transcript; the freshness gate above has
+# already refused to run against a module older than the sources (kaappi#2197).
+echo "wasm:    $WASM ($(wc -c < "$WASM" 2> /dev/null | tr -d ' ') bytes, verified newer than src/)"
 echo "runtime: $(wasmtime --version 2> /dev/null | head -1)"
 printf 'corpus: '
 # shellcheck disable=SC2086  # deliberate word splitting over the dir list

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -562,6 +562,23 @@ if command -v zig > /dev/null 2>&1; then
         echo "  WARN  zig build lib failed; compile scripts will each retry it"
     fi
 fi
+
+# The WASM differential compares this tree's interpreter against
+# zig-out/bin/kaappi.wasm, but nothing else on this path rebuilds that module —
+# so without this step a local run-all.sh would measure today's interpreter
+# against whatever stale .wasm happens to be in zig-out/, producing confident
+# FALSE divergences (or, worse, a clean PASS that tested nothing) against a
+# module from another commit (kaappi#2197). CI's `wasm` job builds it first; do
+# the same here. Gated on wasmtime too, since without it the differential SKIPs
+# regardless and the build would be wasted. Best-effort: run-wasm-differential.sh
+# has its own freshness guard, so if this is skipped or fails the leg degrades to
+# a clear SKIP rather than a false FAIL.
+if command -v zig > /dev/null 2>&1 && command -v wasmtime > /dev/null 2>&1; then
+    echo "Building the WebAssembly module (zig build wasm) for the WASM differential."
+    if ! zig build wasm > /dev/null 2>&1; then
+        echo "  WARN  zig build wasm failed; the WASM differential will SKIP (stale/missing module)"
+    fi
+fi
 echo ""
 
 check_unreachable_tests


### PR DESCRIPTION
## Problem

`tests/scheme/differential/run-wasm-differential.sh` compared today's
interpreter against `zig-out/bin/kaappi.wasm` but only guarded the module's
*existence* — never that it was built from the tree under test. Because
`run-all.sh` has no `zig build wasm` step, a local `run-all.sh` measured the
current interpreter against whatever module happened to be sitting in
`zig-out/` — possibly from another commit or weeks earlier. That produced
confident, specific **FALSE** tier-divergence FAILs naming real corpus files
(the harness's message-text matching worked correctly; it was matching against
an engine that predated the message, e.g. the pre-#2016 file-error wording).
The silent direction is worse: a stale module that still agrees yields a clean
**PASS** while testing nothing about the current tree. CI was unaffected — its
`wasm` job runs `zig build wasm` first.

## Fix

The key invariant: **a divergence FAIL can only be produced against a module
known to be built from this tree; otherwise SKIP with a clear reason.**

- **`run-wasm-differential.sh` is now self-protecting (correct however
  invoked).** A freshness gate runs after the existence check: if any
  interpreter source compiled *into* the module (`src/`, `build.zig{,.zon}`,
  `vendor/`) is newer than the module, it cannot reflect this tree, so the
  harness SKIPs (77) with a message telling you to run `zig build wasm` —
  instead of reporting divergences against a module of unknown provenance. Only
  the binary's build inputs are checked, so editing a test or a doc does not
  trip it (both tiers read those live from disk). The check is plain POSIX
  (`find -newer`; no GNU-only predicate, so the strict OpenBSD grep leg is
  unaffected — it sees no regex here). The preamble also now prints the module
  size as a cheap staleness tell in transcripts.

- **`run-all.sh` builds the module up front** (like CI) when both `zig` and
  `wasmtime` are present, so the common local path actually *runs* the leg
  instead of SKIPping. Best-effort and gated: without the toolchain the build
  is skipped and the differential's own freshness guard degrades the leg to a
  clear SKIP rather than a false FAIL.

The module cannot report its own `build_id` (the wasm entry point only runs a
`.scm` file — no `features`/`--version` subcommand), so an mtime-vs-sources
freshness check is the robust signal, matching the `make`-style freshness model
and issue suggestion (2).

## Verification (macOS arm64, wasmtime 48.0.0, zig 0.16.0)

**Fresh module** — `zig build wasm`, then run the differential: behaves as
before.

```
=== differential: WASM tier vs interpreter oracle ===
native:  .../zig-out/bin/kaappi (Kaappi Scheme v0.23.0)
wasm:    zig-out/bin/kaappi.wasm (1510794 bytes, verified newer than src/)
runtime: wasmtime 48.0.0 ...
...
  DIVERGENCES:                     0
  wasm hangs:                      0
PASS: no unknown WASM tier divergence across 368 files      # exit 0
```

**Missing module** — SKIPs 77 (unchanged message):

```
SKIP: no wasm module at zig-out/bin/does-not-exist.wasm (run 'zig build wasm' first)
# exit 77
```

**Stale module** — a source newer than the module (simulated with
`touch src/main.zig`) now SKIPs 77 instead of FAILing:

```
SKIP: wasm module zig-out/bin/kaappi.wasm is stale — interpreter sources are newer
      than it (e.g. src/main.zig), so it was not built from this tree.
      Run 'zig build wasm' to refresh it.  Refusing to report WASM
      tier divergences against a module of unknown provenance
      (kaappi#2197).
# exit 77
```

Both scripts pass `bash -n`; `shellcheck -x` reports no new findings.

Closes #2197

🤖 Generated with [Claude Code](https://claude.com/claude-code)
