### PR TITLE
Accept unresolvable SRFI 211 transformer-specs under kaappi check (Fixes #2007)

### DIFF
--- a/src/compiler_define_syntax.zig
+++ b/src/compiler_define_syntax.zig
@@ -19,6 +19,7 @@ const compiler_mod = @import("compiler.zig");
 const expander = @import("expander.zig");
 const globals_mod = @import("globals.zig");
 const ir_mod = @import("ir.zig");
+const check_lint = @import("check_lint.zig");
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
 const Value = types.Value;
@@ -542,14 +543,35 @@ fn resolveTransformerSpecRec(self: *Compiler, spec_in: Value, merged_macros: *st
             // `(define-syntax foo t)`. Only already-executed defines are
             // visible (top-level and library bodies run form-by-form), which
             // is the same left-to-right visibility every global has.
+            var bound_non_transformer = false;
             if (self.globals) |g| {
                 const glk = globals_mod.acquireGlobalsRead(g);
                 const gv = g.get(alias_name);
                 globals_mod.releaseGlobalsRead(glk);
                 if (gv) |v| {
                     if (types.isTransformer(v)) return v;
+                    // The name resolves to a real value that is NOT a
+                    // transformer (e.g. a procedure like `car`): this is
+                    // statically wrong at run time too, so keep rejecting it
+                    // even under analysis — the placeholder fallback below is
+                    // only for names we genuinely cannot resolve.
+                    bound_non_transformer = true;
                 }
             }
+            // kaappi#2007: `kaappi check` (and the LSP) execute nothing, so a
+            // define/define-values that would bind this name to a Transformer
+            // at run time never ran — the globals lookup above comes back
+            // empty even for a program that compiles and runs cleanly. Flagging
+            // it KP2001 is a false positive on a valid file. When analysing
+            // (check_lint.active != null) rather than really compiling for
+            // execution, and only when the name is otherwise unresolvable (not
+            // a known non-transformer binding), accept the still-unresolved
+            // alias as a benign placeholder macro instead of rejecting it. A
+            // normal run never takes this branch: by the time this
+            // define-syntax executes, the earlier define has run and the
+            // transformer is in globals.
+            if (check_lint.active != null and !bound_non_transformer)
+                return makeCheckPlaceholderTransformer(self);
             return CompileError.InvalidSyntax;
         }
         if (!types.isPair(spec)) return CompileError.InvalidSyntax;
@@ -572,11 +594,25 @@ fn resolveTransformerSpecRec(self: *Compiler, spec_in: Value, merged_macros: *st
             // Evaluated NOW, at macro-definition time, in the global
             // environment (phase separation: enclosing runtime locals have
             // no values at expansion time and are deliberately invisible).
-            const proc = eval_fn(types.car(rest_spec)) catch |err| return switch (err) {
-                error.OutOfMemory => CompileError.OutOfMemory,
-                else => CompileError.InvalidSyntax,
+            const proc = eval_fn(types.car(rest_spec)) catch |err| switch (err) {
+                error.OutOfMemory => return CompileError.OutOfMemory,
+                // kaappi#2007: SRFI 211 evaluates the transformer expression at
+                // macro-definition time, so it may legally reference a global
+                // that only gets bound when the program runs. `kaappi check`
+                // executes nothing, so that global is unbound and the eval
+                // fails — but the arity-checked spec is structurally valid and
+                // the program compiles and runs. Under analysis accept it as a
+                // placeholder rather than emit a KP2001 false positive; a real
+                // run reaches here only when the eval genuinely succeeds.
+                else => if (check_lint.active != null)
+                    return makeCheckPlaceholderTransformer(self)
+                else
+                    return CompileError.InvalidSyntax,
             };
-            if (!types.isProcedure(proc)) return CompileError.InvalidSyntax;
+            if (!types.isProcedure(proc)) {
+                if (check_lint.active != null) return makeCheckPlaceholderTransformer(self);
+                return CompileError.InvalidSyntax;
+            }
             var proc_root = proc;
             self.gc.pushRoot(&proc_root);
             const tx_val = self.gc.allocProceduralTransformer(
@@ -684,6 +720,36 @@ fn resolveTransformerSpecRec(self: *Compiler, spec_in: Value, merged_macros: *st
         if (expander.isUsertextPair(spec)) spec = expander.unwrapUsertext(spec);
         if (types.isPair(spec) or types.isVector(spec)) expander.stripUsertextMarkers(self.gc, spec);
     }
+}
+
+/// kaappi#2007: build a benign catch-all transformer for a transformer-spec
+/// that `kaappi check`/the LSP cannot resolve because nothing has executed
+/// (a runtime-bound Transformer alias, or an er/lisp-transformer expression
+/// that references a not-yet-bound global). Equivalent to
+/// `(syntax-rules () ((_ . rest) (if #f #f)))`: every use of the defined
+/// keyword expands to void, so the macro use itself compiles cleanly during
+/// analysis instead of surfacing as an "undefined variable" downstream. Only
+/// ever called under check_lint.active — a normal run resolves the real
+/// transformer. The returned Transformer is freshly allocated and unrooted,
+/// exactly like parseSyntaxRules' result; compileDefineSyntax roots it via
+/// extra_roots with nothing allocating in between (same contract).
+fn makeCheckPlaceholderTransformer(self: *Compiler) CompileError!Value {
+    const gc = self.gc;
+    // Suppress collection while assembling this small transient spec so the
+    // intermediate pairs/symbols need no manual rooting (mirrors the
+    // no_collect window expandMacro uses); parseSyntaxRules copies every
+    // slice with the raw allocator before it could collect anyway.
+    gc.no_collect += 1;
+    defer gc.no_collect -= 1;
+    const underscore = gc.allocSymbol("_") catch return CompileError.OutOfMemory;
+    const rest = gc.allocSymbol("rest") catch return CompileError.OutOfMemory;
+    const pattern = gc.allocPair(underscore, rest) catch return CompileError.OutOfMemory; // (_ . rest)
+    const if_sym = gc.allocSymbol("if") catch return CompileError.OutOfMemory;
+    const template = gc.makeList(&.{ if_sym, types.FALSE, types.FALSE }) catch return CompileError.OutOfMemory; // (if #f #f)
+    const rule = gc.makeList(&.{ pattern, template }) catch return CompileError.OutOfMemory; // ((_ . rest) (if #f #f))
+    const sr = gc.allocSymbol("syntax-rules") catch return CompileError.OutOfMemory;
+    const spec = gc.makeList(&.{ sr, types.NIL, rule }) catch return CompileError.OutOfMemory; // (syntax-rules () <rule>)
+    return parseSyntaxRules(self, spec, &.{});
 }
 
 pub fn parseSyntaxRules(self: *Compiler, spec: Value, extra_bound: []const []const u8) CompileError!Value {

--- a/tests/scheme/errors/check.sh
+++ b/tests/scheme/errors/check.sh
@@ -136,6 +136,47 @@ assert_exit "unshadowed define-record-type still establishes accessors" 0 \
     '(define-record-type <pt> (mk x) pt? (x pt-x))
      (display (pt-x (mk 1)))'
 
+echo "== SRFI 211 runtime transformer-spec is not a false positive (kaappi#2007) =="
+# `check` executes nothing, so a Transformer that only exists at run time
+# cannot be resolved statically. It must still accept the (valid, running)
+# program rather than emit KP2001. Both shapes below print "ok" when run.
+#
+# Shape 1: a runtime-bound Transformer value used as a transformer-spec alias.
+assert_exit "runtime-bound transformer alias is clean" 0 \
+    '(import (scheme base) (scheme write) (srfi 211 explicit-renaming))
+     (define tx (er-macro-transformer (lambda (f r c) (list (r (quote quote)) (quote ok)))))
+     (define-syntax m tx)
+     (display (m)) (newline)'
+# Shape 2: an er-macro-transformer expression that references a global (SRFI
+# 211 evaluates the expression at macro-definition time in the global env).
+assert_exit "transformer expr referencing a global is clean" 0 \
+    '(import (scheme base) (scheme write) (srfi 211 explicit-renaming))
+     (define w (quote ok))
+     (define-syntax m
+       (er-macro-transformer (let ((v w)) (lambda (f r c) (list (r (quote quote)) v)))))
+     (display (m)) (newline)'
+# The control literal-lambda spec (resolvable without executing) stays clean too.
+assert_exit "literal-lambda transformer spec is clean" 0 \
+    '(import (scheme base) (scheme write) (srfi 211 explicit-renaming))
+     (define-syntax m (er-macro-transformer (lambda (f r c) (list (r (quote quote)) (quote ok)))))
+     (display (m)) (newline)'
+
+echo "== genuinely-invalid transformer-specs are STILL reported (kaappi#2007) =="
+# A non-symbol, non-pair literal can never be a transformer — reject as before.
+assert_exit "a literal transformer-spec is an error"       1 '(define-syntax m 42)'
+assert_out  "...and reports KP2001"                        'error\[KP2001\]' '(define-syntax m 42)'
+# A bare alias that resolves to a bound, NON-transformer value (a procedure) is
+# statically wrong at run time too, so analysis keeps rejecting it — the
+# placeholder fallback is only for names that are genuinely unresolvable.
+assert_exit "alias to a non-transformer global is an error" 1 \
+    '(import (scheme base))
+     (define-syntax m car)
+     (display (m))'
+# A structurally malformed er-macro-transformer (wrong arity) is still rejected.
+assert_exit "er-macro-transformer with no argument is an error" 1 \
+    '(import (scheme base) (srfi 211 explicit-renaming))
+     (define-syntax m (er-macro-transformer))'
+
 echo "== --diagnostics=json parity =="
 printf '(car 5)\n' > "$TMP/j.scm"
 JSON="$("$KAAPPI" check --diagnostics=json "$TMP/j.scm" 2>&1 || true)"


### PR DESCRIPTION
## Problem

`kaappi check` runs compile-only static analysis — it reads, expands, and compiles every top-level form but **executes nothing** (`docs/dev/check.md`). Two valid SRFI 211 transformer-spec shapes were wrongly reported as `KP2001: invalid syntax` (exit 1) even though the program compiles and runs correctly:

**Shape 1 — a runtime-bound `Transformer` used as a bare-symbol alias:**

```scheme
(import (scheme base) (scheme write) (srfi 211 explicit-renaming))
(define tx (er-macro-transformer (lambda (f r c) (list (r 'quote) 'ok))))
(define-syntax m tx)
(display (m)) (newline)
```

**Shape 2 — an `er-macro-transformer` expression that references a global** (SRFI 211 evaluates the transformer expression at macro-definition time in the global environment):

```scheme
(import (scheme base) (scheme write) (srfi 211 explicit-renaming))
(define w 'ok)
(define-syntax m
  (er-macro-transformer (let ((v w)) (lambda (f r c) (list (r 'quote) v)))))
(display (m)) (newline)
```

Both print `ok` when run. Both were flagged by `check`.

### Root cause

`check` never executes the earlier `define`, so `resolveTransformerSpecRec` (`src/compiler_define_syntax.zig`) finds nothing in globals for the bare alias, and the transformer-expression `eval` fails on the unbound global. Both fall through to `InvalidSyntax`. One mechanism, two symptoms.

## Fix

Under analysis only (`check_lint.active != null`, set by the check/LSP path and never by a normal run), accept a still-unresolvable transformer-spec as a benign catch-all placeholder macro — equivalent to `(syntax-rules () ((_ . rest) (if #f #f)))` — so the file is clean and later uses of the keyword also compile. A normal run never reaches these branches: by the time the `define-syntax` executes, the earlier `define` has run and the transformer is in globals.

## Before / after

```console
$ kaappi check chk1.scm      # before: 3:1: error[KP2001]: invalid syntax  (exit 1)
$ kaappi check chk1.scm      # after:  check: no issues found              (exit 0)
```

Both shapes now `check` clean and still run; the cited `tests/scheme/audit/primitives_smallbatch-audit.scm` is check-clean again.

## Genuine invalid-syntax detection kept intact

The placeholder fallback fires only for genuinely-unresolvable specs. Still reported as `KP2001`:
- a non-symbol/non-pair literal — `(define-syntax m 42)`
- a bare alias to a bound **non-transformer** value (e.g. a procedure) — `(define-syntax m car)` (we can tell statically it's wrong)
- a malformed-arity form — `(define-syntax m (er-macro-transformer))`

## Tests

Added a `kaappi#2007` section to `tests/scheme/errors/check.sh` asserting both shapes (plus the resolvable control) exit 0, and that all three genuine-invalid specs are still reported. `zig build` and `zig build test` pass; the full `check.sh` suite is 37/37.

Closes #2007

🤖 Generated with [Claude Code](https://claude.com/claude-code)
