### PR TITLE
Reject subcommand-scoped CLI flags at global scope

### DIFF
--- a/docs/dev/cli-surface.md
+++ b/docs/dev/cli-surface.md
@@ -177,19 +177,27 @@ valid as `thottam --locked install pkg`.
 For a flag that belongs to one subcommand only, put it in that subcommand's
 table. For a global flag that is only *meaningful* under one subcommand — as
 `--no-opt` (ir) and `--check` (fmt) are — leave it in `global_flags`, set
-`top_level = false`, and name it in that subcommand's `globalSubset`: the
-parser keeps accepting it anywhere (unchanged behaviour), while `--help` and
-the top-level completion list stay uncluttered.
+`top_level = false`, and name it in that subcommand's `globalSubset`: `--help`
+and the top-level completion list stay uncluttered, and `cli.parse` will accept
+the flag only after its owning subcommand word and reject it at global scope
+(see below). `owningSubcommand` derives that owner from the same `globalSubset`
+membership, and a comptime check requires every `top_level = false` flag to
+belong to exactly one subcommand, so the reject path always has an owner to
+name.
 
-## Known limitations
+## Subcommand-scoped flags at global scope
 
-`--no-opt` and `--check` carry `top_level = false`, which scopes them for
-`--help` and the completions but **not** for the parser: the global loop still
-accepts them anywhere. For `--check` that is a live hazard, since it is one
-hyphen-pair from the `check` subcommand whose contract is that nothing
-executes — `kaappi --check foo.scm` runs the program. Tracked as
-[kaappi#2096](https://github.com/kaappi/kaappi/issues/2096); the scoping data
-this fix would need already lives in `subcommands`.
+`--no-opt` and `--check` carry `top_level = false`. They stay in `global_flags`
+(so the inline subcommands' shared loop still parses them), but the loop accepts
+them **only after their owning subcommand word** — `kaappi ir --no-opt`,
+`kaappi fmt --check`. At global scope each is a usage error (exit 2) that names
+the subcommand it belongs to, rather than being accepted silently. For
+`--check` that also points at the `check` subcommand, since the two differ only
+by the leading `--` and have opposite execution semantics: before this check,
+`kaappi --check foo.scm` *ran* the program the `check` subcommand promises never
+to execute (kaappi#2096). `cli_spec.owningSubcommand` supplies the owner, and a
+comptime check pins every scoped flag to exactly one subcommand so that lookup
+never comes up empty.
 
 fish has no way to express an optional attached value, so `--timings` is
 emitted without `-r`: the bare spelling — the common one — completes, and

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -137,39 +137,63 @@ pub fn parse(args: std.process.Args) Options {
     // toOwnedSlice below, leaving lib_paths_slice empty — they never consult it.
     var lib_paths: std.ArrayList([]const u8) = .empty;
 
+    // The inline subcommand word in play (compile/check/ast/expand/ir/fmt),
+    // once one has been consumed. A subcommand-scoped flag (`top_level =
+    // false`, e.g. `--no-opt`, `--check`) is legal only after its owning
+    // subcommand word; at global scope it is rejected rather than silently
+    // accepted, which is what let `kaappi --check foo.scm` run the file the
+    // `check` subcommand promises never to execute (kaappi#2096).
+    var active_subcommand: ?[]const u8 = null;
+
     while (iter.next()) |arg| {
         if (std.mem.eql(u8, arg, "compile")) {
             opts.native_compile_mode = true;
+            active_subcommand = arg;
             continue;
         }
 
         if (std.mem.eql(u8, arg, "check")) {
             opts.check_mode = true;
+            active_subcommand = arg;
             continue;
         }
 
         if (std.mem.eql(u8, arg, "ast")) {
             opts.ast_mode = true;
+            active_subcommand = arg;
             continue;
         }
 
         if (std.mem.eql(u8, arg, "expand")) {
             opts.expand_mode = true;
+            active_subcommand = arg;
             continue;
         }
 
         if (std.mem.eql(u8, arg, "ir")) {
             opts.ir_mode = true;
+            active_subcommand = arg;
             continue;
         }
 
         if (std.mem.eql(u8, arg, "fmt")) {
             opts.fmt_mode = true;
+            active_subcommand = arg;
             continue;
         }
 
         if (matchFlag(arg)) |m| {
             const f = m.flag;
+
+            // A subcommand-scoped flag is meaningful only under its owning
+            // subcommand; reject it (usage error, exit 2) anywhere else instead
+            // of accepting it inertly — or, for `--check`, running the file.
+            if (spec.owningSubcommand(f.id)) |owner| {
+                const in_scope = active_subcommand != null and
+                    std.mem.eql(u8, active_subcommand.?, owner);
+                if (!in_scope) scopedFlagError(f.long, owner);
+            }
+
             const value: ?[]const u8 = if (m.inline_value) |v| v else if (f.takesSeparateValue()) blk: {
                 break :blk iter.next() orelse {
                     writeStderr(f.long);
@@ -294,9 +318,9 @@ fn oomCollectingArgs() noreturn {
 
 /// The `Options:` block, generated from the same table the parse loop and the
 /// completion scripts read. It used to be a fourth hand-maintained list.
-/// `--no-opt` and `--check` are `top_level = false`: the loop accepts them
-/// anywhere, but they only mean anything under `ir` / `fmt`, where the
-/// `Commands:` block above already documents them.
+/// `--no-opt` and `--check` are `top_level = false`: the loop accepts them only
+/// after their owning `ir` / `fmt` subcommand word (kaappi#2096) and the
+/// `Commands:` block above documents them there, so they stay out of this block.
 const options_block = blk: {
     @setEvalBranchQuota(100_000);
     // One column for every spelling, so the descriptions line up.
@@ -367,6 +391,30 @@ const usage_text =
 
 pub fn usageError(msg: []const u8) noreturn {
     writeStderr(msg);
+    std.process.exit(USAGE_ERROR_EXIT);
+}
+
+/// A subcommand-scoped flag appeared at global scope (kaappi#2096). Name the
+/// subcommand it belongs to and, when a same-named subcommand exists (as for
+/// `--check` vs the `check` subcommand), point at the likely intent, then exit
+/// with the usage-error status rather than running the file.
+fn scopedFlagError(flag_long: []const u8, owner: []const u8) noreturn {
+    writeStderr("kaappi: ");
+    writeStderr(flag_long);
+    writeStderr(" is a `kaappi ");
+    writeStderr(owner);
+    writeStderr("` option, not a global flag\n");
+    // `--check` strips to `check`, which is also a subcommand with the opposite
+    // execution semantics — surface that so the user is not left running the
+    // file they meant only to analyse.
+    const bare = std.mem.trimStart(u8, flag_long, "-");
+    if (spec.isInlineSubcommand(bare)) {
+        writeStderr("  did you mean the `");
+        writeStderr(bare);
+        writeStderr("` subcommand? (kaappi ");
+        writeStderr(bare);
+        writeStderr(" <file> executes nothing)\n");
+    }
     std.process.exit(USAGE_ERROR_EXIT);
 }
 
@@ -753,6 +801,24 @@ test "parse: no-ir-opt" {
     const argv = [_][*:0]const u8{ "kaappi", "--no-ir-opt", "test.scm" };
     const opts = parse(testArgs(&argv));
     try std.testing.expect(opts.no_ir_opt);
+    try std.testing.expectEqualStrings("test.scm", opts.file_path.?);
+}
+
+test "parse: fmt --check is accepted in scope (kaappi#2096)" {
+    // The subcommand-scoped `--check` is legal after its owning `fmt` word.
+    // The out-of-scope spelling `kaappi --check file` is rejected with a usage
+    // error (exit 2) — covered by tests/scheme/errors, since it exits.
+    const argv = [_][*:0]const u8{ "kaappi", "fmt", "--check", "test.scm" };
+    const opts = parse(testArgs(&argv));
+    try std.testing.expect(opts.fmt_mode);
+    try std.testing.expect(opts.fmt_check);
+}
+
+test "parse: ir --no-opt is accepted in scope (kaappi#2096)" {
+    const argv = [_][*:0]const u8{ "kaappi", "ir", "--no-opt", "test.scm" };
+    const opts = parse(testArgs(&argv));
+    try std.testing.expect(opts.ir_mode);
+    try std.testing.expect(opts.ir_no_opt);
     try std.testing.expectEqualStrings("test.scm", opts.file_path.?);
 }
 

--- a/src/cli_spec.zig
+++ b/src/cli_spec.zig
@@ -356,6 +356,32 @@ pub fn isInlineSubcommand(arg: []const u8) bool {
     return false;
 }
 
+/// For a subcommand-scoped (`top_level = false`) global flag, the name of the
+/// subcommand that gives it meaning; `null` for a genuinely top-level flag.
+///
+/// Derived from `subcommands` membership — the same `globalSubset` lists that
+/// drive `--help` and the completions — so a scoped flag's owner cannot drift
+/// from where it is documented and offered. `cli.parse` uses this to reject a
+/// scoped flag seen at global scope and name the subcommand it belongs to
+/// (kaappi#2096). The comptime block below guarantees the lookup succeeds for
+/// every scoped flag, so a caller may safely `.?` the result.
+pub fn owningSubcommand(id: GlobalId) ?[]const u8 {
+    var flag_long: []const u8 = "";
+    for (global_flags) |g| {
+        if (g.id == id) {
+            if (g.top_level) return null; // a top-level flag has no owner
+            flag_long = g.long;
+        }
+    }
+    if (flag_long.len == 0) return null;
+    for (subcommands) |s| {
+        for (s.flags) |sf| {
+            if (std.mem.eql(u8, sf.long, flag_long)) return s.name;
+        }
+    }
+    return null;
+}
+
 // ── thottam ────────────────────────────────────────────────────────────
 
 pub const ThottamId = enum { locked, help, version_flag, completions_flag };
@@ -421,6 +447,24 @@ comptime {
     validateTable(CacheId, &cache_flags, "cache_flags");
     validateTable(ThottamId, &thottam_flags, "thottam_flags");
 
+    // Every subcommand-scoped flag (`top_level = false`) must belong to exactly
+    // one subcommand's `globalSubset`, so `owningSubcommand` can name its owner
+    // when `cli.parse` rejects it at global scope (kaappi#2096). Without this a
+    // scoped flag with no owner would return null and the reject path would have
+    // no subcommand to point at.
+    for (global_flags) |g| {
+        if (g.top_level) continue;
+        var owners = 0;
+        for (subcommands) |s| {
+            for (s.flags) |sf| {
+                if (std.mem.eql(u8, sf.long, g.long)) owners += 1;
+            }
+        }
+        if (owners != 1) {
+            @compileError("global_flags: subcommand-scoped " ++ g.long ++ " must belong to exactly one subcommand's globalSubset");
+        }
+    }
+
     // Every subcommand's own flags must be a *sound* offer: a flag a
     // subcommand's parser would reject must never be completed for it. For the
     // five out-of-line subcommands `flags` IS the parser's table, so soundness
@@ -481,4 +525,13 @@ test "isInlineSubcommand: exactly the ones cli.parse consumes" {
 
 test "subcommand table names every subcommand printUsage documents" {
     try std.testing.expectEqual(@as(usize, 11), subcommands.len);
+}
+
+test "owningSubcommand: scoped flags resolve to their subcommand, top-level to null" {
+    try std.testing.expectEqualStrings("fmt", owningSubcommand(.check).?);
+    try std.testing.expectEqualStrings("ir", owningSubcommand(.no_opt).?);
+    // A representative top-level flag has no owner.
+    try std.testing.expect(owningSubcommand(.sandbox) == null);
+    try std.testing.expect(owningSubcommand(.deny_warnings) == null);
+    try std.testing.expect(owningSubcommand(.help) == null);
 }

--- a/tests/scheme/errors/check-flag-scope.sh
+++ b/tests/scheme/errors/check-flag-scope.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Subcommand-scoped flags at global scope are a usage error, not silently
+# accepted (kaappi#2096).
+#
+# `--check` belongs to `kaappi fmt` and `--no-opt` to `kaappi ir`, but the
+# global flag loop used to accept them in any position with no scope check.
+# For `--no-opt` that was merely inert; for `--check` it was a live hazard —
+# one hyphen-pair from the `check` subcommand whose contract is "executes
+# nothing", so `kaappi --check foo.scm` (instead of `check foo.scm`) RAN the
+# program. This asserts the file is no longer executed, the two spellings are
+# distinguishable by exit code, and the in-scope spellings still work.
+
+set -euo pipefail
+
+. "$(dirname "$0")/../shell-common.sh"
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+PASS=0
+FAIL=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# A program whose only observable effect is a side-effecting print, so we can
+# tell "the file ran" from "the file did not run" by the presence of "ran".
+PROG="$TMP/prog.scm"
+printf '(display "ran\\n")\n(car 1)\n' > "$PROG"
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "== --check (global) is rejected and does NOT run the file =="
+status=0
+out="$("$KAAPPI" --check "$PROG" 2>&1)" || status=$?
+if [[ "$status" -eq 2 ]]; then
+    pass "kaappi --check exits with the usage-error status (2)"
+else
+    fail "kaappi --check should exit 2, got $status"
+fi
+if grep -qE '^ran$' <<< "$out"; then
+    fail "kaappi --check executed the file (printed 'ran')"
+else
+    pass "kaappi --check did not execute the file"
+fi
+if grep -qE 'kaappi fmt' <<< "$out"; then
+    pass "the error names the owning subcommand (kaappi fmt)"
+else
+    fail "the error should name the owning subcommand; got: $out"
+fi
+if grep -qE 'check` subcommand' <<< "$out"; then
+    pass "the error points at the check subcommand as the likely intent"
+else
+    fail "the error should point at the check subcommand; got: $out"
+fi
+
+echo "== --no-opt (global) is rejected and does NOT run the file =="
+status=0
+out="$("$KAAPPI" --no-opt "$PROG" 2>&1)" || status=$?
+if [[ "$status" -eq 2 ]]; then
+    pass "kaappi --no-opt exits with the usage-error status (2)"
+else
+    fail "kaappi --no-opt should exit 2, got $status"
+fi
+if grep -qE '^ran$' <<< "$out"; then
+    fail "kaappi --no-opt executed the file (printed 'ran')"
+else
+    pass "kaappi --no-opt did not execute the file"
+fi
+if grep -qE 'kaappi ir' <<< "$out"; then
+    pass "the error names the owning subcommand (kaappi ir)"
+else
+    fail "the error should name the owning subcommand; got: $out"
+fi
+
+echo "== the check subcommand still analyses without executing =="
+status=0
+out="$("$KAAPPI" check "$PROG" 2>&1)" || status=$?
+if [[ "$status" -eq 1 ]]; then
+    pass "kaappi check reports the error (exit 1)"
+else
+    fail "kaappi check should exit 1, got $status"
+fi
+if grep -qE '^ran$' <<< "$out"; then
+    fail "kaappi check executed the file (printed 'ran')"
+else
+    pass "kaappi check did not execute the file"
+fi
+
+echo "== fmt --check still works (in-scope) =="
+UGLY="$TMP/ugly.scm"
+printf '(define   x     1)\n' > "$UGLY"
+status=0
+out="$("$KAAPPI" fmt --check "$UGLY" 2>&1)" || status=$?
+# --check reports paths needing formatting and exits nonzero without writing.
+if [[ "$status" -ne 2 ]]; then
+    pass "kaappi fmt --check is accepted (no usage error), exit $status"
+else
+    fail "kaappi fmt --check was wrongly rejected as a usage error"
+fi
+if grep -qE 'is a `kaappi' <<< "$out"; then
+    fail "kaappi fmt --check emitted the scope-rejection message: $out"
+else
+    pass "kaappi fmt --check did not emit a scope-rejection message"
+fi
+
+echo "== ir --no-opt still works (in-scope) =="
+CLEAN="$TMP/clean.scm"
+printf '(+ 1 2)\n' > "$CLEAN"
+status=0
+out="$("$KAAPPI" ir --no-opt "$CLEAN" 2>&1)" || status=$?
+if [[ "$status" -eq 0 ]]; then
+    pass "kaappi ir --no-opt is accepted (exit 0)"
+else
+    fail "kaappi ir --no-opt should exit 0, got $status: $out"
+fi
+
+echo ""
+echo "check-flag-scope: $PASS pass, $FAIL fail"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Problem

`--check` and `--no-opt` are *subcommand-scoped* flags — `--check` belongs to
`kaappi fmt`, `--no-opt` to `kaappi ir` — but both were parsed by the **global**
flag loop, which accepted them in any position with no scope check. For
`--no-opt` that was merely inert. For `--check` it was a live hazard: the
spelling is one hyphen-pair from the `check` **subcommand**, whose contract is
that it *executes nothing*, so `kaappi --check foo.scm` (a typo for
`kaappi check foo.scm`) silently **ran** the program.

```console
$ kaappi check bad.scm     # the subcommand: nothing executes
2:1: error[KP4003]: ...
$ kaappi --check bad.scm    # the flag: the program RAN
ran
bad.scm:2:1: error[KP3002]: ...
```

Both exited 1, so a CI step inspecting only the exit code could not tell them
apart.

## The scope check

`cli.parse` now tracks the active inline subcommand word and rejects a
`top_level = false` flag at global scope with a usage error (exit 2), instead of
accepting it inertly or — for `--check` — running the file:

```console
$ kaappi --check bad.scm
kaappi: --check is a `kaappi fmt` option, not a global flag
  did you mean the `check` subcommand? (kaappi check <file> executes nothing)
$ echo $?
2

$ kaappi --no-opt bad.scm
kaappi: --no-opt is a `kaappi ir` option, not a global flag
$ echo $?
2
```

The owning subcommand is derived **data-driven** from cli_spec's `globalSubset`
membership (`cli_spec.owningSubcommand`), not hardcoded, and a new comptime
check pins every `top_level = false` flag to exactly one subcommand so the
reject path always has an owner to name. The `--check` hint fires generically
whenever a same-named subcommand exists (`isInlineSubcommand`).

The in-scope spellings keep working: `kaappi fmt --check`, `kaappi ir --no-opt`,
and `kaappi ir <file> --no-opt` are unaffected. `--deny-warnings` and other
genuine global flags are unchanged.

## Before / after

| Command | Before | After |
|---------|--------|-------|
| `kaappi --check bad.scm` | prints `ran`, exit 1 | usage error, exit 2, file not run |
| `kaappi --no-opt bad.scm` | runs file (inert flag), exit 1 | usage error, exit 2, file not run |
| `kaappi check bad.scm` | analyses, exit 1 | unchanged |
| `kaappi fmt --check ugly.scm` | works | unchanged |
| `kaappi ir --no-opt f.scm` | works | unchanged |

## Tests

- `tests/scheme/errors/check-flag-scope.sh` — asserts `kaappi --check`/`--no-opt`
  do not execute the file and exit 2, that `kaappi check` still analyses, and
  that `kaappi fmt --check` / `kaappi ir --no-opt` still work.
- Unit tests in `src/cli_spec.zig` (`owningSubcommand`) and `src/cli.zig`
  (in-scope acceptance).
- `zig build test` passes; the completions, fmt, pipeline, and check shell
  suites all pass.

`docs/dev/cli-surface.md` is updated to describe the scope check.

Closes #2096

🤖 Generated with [Claude Code](https://claude.com/claude-code)