### PR TITLE
Make the untraced env-map invariant explicit and checkable (#1962)

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1389,6 +1389,9 @@ pub fn compileExpressionInEnv(gc: *memory.GC, expr: Value, vm_macros: *std.Strin
     try c.compile(expr, is_tail);
     c.func.env = env;
     c.func.env_val = env_val;
+    // #1962: env is untraced -- assert it is reachable via env_val, or is a
+    // VM-rooted registry map when env_val is NIL (the five library sites).
+    globals_mod.assertEnvMapInvariant(env, env_val);
     var out_it = c.macros.iterator();
     while (out_it.next()) |entry| {
         vm_macros.put(entry.key_ptr.*, entry.value_ptr.*) catch return CompileError.OutOfMemory;

--- a/src/compiler_define_syntax.zig
+++ b/src/compiler_define_syntax.zig
@@ -64,6 +64,7 @@ pub fn compileDefineSyntax(self: *Compiler, args: Value, dst: u16) CompileError!
     if (self.lib_env) |env| {
         tx.def_env = env;
         tx.def_env_val = self.lib_env_val;
+        globals_mod.assertEnvMapInvariant(env, self.lib_env_val); // #1962
         // #1812: pairs with def_env so renameForHygiene can build a
         // def_env_binding_prefix-marked reference that survives being
         // imported anywhere, instead of resolving by bare name against
@@ -648,6 +649,7 @@ fn resolveTransformerSpecRec(self: *Compiler, spec_in: Value, merged_macros: *st
                     const def_tx = types.toObject(def_transformer).as(types.Transformer);
                     def_tx.def_env = env;
                     def_tx.def_env_val = self.lib_env_val;
+                    globals_mod.assertEnvMapInvariant(env, self.lib_env_val); // #1962
                 }
                 try finalizeTransformer(self, def_transformer);
                 try self.recordBodyMacro(def_name);

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -595,6 +595,7 @@ pub fn scanBodyDefs(compiler: *Compiler, body: Value, handle_define_syntax: bool
             if (compiler.lib_env) |env| {
                 tx.def_env = env;
                 tx.def_env_val = compiler.lib_env_val;
+                globals_mod.assertEnvMapInvariant(env, compiler.lib_env_val); // #1962
             }
             try macro.captureLocalsOnTransformer(compiler, transformer);
             compiler.macros.put(name, transformer) catch return CompileError.OutOfMemory;

--- a/src/globals.zig
+++ b/src/globals.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const types = @import("types.zig");
 const Value = types.Value;
 
@@ -270,6 +271,43 @@ pub var def_env_binding_set: ?DefEnvBindingSetFn = null;
 pub fn setDefEnvBinding(libname: []const u8, origname: []const u8, val: Value) bool {
     if (def_env_binding_set) |setter| return setter(libname, origname, val);
     return false;
+}
+
+/// Callback reporting whether a `*StringHashMap(Value)` is one of the VM's
+/// GC-rooted environment registries -- the maps `vm.markVmRoots` traces
+/// unconditionally on every collection (each registered library's `lib_env`,
+/// a `retired_env` of a replaced library, an in-flight `pending_lib_env`, or
+/// the library env currently being compiled, `current_lib_env`). Registered by
+/// the VM so the compiler can enforce the `Function.env` / `Transformer.def_env`
+/// invariant without importing vm.zig -- the same indirection #1812's
+/// `current_lib_name_lookup` uses (#1962).
+pub const EnvMapRootedFn = *const fn (map: *std.StringHashMap(Value)) bool;
+pub var env_map_rooted_lookup: ?EnvMapRootedFn = null;
+
+/// The invariant every `Function.env` / `Transformer.def_env` must satisfy:
+/// the raw map pointer is GC-reachable ONLY through its paired traced Value
+/// (`env_val` / `def_env_val`) -- EXCEPT when the map is one of the VM-rooted
+/// library registries (see `env_map_rooted_lookup`), in which case the paired
+/// value is allowed to be NIL because the registry keeps every binding alive
+/// independently. Returns true when the pairing is sound. Holds vacuously when
+/// no VM has registered the callback (a bare-GC unit test), since then no
+/// collection can observe the field either (#1962).
+pub fn envMapInvariantHolds(map: *std.StringHashMap(Value), paired_val: Value) bool {
+    if (paired_val != types.NIL) return true; // route 1: paired, traced value
+    const lookup = env_map_rooted_lookup orelse return true;
+    return lookup(map); // route 2: a VM-rooted registry map
+}
+
+/// Debug/test-only guard for `envMapInvariantHolds`. Compiled out entirely in
+/// release builds (ReleaseSafe/ReleaseFast), so it never changes shipped
+/// behavior or costs a registry scan there; in Debug and test builds it fires
+/// deterministically the moment a future call site mints a `Function`/
+/// `Transformer` holding a private map with a NIL paired value -- the exact
+/// latent hazard #1962 was filed for, which would otherwise silently lose
+/// every binding at the next collection and look identical to the safe sites.
+pub fn assertEnvMapInvariant(map: *std.StringHashMap(Value), paired_val: Value) void {
+    if (comptime !(builtin.mode == .Debug or builtin.is_test)) return;
+    std.debug.assert(envMapInvariantHolds(map, paired_val));
 }
 
 pub const def_env_binding_prefix = types.def_env_binding_prefix;

--- a/src/tests_gc_tracing.zig
+++ b/src/tests_gc_tracing.zig
@@ -59,6 +59,8 @@ const std = @import("std");
 const memory = @import("memory.zig");
 const types = @import("types.zig");
 const fiber_mod = @import("fiber.zig");
+const globals_mod = @import("globals.zig");
+const th = @import("testing_helpers.zig");
 
 const Value = types.Value;
 const Object = types.Object;
@@ -1880,4 +1882,88 @@ test "gc remembered set (#2196): a full collect drain resets every dedup flag" {
     gc.writeBarrier(&vec.header, b);
     try std.testing.expectEqual(@as(usize, 1), gc.remembered_set.items.len);
     try std.testing.expect(vec.header.flags.in_remembered_set);
+}
+
+// ---------------------------------------------------------------------------
+// #1962: the untraced env-map invariant (Function.env / Transformer.def_env)
+//
+// No GC switch traces these raw *StringHashMap pointers. They are safe only
+// through their paired env_val/def_env_val, OR because the map is one of the
+// VM-rooted library registries markVmRoots traces. `globals.assertEnvMapInvariant`
+// makes that unwritten rule checkable at every construction site; these tests
+// exercise the predicate it asserts on directly (an assertion firing panics,
+// which a Zig test cannot catch, so the check is factored as a bool predicate).
+// ---------------------------------------------------------------------------
+
+test "gc tracing (#1962): env-map invariant predicate distinguishes the three routes" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // A genuinely private map: allocated here, never handed to any VM registry.
+    // This is the shape a future unsafe call site would produce.
+    var private = std.StringHashMap(Value).init(vm.gc.allocator);
+    defer private.deinit();
+
+    const non_nil = types.makeFixnum(7); // stands in for a real paired env_val
+
+    // Route 1 -- paired with a non-NIL (traced) value: always sound, private or
+    // not. This is the restricted-environment / (eval expr env) case.
+    try std.testing.expect(globals_mod.envMapInvariantHolds(&private, non_nil));
+
+    // The hazard #1962 is about: a private map with a NIL paired value is
+    // reachable by nothing once collected. The predicate must reject it, which
+    // is what turns `assertEnvMapInvariant` into a deterministic trip wire.
+    try std.testing.expect(!globals_mod.envMapInvariantHolds(&private, types.NIL));
+
+    // Route 2 -- the same NIL pairing is sound once the map is a VM-rooted
+    // registry. Register `private` as an in-flight pending_lib_env exactly as
+    // handleDefineLibrary does; markVmRoots now traces it, so NIL is fine.
+    vm.pending_lib_envs[vm.pending_lib_env_count] = &private;
+    vm.pending_lib_env_count += 1;
+    defer vm.pending_lib_env_count -= 1;
+    try std.testing.expect(vm.isGcRootedEnvMap(&private));
+    try std.testing.expect(globals_mod.envMapInvariantHolds(&private, types.NIL));
+}
+
+test "gc tracing (#1962): current_lib_env and a registered library both count as rooted" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    var map = std.StringHashMap(Value).init(vm.gc.allocator);
+    defer map.deinit();
+
+    // current_lib_env is the library env actively being compiled -- one of the
+    // maps markVmRoots traces, so a Function/Transformer minted against it may
+    // carry a NIL paired value (the five known-safe library sites).
+    try std.testing.expect(!vm.isGcRootedEnvMap(&map));
+    const saved = vm.current_lib_env;
+    vm.current_lib_env = &map;
+    defer vm.current_lib_env = saved;
+    try std.testing.expect(vm.isGcRootedEnvMap(&map));
+
+    // A retired env of a replaced library is likewise traced (#820), so it too
+    // is accepted with a NIL pairing.
+    vm.current_lib_env = saved;
+    try std.testing.expect(!vm.isGcRootedEnvMap(&map));
+    try vm.libraries.retired_envs.append(vm.gc.allocator, &map);
+    try std.testing.expect(vm.isGcRootedEnvMap(&map));
+    _ = vm.libraries.retired_envs.pop();
+}
+
+test "gc tracing (#1962): with no VM registered the invariant holds vacuously" {
+    // A bare-GC context (this file's own default) has no vm_instance, so the
+    // rooted-map callback is unregistered. envMapInvariantHolds must not treat
+    // that as a violation -- without a VM no collection observes the field.
+    const prev = globals_mod.env_map_rooted_lookup;
+    globals_mod.env_map_rooted_lookup = null;
+    defer globals_mod.env_map_rooted_lookup = prev;
+
+    var map = std.StringHashMap(Value).init(std.testing.allocator);
+    defer map.deinit();
+    try std.testing.expect(globals_mod.envMapInvariantHolds(&map, types.NIL));
+    try std.testing.expect(globals_mod.envMapInvariantHolds(&map, types.makeFixnum(1)));
 }

--- a/src/types.zig
+++ b/src/types.zig
@@ -415,6 +415,13 @@ pub const Function = struct {
     line_table: std.ArrayList(LineEntry) = .empty,
     global_cache: ?[]Value = null,
     cache_version: u32 = 0,
+    // A restricted environment's binding map, or a library's lib_env. INVARIANT
+    // (#1962): no GC switch traces this raw pointer -- it is GC-reachable ONLY
+    // through the paired `env_val` below, EXCEPT when it is one of the VM-rooted
+    // library registries (`markVmRoots`: every library's lib_env, retired_envs,
+    // pending_lib_envs, current_lib_env), in which case `env_val` may be NIL and
+    // the registry keeps the bindings alive. Construction sites must satisfy
+    // this; `globals.assertEnvMapInvariant` checks it in debug/test builds.
     env: ?*std.StringHashMap(Value) = null,
     env_val: Value = NIL,
     // `env` is authoritative: a name missing from it must not fall back to

--- a/src/types_macro.zig
+++ b/src/types_macro.zig
@@ -50,6 +50,13 @@ pub const Transformer = struct {
     // snapshot rather than just wasting an allocation.
     peers_computed: bool = false,
     captured_locals: []CapturedLocal = &.{},
+    // The defining library's lib_env (or a restricted env), for def-env-scoped
+    // free-reference resolution. INVARIANT (#1962), identical to `Function.env`:
+    // no GC switch traces this raw pointer -- it is GC-reachable ONLY through
+    // the paired `def_env_val` below, EXCEPT when it is one of the VM-rooted
+    // library registries (`markVmRoots`), in which case `def_env_val` may be NIL
+    // because the registry keeps the bindings alive. Construction sites must
+    // satisfy this; `globals.assertEnvMapInvariant` checks it in debug/test.
     def_env: ?*std.StringHashMap(Value) = null,
     def_env_val: Value = NIL,
     /// Canonical name (e.g. "demo.srmac") of the library def_env belongs to,

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -46,6 +46,17 @@ pub fn setVMInstance(vm: *VM) void {
     globals_mod.error_detail_for_macro = &errorDetailForMacro;
     globals_mod.syntax_property_set = &syntaxPropertySet;
     globals_mod.syntax_property_get = &syntaxPropertyGet;
+    globals_mod.env_map_rooted_lookup = &envMapIsGcRooted;
+}
+
+/// #1962: whether `map` is one of the environment maps `markVmRoots` traces
+/// unconditionally, exposed to the compiler through
+/// `globals.env_map_rooted_lookup` so it can enforce the untraced-env-map
+/// invariant (see `VM.isGcRootedEnvMap`). Returns false when no VM is live,
+/// which is safe: without a VM no collection can observe the field.
+fn envMapIsGcRooted(map: *std.StringHashMap(Value)) bool {
+    const vm = vm_instance orelse return false;
+    return vm.isGcRootedEnvMap(map);
 }
 
 /// SRFI 211: evaluate a datum at macro-expansion time in the global
@@ -1042,6 +1053,38 @@ pub const VM = struct {
 
     pub fn getErrorDetail(self: *VM) []const u8 {
         return self.last_error_detail[0..self.last_error_detail_len];
+    }
+
+    /// #1962: whether `map` is one of the environment maps `markVmRoots`
+    /// traces unconditionally each collection -- every registered library's
+    /// `lib_env`, a `retired_env` of a replaced library, an in-flight
+    /// `pending_lib_env`, or the library env currently being compiled
+    /// (`current_lib_env`, which becomes one of the former once its
+    /// `define-library` finishes registering). A `Function.env` /
+    /// `Transformer.def_env` pointing at such a map stays reachable with a NIL
+    /// paired `env_val` / `def_env_val`; any other map must carry a non-NIL,
+    /// GC-traced paired value or its bindings are lost at the next collection.
+    /// Pointer-identity match; runs only from the debug/test assertion guard,
+    /// so the O(libraries) scan never costs a release build anything.
+    pub fn isGcRootedEnvMap(self: *VM, map: *std.StringHashMap(Value)) bool {
+        if (self.current_lib_env) |e| {
+            if (e == map) return true;
+        }
+        var lit = self.libraries.libraries.valueIterator();
+        while (lit.next()) |lib| {
+            if (lib.lib_env) |e| {
+                if (e == map) return true;
+            }
+        }
+        for (self.libraries.retired_envs.items) |e| {
+            if (e == map) return true;
+        }
+        for (self.pending_lib_envs[0..self.pending_lib_env_count]) |maybe| {
+            if (maybe) |e| {
+                if (e == map) return true;
+            }
+        }
+        return false;
     }
 
     /// Writes `eo`'s own `message` + `irritants` (display mode for the


### PR DESCRIPTION
## Problem

`Function.env` and `Transformer.def_env` are raw `*StringHashMap(Value)` pointers that **no GC switch traces** — not `markObjectContents`, not `markValueInner`, not `referencesYoung`. They are safe today only by an unwritten, unenforced invariant, one of two routes:

1. the call site pairs the map with a traced `env_val` / `def_env_val`, or
2. the map is one of the VM-rooted library registries `markVmRoots` traces unconditionally (`vm.libraries` lib_envs, `retired_envs`, `pending_lib_envs`).

Five call sites pass `env_val = types.NIL` with a live map and rely entirely on route 2 (`vm_library.zig`, `vm_records.zig` ×5). No live bug — but a future call site handing a *private* map a NIL paired value would silently lose every binding at the next collection, looking exactly like the safe five.

## Fix (low-risk: no new GC tracing)

Per the issue's recommended direction — make the invariant explicit and checkable rather than trace the maps (route-2 maps are already rooted by `markVmRoots`; tracing them from Function/Transformer risks double-work):

- **Document** the invariant on both fields (`Function.env`, `Transformer.def_env`).
- **`VM.isGcRootedEnvMap(map)`** — pointer-identity predicate over the four registry sources (`current_lib_env`, every library's `lib_env`, `retired_envs`, `pending_lib_envs`).
- **`globals.assertEnvMapInvariant(map, paired_val)`** — a debug/test-only guard (compiled out of ReleaseSafe/ReleaseFast, so **no shipped behavior or perf change**) that fires deterministically the moment a construction site holds a private map with a NIL paired value. It reaches the VM through a registered callback (`globals.env_map_rooted_lookup`) so the compiler need not import `vm.zig` — mirroring #1812's `current_lib_name_lookup`.
- **Wired into all construction sites:** the one `Function.env` site (`compileExpressionInEnv`) and the three `Transformer.def_env` sites (`compiler_define_syntax.zig` ×2, `compiler_lambda.zig`).

Verified all NIL callers pass `current_lib_env` (or the equal `lib_env`), so the five known-safe sites do **not** trip the assertion; the non-NIL `eval`/`load`/dispatch callers satisfy route 1.

## Test

`src/tests_gc_tracing.zig` gains three unit tests: a private map + NIL is rejected by the predicate, the paired (non-NIL) form and the registry form (pending_lib_env / current_lib_env / retired_env) are accepted, and the no-VM case holds vacuously. (The check is factored as a bool predicate the tests call directly, since a firing `std.debug.assert` panic cannot be caught in a Zig test.)

`zig build test` and `zig build test -Dgc-stress=true` both green.

Closes #1962

🤖 Generated with [Claude Code](https://claude.com/claude-code)