### PR TITLE
Run top-level call/cc forms wholly in the VM natively (#2119)

### DIFF
--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -256,7 +256,30 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
             return err;
         };
 
-        try ir_nodes.append(allocator, root);
+        // #2119: a top-level form whose own evaluation may capture a full
+        // (re-entrant) continuation must run entirely in the VM, as one
+        // eval unit. The native backend otherwise lowers the form's outer
+        // structure — a `set!`, a `define`'s value store, a plain call — to
+        // straight-line native code and eval-fallbacks *only* the call/cc
+        // subexpression. The continuation captured inside that subexpression
+        // then spans just it, so invoking the continuation after the form
+        // returned (from a later top-level form) re-runs only the
+        // subexpression and delivers its value to a native context that has
+        // already completed and cannot re-run: the enclosing `set!`/`define`
+        // store never fires again, silently keeping the pre-capture value
+        // (`(set! result (+ 100 (call/cc …)))` kept 100 instead of 142).
+        // Emitting the whole raw form as a single passthrough — evaluated by
+        // the interpreter, which owns continuation capture/restore — makes the
+        // captured continuation span the whole form, so a later resume re-runs
+        // its tail exactly as the pure-VM tier does. A form that already
+        // lowered to a whole-form passthrough (root.tag == .passthrough, e.g.
+        // a bare `(call/cc …)` or a `(define (f …) …)` whose body reaches one)
+        // needs no change — it is already one VM eval unit.
+        const node_to_emit: *ir_mod.Node = if (root.tag != .passthrough and exprMayCaptureContinuation(expr))
+            (ir_instance.makePassthrough(expr) catch return error.OutOfMemory)
+        else
+            root;
+        try ir_nodes.append(allocator, node_to_emit);
 
         // Record any define/set! target from this form so that the next
         // form's constant folding does not assume the primitive is unmodified.
@@ -438,6 +461,37 @@ fn getExeRelativeLibDir(allocator: std.mem.Allocator) ?[]const u8 {
     const dir = kaappi_paths.getExeRelativeLibDir(&buf) orelse return null;
     if (!checkLibDir(allocator, dir)) return null;
     return allocator.dupe(u8, dir) catch null;
+}
+
+/// True when evaluating `expr` may itself capture a full (re-entrant)
+/// continuation — i.e. `call/cc` / `call-with-current-continuation` appears
+/// somewhere in `expr` outside quoted data. Drives the #2119 whole-form VM
+/// fallback in the read loop above; see the comment there for why a top-level
+/// form matching this must not have its outer structure lowered natively.
+///
+/// Conservative by construction: it descends into every non-`quote` sub-list,
+/// including lambda and define bodies, so it over-matches a `call/cc` that is
+/// only reached by a *later* call rather than by the form's own evaluation
+/// (e.g. `(define f (lambda () (call/cc …)))`). Over-matching is safe — it
+/// only forces one more top-level form onto the (correct, slower) interpreter
+/// path, never changes a result — while under-matching would reintroduce the
+/// silent-wrong-value bug. Macro-hidden uses are not expanded here; the direct
+/// uses this catches cover the divergence the issue documents.
+fn exprMayCaptureContinuation(expr: types.Value) bool {
+    if (!types.isPair(expr)) return false;
+    const head = types.car(expr);
+    if (types.isSymbol(head)) {
+        const name = types.stripHygienicPrefix(types.symbolName(head));
+        // Quoted data is inert — a `call/cc` symbol inside it is never called.
+        if (std.mem.eql(u8, name, "quote")) return false;
+        if (std.mem.eql(u8, name, "call/cc") or
+            std.mem.eql(u8, name, "call-with-current-continuation")) return true;
+    }
+    var cur = expr;
+    while (types.isPair(cur)) : (cur = types.cdr(cur)) {
+        if (exprMayCaptureContinuation(types.car(cur))) return true;
+    }
+    return false;
 }
 
 fn collectRedefinedNames(expr: types.Value, map: *std.StringHashMap(void)) void {

--- a/tests/scheme/compile/native-toplevel-continuation-resume-2119.sh
+++ b/tests/scheme/compile/native-toplevel-continuation-resume-2119.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Regression test for #2119: re-invoking a TOP-LEVEL continuation from inside a
+# bootstrapped higher-order callback (for-each / map) must resume the captured
+# top-level form's *tail* natively, exactly as the interpreter does.
+#
+# The bug: a top-level form like
+#
+#     (set! result (+ 100 (call-with-current-continuation (lambda (c) (set! k c) 0))))
+#
+# lowered natively split the form — the `set!` (and the `(+ 100 …)` around the
+# call/cc) became straight-line native code, and only the `call/cc`
+# subexpression was eval-fallbacked to the VM. The continuation captured inside
+# that subexpression therefore spanned *only* the subexpression, not the
+# enclosing `set!`. Invoking it later (from a for-each callback in a subsequent
+# form) re-ran just the subexpression and delivered its value to a native
+# context that had already completed: the `set!` never re-fired, so `result`
+# silently kept its pre-capture value (native printed 100 where the interpreter
+# prints 142) and exited 0 with no diagnostic.
+#
+# The fix (src/native_compiler.zig) forces any top-level form whose own
+# evaluation may capture a full continuation onto whole-form VM evaluation, so
+# the captured continuation spans the entire form and a later resume re-runs its
+# tail. This test runs the issue's exact repro AND its discriminating control
+# through `kaappi compile`, with the interpreter as oracle — a `.scm` file that
+# only ever runs under the interpreter proves nothing about the native tier
+# (kaappi#2117/#2118).
+#
+# Usage: bash tests/scheme/compile/native-toplevel-continuation-resume-2119.sh [path-to-kaappi]
+
+set -euo pipefail
+
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+ensure_runtime_lib "$REPO_DIR"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+# Compile `src`, run both tiers, and assert they agree. `expected` documents
+# intent and still catches a value both tiers get wrong. See the "interpreter as
+# the native tier's oracle" block in ../shell-common.sh.
+check_both() {
+    local src="$1" expected="$2" label="$3"
+    local bin="$DIR/${label}.bin"
+
+    local interp_out interp_status=0
+    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src")" || interp_status=$?
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        exit 1
+    fi
+    if [[ "$interp_out" != "$expected" ]]; then
+        echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        exit 1
+    fi
+
+    (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" > /dev/null 2>&1)
+    if [[ ! -x "$bin" ]]; then
+        echo "FAIL: $label — native compile did not produce a binary" >&2
+        exit 1
+    fi
+    local out status=0
+    out="$("$bin" 2> /dev/null)" || status=$?
+    assert_tiers_agree "$label" "$interp_out" "$interp_status" "$out" "$status" || exit 1
+}
+
+# --- Case 1: the issue's exact repro (was native 100, interpreter 142) ---
+cat > "$DIR/repro.scm" << 'SCHEME'
+(define k1 #f)
+(define result 0)
+(set! result (+ 100 (call-with-current-continuation (lambda (c) (set! k1 c) 0))))
+(define (go) (for-each (lambda (x) (when (= x 2) (k1 42))) (list 1 2 3)) (display "reached\n"))
+(go)
+(display result) (newline)
+SCHEME
+
+check_both "$DIR/repro.scm" "142" "toplevel-set-resume"
+
+# --- Case 2: capture in a top-level (define value …), resumed through map ---
+cat > "$DIR/define-value.scm" << 'SCHEME'
+(define k #f)
+(define captured (+ 200 (call-with-current-continuation (lambda (c) (set! k c) 0))))
+(define (go) (map (lambda (x) (when (= x 3) (k 50))) (list 1 2 3)) (display "reached\n"))
+(go)
+(display captured) (newline)
+SCHEME
+
+check_both "$DIR/define-value.scm" "250" "toplevel-define-resume"
+
+# --- Case 3: the discriminating control — an escape used WITHIN its dynamic
+# extent still works on both tiers (this path was never broken). ---
+cat > "$DIR/control.scm" << 'SCHEME'
+(define (esc)
+  (call-with-current-continuation
+    (lambda (k) (for-each (lambda (x) (if (= x 2) (k 42))) (list 1 2 3)) 100)))
+(display (esc)) (newline)
+SCHEME
+
+check_both "$DIR/control.scm" "42" "escape-within-extent"
+
+# --- Case 4: the issue's measured blast radius — the 5-assertion smoke test,
+# which mixes for-each, map, and dynamic-wind continuation invocations. ---
+check_both "tests/scheme/smoke/call-global-continuation.scm" "5 passed, 0 failed" "call-global-continuation-smoke"
+
+echo "PASS"


### PR DESCRIPTION
## Problem

`docs/dev/decisions/continuation-strategy.md` commits to **behavioral equivalence**: a `call/cc` program must give identical results native (with VM fallback) vs. pure VM, with "continuation captured across function boundaries" merely *deferred to VM fallback* — slower, not wrong. It was wrong.

Re-invoking a **top-level** continuation from a bootstrapped higher-order callback silently kept the pre-capture value:

```scheme
(define k1 #f)
(define result 0)
(set! result (+ 100 (call-with-current-continuation (lambda (c) (set! k1 c) 0))))
(define (go) (for-each (lambda (x) (when (= x 2) (k1 42))) (list 1 2 3)) (display "reached\n"))
(go)
(display result) (newline)
```

```
interpreter: 142      native (before): 100
```

## Root cause

The native backend lowers `(set! result (+ 100 (call/cc …)))` by compiling the **`set!` (and the `(+ 100 …)`) to straight-line native code** and eval-fallbacking **only the `call/cc` subexpression** to the VM. The continuation captured inside that subexpression therefore spans *only the subexpression*, not the enclosing `set!`.

When `k1` is invoked from a later top-level form, the VM restore re-runs `(+ 100 42) = 142` and completes the sub-eval — but delivers 142 into a native context (`kaappi_set_global("result", …)`) that already ran and cannot re-run. The `set!` never fires again, so `result` keeps `100`. The interpreter runs the whole form as one `execute`, so its continuation spans the `set!` and the resume re-runs it.

## Fix

`src/native_compiler.zig`: in the AOT read loop, a top-level form whose own evaluation may capture a full continuation (`call/cc` / `call-with-current-continuation` appears outside quoted data) is emitted as a **single whole-form passthrough** instead of having its outer structure lowered natively. The interpreter then owns the whole form, so the captured continuation spans it and a later resume re-runs its tail — exactly as the pure-VM tier does.

The predicate is deliberately conservative (over-matching only forces one more top-level form onto the correct, slower interpreter path; under-matching would reintroduce the silent wrong value). Forms already lowered to a whole-form passthrough (a bare `(call/cc …)`, a `(define (f …) …)` whose body reaches one) are unchanged.

## Before / after

| | interpreter | native before | native after |
|---|---|---|---|
| repro (`set!` + for-each) | 142 | **100** | 142 |
| `(define v (+ 200 (call/cc …)))` + map | 250 | 200 | 250 |
| control (escape within extent) | 42 | 42 | 42 |
| `call-global-continuation.scm` (blast radius) | 5/5 | **3/5** | 5/5 |

## Tests

New `tests/scheme/compile/native-toplevel-continuation-resume-2119.sh` runs the repro, a `define`-value variant, the discriminating control, and the measured blast-radius smoke test through `kaappi compile` with the interpreter as oracle (a `.scm`-only test is not native-tier evidence, per kaappi#2117/#2118). Verified failing before the fix (`native 100 != interpreter 142`), passing after. `zig build test` green; existing `tests/scheme/compile/*.sh` unaffected.

## Scope note

This fixes the silent-wrong-value case the issue documents (continuation invoked from a callback that runs inside a VM excursion). Invoking a top-level continuation *directly* from bare native top-level code — where there is no VM excursion to unwind into — still raises loudly (`ContinuationInvoked`) rather than resuming; that pre-existing native limitation is the issue's explicitly-accepted "raise rather than continue with a stale value" outcome, and would need the larger architectural change (a persistent top-level VM driver) the continuation-strategy doc defers.

Closes #2119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
