### PR TITLE
Report call_cc/call_ec as medians and widen the PR-gate noise floor

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -52,5 +52,12 @@ jobs:
           pr-benchmark-file-path: pr-results.json
           base-benchmark-file-path: base-results.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          alert-threshold: '120%'
+          # This gate re-measures both branches from scratch on a shared GitHub
+          # runner, and its own base-vs-base spread reaches ~1.62x for the same
+          # commit (kaappi#1906). A 120% threshold sat well inside that noise, so
+          # a red check meant nothing. 175% is above the measured noise floor yet
+          # still flags a genuine >=2x regression. Tightening it back toward 120%
+          # only makes sense once the comparison interleaves repeated A/B rounds
+          # (kaappi#1906 direction 3) rather than one PR block then one base block.
+          alert-threshold: '175%'
           comment-always: true

--- a/benchmarks/run-benchmarks.sh
+++ b/benchmarks/run-benchmarks.sh
@@ -76,14 +76,24 @@ run_callcc_bench() {
     cc_line=$(echo "$output" | grep "^name: call_cc," || true)
     ec_line=$(echo "$output" | grep "^name: call_ec," || true)
 
-    local cc_time cc_status ec_time ec_status
+    # zig build bench now reports a median over N runs with real min/max/
+    # iterations (kaappi#2101), so parse them like the general path instead of
+    # hardcoding the single-shot "0 0 1" that the PR gate treated as signal.
+    local cc_time cc_status cc_min cc_max cc_iters
+    local ec_time ec_status ec_min ec_max ec_iters
     cc_time=$(extract_field "$cc_line" "time")
     cc_status=$(extract_field "$cc_line" "status")
+    cc_min=$(extract_field "$cc_line" "min")
+    cc_max=$(extract_field "$cc_line" "max")
+    cc_iters=$(extract_field "$cc_line" "iterations")
     ec_time=$(extract_field "$ec_line" "time")
     ec_status=$(extract_field "$ec_line" "status")
+    ec_min=$(extract_field "$ec_line" "min")
+    ec_max=$(extract_field "$ec_line" "max")
+    ec_iters=$(extract_field "$ec_line" "iterations")
 
-    echo "call_cc ${cc_time:-0} ${cc_status:-fail} 0 0 1 0 0 0"
-    echo "call_ec ${ec_time:-0} ${ec_status:-fail} 0 0 1 0 0 0"
+    echo "call_cc ${cc_time:-0} ${cc_status:-fail} ${cc_min:-0} ${cc_max:-0} ${cc_iters:-0} 0 0 0"
+    echo "call_ec ${ec_time:-0} ${ec_status:-fail} ${ec_min:-0} ${ec_max:-0} ${ec_iters:-0} 0 0 0"
 }
 
 # Collect results

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -26,6 +26,22 @@ fn nowNs() u64 {
 
 const Result = struct { ns_per: f64, heap_mb: usize };
 
+const Stats = struct { median: f64, min: f64, max: f64 };
+
+/// Median / min / max over `samples`, sorted in place. Mirrors the median-of-N
+/// reporting the general benchmark path uses in benchmarks/common.scm, so
+/// call_cc / call_ec land in the PR-gate JSON with the same dispersion columns
+/// as every other row instead of a single-shot `min 0, max 0, iterations 1`
+/// (kaappi#2101).
+fn summarize(samples: []f64) Stats {
+    std.mem.sort(f64, samples, {}, std.sort.asc(f64));
+    return .{
+        .median = samples[samples.len / 2],
+        .min = samples[0],
+        .max = samples[samples.len - 1],
+    };
+}
+
 /// Time `iters` immediately-escaping captures of `prim` (call/cc or call/ec) at
 /// stack depth `depth`. Each run uses a fresh VM with GC disabled.
 fn measure(allocator: std.mem.Allocator, prim: []const u8, depth: u32, iters: u32) !Result {
@@ -79,23 +95,31 @@ pub fn main() !void {
     std.debug.print("capture benchmark: {d} immediately-escaping captures, GC off\n", .{iters});
     std.debug.print("{s:>6} | {s:>22} | {s:>22} | {s:>8}\n", .{ "depth", "call/cc (full)", "call/ec (escape)", "speedup" });
     std.debug.print("-------+------------------------+------------------------+---------\n", .{});
-    var cc_d0: Result = undefined;
-    var ec_d0: Result = undefined;
     for (depths) |d| {
         const cc = try measure(allocator, "call/cc", d, iters);
         const ec = try measure(allocator, "call/ec", d, iters);
-        if (d == 0) {
-            cc_d0 = cc;
-            ec_d0 = ec;
-        }
         std.debug.print(
             "{d:>6} | {d:>9.0} ns  {d:>4} MB | {d:>9.0} ns  {d:>4} MB | {d:>6.1}x\n",
             .{ d, cc.ns_per, cc.heap_mb, ec.ns_per, ec.heap_mb, cc.ns_per / ec.ns_per },
         );
     }
 
-    const cc_secs = cc_d0.ns_per * @as(f64, @floatFromInt(iters)) / 1e9;
-    const ec_secs = ec_d0.ns_per * @as(f64, @floatFromInt(iters)) / 1e9;
-    std.debug.print("name: call_cc, time: {d:.6}, status: ok, min: {d:.6}, max: {d:.6}, iterations: {d}\n", .{ cc_secs, cc_secs, cc_secs, iters });
-    std.debug.print("name: call_ec, time: {d:.6}, status: ok, min: {d:.6}, max: {d:.6}, iterations: {d}\n", .{ ec_secs, ec_secs, ec_secs, iters });
+    // Machine-readable summary for the PR benchmark gate. Repeat the depth-0
+    // measurement `bench_runs` times and report the median with real min/max,
+    // matching the median-over-*bench-runs* the general path emits. A single
+    // ~45ms sample was noise the gate treated as signal (kaappi#2101).
+    const bench_runs: u32 = 5;
+    var cc_secs: [bench_runs]f64 = undefined;
+    var ec_secs: [bench_runs]f64 = undefined;
+    for (0..bench_runs) |i| {
+        const cc = try measure(allocator, "call/cc", 0, iters);
+        const ec = try measure(allocator, "call/ec", 0, iters);
+        const scale = @as(f64, @floatFromInt(iters)) / 1e9;
+        cc_secs[i] = cc.ns_per * scale;
+        ec_secs[i] = ec.ns_per * scale;
+    }
+    const cc = summarize(&cc_secs);
+    const ec = summarize(&ec_secs);
+    std.debug.print("name: call_cc, time: {d:.6}, status: ok, min: {d:.6}, max: {d:.6}, iterations: {d}\n", .{ cc.median, cc.min, cc.max, bench_runs });
+    std.debug.print("name: call_ec, time: {d:.6}, status: ok, min: {d:.6}, max: {d:.6}, iterations: {d}\n", .{ ec.median, ec.min, ec.max, bench_runs });
 }


### PR DESCRIPTION
The PR benchmark gate presented run-to-run noise with the same 🟢/🔴 confidence as real results. This fixes the two ways it did so, both rooted in `benchmarks/run-benchmarks.sh`.

## #2101 — call_cc/call_ec were single-shot while every other row is a median

`run_callcc_bench` emitted `call_cc`/`call_ec` with a hardcoded `min 0, max 0, iterations 1`, while the general path reports a median over 5 runs (`benchmarks/common.scm`, `*bench-runs* 5`) with real min/max. A ~45ms unrepeated sample on a shared runner is one scheduling hiccup away from tripping the threshold — which is exactly what happened on #2099 (`call_ec` 1.22x, everything else 0.98–1.02x).

Fix (issue's option 1, the real fix): `zig build bench` now repeats the depth-0 capture measurement 5 times and reports the **median** with real `min`/`max`/`iterations`, mirroring the general path. `run-benchmarks.sh` parses those fields instead of hardcoding `0 0 1`.

Before → after for the two rows in the emitted JSON:

```
# before
{"name": "call_cc", ..., "value": <one shot>, "min": 0, "max": 0, "iterations": 1, ...}
{"name": "call_ec", ..., "value": <one shot>, "min": 0, "max": 0, "iterations": 1, ...}

# after
{"name": "call_cc", ..., "value": 0.292061, "min": 0.282445, "max": 0.317008, "iterations": 5, ...}
{"name": "call_ec", ..., "value": 0.016299, "min": 0.016207, "max": 0.017191, "iterations": 5, ...}
```

They now carry the same dispersion columns as `fib`, `tak`, `vector`, and the rest.

## #1906 — the gate flagged differences smaller than its own noise floor

The gate re-measures both branches from scratch on a shared runner; its own base-vs-base spread reaches **~1.62x for the same commit**. At a 120% threshold a red check sat well inside that noise. This raises `alert-threshold` to **175%** — above the measured noise floor, still catches a genuine ≥2x regression — with a comment recording why and pointing at the interleaved-A/B direction that would let it be tightened again.

### Deliberately left out of scope (noted per the task)
- #1906 direction 1 (**render base/PR min–max next to the ratio in the comment**) lives in the `kaappi/github-action-pull-request-benchmark` action repo, not here — the JSON already carries the dispersion; surfacing it is a change to that action, not to this repo. This PR does the honest-reporting piece that fits in-repo (threshold above noise) and makes the dispersion available.
- #1906 direction 3 (interleaved repeated A/B rounds) is a harness redesign, intentionally not attempted.

## Verification
- `zig build` and `zig build bench` succeed; bench prints `iterations: 5` with real min/max for both metrics.
- `bash -n benchmarks/run-benchmarks.sh` passes; a full `--json` dry run shows `call_cc`/`call_ec` with `iterations: 5` and non-zero min/max matching every other row.
- Pre-existing/unrelated: `src/tests_step.zig` (bounded-step, #2283) fails identically on the clean `v0.24.0` base commit and after this change; it is not in the benchmark path and is untouched here.

Closes #2101
Closes #1906

🤖 Generated with [Claude Code](https://claude.com/claude-code)