### PR TITLE
Widen the bare-error gate to src/ffi.zig and fix misclassified FFI ranges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,24 +123,41 @@ jobs:
       - name: Format check
         run: zig fmt --check src/
 
-      # This was a ratchet (91 at introduction, then 20) while a backlog of
-      # anonymous TypeErrors was worked off. kaappi#1868 cleared the last of
-      # them, so the baseline is now 0 and there is no number to keep in step
-      # with the source -- every bare return must carry a `bare-ok` reason.
-      - name: Check bare TypeError regression
+      # A bare `return <set>.TypeError/IndexOutOfBounds/InvalidArgument` reaches
+      # the user through mapNativeError/mapFfiError's fallback, which names the
+      # primitive but reports args[0] as the offending value -- so every such
+      # return must instead use primitives.typeError/indexError/argError, or
+      # carry a `// bare-ok: <reason>` when it is an infrastructure guard with no
+      # procedure context (see kaappi#1874).
+      #
+      # kaappi#2026 widened this gate on two axes at once: it now scans all of
+      # src/ (not just src/primitives*.zig, which missed src/ffi.zig entirely)
+      # and both spellings -- `error.Foo` as well as `PrimitiveError.Foo` /
+      # `VMError.Foo` -- across the whole taxonomy, not TypeError alone. ffi.zig
+      # is clean; a backlog of bare IndexOutOfBounds/InvalidArgument in the
+      # primitives (kaappi#2020/#2021/#2022) is not, so this is once again a
+      # ratchet, exactly as it was for TypeError (91 -> 20 -> 0, cleared by
+      # kaappi#1868). BASELINE may only go DOWN: lower it whenever you remove a
+      # bare return, and delete it when it reaches 0. Test files legitimately
+      # write `error.TypeError` in `expectError`, so src/tests_*.zig is excluded.
+      - name: Check bare error-taxonomy regression
         run: |
-          if grep -rn 'return PrimitiveError\.TypeError' src/primitives*.zig | grep -v 'bare-ok'; then
-            echo "::error::Bare PrimitiveError.TypeError without a 'bare-ok' annotation (listed above)."
-            echo "Use primitives.typeError(proc, expected, got) for type checks --"
-            echo "a bare return reaches the user as vm_calls.mapNativeError's fallback,"
-            echo "which names the primitive but reports args[0] as the offending value."
-            echo "Only add '// bare-ok: <reason>' for infrastructure guards that have no"
-            echo "procedure context to report, and only when TypeError is the tag the"
-            echo "function returns anyway -- a 'vm_instance orelse' whose function has no"
-            echo "natural tag is InvalidBytecode (kaappi#1874), not an annotated TypeError."
+          BASELINE=28
+          hits=$(grep -rnE 'return (PrimitiveError|VMError|error)\.(TypeError|IndexOutOfBounds|InvalidArgument)' src/*.zig \
+                 | grep -v '^src/tests_' | grep -v 'bare-ok' || true)
+          count=$(printf '%s' "$hits" | grep -c . || true)
+          echo "Unannotated bare error-taxonomy returns: $count (baseline $BASELINE)."
+          if [ "$count" -gt "$BASELINE" ]; then
+            printf '%s\n' "$hits"
+            echo "::error::Bare error-taxonomy returns rose to $count (baseline $BASELINE)."
+            echo "Use primitives.typeError/indexError/argError with a procedure name,"
+            echo "or add '// bare-ok: <reason>' for an infrastructure guard that has no"
+            echo "procedure context (kaappi#1874). Do not raise BASELINE."
             exit 1
           fi
-          echo "No unannotated bare TypeErrors."
+          if [ "$count" -lt "$BASELINE" ]; then
+            echo "::warning::Bare error-taxonomy returns dropped to $count -- lower BASELINE to $count in .github/workflows/ci.yml."
+          fi
 
       # Globs, ignores, and the rule set all live in .markdownlint-cli2.jsonc,
       # so `npx markdownlint-cli2` locally lints exactly what this step does.

--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -73,12 +73,12 @@ fn toIntArgOpt(v: Value) ?i64 {
 }
 
 fn toIntArg(v: Value) error{TypeError}!i64 {
-    return toIntArgOpt(v) orelse return error.TypeError;
+    return toIntArgOpt(v) orelse return error.TypeError; // bare-ok: marshalling helper, no proc context; funnels through mapFfiError
 }
 
 fn toCheckedInt(comptime T: type, v: Value) error{TypeError}!T {
-    const wide = toIntArgOpt(v) orelse return error.TypeError;
-    return std.math.cast(T, wide) orelse return error.TypeError;
+    const wide = toIntArgOpt(v) orelse return error.TypeError; // bare-ok: marshalling helper, no proc context; funnels through mapFfiError
+    return std.math.cast(T, wide) orelse return error.TypeError; // bare-ok: marshalling helper, no proc context; funnels through mapFfiError
 }
 
 fn toUnsignedArgOpt(v: Value) ?u64 {
@@ -98,8 +98,8 @@ fn toUnsignedArgOpt(v: Value) ?u64 {
 
 fn toLongArg(v: Value, declared: FfiType) error{TypeError}!i64 {
     if (declared == .uint64 or declared == .size_type) {
-        const unsigned = toUnsignedArgOpt(v) orelse return error.TypeError;
-        const narrowed = std.math.cast(u64, unsigned) orelse return error.TypeError;
+        const unsigned = toUnsignedArgOpt(v) orelse return error.TypeError; // bare-ok: marshalling helper, no proc context; funnels through mapFfiError
+        const narrowed = std.math.cast(u64, unsigned) orelse return error.TypeError; // bare-ok: marshalling helper, no proc context; funnels through mapFfiError
         return @bitCast(narrowed);
     }
     return toCheckedInt(i64, v);
@@ -163,7 +163,7 @@ fn marshalReturn(comptime T: type, result: T, rt: FfiType, gc: *memory.GC) !Valu
     } else if (T == void) {
         return types.VOID;
     }
-    return error.TypeError;
+    return error.TypeError; // bare-ok: unreachable return carrier; funnels through mapFfiError
 }
 
 fn marshalCStringReturn(cstr: [*:0]const u8, gc: *memory.GC) !Value {
@@ -237,30 +237,37 @@ fn validateArg(v: Value, t: FfiType) bool {
     };
 }
 
-fn checkNarrowIntRange(v: Value, declared: FfiType) error{TypeError}!void {
+/// Range-check a value already known (by `validateArg`) to be an integer of an
+/// int/long class against a narrower declared type. Every failure here is a
+/// *magnitude* failure — the value is the right kind but too large, too small,
+/// or the wrong sign — so it signals `InvalidArgument` (KP3007), not
+/// `TypeError` (KP3002): a wrong magnitude is not a wrong type (kaappi#2026).
+/// The returned tag is a bare signal; `validateArgsDetailed` attaches the
+/// per-argument KP3007 detail message.
+fn checkNarrowIntRange(v: Value, declared: FfiType) error{InvalidArgument}!void {
     if (declared == .uint64 or declared == .size_type) {
-        if (toUnsignedArgOpt(v) == null) return error.TypeError;
+        if (toUnsignedArgOpt(v) == null) return error.InvalidArgument; // bare-ok: KP3007 range signal; validateArgsDetailed sets the detail
         return;
     }
     const wide = switch (declared) {
-        .int8, .uint8, .int16, .uint16, .char_type, .uint32 => toIntArgOpt(v) orelse return error.TypeError,
+        .int8, .uint8, .int16, .uint16, .char_type, .uint32 => toIntArgOpt(v) orelse return error.InvalidArgument, // bare-ok: KP3007 range signal; validateArgsDetailed sets the detail
         else => return,
     };
     switch (declared) {
         .int8 => {
-            if (wide < std.math.minInt(i8) or wide > std.math.maxInt(i8)) return error.TypeError;
+            if (wide < std.math.minInt(i8) or wide > std.math.maxInt(i8)) return error.InvalidArgument; // bare-ok: KP3007 range signal
         },
         .uint8, .char_type => {
-            if (wide < 0 or wide > std.math.maxInt(u8)) return error.TypeError;
+            if (wide < 0 or wide > std.math.maxInt(u8)) return error.InvalidArgument; // bare-ok: KP3007 range signal
         },
         .int16 => {
-            if (wide < std.math.minInt(i16) or wide > std.math.maxInt(i16)) return error.TypeError;
+            if (wide < std.math.minInt(i16) or wide > std.math.maxInt(i16)) return error.InvalidArgument; // bare-ok: KP3007 range signal
         },
         .uint16 => {
-            if (wide < 0 or wide > std.math.maxInt(u16)) return error.TypeError;
+            if (wide < 0 or wide > std.math.maxInt(u16)) return error.InvalidArgument; // bare-ok: KP3007 range signal
         },
         .uint32 => {
-            if (wide < 0 or wide > std.math.maxInt(u32)) return error.TypeError;
+            if (wide < 0 or wide > std.math.maxInt(u32)) return error.InvalidArgument; // bare-ok: KP3007 range signal
         },
         else => {},
     }
@@ -272,28 +279,32 @@ fn validateArgsDetailed(ffi_fn: *types.FfiFunction, args: []const Value, vm: *VM
             vm.setErrorDetail("'{s}': argument {d} must be {s}, got {s}", .{
                 ffi_fn.name, i + 1, ffiTypeName(ffi_fn.param_types[i]), schemeTypeName(args[i]),
             });
-            return error.TypeError;
+            return error.TypeError; // bare-ok: genuine type mismatch (KP3002); detail set above, mapFfiError preserves it
         }
+        // A value of the right kind whose magnitude does not fit the declared
+        // narrow type is an argument-range failure, not a type failure: it
+        // must surface as KP3007 (InvalidArgument), not KP3002, so a caller
+        // can tell a wrong type from a wrong magnitude (kaappi#2026).
         checkNarrowIntRange(args[i], ffi_fn.param_types[i]) catch {
             vm.setErrorDetail("'{s}': argument {d} out of range for {s}", .{
                 ffi_fn.name, i + 1, ffiTypeName(ffi_fn.param_types[i]),
             });
-            return error.TypeError;
+            return error.InvalidArgument; // bare-ok: out-of-range (KP3007); detail set above
         };
         const nt = normalizeType(ffi_fn.param_types[i]);
         if (nt == .int and ffi_fn.param_types[i] != .bool_type) {
             if (toIntArgOpt(args[i])) |wide| {
                 if (std.math.cast(c_int, wide) == null) {
-                    vm.setErrorDetail("'{s}': argument {d} out of range for {s}", .{
-                        ffi_fn.name, i + 1, ffiTypeName(ffi_fn.param_types[i]),
+                    vm.setErrorDetail("'{s}': argument {d} = {d} out of range for {s}", .{
+                        ffi_fn.name, i + 1, wide, ffiTypeName(ffi_fn.param_types[i]),
                     });
-                    return error.TypeError;
+                    return error.InvalidArgument; // bare-ok: out-of-range (KP3007); detail set above
                 }
             } else {
                 vm.setErrorDetail("'{s}': argument {d} out of range for {s}", .{
                     ffi_fn.name, i + 1, ffiTypeName(ffi_fn.param_types[i]),
                 });
-                return error.TypeError;
+                return error.InvalidArgument; // bare-ok: out-of-range (KP3007); detail set above
             }
         }
         if (nt == .string) {
@@ -302,13 +313,13 @@ fn validateArgsDetailed(ffi_fn: *types.FfiFunction, args: []const Value, vm: *VM
                 vm.setErrorDetail("'{s}': argument {d} string too long ({d} bytes, max 4095)", .{
                     ffi_fn.name, i + 1, str.len,
                 });
-                return error.TypeError;
+                return error.InvalidArgument; // bare-ok: string of the right type violates a size constraint (KP3007); detail set above
             }
             if (std.mem.indexOfScalar(u8, str.data[0..str.len], 0) != null) {
                 vm.setErrorDetail("'{s}': argument {d} string contains NUL byte", .{
                     ffi_fn.name, i + 1,
                 });
-                return error.TypeError;
+                return error.InvalidArgument; // bare-ok: string of the right type violates a content constraint (KP3007); detail set above
             }
         }
     }
@@ -370,7 +381,7 @@ fn marshalArg(comptime t: FfiType, v: Value, buf: *[4096]u8, declared: FfiType) 
         .long => toLongArg(v, declared),
         .double => types.toF64(v),
         .float => @floatCast(types.toF64(v)),
-        .string => toCString(v, buf) orelse return error.TypeError,
+        .string => toCString(v, buf) orelse return error.TypeError, // bare-ok: marshalling helper, no proc context; funnels through mapFfiError
         .pointer => marshalToPointer(v),
         else => unreachable,
     };
@@ -445,7 +456,7 @@ fn callFfiGeneric(comptime N: u4, ffi_fn: *types.FfiFunction, args: []const Valu
             }
         }
     }
-    return error.TypeError;
+    return error.TypeError; // bare-ok: unsupported signature fall-through; mapFfiError fills the detail
 }
 
 /// Main FFI call dispatcher. Routes to arity-specific handlers.
@@ -464,7 +475,7 @@ pub fn callFfi(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC, 
         const lib = types.toObject(ffi_fn.library).as(types.FfiLibrary);
         if (lib.handle == null) {
             vm.setErrorDetail("'{s}': FFI library is closed", .{ffi_fn.name});
-            return error.TypeError;
+            return error.TypeError; // bare-ok: closed-library state error; detail set above, mapFfiError preserves it
         }
     }
     try validateArgsDetailed(ffi_fn, args, vm);
@@ -479,7 +490,7 @@ pub fn callFfi(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC, 
         5 => callFfi5(ffi_fn, call_args, gc),
         else => {
             vm.setErrorDetail("'{s}': unsupported parameter count ({d})", .{ ffi_fn.name, ffi_fn.param_count });
-            return error.TypeError;
+            return error.TypeError; // bare-ok: unsupported-arity signature error; detail set above, mapFfiError preserves it
         },
     };
     // A Scheme error raised inside an ffi-callback during this call was
@@ -495,12 +506,12 @@ pub fn callFfi(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC, 
             return error.ExceptionRaised;
         }
         vm.setErrorDetail("'{s}': error in FFI callback", .{ffi_fn.name});
-        return error.TypeError;
+        return error.TypeError; // bare-ok: callback failure with no stashed exception; detail set above, mapFfiError preserves it
     }
     const result = call_result catch {
         if (vm.last_error_detail_len == 0)
             vm.setErrorDetail("'{s}': unsupported FFI signature", .{ffi_fn.name});
-        return error.TypeError;
+        return error.TypeError; // bare-ok: unsupported-signature funnel; detail set above, mapFfiError preserves it
     };
     if (ffi_fn.return_type == .bool_type) {
         if (types.isFixnum(result))
@@ -571,7 +582,7 @@ fn callFfi4(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
         return marshalRetValue(.pointer, result, ffi_fn.return_type, gc);
     }
 
-    return error.TypeError;
+    return error.TypeError; // bare-ok: unsupported 4-arg signature fall-through; mapFfiError fills the detail
 }
 
 // ---------------------------------------------------------------------------
@@ -666,7 +677,7 @@ fn callFfi5(ffi_fn: *types.FfiFunction, args: []const Value, gc: *memory.GC) !Va
         return marshalRetValue(.pointer, result, ffi_fn.return_type, gc);
     }
 
-    return error.TypeError;
+    return error.TypeError; // bare-ok: unsupported 5-arg signature fall-through; mapFfiError fills the detail
 }
 
 // ---------------------------------------------------------------------------
@@ -839,9 +850,9 @@ test "checkNarrowIntRange: int8 accepts [-128, 127]" {
 }
 
 test "checkNarrowIntRange: int8 rejects out of range" {
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(128), .int8));
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-129), .int8));
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(200), .int8));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(128), .int8));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(-129), .int8));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(200), .int8));
 }
 
 test "checkNarrowIntRange: uint8 accepts [0, 255]" {
@@ -851,9 +862,9 @@ test "checkNarrowIntRange: uint8 accepts [0, 255]" {
 }
 
 test "checkNarrowIntRange: uint8 rejects out of range" {
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(256), .uint8));
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-1), .uint8));
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(300), .uint8));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(256), .uint8));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(-1), .uint8));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(300), .uint8));
 }
 
 test "checkNarrowIntRange: int16 accepts [-32768, 32767]" {
@@ -863,9 +874,9 @@ test "checkNarrowIntRange: int16 accepts [-32768, 32767]" {
 }
 
 test "checkNarrowIntRange: int16 rejects out of range" {
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(32768), .int16));
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-32769), .int16));
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(40000), .int16));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(32768), .int16));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(-32769), .int16));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(40000), .int16));
 }
 
 test "checkNarrowIntRange: uint16 accepts [0, 65535]" {
@@ -875,9 +886,9 @@ test "checkNarrowIntRange: uint16 accepts [0, 65535]" {
 }
 
 test "checkNarrowIntRange: uint16 rejects out of range" {
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(65536), .uint16));
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-1), .uint16));
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(70000), .uint16));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(65536), .uint16));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(-1), .uint16));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(70000), .uint16));
 }
 
 test "checkNarrowIntRange: uint32 accepts [0, 4294967295]" {
@@ -887,15 +898,15 @@ test "checkNarrowIntRange: uint32 accepts [0, 4294967295]" {
 }
 
 test "checkNarrowIntRange: uint32 rejects out of range" {
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-1), .uint32));
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(4294967296), .uint32));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(-1), .uint32));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(4294967296), .uint32));
 }
 
 test "checkNarrowIntRange: char_type same as uint8" {
     try checkNarrowIntRange(types.makeFixnum(0), .char_type);
     try checkNarrowIntRange(types.makeFixnum(255), .char_type);
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(256), .char_type));
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-1), .char_type));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(256), .char_type));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(-1), .char_type));
 }
 
 test "toIntArgOpt: extracts codepoint from Scheme character" {
@@ -918,20 +929,20 @@ test "checkNarrowIntRange: char_type accepts Scheme characters in 0-255" {
 }
 
 test "checkNarrowIntRange: char_type rejects codepoint > 255" {
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeChar(256), .char_type));
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeChar(0x03BB), .char_type));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeChar(256), .char_type));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeChar(0x03BB), .char_type));
 }
 
 test "checkNarrowIntRange: uint64 rejects negative" {
     try checkNarrowIntRange(types.makeFixnum(0), .uint64);
     try checkNarrowIntRange(types.makeFixnum(1000000), .uint64);
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-1), .uint64));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(-1), .uint64));
 }
 
 test "checkNarrowIntRange: size_type rejects negative" {
     try checkNarrowIntRange(types.makeFixnum(0), .size_type);
     try checkNarrowIntRange(types.makeFixnum(1000000), .size_type);
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(types.makeFixnum(-1), .size_type));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(types.makeFixnum(-1), .size_type));
 }
 
 test "checkNarrowIntRange: non-narrow types pass through" {
@@ -1029,6 +1040,6 @@ test "checkNarrowIntRange: uint64 rejects negative bignum" {
     defer gc.deinit();
 
     const neg = try gc.allocBignumFromI64(-1);
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(neg, .uint64));
-    try std.testing.expectError(error.TypeError, checkNarrowIntRange(neg, .size_type));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(neg, .uint64));
+    try std.testing.expectError(error.InvalidArgument, checkNarrowIntRange(neg, .size_type));
 }

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -521,9 +521,9 @@ pub fn expectPort(proc: []const u8, v: Value) PrimitiveError!*types.Port {
 }
 
 pub fn indexError(proc: []const u8, index: i64, len: usize) PrimitiveError {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.IndexOutOfBounds;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.IndexOutOfBounds; // bare-ok: no VM
     vm.setErrorDetail("{s}: index {d} out of range for length {d}", .{ proc, index, len });
-    return PrimitiveError.IndexOutOfBounds;
+    return PrimitiveError.IndexOutOfBounds; // bare-ok: this is indexError itself
 }
 
 /// The `typeError`/`indexError` sibling for a constraint that is about neither
@@ -531,9 +531,9 @@ pub fn indexError(proc: []const u8, index: i64, len: usize) PrimitiveError {
 /// rejects it (R6RS's "parent is sealed", a uid whose field specs disagree).
 /// `explanation` says what the procedure requires, in the caller's own words.
 pub fn argError(proc: []const u8, comptime explanation: []const u8, fmt_args: anytype) PrimitiveError {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidArgument;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidArgument; // bare-ok: no VM
     vm.setErrorDetail("{s}: " ++ explanation, .{proc} ++ fmt_args);
-    return PrimitiveError.InvalidArgument;
+    return PrimitiveError.InvalidArgument; // bare-ok: this is argError itself
 }
 
 /// The catchable error a rejected cross-heap store raises (kaappi#1924).

--- a/src/tests_ffi.zig
+++ b/src/tests_ffi.zig
@@ -331,6 +331,25 @@ test "mapFfiError never overwrites a detail callFfi already set (#1880)" {
     );
 }
 
+test "mapFfiError preserves an out-of-range argument as InvalidArgument (#2026)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    var ptypes = [_]types.FfiType{.int32};
+    var ffi_fn = makeBoolFn(ptypes[0..], .int);
+
+    // A wrong *magnitude* is KP3007 (InvalidArgument), not KP3002 (TypeError):
+    // mapFfiError must carry the tag validateArgsDetailed assigned rather than
+    // flattening every FFI failure to TypeError, or a caller cannot tell a
+    // wrong type from a wrong magnitude.
+    ctx.vm.setErrorDetail("'{s}': argument 1 out of range for int32", .{ffi_fn.name});
+    try std.testing.expectEqual(
+        vm_mod.VMError.InvalidArgument,
+        vm_calls.mapFfiError(ctx.vm, error.InvalidArgument, &ffi_fn),
+    );
+}
+
 test "mapFfiError passes a raised Scheme exception through untouched (#1880)" {
     var ctx: th.TestContext = undefined;
     try ctx.init();

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -448,7 +448,7 @@ fn mainFiberResult(sched: *fiber_mod.FiberScheduler) Value {
 }
 
 /// `mapNativeError`'s counterpart for `ffi.callFfi`, which reports through an
-/// inline `error{TypeError}` set of its own rather than the VM's.
+/// inline error set of its own rather than the VM's.
 ///
 /// `callFfi` guarantees a detail on every path it can currently fail through
 /// (`validateArgsDetailed` covers every user-reachable argument problem, and
@@ -468,7 +468,14 @@ pub fn mapFfiError(vm: *VM, err: anyerror, ffi_fn: *types.FfiFunction) VMError {
     if (err == error.ExceptionRaised) return VMError.ExceptionRaised;
     if (vm.last_error_detail_len == 0)
         vm.setErrorDetail("'{s}': unsupported FFI signature", .{ffi_fn.name});
-    return VMError.TypeError; // bare-ok: this is mapFfiError itself
+    // Preserve the argument-fault taxonomy `validateArgsDetailed` assigns: an
+    // out-of-range marshalling argument is KP3007 (InvalidArgument), not KP3002
+    // (TypeError) — a wrong magnitude is not a wrong type (kaappi#2026).
+    return switch (err) {
+        error.InvalidArgument => VMError.InvalidArgument,
+        error.IndexOutOfBounds => VMError.IndexOutOfBounds,
+        else => VMError.TypeError, // bare-ok: this is mapFfiError itself
+    };
 }
 
 pub fn mapNativeError(vm: *VM, err: anyerror, name: []const u8, args: []const Value) VMError {

--- a/tests/scheme/ffi/error-messages.scm
+++ b/tests/scheme/ffi/error-messages.scm
@@ -59,6 +59,36 @@
     (c-abs (expt 2 40))
     #f))
 
+;; kaappi#2026: an out-of-range FFI argument is a wrong *magnitude*, not a
+;; wrong *type*, so it must carry KP3007 (invalid argument) while a genuine
+;; type mismatch stays KP3002. Message text alone cannot tell them apart
+;; (both name the function); `error-object-code` is the control a caller
+;; recovers on. The FFI marshalling path used to collapse both to KP3002.
+(test-equal "out-of-range int argument is KP3007, not KP3002"
+  'KP3007
+  (guard (e (#t (error-object-code e)))
+    (c-abs (expt 2 40))
+    'no-error))
+
+(test-equal "wrong-type argument stays KP3002"
+  'KP3002
+  (guard (e (#t (error-object-code e)))
+    (c-abs "x")
+    'no-error))
+
+;; The narrow-integer range checks (int8/uint8/… ) reclassify too.
+(let ((c-abs-i8 (ffi-fn lib "abs" '(int8) 'int)))
+  (test-equal "narrow int8 out-of-range is KP3007"
+    'KP3007
+    (guard (e (#t (error-object-code e)))
+      (c-abs-i8 200)
+      'no-error))
+  (test-equal "narrow int8 wrong-type stays KP3002"
+    'KP3002
+    (guard (e (#t (error-object-code e)))
+      (c-abs-i8 "x")
+      'no-error)))
+
 ;; kaappi#1880: one FFI failure, four dispatch sites. `callFfi` is reached from
 ;; four places -- callValue and callWithArgs in vm_calls.zig, and the tail-call
 ;; and tail-apply opcodes in vm_dispatch.zig -- and until #1880 only the first


### PR DESCRIPTION
## Summary

Closes the two blind spots that hid `src/ffi.zig` from the `Check bare
TypeError regression` CI gate, and fixes the FFI range checks that fell
through them.

The gate scanned only `src/primitives*.zig` for
`return PrimitiveError.TypeError`, so it never saw `src/ffi.zig` — the glob
excluded the file (**wrong path**) *and* all 27 of its bare returns are
spelled `return error.TypeError` (**wrong spelling**). Zig infers the error
set, so both spellings compile to the same tag; only one was greppable.

Among those 27, the narrow-integer range checks were misclassified: a wrong
*magnitude* (e.g. `4294967296` for an `int32` parameter) surfaced as KP3002
(type error) rather than KP3007 (invalid argument), so a program catching
`error-object-code` could not distinguish a wrong type from a value that is
simply too large — exactly the distinction FFI marshalling callers need to
recover.

## What changed

**CI gate (`.github/workflows/ci.yml`)** — widened on both axes and across
the taxonomy:

```
grep -rnE 'return (PrimitiveError|VMError|error)\.(TypeError|IndexOutOfBounds|InvalidArgument)' src/*.zig \
  | grep -v '^src/tests_' | grep -v 'bare-ok'
```

`src/tests_*.zig` is excluded (test files legitimately write
`error.TypeError` in `expectError`). `src/ffi.zig` is now clean, but a
backlog of bare `IndexOutOfBounds`/`InvalidArgument` returns in the
primitives (the taxonomy sweep of #2020/#2021/#2022) is out of scope here,
so the gate is once again a **ratchet** with `BASELINE=28` that may only
decrease — the same shape it had for TypeError before #1868 drove it to 0.

**`src/ffi.zig`** — `validateArgsDetailed` now assigns a clean taxonomy:
- genuine type mismatch → `error.TypeError` (KP3002)
- right kind, magnitude out of range for the narrow/`c_int` type → `error.InvalidArgument` (KP3007)
- right type, string violates a size/content constraint → `error.InvalidArgument` (KP3007)

`checkNarrowIntRange` now signals `InvalidArgument`, and the `c_int`
out-of-range message names the offending value. The remaining marshalling
helpers and signature fall-throughs funnel through `mapFfiError` and each
carry a `// bare-ok:` reason.

**`src/vm_calls.zig`** — `mapFfiError` preserves `InvalidArgument`/
`IndexOutOfBounds` instead of flattening every FFI failure to `TypeError`,
so the tag `validateArgsDetailed` assigned actually reaches the user.

**`src/primitives.zig`** — the `argError`/`indexError` helper definitions
get the same `// bare-ok` annotation their `typeError` sibling already had
(they *are* the helpers; the widened gate now sees their `InvalidArgument`/
`IndexOutOfBounds` returns).

## Behaviour, before → after

```scheme
(define abs-i32 (ffi-fn (ffi-open #f) "abs" '(int32) 'int))
(abs-i32 4294967296)   ; was KP3002, now KP3007 "'abs': argument 1 = 4294967296 out of range for int32"
(abs-i32 'sym)         ; stays KP3002 "'abs': argument 1 must be int32, got symbol"
```

## Tests

- New Scheme regressions in `tests/scheme/ffi/error-messages.scm` assert the
  KP3007-vs-KP3002 distinction via `error-object-code` (out-of-range int,
  narrow int8 out-of-range, and the wrong-type controls that must stay
  KP3002).
- New unit test in `src/tests_ffi.zig` pins `mapFfiError` preserving
  `InvalidArgument`.
- The `checkNarrowIntRange` unit tests now expect `error.InvalidArgument`.
- `zig build` and `zig build test` green; all `tests/scheme/ffi/*` suites
  pass (uint64-range skips on a missing C fixture, unrelated).

## Out of scope (follow-ups)

The widened gate now also sees a backlog it does not fix here, tracked by the
taxonomy issues: 18 bare `IndexOutOfBounds` in `primitives_string_ext.zig`
(#2020) plus assorted `InvalidArgument` guards in `primitives_io.zig`,
`fiber_wait.zig`, `vm_dispatch_helpers.zig`, `vm_calls.zig`,
`vm_continuations.zig`, and `primitives_fiber.zig`. These are held by the
`BASELINE=28` ratchet, to be driven to zero by #2020/#2021/#2022. No
`parseOptionalRange` or `primitives_*.zig` taxonomy site was touched.

Closes #2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)