### PR TITLE
srfi-158: begin range generators with start; gflatten yields nothing for empty lists

### DIFF
--- a/lib/srfi/158-impl.scm
+++ b/lib/srfi/158-impl.scm
@@ -66,11 +66,19 @@
 
 
 ;; make-range-generator
+;; "The sequence begins with start": coerce an exact start to inexact with
+;; exact->inexact when step is inexact, never with the reference
+;; implementation's (- (+ start step) step) round trip.  The round trip
+;; achieves the exactness contagion but does not leave an already-inexact
+;; start alone — it perturbs it by a rounding error, and when step dwarfs
+;; start it annihilates it to 0.0 entirely (#2055; chibi-scheme, which
+;; carries the reference code, reproduces both).
 (define make-range-generator
   (case-lambda ((start end) (make-range-generator start end 1))
                ((start) (make-infinite-range-generator start))
                ((start end step)
-                (set! start (- (+ start step) step))
+                (unless (and (exact? start) (exact? step))
+                  (set! start (exact->inexact start)))
                 (lambda () (if (< start end)
                              (let ((v start))
                               (set! start (+ start step))
@@ -195,15 +203,24 @@
                   v)))))
 
 ;; gflatten
+;; The refill loops until state holds a non-empty list (#2057): the
+;; reference implementation refills exactly once, so an empty list from the
+;; source reaches car and raises (chibi-scheme reproduces this).  The spec —
+;; "yields the elements of the lists produced by the given generator" —
+;; means a list with no elements contributes no elements.
 (define (gflatten gen)
   (let ((state '()))
     (lambda ()
-      (if (null? state) (set! state (gen)))
-      (if (eof-object? state)
-        state
-        (let ((obj (car state)))
-          (set! state (cdr state))
-          obj)))))
+      (let refill ()
+        (cond ((null? state)
+               (set! state (gen))
+               (refill))
+              ((eof-object? state)
+               state)
+              (else
+                (let ((obj (car state)))
+                  (set! state (cdr state))
+                  obj)))))))
 
 ;; ggroup
 (define ggroup

--- a/tests/scheme/srfi/srfi158-audit.scm
+++ b/tests/scheme/srfi/srfi158-audit.scm
@@ -13,9 +13,11 @@
 ;;; The three areas ranked highest going in — laziness/effect ordering,
 ;;; exhaustion stickiness, and infinite generators under bounded consumers —
 ;;; came back CLEAN, and are pinned below with counter-instrumented sources
-;;; rather than left as prose.  The bugs are elsewhere: an inexact `start`
-;;; that the sequence does not begin with, an empty sub-list that raises, and
-;;; a documented spec example that cannot run at all.
+;;; rather than left as prose.  The bugs were elsewhere: an inexact `start`
+;;; that the sequence did not begin with (#2055) and an empty sub-list that
+;;; raised (#2057) are fixed and pinned as passing regressions in sections 6
+;;; and 7; a documented spec example that cannot run at all (#2060) is still
+;;; pinned as raises? in section 15.
 ;;;
 ;;; Portability notes for the emulated CI legs:
 ;;;   * Never write (list (g) (g)) — R7RS leaves argument evaluation order
@@ -480,8 +482,12 @@
 ;;    "The sequence begins with start, increases by step (default 1) ...
 ;;     If both start and step are exact, it generates exact numbers;
 ;;     otherwise it generates inexact numbers."
-;;    The impl coerces start with (- (+ start step) step), which achieves the
-;;    exactness contagion but does not leave an already-inexact start alone.
+;;    Contagion without perturbation (#2055): an exact start is coerced with
+;;    exact->inexact only when step is inexact, so the sequence begins with
+;;    start itself.  The reference implementation's (- (+ start step) step)
+;;    round trip — which this port and chibi-scheme both carried — achieves
+;;    the contagion but perturbs an already-inexact start, annihilating it
+;;    to 0.0 when step dwarfs it.
 ;; ---------------------------------------------------------------------------
 
 (test-equal "range: exact start and step stay exact"
@@ -519,18 +525,16 @@
             '() (generator->list (make-iota-generator -3)))
 (test-equal "CONTROL iota: default start and step" '(0 1 2) (generator->list (make-iota-generator 3)))
 
-;; FAIL: #2055 (make-range-generator does not begin the sequence with an inexact start)
-;; (test-equal "range: begins with an inexact start exactly (default step)"
-;;             0.1 (car (generator->list (make-range-generator 0.1 3))))
-;; FAIL: #2055 (make-range-generator does not begin the sequence with an inexact start)
-;; (test-equal "range: begins with an inexact start exactly (inexact step)"
-;;             0.1 (car (generator->list (make-range-generator 0.1 0.5 0.2))))
-;; FAIL: #2055 (a large step annihilates start entirely: 1e-20 becomes 0.0)
-;; (test-equal "range: a tiny start survives a step of 1.0"
-;;             1e-20 (car (generator->list (gtake (make-range-generator 1e-20 1.0 1.0) 1))))
-;; FAIL: #2055 (a large step annihilates start entirely: 5.0 becomes 0.0)
-;; (test-equal "range: start survives a step 16 orders of magnitude larger"
-;;             5.0 (car (generator->list (gtake (make-range-generator 5.0 1e30 1e17) 1))))
+;; Regressions for #2055: the sequence begins with start itself, at every
+;; mix of exactness and every magnitude ratio between start and step.
+(test-equal "range: begins with an inexact start exactly (default step)"
+            0.1 (car (generator->list (make-range-generator 0.1 3))))
+(test-equal "range: begins with an inexact start exactly (inexact step)"
+            0.1 (car (generator->list (make-range-generator 0.1 0.5 0.2))))
+(test-equal "range: a tiny start survives a step of 1.0"
+            1e-20 (car (generator->list (gtake (make-range-generator 1e-20 1.0 1.0) 1))))
+(test-equal "range: start survives a step 16 orders of magnitude larger"
+            5.0 (car (generator->list (gtake (make-range-generator 5.0 1e30 1e17) 1))))
 
 ;; ---------------------------------------------------------------------------
 ;; 7. gflatten.  "Returns a generator that yields the elements of the lists
@@ -544,27 +548,22 @@
             '(1 2 3) (generator->list (gflatten (generator '(1 2 3)))))
 (test-equal "gflatten: an empty source generator yields nothing"
             '() (generator->list (gflatten (generator))))
-(test-assert "gflatten: an empty sub-list anywhere raises (see #2057)"
-             (raises? (lambda () (generator->list (gflatten (generator '(1) '() '(2)))))))
-(test-assert "gflatten: an empty sub-list first raises (see #2057)"
-             (raises? (lambda () (generator->list (gflatten (generator '() '(1)))))))
-(test-assert "gflatten: an empty sub-list last raises (see #2057)"
-             (raises? (lambda () (generator->list (gflatten (generator '(1) '()))))))
 
-;; FAIL: #2057 (gflatten raises on an empty list from its source)
-;; (test-equal "gflatten: skips an empty sub-list in the middle"
-;;             '(1 2) (generator->list (gflatten (generator '(1) '() '(2)))))
-;; FAIL: #2057 (gflatten raises on an empty list from its source)
-;; (test-equal "gflatten: skips a leading empty sub-list"
-;;             '(1) (generator->list (gflatten (generator '() '(1)))))
-;; FAIL: #2057 (gflatten raises on an empty list from its source)
-;; (test-equal "gflatten: skips a trailing empty sub-list"
-;;             '(1) (generator->list (gflatten (generator '(1) '()))))
-;; FAIL: #2057 (gflatten raises on an empty list from its source)
-;; (test-equal "gflatten: a filtering gmap that yields '() is a natural source"
-;;             '(0 2)
-;;             (generator->list (gflatten (gmap (lambda (x) (if (even? x) (list x) '()))
-;;                                              (make-range-generator 0 4)))))
+;; Regressions for #2057: an empty sub-list contributes no elements, wherever
+;; it falls in the sequence.  The interior and consecutive cases are the ones
+;; a refill that loops only once more can still miss.
+(test-equal "gflatten: skips an empty sub-list in the middle"
+            '(1 2) (generator->list (gflatten (generator '(1) '() '(2)))))
+(test-equal "gflatten: skips a leading empty sub-list"
+            '(1) (generator->list (gflatten (generator '() '(1)))))
+(test-equal "gflatten: skips a trailing empty sub-list"
+            '(1) (generator->list (gflatten (generator '(1) '()))))
+(test-equal "gflatten: skips consecutive empty sub-lists"
+            '(1 2) (generator->list (gflatten (generator '() '() '(1) '() '(2) '()))))
+(test-equal "gflatten: a filtering gmap that yields '() is a natural source"
+            '(0 2)
+            (generator->list (gflatten (gmap (lambda (x) (if (even? x) (list x) '()))
+                                             (make-range-generator 0 4)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 8. Predicate argument order, which the errata specifically clarified.


### PR DESCRIPTION
## What

Two fixes in `lib/srfi/158-impl.scm`, both deviations the SRFI 158 spec explicitly forbids and both inherited from the SRFI's own reference implementation (chibi-scheme 0.11 reproduces each identically, per the verification notes on both issues).

### #2057 — `gflatten` raised on an empty list from its source

The reference implementation's refill ran exactly once, so an empty list from the source reached `car` and raised a type error instead of contributing no elements. The spec: *"Returns a generator that yields the elements of the lists produced by the given generator"* — a list with no elements contributes none. This is the natural shape of a filtering map (`gmap` returning `'()` for every rejected element), which previously could not be flattened at all:

```scheme
(generator->list (gflatten (generator '(1) '() '(2))))
;; before: type error in 'car': expected pair, got ()   after: (1 2)
```

The refill is now a named-let loop that runs until state holds a non-empty list or eof. Exhaustion stickiness is preserved (pinned by the pre-existing audit assertions).

### #2055 — `make-range-generator` did not begin the sequence with an inexact start

The three-argument case coerced `start` with `(- (+ start step) step)`. That achieved the spec's exactness contagion but did not leave an already-inexact start alone — and the error is not bounded by one ulp: when `step` dwarfs `start` the addition rounds `start` away entirely and the subtraction returns `0.0`. The spec: *"The sequence begins with start"*:

```scheme
(car (generator->list (gtake (make-range-generator 1e-20 1.0 1.0) 1)))
;; before: 0.0   after: 1e-20
(car (generator->list (make-range-generator 0.1 3)))
;; before: 0.10000000000000009   after: 0.1
```

Now `start` is coerced with `exact->inexact` only when `step` is inexact; an inexact start passes through untouched, and exact/exact stays exact. All three contagion controls from the issue keep holding (`0 5 0.5` → inexact, `0.5 5 1` → inexact, `0 5 1` → exact).

Both fixes diverge deliberately from the reference implementation and from every port of it; the divergence and why is recorded in comments at both sites, as the issue discussions recommended.

## Tests

`tests/scheme/srfi/srfi158-audit.scm` (discovered by `tests/scheme/run-all.sh`'s `tests/scheme/srfi/*.scm` glob):

- The eight assertions the audit had parked under `;; FAIL: #2055` / `;; FAIL: #2057` markers are enabled, and the three `raises?` assertions that had pinned `gflatten`'s raising behavior in the meantime are removed.
- One new regression added: `gflatten` over consecutive empty sub-lists — the case a naive fix that refills only once more still misses.

## Evidence

- All nine regressions **fail on the old library** (reverted `lib/srfi/158-impl.scm` via `git stash`, rebuilt, reran: 9 FAIL lines, 346 passes).
- With the fix: `srfi158-audit.scm` reports **355 expected passes, 0 failures, exit 0**.
- All ten other suites importing `(srfi 158)` pass (`srfi158`, `srfi221`, `srfi168`, `srfi190`, `srfi194`, `srfi214`, `srfi225-audit`, `srfi252`, `srfi-import-order`, `environment-file-sld-2012`).
- `zig build test` green (exit 0).

No `.zig` files touched — pure portable-Scheme library change.

Closes #2057
Closes #2055

🤖 Generated with [Claude Code](https://claude.com/claude-code)
