### PR TITLE
fmt: pin the #2143 lexeme-glue and #2080 diagnostic fixes in fmt-adversarial

### DIFF
--- a/tests/scheme/fmt/fmt-adversarial.sh
+++ b/tests/scheme/fmt/fmt-adversarial.sh
@@ -15,7 +15,7 @@
 #
 # The generator that found the failures below is `tools/fmt_fuzz.py` — it is
 # deliberately *not* run here (it takes minutes; this file takes ~2 seconds).
-# See kaappi#2141, kaappi#2142, kaappi#2143, kaappi#2149.
+# See kaappi#2141, kaappi#2142, kaappi#2143, kaappi#2080, kaappi#2149.
 
 set -uo pipefail
 
@@ -147,6 +147,39 @@ case_ "vector after an identifier, spaced"           '(a b #(1) d)\n'
 case_ "block comment glued to an identifier"         '(a b#|c|# d)\n'
 case_ "datum comment glued to an identifier"         '(list a#;(b) c)\n'
 case_ "vector glued to an identifier"                '(a b#(1) d)\n'
+# The two shapes from #2143's byte-mutation campaign that tripped the round-trip
+# guard outright: a `#(` glued after an identifier once carved `…#` as one atom,
+# leaving a bare `(` that opens a *list* where the reader opens a vector — a
+# different program, so the guard refused and the file was unformattable.
+case_ "vector open glued after import"               '(import#(scheme base))\n'
+case_ "datum labels inside a glued vector"           '(define shared-pair#(#2=(a) #2# #2#))\n'
+
+# ── A user syntax error is the reader's error, not an internal one ─────────
+#
+# The round-trip guard reads the *original* first: when that read fails — a
+# syntax error the CST lexer happened to tolerate — `fmt` must report the
+# reader's own KP1xxx diagnostic with its position, exactly as `kaappi check`
+# does. The "internal error: formatting would change the program" wording is
+# reserved for a genuine mismatch between two successfully-read texts and must
+# never appear on this path (kaappi#2080). All four are the error classes of
+# that issue's table; the file is left untouched in every case.
+
+# assert_reader_error <label> <expected-kp-code> <source-with-\n-escapes>
+assert_reader_error() {
+    local label="$1" kp="$2" src="$3" status=0 err
+    printf '%b' "$src" > "$TMP/e.scm"
+    err="$("$KAAPPI" fmt < "$TMP/e.scm" 2>&1)" || status=$?
+    if [[ "$status" -eq 1 && "$err" == *"read error[$kp]"* && "$err" != *"internal error"* ]]; then
+        pass "$label"
+    else
+        fail "$label" "exit $status, stderr: [$err]"
+    fi
+}
+
+assert_reader_error "user error: invalid character name"       KP1005 '(display #\\qqq)\n'
+assert_reader_error "user error: invalid hex char literal"     KP1005 '(display #\\xZZ)\n'
+assert_reader_error "user error: '.' outside of a list"        KP1008 '(a . . b)\n'
+assert_reader_error "user error: form feed is not whitespace"  KP1002 "(display '(a\fb))\n"
 
 # ── Fit-to-width is measured in columns (Unicode code points) ────────────
 


### PR DESCRIPTION
## What

Group H task for #2143 + #2080. **Both issues were already fixed on main by #2291 (commit `e5bd7747`) before this branch was cut** — this PR is **verify-and-close** for the code fixes and adds the regression coverage the issues' own bodies call for, which `fmt-adversarial.sh` (the file both issues name) did not yet have.

## Verify: neither issue reproduces on main @ 645d2bba

Every reproduction from both issue bodies, run against a fresh ReleaseSafe build of this branch:

| Issue repro | Pre-fix (as filed) | Now |
|---|---|---|
| `(list a#;(b) c)` | `syntax error: unterminated list` | formats to `(list a #;(b) c)`, exit 0 |
| `(a b#|c|# d)` | `internal error: formatting would change the program` | formats to `(a b #|c|# d)`, exit 0 |
| `(a b#(1) d)` | `internal error: …` | formats to `(a b #(1) d)`, exit 0 |
| g2.scm (`(display (list a#;(b) c))`) | `fmt --check`: `syntax error: unterminated list` | reported as merely unformatted; formats to `(display (list a #;(b) c))`, second pass clean |
| `(display #\qqq)` | `internal error: formatting would change the program` | `:1:15: read error[KP1005]: invalid character name` (fmt, fmt --check, stdin) |
| `#\xZZ` / `(a . . b)` / form feed U+000C | `internal error: …` | KP1005 / KP1008 / KP1002 with line:column |

## The coupling

#2143's mis-lex is what produced #2080's bogus message in half these cases: the CST lexer glued `ident#` into one atom, carved a different lexeme stream than the reader, and the resulting divergence surfaced through the single shared "internal error" funnel. The two fixes in `src/fmt.zig` (#2291) are two halves of one behavior: `scanIdentifier` now ends at the first non-⟨subsequent⟩ byte — delegating to `Reader.isSubsequent`/`isUnicodeSubsequent`, the reader's own functions rather than a copy — and `verifyRoundTrip` returns a `RoundTrip` union whose `original_unreadable` arm reports the reader's KP1xxx diagnostic instead of claiming an internal fault.

## Tests added

`tests/scheme/fmt/fmt-adversarial.sh` (+6 cases):

- #2143 — the two guard-tripping shapes from the issue's byte-mutation campaign, absent from the six existing glue cases: `(import#(scheme base))` and `(define shared-pair#(#2=(a) #2# #2#))` (a `#(` glued after an identifier once carved `…#` as one atom, leaving a list where the reader opens a vector).
- #2080 — the diagnostic path, previously untested in this suite (fmt.sh had one case, `#\qqq`): an `assert_reader_error` helper asserting fmt exits 1 with the reader's own `KP1xxx` diagnostic and **never** "internal error", over all four error classes of the issue's table (`#\qqq` KP1005, `#\xZZ` KP1005, `(a . . b)` KP1008, form feed KP1002).

Each new case was proven to fail without the fix by rebuilding with the pre-fix `src/fmt.zig` (`220e31a2`): all six fail with exactly the filed symptom (`kaappi fmt: internal error: formatting would change the program`); `fmt-adversarial: 72 passed, 9 failed` pre-fix vs **81 passed, 0 failed** post-fix. Also green: `tests/scheme/fmt/fmt.sh` (38/38) and `zig build test`.

Closes #2143
Closes #2080

🤖 Generated with [Claude Code](https://claude.com/claude-code)
