### PR TITLE
docs: SRFI 248's third caveat and the script top-level echo (#2038, #1994, #2252)

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -2,6 +2,16 @@
 
 Kaappi implements every identifier from [R7RS Appendix A](https://small.r7rs.org/) — 695 built-in procedures, 32 syntax forms, and all 16 standard libraries. R7RS test suite: 1,395 pass, 0 fail.
 
+One behavior of the program runner, beyond the language proper: running a
+script (`kaappi program.scm`) echoes the value of every non-void top-level
+expression to stdout, exactly as the REPL does. `define` and other
+void-valued forms print nothing, but a top-level `guard` that yields `#f` or
+a `map` used for effect prints its result, interleaved with the program's own
+output — Chibi and Guile print nothing when running the same file. The echo
+is deliberate (`printTopLevelResult` in `src/main.zig`) and no flag disables
+it; end effectful top-level sequences with a void-valued form when output
+must stay clean. See README.md "Known limitations → Script output".
+
 ---
 
 ## SRFI conformance
@@ -360,7 +370,7 @@ to an explicit target, and resend from a directly-overriding method, both work.
 `.sld` on `(import (srfi 267))`.
 
 ‡ SRFI 248's `with-unwind-handler` prompt is layered over stack-copying
-`call/cc` via a sticky exception handler, with two caveats. (1) Delimited
+`call/cc` via a sticky exception handler, with three caveats. (1) Delimited
 continuations are effectively single-shot: each captured `k` may be resumed at
 most once — re-entering it twice crosses a native frame that cannot be
 re-entered after it returns, the same restriction as continuations captured
@@ -370,6 +380,19 @@ invokes each `k` once. (2) The handler runs at the raise point rather than after
 unwinding to `with-unwind-handler`, so a handler side effect and a
 dynamic-wind after-thunk of the guarded body run in the opposite order to what
 the SRFI wording implies; the captured continuation itself is unaffected.
+(3) The prompt is a single metacontinuation cell per VM — per OS thread —
+shared by every fiber in the thread, so a `with-unwind-handler`/`guard` body
+must not span a fiber suspension point (a blocking channel operation, parked
+I/O) while another fiber runs delimited control: the prompts cross silently —
+a parked body's handler value can surface in the other fiber's
+`with-unwind-handler` while the parked body never completes, with no error
+raised and exit status 0. Mixing in user `call/cc` is unsupported the same
+way: a `call/cc` capture that crosses a `with-unwind-handler` boundary makes
+the guarded body re-run exponentially. A loop that escapes through user
+`call/cc` from inside `with-unwind-handler`, run under SRFI 248's `guard`,
+executes its body 2^n-1 times instead of n — 255 where 8 is correct at n = 8 —
+while the same loop under the built-in `guard`, or with no boundary crossing,
+returns 8.
 
 § SRFI 226 (Control Features, 12 sub-libraries: prompts, continuations,
 shift-reset, continuation-marks, parameters, fluids, promises, exceptions,

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ expression cannot re-enter subsequent top-level expressions (standard behavior
 shared by Guile, Chibi, Chicken, Chez, and Racket).
 
 SRFI 248's delimited continuations (`with-unwind-handler`, and the extended
-`guard`) are built on this `call/cc` via a sticky exception handler, with two
+`guard`) are built on this `call/cc` via a sticky exception handler, with three
 observable caveats:
 
 - **Single-shot** — each captured delimited continuation may be resumed at most
@@ -400,9 +400,20 @@ observable caveats:
   after-thunk of the guarded body, where R7RS-small runs it after. All the
   effects still happen; only their order differs. See
   [CONFORMANCE.md](CONFORMANCE.md) for details.
+- **Shared prompt cell** — the delimited-control prompt is a single cell per
+  thread, shared by every fiber in it, so a `with-unwind-handler`/`guard` body
+  must not span a fiber suspension point (a blocking channel operation, parked
+  I/O) while another fiber runs delimited control: the prompts cross silently —
+  one fiber's `with-unwind-handler` can return another fiber's handler value
+  while the parked body never completes, with no error raised. Mixing in user
+  `call/cc` is unsupported the same way: a `call/cc` capture that crosses a
+  `with-unwind-handler` boundary makes the guarded body re-run exponentially —
+  a loop that escapes through user `call/cc` from inside `with-unwind-handler`,
+  run under SRFI 248's `guard`, executes its body 2^n-1 times instead of n (255
+  where 8 is correct, at n = 8) and still exits 0.
 
-Both are limited to SRFI 248; plain `call/cc`, `dynamic-wind`, and the built-in
-`guard` are unaffected unless you import `(srfi 248)`.
+All three are limited to SRFI 248; plain `call/cc`, `dynamic-wind`, and the
+built-in `guard` are unaffected unless you import `(srfi 248)`.
 
 ### Exceptions
 
@@ -500,6 +511,17 @@ very large inputs, chunking manually with `make-pool`/`pool-submit`/
 `task-wait` (one task per processor, each covering a slice of the input with
 an ordinary sequential loop) reduces per-task submission overhead — see
 `kaappi-examples/parallel-primes` for a worked example.
+
+### Script output
+
+Running a script (`kaappi program.scm`) echoes the value of every non-void
+top-level expression to stdout, as a REPL does; `define` and other
+void-valued forms print nothing. A top-level call used for effect therefore
+adds a datum to the program's own output — a cleanup helper ending in
+`(guard (e (#t #f)) ...)` prints its `#f`, and `(map f rows)` prints the
+resulting list. Chibi and Guile print nothing when running the same file. No
+flag disables the echo; keep effectful top-level sequences void-valued (end a
+`begin` with `(if #f #f)`) when the program's output must stay parseable.
 
 ### Macros
 


### PR DESCRIPTION
Doc-truth corrections, group P. Every claim below was verified against a fresh
`zig build` (ReleaseSafe) of this branch's tree (`zig-out/bin/kaappi`), with an
isolated `KAAPPI_HOME`. No `.zig` behavior changed.

## #2038 — SRFI 248 has a third caveat, not two

**Change:** `README.md` ("Known limitations → Continuations") and `CONFORMANCE.md`
(footnote ‡) said "two observable caveats" / "two caveats" and asserted the list
was complete ("Both are limited to SRFI 248"). Both now say **three** and carry
the two extra restrictions from `lib/srfi/248.sld`'s header: a
`with-unwind-handler`/`guard` body must not span a fiber suspension point, and a
user `call/cc` capture must not cross a `with-unwind-handler` boundary — plus
what happens when each is violated. "Both are limited" became "All three are
limited".

**Evidence — user `call/cc` crossing (the 2^n−1 loop).** The issue's
reproduction, run verbatim (`esc-loop n 0` under SRFI 248's `guard`):

```
$ KAAPPI_HOME=/tmp/p2038/home zig-out/bin/kaappi esc8.scm   # n = 8
255
end
$ # exit status 0
```

The full progression, every run exiting 0 — the body runs 2^n−1 times:

| n | expected | actual |
|--:|--:|---:|
| 1 | 1 | 1 |
| 2 | 2 | 3 |
| 3 | 3 | 7 |
| 4 | 4 | 15 |
| 8 | 8 | 255 |
| 12 | 12 | 4095 |
| 20 | 20 | 1048575 |
| 22 | 22 | 4194303 |
| 24 | 24 | 16777215 |

Both discriminating controls from the issue return the **correct** value 8 at
n = 8, isolating the crossing as the cause:

- same loop with plain R7RS `guard` + `with-exception-handler` (no `(srfi 248)`
  import) → `8`, exit 0;
- same loop with `(srfi 248)` imported but **no** `with-unwind-handler` in the
  loop → `8`, exit 0.

The issue's n = 200 escalation ("no output at all, exit 0") could not be
reproduced within this session's time budget (at n = 24 the loop already takes
40 s wall and the work doubles with every +1, so 2^200 iterations cannot
complete; a 30-minute n = 200 run was killed with nothing printed). The docs
therefore state only the demonstrated consequence — 2^n−1 re-runs, wrong
result, exit 0 — which is what the issue's "What to change" asks for.

**Evidence — fiber-suspension half.** Deterministic, 4/4 identical runs:

```scheme
(import (scheme base) (scheme write) (srfi 248) (kaappi fibers))
(define a-ch (make-channel)) (define b-ch (make-channel))
(display "main: start\n")
(define _a (spawn (lambda ()
  (display "A: entering with-unwind-handler\n")
  (let ((v (with-unwind-handler (lambda (o k) 'A-HANDLER)
             (lambda () (display "A: body parking\n") (channel-receive a-ch)))))
    (display "A: with-unwind-handler returned ") (write v) (newline)))))
(define _b (spawn (lambda ()
  (display "B: entering with-unwind-handler\n")
  (let ((v (with-unwind-handler
             (lambda (o k) (display "B: handler parking mid-shift\n")
                      (channel-receive b-ch) (k 'B-RESUMED))
             (lambda () (raise 'go)))))
    (display "B: with-unwind-handler returned ") (write v) (newline)))))
(yield) (yield)
(display "main: waking A's body\n")
(channel-send a-ch 'WAKE-A)
(yield)
(display "main: end\n")
```

```
main: start
A: entering with-unwind-handler
A: body parking
B: entering with-unwind-handler
B: handler parking mid-shift
B: handler parking mid-shift
B: with-unwind-handler returned A-HANDLER      <-- B returns A's handler value
main: waking A's body
main: end                                      <-- A never returns at all
$ # exit status 0, no error printed
```

One fiber's `with-unwind-handler` returned the *other* fiber's handler value;
A's parked body never completed — silently, exit 0.

## #1994 — script execution echoes non-void top-level values

**Change:** the behavior was documented only in `docs/dev/fuzzing.md`. It is
now in the user-facing docs: a new "Script output" subsection in `README.md`
§ Known limitations, and a paragraph in `CONFORMANCE.md`'s intro alongside the
other deliberate deviations (the issue's first option — documenting, not
gating the echo to the REPL, which would be a behavior change outside this
group's scope).

**Evidence.** The issue's minimal file, run verbatim:

```
$ cat echo.scm
(import (scheme base) (scheme write))
(define x 1)     ; not printed
#f               ; printed
42               ; printed
"hi"             ; printed
(if #f #f)       ; not printed (void)
(+ 1 2)          ; printed
(display "END\n")
$ KAAPPI_HOME=/tmp/p2038/home zig-out/bin/kaappi echo.scm
#f
42
"hi"
3
END
$ # exit 0
```

`define` and `(if #f #f)` print nothing — the rule is precisely "non-void
top-level result". The realistic CLI example from the issue behaves the same
(`#f` and `(2 4)` pollute the structured output). Locally installed
`chibi-scheme` and `guile` (2>/dev/null) run the byte-identical file and print
only `END` — the contrast claim in both docs names only those two, since they
are the ones this session demonstrated. `kaappi --help` confirms no flag
disables the echo, and ending a top-level `begin` with `(if #f #f)` silences
it (verified: prints only the program's own line).

## #2252 — FORMAL_FLAG comments already corrected on main; no change needed

The three comments in `src/expander_instantiate.zig` that the issue quotes were
already re-scoped to **lambda formals only** by #2251 (merge commit 6ee91e23,
an ancestor of this branch): line 44 reads "identifier is a lambda formal",
the block comment at lines 413–429 states case-lambda formals are *not*
included and go through the ordinary pair recursion without the flag, and the
`isProcedure` branch at lines 1044–1052 states the exception is "deliberately
NOT extended to let variables (#681) or to case-lambda formals (#2252)".

Verified against the code and the binary — the comments now match the behavior:

```
$ kaappi expand case_lambda.scm      # (case-lambda ((car) (car)) ...)
(define f (__hyg_1_case-lambda ((__hyg_2_car) (__hyg_2_car))
                               ((__hyg_2_car __hyg_3_x) (__hyg_4_+ __hyg_2_car __hyg_3_x))))
$ kaappi expand plain_lambda.scm     # identical formal under plain lambda
(define g (__hyg_1_lambda (car) (car)))
```

The case-lambda formal is hygiene-renamed; the lambda formal keeps its bare
spelling. The pinning regression test from #2251 passes:

```
$ zig-out/bin/kaappi tests/scheme/hygiene/template-binds-builtin-name.scm
  PASS  template let binding shadows builtin exp
  ...
  PASS  case-lambda formal does not capture spliced body
  PASS  lambda formal keeps its anaphoric spelling
```

(`kaappi test` on the same file: file-level PASS, exit 0.) Since the issue
predates the comment landing via #2251, this PR carries the verification and
the closing keyword; there is nothing further to edit.

## Checks

- `zig build test` — exit 0 (green).
- `npx markdownlint-cli2` — 0 issues in 89 files (CI `format` job rules).

Closes #2038
Closes #1994
Closes #2252

🤖 Generated with [Claude Code](https://claude.com/claude-code)
