### PR TITLE
Preserve fiber fault identity and fix (kaappi fibers) argument diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
       # write `error.TypeError` in `expectError`, so src/tests_*.zig is excluded.
       - name: Check bare error-taxonomy regression
         run: |
-          BASELINE=28
+          BASELINE=27
           hits=$(grep -rnE 'return (PrimitiveError|VMError|error)\.(TypeError|IndexOutOfBounds|InvalidArgument)' src/*.zig \
                  | grep -v '^src/tests_' | grep -v 'bare-ok' || true)
           count=$(printf '%s' "$hits" | grep -c . || true)

--- a/src/fiber_wait.zig
+++ b/src/fiber_wait.zig
@@ -12,6 +12,8 @@ const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const reactor_mod = @import("reactor.zig");
 const fiber_mod = @import("fiber.zig");
+const errors = @import("errors.zig");
+const primitives_control = @import("primitives_control.zig");
 const Value = types.Value;
 const VM = vm_mod.VM;
 const VMError = vm_mod.VMError;
@@ -451,6 +453,40 @@ pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberSche
                     sched.markRunnable(fiber);
                 }
                 continue;
+            }
+            // #2204: a VM-level fault (type error, unbound variable, bad
+            // index, arity mismatch) carries its identity in two places the
+            // fiber's saved state never transports — the VMError tag and
+            // vm.last_error_detail — so fiber-join used to substitute a
+            // contentless KP3007 "fiber error (no exception value)" for the
+            // real diagnostic. Convert the fault HERE, before anything else
+            // runs (retireSlot/abandonFiberMutexes/wakeWaiters, or any later
+            // native call, can overwrite the detail), into the same coded
+            // ErrorObject withExceptionHandlerFn hands a guard, and stage it
+            // in vm.current_exception — the one error channel
+            // saveCurrentFiber copies into fiber.current_exception below,
+            // which is what the joiner's reraiseFiberError re-raises. A
+            // Scheme-level raise (ExceptionRaised) already carries its
+            // condition that way; a continuation jump (ContinuationInvoked)
+            // is control flow, not a fault; and an uncatchable error
+            // (StackOverflow, ExecutionTimeout, Terminated —
+            // errors.isUncatchable) must not become a catchable condition
+            // on its way through (#1886), so none of those convert.
+            if (err != VMError.ExceptionRaised and
+                err != VMError.ContinuationInvoked and
+                !errors.isUncatchable(err))
+            {
+                if (primitives_control.nativeErrorToErrorObject(vm, vm.gc, err)) |exc| {
+                    // Assigning straight into vm.current_exception (a GC
+                    // root, vm.zig markVmRoots) with no allocating call in
+                    // between is what roots the otherwise-unrooted object
+                    // the conversion contract warns about.
+                    vm.current_exception = exc;
+                } else |_| {
+                    // The conversion itself failed (OOM): keep the retire
+                    // bookkeeping and let the joiner see the fallback
+                    // placeholder — better a vague error than a lost fiber.
+                }
             }
             // Fiber 0 is the main fiber: finishing or aborting one
             // top-level form is not thread death, so its mutexes stay

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -622,7 +622,10 @@ pub fn parseOptionalRange(args: []const Value, arg_offset: usize, max_len: usize
 ///       one-level summary (a vector/bytevector reports its length; a rational
 ///       renders its two exact-integer components), never a recursive print —
 ///       so a cyclic structure cannot make this loop.
-fn safeValueDescription(buf: *[128]u8, value: Value) []const u8 {
+/// `pub` since #2002: primitives_fiber.makeChannelFn's range rejection needs
+/// the offending value in its argError message ("…between 0 and 4294967295,
+/// got <value>") without duplicating this deliberately-defensive renderer.
+pub fn safeValueDescription(buf: *[128]u8, value: Value) []const u8 {
     var w: std.Io.Writer = .fixed(buf);
     describeValue(&w, value);
     const out = w.buffered();

--- a/src/primitives_control.zig
+++ b/src/primitives_control.zig
@@ -168,7 +168,12 @@ pub fn raiseContinuable(vm: *vm_mod.VM, obj: Value) PrimitiveError!Value {
 /// two error-coding boundaries cannot drift apart.
 ///
 /// The returned object is *unrooted* — root it before allocating again.
-fn nativeErrorToErrorObject(vm: *vm_mod.VM, gc: *memory.GC, err: anyerror) PrimitiveError!Value {
+///
+/// `pub` since #2204: the fiber dispatch loop's error arm (fiber_wait.zig)
+/// runs the same conversion so a VM-level fault inside a fiber keeps its
+/// code and message across the fiber boundary — the fourth error-coding
+/// boundary, deliberately the same function so none of them can drift.
+pub fn nativeErrorToErrorObject(vm: *vm_mod.VM, gc: *memory.GC, err: anyerror) PrimitiveError!Value {
     const detail = vm.getErrorDetail();
     var msg_str = if (detail.len > 0)
         gc.allocString(detail) catch return PrimitiveError.OutOfMemory

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -119,8 +119,16 @@ fn reraiseFiberError(fiber: *fiber_mod.Fiber) PrimitiveError {
         vm.current_exception = exc;
         return PrimitiveError.ExceptionRaised;
     }
+    // Since #2204 the dispatch loop converts every catchable VM-level fault
+    // into a coded ErrorObject before the fiber is retired, so this fallback
+    // is reached only for faults that deliberately carry no condition across
+    // the boundary: an uncatchable one (StackOverflow, ExecutionTimeout,
+    // Terminated — errors.isUncatchable, which must stay uncatchable) or the
+    // conversion itself failing. The detail below is set by hand, so this is
+    // a described error, not the synthesized blame-a-real-argument kind the
+    // bare-return gate exists to catch.
     vm.setErrorDetail("fiber error (no exception value)", .{});
-    return PrimitiveError.InvalidArgument;
+    return PrimitiveError.InvalidArgument; // bare-ok: detail set above; uncatchable-fault fallback (#2204)
 }
 
 fn fiberPredFn(args: []const Value) PrimitiveError!Value {
@@ -131,10 +139,23 @@ fn makeChannelFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     if (args.len == 0) return gc.allocChannel() catch return PrimitiveError.OutOfMemory;
 
-    if (!types.isFixnum(args[0])) return primitives.typeError("make-channel", "non-negative exact integer", args[0]);
+    // #2002: the capacity is stored as a u32, and a value that IS an exact
+    // integer but sits outside [0, 2^32-1] is a range rejection — argError
+    // (KP3007, "a value of acceptable type the procedure rejects anyway"),
+    // never a type error. The old one-size typeError read "expected
+    // non-negative exact integer, got 4294967296", contradicting itself and
+    // hiding the actual bound. A bignum is always out of range (a fixnum
+    // already spans ±2^47, so anything bignum-sized dwarfs u32); only a
+    // genuinely non-integer argument (1.0, 'x, 1/2) stays a typeError.
+    if (!types.isFixnum(args[0])) {
+        if (!types.isBignum(args[0]))
+            return primitives.typeError("make-channel", "non-negative exact integer", args[0]);
+        var buf: [128]u8 = undefined;
+        return primitives.argError("make-channel", "capacity must be an exact integer between 0 and 4294967295, got {s}", .{primitives.safeValueDescription(&buf, args[0])});
+    }
     const fx = types.toFixnum(args[0]);
     if (fx < 0 or fx > std.math.maxInt(u32))
-        return primitives.typeError("make-channel", "non-negative exact integer", args[0]);
+        return primitives.argError("make-channel", "capacity must be an exact integer between 0 and 4294967295, got {d}", .{fx});
     const capacity: u32 = @intCast(fx);
     return gc.allocChannelBounded(capacity) catch return PrimitiveError.OutOfMemory;
 }
@@ -164,7 +185,7 @@ fn channelSendFn(args: []const Value) PrimitiveError!Value {
     var has_timeout_val = false;
     var timeout_val: Value = types.VOID;
     if (args.len > 2) {
-        deadline_ns = try srfi18.timeoutToDeadlineNs(args[2]);
+        deadline_ns = try srfi18.timeoutToDeadlineNs("channel-send", args[2]);
         if (args.len > 3) {
             has_timeout_val = true;
             timeout_val = args[3];
@@ -1062,7 +1083,7 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
     var has_timeout_val = false;
     var timeout_val: Value = types.VOID;
     if (args.len > 1) {
-        deadline_ns = try srfi18.timeoutToDeadlineNs(args[1]);
+        deadline_ns = try srfi18.timeoutToDeadlineNs("channel-receive", args[1]);
         if (args.len > 2) {
             has_timeout_val = true;
             timeout_val = args[2];

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -420,7 +420,12 @@ fn saturatedNsFromSeconds(secs: f64) u64 {
 /// `pub` since KEP-0002 Phase 4 (#1469): primitives_fiber.zig's
 /// channel-send/channel-receive timeouts reuse this exact SRFI-18-shaped
 /// number-or-time-object-or-#f parsing rather than duplicating it.
-pub fn timeoutToDeadlineNs(timeout: Value) PrimitiveError!?u64 {
+///
+/// `proc` is the calling procedure's name, used verbatim in the timeout's
+/// type error (#2002). It used to be hardcoded 'thread', so
+/// `(channel-receive ch 'bad)` reported `type error in 'thread'` — a
+/// procedure that does not exist, in a library the caller never imported.
+pub fn timeoutToDeadlineNs(proc: []const u8, timeout: Value) PrimitiveError!?u64 {
     if (timeout == types.FALSE) return null;
     if (types.isSrfi18Time(timeout)) {
         const t = types.toSrfi18Time(timeout);
@@ -441,7 +446,7 @@ pub fn timeoutToDeadlineNs(timeout: Value) PrimitiveError!?u64 {
         return mono_now +| (sec_ns - now_ns);
     }
     const secs = primitives.toF64(timeout) catch
-        return primitives.typeError("thread", "time object or number", timeout);
+        return primitives.typeError(proc, "time object or number", timeout);
     const mono_now = fiber_mod.clockNs();
     // The saturating add keeps a saturated delta pinned at "never" instead
     // of wrapping around into the past (#1983).
@@ -1123,7 +1128,7 @@ fn threadJoinFn(args: []const Value) PrimitiveError!Value {
     var has_timeout_val = false;
     var timeout_val: Value = types.VOID;
     if (args.len > 1) {
-        deadline_ns = try timeoutToDeadlineNs(args[1]);
+        deadline_ns = try timeoutToDeadlineNs("thread-join!", args[1]);
         if (args.len > 2) {
             has_timeout_val = true;
             timeout_val = args[2];
@@ -1606,7 +1611,7 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
 
     var deadline: ?u64 = null;
     if (args.len > 1) {
-        deadline = try timeoutToDeadlineNs(args[1]);
+        deadline = try timeoutToDeadlineNs("mutex-lock!", args[1]);
         if (deadline != null and deadline.? == 0) return types.FALSE;
     }
 
@@ -1787,7 +1792,7 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
     if (cv) |c| {
         var deadline: ?u64 = null;
         if (args.len > 2) {
-            deadline = try timeoutToDeadlineNs(args[2]);
+            deadline = try timeoutToDeadlineNs("mutex-unlock!", args[2]);
         }
 
         const me = ctx.vm.current_fiber orelse return PrimitiveError.OutOfMemory;

--- a/src/tests_fibers.zig
+++ b/src/tests_fibers.zig
@@ -630,3 +630,154 @@ test "a rejected spawn allocates no fiber and leaves the scheduler usable (#1999
     const result = try vm.eval("(list (fiber-join before) (fiber-join (spawn (lambda () 'after))))");
     try std.testing.expect(types.isPair(result));
 }
+
+// #2204: a VM-level fault in a fiber body (type error, unbound variable,
+// bad index, arity mismatch) used to cross the fiber boundary as a
+// contentless KP3007 "fiber error (no exception value)". The dispatch
+// loop's error arm (fiber_wait.zig) dropped the VMError tag, and
+// vm.last_error_detail -- where the whole message lives -- is not part of
+// the fiber's saved state, so fiber-join substituted a placeholder
+// condition. The loop now converts the fault into the same coded
+// ErrorObject a guard sees outside a fiber, before anything else can
+// overwrite the detail, and stages it in vm.current_exception for
+// saveCurrentFiber/reraiseFiberError to carry to the joiner.
+test "fiber-join re-raises a fiber's VM fault with its code and message (#2204)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define five 5)");
+    // CONTROL: the same fault outside a fiber is KP3002 with this message.
+    const direct = try vm.eval(
+        \\(guard (e (#t (list (error-object-code e) (error-object-message e))))
+        \\  (car five))
+    );
+    // A fault after a yield exercises the dispatched-fiber path too, not
+    // just the driven-in-place one.
+    const joined = try vm.eval(
+        \\(guard (e (#t (list (error-object-code e) (error-object-message e))))
+        \\  (fiber-join (spawn (lambda () (yield) (car five)))))
+    );
+
+    const printer = @import("printer.zig");
+    const want = "(KP3002 \"type error in 'car': expected pair, got 5\")";
+    const s1 = try printer.valueToString(std.testing.allocator, direct, .write);
+    defer std.testing.allocator.free(s1);
+    try std.testing.expectEqualStrings(want, s1);
+    const s2 = try printer.valueToString(std.testing.allocator, joined, .write);
+    defer std.testing.allocator.free(s2);
+    // Identical condition outside and inside a fiber: pre-fix the joined
+    // form printed (KP3007 "fiber error (no exception value)").
+    try std.testing.expectEqualStrings(want, s2);
+}
+
+test "each VM fault class keeps its own code across the fiber boundary (#2204)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Unbound variable KP3001, index KP3006, call arity KP3003 -- all used
+    // to collapse to the same KP3007 placeholder.
+    const result = try vm.eval(
+        \\(define (code-of thunk) (guard (e (#t (error-object-code e))) (thunk) 'no-raise))
+        \\(list (code-of (lambda () (no-such-variable-2204)))
+        \\      (code-of (lambda () (vector-ref (vector 1) 9)))
+        \\      (code-of (lambda () ((lambda (x) x))))
+        \\      (code-of (lambda () (fiber-join (spawn (lambda () (no-such-variable-2204))))))
+        \\      (code-of (lambda () (fiber-join (spawn (lambda () (vector-ref (vector 1) 9))))))
+        \\      (code-of (lambda () (fiber-join (spawn (lambda () ((lambda (x) x))))))))
+    );
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("(KP3001 KP3006 KP3003 KP3001 KP3006 KP3003)", s);
+}
+
+test "a fiber's VM fault is re-raised identically on every join (#2204)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define five 5)");
+    const result = try vm.eval(
+        \\(let ((f (spawn (lambda () (car five)))))
+        \\  (list (guard (e (#t (error-object-code e))) (fiber-join f))
+        \\        (guard (e (#t (error-object-code e))) (fiber-join f))))
+    );
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("(KP3002 KP3002)", s);
+}
+
+// #2002: make-channel's capacity is stored as a u32, so a value that IS an
+// exact integer outside [0, 2^32-1] is a range rejection -- an argument
+// error (KP3007) whose message names the real bound -- while a genuinely
+// non-integer argument stays a type error (KP3002). The old one-size
+// typeError claimed "expected non-negative exact integer, got 4294967296",
+// which argues against itself and hides the actual constraint.
+test "make-channel's range rejections are argument errors naming the bound (#2002)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(define (code-of thunk) (guard (e (#t (error-object-code e))) (thunk) 'no-raise))
+        \\(list (code-of (lambda () (make-channel 4294967296)))
+        \\      (code-of (lambda () (make-channel -1)))
+        \\      (code-of (lambda () (make-channel (expt 10 30))))  ; bignum
+        \\      (code-of (lambda () (make-channel 1.0)))
+        \\      (code-of (lambda () (make-channel 'x))))
+    );
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("(KP3007 KP3007 KP3007 KP3002 KP3002)", s);
+
+    // The range rejection's message states the constraint it enforced.
+    // (string-contains is SRFI 13: it returns a match INDEX or #f, so the
+    // and-chain ends in an explicit #t rather than the last index.)
+    const msg = try vm.eval(
+        \\(guard (e (#t (and (string-contains (error-object-message e) "4294967295")
+        \\                    (string-contains (error-object-message e) "4294967296")
+        \\                    (string-contains (error-object-message e) "make-channel")
+        \\                    #t)))
+        \\  (make-channel 4294967296)
+        \\  'missing-substrings)
+    );
+    try std.testing.expectEqual(types.TRUE, msg);
+}
+
+// #2002: a bad timeout argument to channel-send/channel-receive used to be
+// blamed on a procedure named 'thread' -- the shared SRFI-18 helper's
+// hardcoded name, which does not exist in (kaappi fibers). Each caller now
+// passes its own name through timeoutToDeadlineNs.
+test "a bad channel timeout names the channel primitive, not 'thread' (#2002)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(guard (e (#t (error-object-message e))) (channel-receive (make-channel) 'bad))
+    );
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("\"type error in 'channel-receive': expected time object or number, got bad\"", s);
+
+    const send_msg = try vm.eval(
+        \\(guard (e (#t (if (and (string-contains (error-object-message e) "channel-send")
+        \\                        (not (string-contains (error-object-message e) "thread")))
+        \\                  'ok 'wrong-name)))
+        \\  (channel-send (make-channel) 1 'bad)
+        \\  'not-raised)
+    );
+    const s2 = try printer.valueToString(std.testing.allocator, send_msg, .write);
+    defer std.testing.allocator.free(s2);
+    try std.testing.expectEqualStrings("ok", s2);
+}

--- a/tests/scheme/audit/primitives_fiber-audit.scm
+++ b/tests/scheme/audit/primitives_fiber-audit.scm
@@ -126,6 +126,29 @@
     (raises? (lambda () (make-channel 100000000000000000000000))))
 (test-assert "make-channel's rejection names make-channel"
     (msg-has? (lambda () (make-channel -1)) "make-channel"))
+;; #2002: the capacity is stored as a u32, so a value that IS an exact
+;; integer outside [0, 2^32-1] is a range rejection — an argument error
+;; (KP3007) naming the real bound — never a type error. The old one-size
+;; typeError read "expected non-negative exact integer, got 4294967296",
+;; which argues against itself (4294967296 is exactly that) and hides the
+;; actual constraint. A bignum is always a range case: a fixnum already
+;; spans ±2^47, so anything bignum-sized dwarfs u32. Only a genuinely
+;; non-integer argument (1.0, 'x) stays a type error.
+(test-equal "an above-u32 capacity is an argument error, not a type error (#2002)"
+    'KP3007 (guard (e (#t (error-object-code e))) (make-channel 4294967296)))
+(test-assert "the above-u32 rejection names the real bound (#2002)"
+    (msg-has? (lambda () (make-channel 4294967296)) "4294967295"))
+(test-equal "a negative capacity is an argument error, not a type error (#2002)"
+    'KP3007 (guard (e (#t (error-object-code e))) (make-channel -1)))
+(test-assert "the negative rejection names the real bound too (#2002)"
+    (msg-has? (lambda () (make-channel -1)) "4294967295"))
+(test-equal "a bignum capacity is a range rejection, not a type error (#2002)"
+    'KP3007 (guard (e (#t (error-object-code e)))
+               (make-channel 100000000000000000000000)))
+(test-equal "an inexact capacity stays a type error (#2002)"
+    'KP3002 (guard (e (#t (error-object-code e))) (make-channel 1.0)))
+(test-equal "a symbol capacity stays a type error (#2002)"
+    'KP3002 (guard (e (#t (error-object-code e))) (make-channel 'x)))
 ;; Surplus arguments are silently ignored — matches the codebase-wide
 ;; convention for variadic primitives (string->number, make-vector,
 ;; thread-join!, make-mutex all do the same), so this pins the convention
@@ -239,6 +262,19 @@
 (test-equal "a timeout never discards an already-admitted send"
     'sent (let ((ch (make-channel 1)))
             (if (eq? (channel-send ch 'v 0 'TO) 'TO) 'timed-out 'sent)))
+;; #2002: a bad timeout argument used to be blamed on a procedure named
+;; 'thread' — the shared SRFI-18 helper's hardcoded name, which does not
+;; exist in (kaappi fibers) and is not imported by a program using only
+;; this library. Each caller now passes its own name through. A symbol
+;; timeout is still a type error (KP3002) — only the name was wrong.
+(test-assert "a bad channel-receive timeout names channel-receive, not 'thread' (#2002)"
+    (msg-has? (lambda () (channel-receive (make-channel) 'bad)) "channel-receive"))
+(test-assert "a bad channel-send timeout names channel-send, not 'thread' (#2002)"
+    (msg-has? (lambda () (channel-send (make-channel) 1 'bad)) "channel-send"))
+(test-equal "a bad timeout is still a type error (#2002)"
+    'KP3002 (guard (e (#t (error-object-code e))) (channel-receive (make-channel) 'bad)))
+(test-assert "a bad thread-join! timeout names thread-join!, not 'thread' (#2002)"
+    (msg-has? (lambda () (thread-join! (make-thread (lambda () 1)) 'bad)) "thread-join!"))
 
 ;;; --- spawn / fiber-join ---
 ;; native procedures are now accepted as spawn thunks (#1155)
@@ -338,6 +374,49 @@
 ;; a guard inside the fiber handles its own error normally
 (test-equal "a guard inside a fiber handles the fiber's own error"
     'handled (fiber-join (spawn (lambda () (guard (e (#t 'handled)) (error "x"))))))
+;; a guard inside the fiber catches a VM fault the same way it would
+;; outside one — the conversion the join path got in #2204 must not change
+;; what the fiber's own guard sees.
+(define five 5)
+(test-equal "a guard inside the fiber catches the fiber's own VM fault"
+    'handled (fiber-join (spawn (lambda () (guard (e (#t 'handled)) (car five))))))
+
+;;; --- #2204: a VM-level fault keeps its code and message across the fiber ---
+;; A fault that travels as a bare VMError (type error, unbound variable,
+;; bad index, arity mismatch) used to lose both its code and its message at
+;; the fiber boundary: the dispatch loop dropped the error tag, the detail
+;; in vm.last_error_detail was never copied into the fiber's saved state,
+;; and fiber-join re-raised a substituted KP3007 "fiber error (no
+;; exception value)" — a *different condition*, so a clause discriminating
+;; on the code could never match. The dispatch loop now converts the fault
+;; into the same coded error object a guard sees outside a fiber.
+(test-equal "CONTROL: the same fault outside a fiber is KP3002"
+    'KP3002 (guard (e (#t (error-object-code e))) (car five)))
+(test-equal "a fiber's type fault keeps its code (#2204)"
+    'KP3002 (guard (e (#t (error-object-code e)))
+               (fiber-join (spawn (lambda () (car five))))))
+(test-assert "a fiber's type fault keeps its message (#2204)"
+    (msg-has? (lambda () (fiber-join (spawn (lambda () (car five)))))
+              "type error in 'car': expected pair, got 5"))
+(test-equal "a fiber's unbound-variable fault keeps its code (#2204)"
+    'KP3001 (guard (e (#t (error-object-code e)))
+               (fiber-join (spawn (lambda () no-such-binding-2204)))))
+(test-equal "a fiber's index fault keeps its code (#2204)"
+    'KP3006 (guard (e (#t (error-object-code e)))
+               (fiber-join (spawn (lambda () (vector-ref (vector 1) 9))))))
+(test-equal "a fiber's call-arity fault keeps its code (#2204)"
+    'KP3003 (guard (e (#t (error-object-code e)))
+               (fiber-join (spawn (lambda () ((lambda (x) x)))))))
+;; an interposed yield makes no difference (dispatch vs. driven in place)
+(test-equal "a fault after a yield keeps its identity too (#2204)"
+    'KP3002 (guard (e (#t (error-object-code e)))
+               (fiber-join (spawn (lambda () (yield) (car five))))))
+;; like Scheme-level raises, re-raised identically on every join
+(test-equal "a fiber's VM fault is re-raised identically on every join (#2204)"
+    '(KP3002 KP3002)
+    (let ((f (spawn (lambda () (car five)))))
+      (list (guard (e (#t (error-object-code e))) (fiber-join f))
+            (guard (e (#t (error-object-code e))) (fiber-join f)))))
 
 ;;; --- D5: parking discipline (KEP-0001) ---
 ;; #1959: map/for-each and dynamic-wind are bootstrapped Scheme, not native


### PR DESCRIPTION
## What

Two issues in fiber error/argument reporting, one PR:

### #2204 — a VM-level fault in a fiber body loses its code and message

`(fiber-join (spawn (lambda () (car five))))` reported `KP3007 "fiber error (no exception value)"` — a *substituted* condition, not the real `KP3002 "type error in 'car': expected pair, got 5"` the identical expression produces outside a fiber. Three steps, per the issue's diagnosis: the dispatch loop's error arm (`src/fiber_wait.zig`) discarded the `VMError` tag; only `vm.current_exception` (the condition-object channel) crosses the fiber boundary via `saveCurrentFiber`; and `reraiseFiberError` substituted the placeholder.

**Fix:** the dispatch loop's error arm now converts the fault into a coded `ErrorObject` — using the same `nativeErrorToErrorObject` (newly `pub`) that `withExceptionHandlerFn` uses, so the error-coding boundaries cannot drift — *at the point of failure*, before `retireSlot`/`abandonFiberMutexes`/`wakeWaiters` or any later native call can overwrite `vm.last_error_detail`, and stages it in `vm.current_exception`, the one error channel `saveCurrentFiber` already transports into `fiber.current_exception` for the joiner to re-raise. GC-safe: the assignment lands directly in a marked VM root with no allocating call in between.

Deliberately unchanged: Scheme-level raises (already carried intact), `ContinuationInvoked` (control flow, not a fault), and uncatchable errors (`StackOverflow`, `ExecutionTimeout`, `Terminated` via `errors.isUncatchable`) which must not become catchable conditions (#1886).

| fault in the fiber body | before | after |
|---|---|---|
| `(car five)` | KP3007 placeholder | KP3002 `type error in 'car': expected pair, got 5` |
| unbound variable | KP3007 placeholder | KP3001 `undefined variable '...'` |
| `(vector-ref (vector 1) 9)` | KP3007 placeholder | KP3006 `vector-ref: index 9 out of range for length 1` |
| call arity mismatch | KP3007 placeholder | KP3003 `expected 1 arguments, got 0` |
| `(/ 1 0)`, `(error ...)`, `(raise ...)` | already correct | unchanged |

### #2002 — argument diagnostics misidentify the problem

1. `make-channel`'s u32 capacity range rejection was a *type* error whose text ("expected non-negative exact integer") described exactly the value it got, hiding the real bound. Now `argError` (KP3007): `"make-channel: capacity must be an exact integer between 0 and 4294967295, got 4294967296"`. A bignum is handled as the range case it is; only genuinely non-integer arguments (`1.0`, `'x`, `1/2`) stay `typeError`/KP3002.
2. A bad timeout to `channel-send`/`channel-receive` was blamed on a nonexistent procedure `'thread'` — `timeoutToDeadlineNs`'s hardcoded name. The caller now passes its own name through the helper, which also fixes the same message from `thread-join!`/`mutex-lock!`/`mutex-unlock!` timeouts. (`mutex-lock!`'s silently-accepted bad timeout remains, as the issue notes, a separate Phase 2.7 item.)

Also made `primitives.safeValueDescription` pub so the range rejection can name the offending value without duplicating the defensive renderer.

## Tests

- `tests/scheme/audit/primitives_fiber-audit.scm`: +20 assertions (129 → 149 passes) — fault codes/messages per class, interposed-yield, join-twice, guard-inside-fiber control, outside-fiber control, make-channel taxonomy/bound, timeout naming.
- `src/tests_fibers.zig`: +5 tests — exact code+message fidelity for `(car five)` (direct vs joined), per-class codes outside vs inside a fiber, join-twice, make-channel codes + bound substrings, timeout naming (including a negative check that `'thread'` no longer appears).

**Fail-without-fix verified** by stashing the five source fixes and keeping the tests: 15/20 new audit assertions and all 5 new Zig tests fail on the pre-fix tree; all pass with the fixes.

## Evidence

- `zig build test`: **1827/1834 pass, 7 skipped, 0 fail** (full suite, single foreground run)
- fiber filter under `-Dgc-stress=true`: 36/36
- Audit suites with the worktree binary: `primitives_fiber-audit` 149, `primitives_srfi18-audit` 287, `srfi18-deepcopy-matrix-audit` 127, `cross-thread-boundary-audit` 51 — all green
- All 22 `tests/scheme/smoke/fiber-*.scm` green
- `zig fmt --check` clean on every touched file

## BASELINE note (for reviewers)

The bare error-taxonomy gate moves **28 → 27**: `reraiseFiberError`'s fallback return is now annotated `bare-ok` — it sets its own detail via `setErrorDetail`, and since #2204 it is only reachable for uncatchable faults and conversion OOM. `.github/workflows/ci.yml` updated. Expected trivial conflict with sibling PRs touching the same line; resolve by re-counting on the rebased tree.

Closes #2204
Closes #2002

🤖 Generated with [Claude Code](https://claude.com/claude-code)
