### PR TITLE
control: align tail-position/dynamic-wind error taxonomy; purge %unwind-to-escape (#2036, #2037)

### DIFF
--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -266,7 +266,18 @@ fn compileSelfTailCall(self: *Compiler, expr: Value, dst: u16, nargs: u8) Compil
 
 pub fn compileApplyTail(self: *Compiler, expr: Value, dst: u16) CompileError!void {
     var arg_list = types.cdr(expr);
-    if (arg_list == types.NIL) return CompileError.InvalidSyntax;
+    // A *proper* operand list of the wrong length (< 2) is an arity question,
+    // not a syntax question: route the form through the ordinary call path so
+    // the native apply's runtime arity check reports KP3003 exactly as the
+    // same form one position away does (#2036). Only an improper list is
+    // malformed syntax.
+    {
+        var count: usize = 0;
+        var cur = arg_list;
+        while (types.isPair(cur)) : (cur = types.cdr(cur)) count += 1;
+        if (cur != types.NIL) return CompileError.InvalidSyntax;
+        if (count < 2) return compileCall(self, expr, dst, true);
+    }
 
     const needs_rebase = (dst + 1 != self.next_register);
     const base = if (needs_rebase) try self.allocReg() else dst;
@@ -276,14 +287,12 @@ pub fn compileApplyTail(self: *Compiler, expr: Value, dst: u16) CompileError!voi
 
     var nargs_count: usize = 0;
     while (arg_list != types.NIL) {
-        if (!types.isPair(arg_list)) return CompileError.InvalidSyntax;
         const arg_reg = try self.allocReg();
         try self.compileExprViaIR(types.car(arg_list), arg_reg, false);
         nargs_count += 1;
         arg_list = types.cdr(arg_list);
     }
 
-    if (nargs_count < 1) return CompileError.InvalidSyntax;
     if (nargs_count > 255) return CompileError.InternalLimit;
     const nargs: u8 = @intCast(nargs_count);
 
@@ -311,13 +320,21 @@ pub fn compileCallWithValuesTail(self: *Compiler, expr: Value, dst: u16) Compile
     // top-level redefinition of either name can affect this call (#1715;
     // the previous plain get_global/call_global-by-name approach only
     // ever protected against the former).
+    // A *proper* argument list of the wrong length is an arity question, not a
+    // syntax question: route the form through the ordinary call path so the
+    // runtime arity check reports KP3003 exactly as the same form one position
+    // away does (#2036). Only an improper list is malformed syntax.
+    {
+        var count: usize = 0;
+        var cur = types.cdr(expr);
+        while (types.isPair(cur)) : (cur = types.cdr(cur)) count += 1;
+        if (cur != types.NIL) return CompileError.InvalidSyntax;
+        if (count != 2) return compileCall(self, expr, dst, true);
+    }
     const args = types.cdr(expr);
-    if (args == types.NIL or !types.isPair(args)) return CompileError.InvalidSyntax;
     const producer = types.car(args);
     const rest = types.cdr(args);
-    if (rest == types.NIL or !types.isPair(rest)) return CompileError.InvalidSyntax;
     const consumer = types.car(rest);
-    if (types.cdr(rest) != types.NIL) return CompileError.InvalidSyntax;
 
     const needs_rebase = (dst + 1 != self.next_register);
     const base = if (needs_rebase) try self.allocReg() else dst;
@@ -348,10 +365,18 @@ pub fn compileCallWithValuesTail(self: *Compiler, expr: Value, dst: u16) Compile
 }
 
 pub fn compileCallCCTail(self: *Compiler, expr: Value, dst: u16) CompileError!void {
-    const args = types.cdr(expr);
-    if (args == types.NIL or !types.isPair(args)) return CompileError.InvalidSyntax;
-    const receiver = types.car(args);
-    if (types.cdr(args) != types.NIL) return CompileError.InvalidSyntax;
+    // A *proper* argument list of the wrong length is an arity question, not a
+    // syntax question: route the form through the ordinary call path so the
+    // runtime arity check reports KP3003 exactly as the same form one position
+    // away does (#2036). Only an improper list is malformed syntax.
+    {
+        var count: usize = 0;
+        var cur = types.cdr(expr);
+        while (types.isPair(cur)) : (cur = types.cdr(cur)) count += 1;
+        if (cur != types.NIL) return CompileError.InvalidSyntax;
+        if (count != 1) return compileCall(self, expr, dst, true);
+    }
+    const receiver = types.car(types.cdr(expr));
 
     const needs_rebase = (dst + 1 != self.next_register);
     const base = if (needs_rebase) try self.allocReg() else dst;

--- a/src/llvm_emit_forms.zig
+++ b/src/llvm_emit_forms.zig
@@ -1016,13 +1016,14 @@ pub fn emitPassthrough(self: *LLVMEmitter, expr: Value, is_tail: bool) EmitError
 //     define/set! of `apply` in this module marks it rebound and routes the
 //     form through an ordinary indirect call instead.
 //   - tail + unshadowed + unrebound + <2 operands → the interpreter's
-//     compileApplyTail raises InvalidSyntax at compile time; abandoning
-//     native compilation routes the enclosing form to that exact error. A
-//     REBOUND `apply` with too few operands is not this case: the
-//     interpreter routes it through the ordinary call path (its #2033
-//     gate), so the generic indirect call below is the matching behavior,
-//     and the user's own procedure (or the built-in arity check) raises at
-//     run time.
+//     compileApplyTail routes the form through the ordinary call path
+//     (#2036), so the built-in arity check raises at run time. Abandoning
+//     native compilation here stays the safe mirror: the eval fallback
+//     recompiles the enclosing form through that same ordinary path and
+//     produces the identical runtime error, so only the executing tier
+//     differs, never the diagnostic. A REBOUND `apply` with too few
+//     operands is the same story through the #2033 gate and the generic
+//     indirect call below.
 //   - everything else — lexically shadowed `apply` (any shape), a rebound
 //     `apply` (tail or non-tail), or a non-tail form with <2 operands — is
 //     an ordinary indirect call through whatever `apply` resolves to in

--- a/src/primitives_control.zig
+++ b/src/primitives_control.zig
@@ -37,6 +37,12 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "%push-wind", .func = &pushWindFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.internal) },
     .{ .name = "%pop-wind", .func = &popWindFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.internal) },
     .{ .name = "%unwind-to-escape", .func = &unwindToEscapeFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.internal) },
+    // Type-check gate for the bootstrapped dynamic-wind: raising through
+    // primitives.typeError stamps the KP3002 code and names the offending
+    // value in the message, where the Scheme-level `(error ...)` it replaces
+    // produced an uncoded object with the value demoted to an irritant
+    // (#2036). Purged from globals with its siblings below.
+    .{ .name = "%check-procedure", .func = &checkProcedureFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.internal) },
     // SRFI 248 (minimal delimited continuations): building blocks for the
     // portable (srfi 248) library. Not for direct use — see lib/srfi/248.sld.
     .{ .name = "%call-with-unwind-handler", .func = &callWithUnwindHandlerFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_248_primitives) },
@@ -548,9 +554,30 @@ fn pushWindFn(args: []const Value) PrimitiveError!Value {
 
 fn popWindFn(_: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
-    if (vm.wind_count == 0) return PrimitiveError.TypeError; // bare-ok: underflow
+    if (vm.wind_count == 0) {
+        // Internal invariant, not an argument problem: the wind stack lost
+        // sync with the bootstrapped dynamic-wind that owns it. KP9001
+        // ("internal error") per docs/dev/gc-safety-and-error-handling.md —
+        // a TypeError here used to surface as "type error in '%pop-wind'",
+        // blaming an argument of a primitive the user never wrote (#2037).
+        vm.setErrorDetail("wind stack underflow in '%pop-wind'", .{});
+        return PrimitiveError.InvalidBytecode;
+    }
     vm.wind_count -= 1;
     return types.VOID;
+}
+
+/// (%check-procedure name value) → value when value is a procedure, else the
+/// coded, value-naming type error a native primitive would raise. Exists so
+/// bootstrapped Scheme (dynamic-wind) can reject bad arguments exactly like
+/// its native siblings instead of an uncoded user `(error ...)` (#2036).
+fn checkProcedureFn(args: []const Value) PrimitiveError!Value {
+    const name: []const u8 = if (types.isString(args[0])) blk: {
+        const s = types.toObject(args[0]).as(types.SchemeString);
+        break :blk s.data[0..s.len];
+    } else "?";
+    if (!types.isProcedure(args[1])) return primitives.typeError(name, "procedure", args[1]);
+    return args[1];
 }
 
 /// Run the dynamic-wind after-thunks standing between here and where `k` — an

--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -719,6 +719,43 @@ test "every spec name resolves in globals (drift guard)" {
     }
 }
 
+test "purged %unwind-to-escape still resolves for guard's desugaring (#2037)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Purged from globals like its %push-wind sibling — user code cannot pop
+    // the wind stack out of sequence. But unlike the sibling it has a
+    // compile-time consumer: compileGuard emits a base-binding reference that
+    // resolves through libraries.internal_bindings, and the registrar's
+    // snapshot of globals runs only AFTER the purge, so vm_bootstrap.install
+    // seeds the entry itself. Dropping either half breaks every guard.
+    try std.testing.expect(vm.globals.get("%unwind-to-escape") == null);
+    try std.testing.expect(vm.libraries.internal_bindings.get("%unwind-to-escape") != null);
+    const r = try vm.eval("(guard (e (#t 42)) (raise 'boom))");
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(r));
+    // And the wind discipline survives the seeded path: the clauses must see
+    // the after-thunks of extents entered in the body already run (#1988).
+    const order = try vm.eval(
+        \\(let ((log '()))
+        \\  (guard (e (#t (set! log (cons 'clause log)) 'done))
+        \\    (dynamic-wind (lambda () (set! log (cons 'B log)))
+        \\                  (lambda () (raise 'x))
+        \\                  (lambda () (set! log (cons 'A log)))))
+        \\  (reverse log))
+    );
+    try std.testing.expect(types.isPair(order));
+    var it = order;
+    const expected = [_][]const u8{ "B", "A", "clause" };
+    for (expected) |name| {
+        try std.testing.expect(types.isSymbol(types.car(it)));
+        try std.testing.expectEqualStrings(name, types.symbolName(types.car(it)));
+        it = types.cdr(it);
+    }
+    try std.testing.expectEqual(types.NIL, it);
+}
+
 test "no standard library exports a %-prefixed internal (#1856)" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/src/vm_bootstrap.zig
+++ b/src/vm_bootstrap.zig
@@ -35,6 +35,16 @@ pub fn install(vm: *VM) VMError!void {
     {
         vm.globals_lock.lock();
         defer vm.globals_lock.unlock();
+        // %unwind-to-escape has a second consumer besides the closures above:
+        // guard's desugaring references it through a base-binding symbol, which
+        // resolves via libraries.internal_bindings (lookupBaseBinding), not
+        // globals. registerStandardLibraries snapshots that map from globals
+        // only AFTER this purge runs, so seed the entry here — removing the
+        // name from globals alone would leave every `guard` raising an
+        // undefined variable instead of unwinding to its clauses (#2037).
+        if (vm.globals.get("%unwind-to-escape")) |val| {
+            vm.libraries.internal_bindings.put("%unwind-to-escape", val) catch return VMError.OutOfMemory;
+        }
         for (internal_helpers) |name| {
             _ = vm.globals.remove(name);
         }
@@ -51,6 +61,8 @@ pub fn install(vm: *VM) VMError!void {
 pub const internal_helpers = [_][]const u8{
     "%push-wind",
     "%pop-wind",
+    "%unwind-to-escape",
+    "%check-procedure",
     "%promise-forced?",
     "%promise-forcing?",
     "%promise-value",
@@ -266,19 +278,19 @@ const string_map_src =
 ;
 
 // Validates all three arguments before running (before), so a bad-argument
-// call cannot leak before's side effects, and errors name 'dynamic-wind'
-// rather than the internal %push-wind (#1375).
+// call cannot leak before's side effects. The checks go through the native
+// %check-procedure so the rejection is the coded, value-naming type error
+// every native control primitive raises (KP3002), not an uncoded user error
+// (#2036); the name in the message stays 'dynamic-wind' rather than the
+// internal %push-wind (#1375).
 const dynamic_wind_src =
     \\(define dynamic-wind
     \\  (let ((%push-wind %push-wind) (%pop-wind %pop-wind)
-    \\        (procedure? procedure?) (not not) (error error))
+    \\        (%check-procedure %check-procedure))
     \\    (lambda (before thunk after)
-    \\      (if (not (procedure? before))
-    \\          (error "type error in 'dynamic-wind': expected procedure, got" before))
-    \\      (if (not (procedure? thunk))
-    \\          (error "type error in 'dynamic-wind': expected procedure, got" thunk))
-    \\      (if (not (procedure? after))
-    \\          (error "type error in 'dynamic-wind': expected procedure, got" after))
+    \\      (%check-procedure "dynamic-wind" before)
+    \\      (%check-procedure "dynamic-wind" thunk)
+    \\      (%check-procedure "dynamic-wind" after)
     \\      (before)
     \\      (%push-wind before after)
     \\      (let ((result (thunk)))

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -1359,7 +1359,15 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
                     return VMError.ContinuationInvoked;
                 } else {
-                    return VMError.NotAProcedure;
+                    // Match the non-tail path (callWithCurrentContinuation's
+                    // primitives.typeError): KP3002 naming call/cc and the
+                    // offending value. A detail-less NotAProcedure surfaced as
+                    // KP3005 with the literal message "error" (#2036).
+                    const p = @import("printer.zig");
+                    const s = p.valueToString(self.gc.allocator, receiver, .write) catch "";
+                    defer if (s.len > 0) self.gc.allocator.free(s);
+                    self.setErrorDetail("type error in 'call/cc': expected procedure, got {s}", .{if (s.len > 0) s else "?"});
+                    return VMError.TypeError; // bare-ok: detail set above
                 }
             },
             .tail_eval => {

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -1362,12 +1362,13 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     // Match the non-tail path (callWithCurrentContinuation's
                     // primitives.typeError): KP3002 naming call/cc and the
                     // offending value. A detail-less NotAProcedure surfaced as
-                    // KP3005 with the literal message "error" (#2036).
-                    const p = @import("printer.zig");
-                    const s = p.valueToString(self.gc.allocator, receiver, .write) catch "";
-                    defer if (s.len > 0) self.gc.allocator.free(s);
-                    self.setErrorDetail("type error in 'call/cc': expected procedure, got {s}", .{if (s.len > 0) s else "?"});
-                    return VMError.TypeError; // bare-ok: detail set above
+                    // KP3005 with the literal message "error" (#2036). Routed
+                    // through typeError itself so the rendering stays
+                    // byte-identical to the non-tail path (safeValueDescription:
+                    // bounded, cycle-safe, no allocation); mapNativeError only
+                    // synthesizes a detail when none is set.
+                    const perr = @import("primitives.zig").typeError("call/cc", "procedure", receiver);
+                    return vm_calls.mapNativeError(self, perr, "call/cc", &[_]Value{receiver});
                 }
             },
             .tail_eval => {

--- a/tests/scheme/audit/primitives_control-audit.scm
+++ b/tests/scheme/audit/primitives_control-audit.scm
@@ -645,35 +645,34 @@
              (begin (%pop-unwind-handler!) (%pop-unwind-handler!)
                     ;; a later raise must still reach the ordinary handler
                     (guard (e (#t #t)) (raise 'still-works))))
-(test-equal "%unwind-to-escape: a non-continuation is a named type error"
-            "type error in '%unwind-to-escape': expected escape continuation, got 42"
-            (raised-msg (%unwind-to-escape 42)))
-(test-assert "%unwind-to-escape: a full continuation is ignored"
-             (begin (call/cc (lambda (k) (%unwind-to-escape k))) #t))
-(test-assert "%unwind-to-escape: an expired escape continuation is ignored"
-             (let ((saved #f))
-               (call/ec (lambda (k) (set! saved k) 'in))
-               (begin (%unwind-to-escape saved) #t)))
-;; It really does run the intervening after-thunks — which is exactly why it
-;; must not be reachable from user code: the bootstrapped dynamic-wind that
-;; pushed those records then pops a stack that is already empty (#2037).
-(test-equal "%unwind-to-escape: it runs the after-thunks down to the escape's depth"
-            '(B1 B2 A2 A1)
+;; #2037: %unwind-to-escape pops dynamic-wind records off the VM's wind
+;; stack, so it exists for exactly one caller — the guard desugaring — and is
+;; purged from globals like %push-wind/%pop-wind. Direct calls used to be
+;; possible and desynchronised the wind stack (the underflow then surfaced as
+;; a type error naming %pop-wind); the assertions that pinned those direct
+;; calls are gone with the reachability.
+(test-equal "D1: %unwind-to-escape is purged from globals after bootstrap"
+            'KP3001 (raised-code (eval '(%unwind-to-escape 1) (interaction-environment))))
+(test-equal "D1: %check-procedure is purged from globals after bootstrap"
+            'KP3001 (raised-code (eval '(%check-procedure "dynamic-wind" 1)
+                                       (interaction-environment))))
+;; It still does its job through its one legitimate caller: a guard's
+;; clauses run in the guard's dynamic environment, so the after-thunks of
+;; every extent entered inside the body must run BEFORE the clause body
+;; (compileGuard's %unwind-to-escape, #1988). Plain unwinding would run the
+;; clause first — this shape is what distinguishes the two.
+(test-equal "%unwind-to-escape: via guard, after-thunks run before the clauses"
+            '(B1 B2 A2 A1 clause)
             (let ((log '()))
-              (guard (e (#t #t))
-                (call/ec (lambda (k)
-                           (dynamic-wind
-                             (lambda () (set! log (cons 'B1 log)))
-                             (lambda ()
-                               (dynamic-wind (lambda () (set! log (cons 'B2 log)))
-                                             (lambda () (%unwind-to-escape k) 'inner)
-                                             (lambda () (set! log (cons 'A2 log)))))
-                             (lambda () (set! log (cons 'A1 log)))))))
+              (guard (e (#t (set! log (cons 'clause log)) 'done))
+                (dynamic-wind
+                  (lambda () (set! log (cons 'B1 log)))
+                  (lambda ()
+                    (dynamic-wind (lambda () (set! log (cons 'B2 log)))
+                                  (lambda () (raise 'boom))
+                                  (lambda () (set! log (cons 'A2 log)))))
+                  (lambda () (set! log (cons 'A1 log)))))
               (reverse log)))
-;; FAIL: #2037 (%unwind-to-escape is reachable from user code and desynchronises
-;; the wind stack; the underflow surfaces as a type error naming %pop-wind)
-;; (test-equal "D1: %unwind-to-escape is purged from globals after bootstrap"
-;;             'KP3001 (raised-code (eval '(%unwind-to-escape 1) (interaction-environment))))
 
 ;;; ------------------------------------------------------------------
 ;;; D2 — error taxonomy for the control primitives
@@ -705,20 +704,51 @@
               (call/ec (lambda (k) (set! saved k) 'in))
               (raised-msg (saved 'x))))
 
-;; FAIL: #2036 (dynamic-wind's argument type errors carry no diagnostic code and
-;; drop the offending value, unlike every other control primitive)
-;; (test-equal "D2: dynamic-wind non-procedure before is KP3002"
-;;             'KP3002 (raised-code (dynamic-wind 1 (lambda () 2) (lambda () 3))))
-;; (test-equal "D2: dynamic-wind names the offending value"
-;;             "type error in 'dynamic-wind': expected procedure, got 1"
-;;             (raised-msg (dynamic-wind 1 (lambda () 2) (lambda () 3))))
-;; FAIL: #2036 (call/cc in tail position reports a non-procedure receiver as
-;; KP3005 with the bare message "error"; the same call non-tail gives KP3002)
-;; (test-equal "D2: call/cc non-procedure receiver is KP3002 in tail position too"
-;;             'KP3002 ((lambda () (raised-code (call/cc 42)))))
-;; (test-equal "D2: call/cc names itself and the offending value in tail position"
-;;             "type error in 'call/cc': expected procedure, got 42"
-;;             ((lambda () (raised-msg (call/cc 42)))))
+;; #2036: dynamic-wind's argument type errors carry the KP3002 code and name
+;; the offending value, like every other control primitive (the checks go
+;; through the native %check-procedure now, not an uncoded Scheme `error`).
+(test-equal "D2: dynamic-wind non-procedure before is KP3002"
+            'KP3002 (raised-code (dynamic-wind 1 (lambda () 2) (lambda () 3))))
+(test-equal "D2: dynamic-wind names the offending value"
+            "type error in 'dynamic-wind': expected procedure, got 1"
+            (raised-msg (dynamic-wind 1 (lambda () 2) (lambda () 3))))
+(test-equal "D2: dynamic-wind non-procedure after is KP3002"
+            'KP3002 (raised-code (dynamic-wind (lambda () 1) (lambda () 2) 3)))
+;; #2036: call/cc in tail position reports a non-procedure receiver exactly
+;; as the non-tail path does — KP3002 naming the value, not KP3005 "error".
+;; The receiver must sit in genuine tail position, hence the lambda wrapper.
+(test-equal "D2: call/cc non-procedure receiver is KP3002 in tail position too"
+            'KP3002 ((lambda () (raised-code (call/cc 42)))))
+(test-equal "D2: call/cc names itself and the offending value in tail position"
+            "type error in 'call/cc': expected procedure, got 42"
+            ((lambda () (raised-msg (call/cc 42)))))
+
+;; #2036: a proper operand list of the wrong length handed to a
+;; tail-dispatched name is a runtime arity error (KP3003), not a KP2001
+;; "invalid syntax" compile error that abandons the whole top-level form —
+;; the same form one position away always reported KP3003. The forms are
+;; built by eval so a residual compile error surfaces as a catchable error
+;; object instead of aborting this file.
+(test-equal "D2: (call/cc) in tail position is a runtime arity error"
+            'KP3003 (raised-code (eval '((lambda () (call/cc)))
+                                       (interaction-environment))))
+(test-equal "D2: (call/cc) in tail position names the procedure and counts"
+            "'call/cc': expected 1 arguments, got 0"
+            (guard (e (#t (error-object-message e)))
+              (eval '((lambda () (call/cc))) (interaction-environment))))
+(test-equal "D2: (call/cc f g) in tail position is a runtime arity error"
+            'KP3003 (raised-code (eval '((lambda () (call/cc 1 2)))
+                                       (interaction-environment))))
+(test-equal "D2: (call-with-values p) in tail position is a runtime arity error"
+            'KP3003 (raised-code (eval '((lambda () (call-with-values 42)))
+                                       (interaction-environment))))
+(test-equal "D2: (apply) in tail position is a runtime arity error"
+            'KP3003 (raised-code (eval '((lambda () (apply)))
+                                       (interaction-environment))))
+(test-equal "D2: (apply) in tail position names the procedure"
+            "'apply': expected at least 2 arguments, got 0"
+            (guard (e (#t (error-object-message e)))
+              (eval '((lambda () (apply))) (interaction-environment))))
 
 ;; call/cc in non-tail position is the discriminating control: it goes through
 ;; callWithCurrentContinuation rather than the tail_call_cc superinstruction.


### PR DESCRIPTION
## What

Two audit findings in the control-flow error paths, one PR:

### #2036 — three divergences

1. **`call/cc` in tail position** reported a non-procedure receiver as `KP3005` with the literal message `"error"` (`tail_call_cc`'s bare `return VMError.NotAProcedure`). The else arm now mirrors the non-tail path's `primitives.typeError`: `KP3002`, `"type error in 'call/cc': expected procedure, got 42"` — identical in both positions, like `call/ec` always was.
2. **`dynamic-wind`'s type errors** were bootstrapped Scheme `(error ...)`, so `error-object-code` answered `#f` and the offending value was an irritant, invisible in the message. The three checks now go through a new internal native `%check-procedure` (`primitives.typeError`), giving `KP3002` and `"type error in 'dynamic-wind': expected procedure, got 1"`. The native raise propagates through the same `nativeErrorToErrorObject` boundary every other primitive uses, so the code is stamped. Validation-before-`(before)` semantics (no leaked side effects, #1375) are unchanged.
3. **A wrong-arity call to a tail-dispatched name** — `compileCallCCTail` / `compileCallWithValuesTail` / `compileApplyTail` returned `CompileError.InvalidSyntax` for a *proper* operand list of the wrong length, so `(call/cc)`, `(call/cc a b)`, `(call-with-values p)`, `(apply)` in tail position were uncatchable KP2001 compile errors that abandoned the whole top-level form. Such lists now route through the ordinary call path (`compileCall`), so the runtime native arity check reports KP3003 (`"'call/cc': expected 1 arguments, got 0"`) exactly as the same form one position away always did. Improper lists (`(call/cc . 5)`) remain genuine KP2001 syntax errors. The native tier already lowered these names as ordinary calls, so this *removes* an interpreter/native divergence rather than adding one; the stale mirror comment in `llvm_emit_forms.zig` (`emitApplyForm`'s `<2 operands` case) is updated — its eval-fallback abandon produces the identical runtime diagnostic.

### #2037 — `%unwind-to-escape` reachability

Added to `vm_bootstrap.internal_helpers` and purged, so user code can no longer pop the wind stack out of sequence (the underflow used to surface as `type error in '%pop-wind'`). `popWindFn`'s underflow guard now reports KP9001 with `"wind stack underflow in '%pop-wind'"` — the internal-invariant tag `docs/dev/gc-safety-and-error-handling.md` prescribes — instead of a TypeError blaming an argument.

**Deviation from the issue's fix shape, found the hard way:** the issue claims compiler-generated `%unwind-to-escape` references resolve against `internal_bindings` as "the pristine snapshot taken before the purge". That ordering does not exist: `registerStandardLibraries` (which snapshots globals into `internal_bindings`) runs **after** `vm_bootstrap.install` purges, on every init path (`main.zig` ×2, `testing_helpers`, benches, LSP). Purging alone breaks every `guard` with `undefined variable '__kaappi_base__%unwind-to-escape'` — verified by temporarily removing the seed. `install()` therefore seeds `internal_bindings` itself, immediately before the remove; this is order-independent and also covers init paths that never register libraries.

## Tests

- `tests/scheme/audit/primitives_control-audit.scm`: the 4 disabled `FAIL: #2036` assertions enabled (dynamic-wind code+message ×2 incl. a new `after` variant, call/cc tail code+message), the disabled `#2037` purge assertion enabled, plus new `%check-procedure` purge and guard-driven after-thunk-ordering assertions, and 6 new tail-arity assertions (KP3003 code + exact messages for `(call/cc)`, `(call/cc 1 2)`, `(call-with-values 42)`, `(apply)` via `eval`, so a residual compile error surfaces as a catchable object instead of aborting the file). The three old direct-call `%unwind-to-escape` tests are gone with the reachability they pinned; the fourth (after-thunk depth) was passing vacuously after the purge and is rewritten to exercise `%unwind-to-escape` through its one legitimate caller (`guard`), where it distinguishes #1988's clause ordering from plain unwinding. Every enabled assertion's pre-fix value was captured on the baseline binary (KP3005 / `#f` / KP2001 / reachable) — each fails without its fix.
- `src/tests_libraries.zig`: new unit test locking the purge+seed pair (purged from globals, present in `internal_bindings`, `guard` works end-to-end with correct wind ordering). Removing the seed fails it.
- Evidence: audit file 200/200 pass; `zig build test` green (1823 passed, 7 skipped); R7RS suite 1395/0; `error-format.sh` 144/0 (its dynamic-wind message assertion still matches — the value moved from irritant into the message, same printed text); `error-object-code.sh` 12/0; all continuation suites; `guard-clause-dynamic-env-1988.scm` 23/23; `exit-wind.sh` 8/0; native tier exercised via `kaappi compile` (apply/guard/call/cc/dynamic-wind program) plus `native-apply-lowering-1803.sh` and `native-bootstrap-callbacks-1376.sh`.

## BASELINE note

Unchanged (28). The one bare `PrimitiveError.TypeError` this PR touches (`popWindFn`'s underflow) was already excluded via `bare-ok` and became a non-gated `InvalidBytecode`; the new `VMError.TypeError` in `tail_call_cc` carries `// bare-ok: detail set above`, matching the adjacent `tail_eval` precedent.

Closes #2036
Closes #2037

🤖 Generated with [Claude Code](https://claude.com/claude-code)
