### PR TITLE
Finish the SRFI 166 rework started in #2292: lazy trimmed/lazy, immutable state variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,7 +456,13 @@ jobs:
           #     tail-recursion fix past the 32,768 frame cap -- ~0.1 s plain,
           #     exit 124 stressed (measured quadratic: ~3 min at 40k on a
           #     fast machine); the n = 0 guard half of #2084 stays stressed
-          #     in srfi178-audit.scm.
+          #     in srfi178-audit.scm. srfi166-audit.scm streams a
+          #     50,000-element list through the token writer to pin #2344's
+          #     iterative (non-recursing) written/pretty stack-safety -- ~0.1 s
+          #     plain, exit 124 stressed since each emitted token allocates
+          #     against the whole live list (and its parallel lane starves a
+          #     sibling into a timeout too); the full 285-assertion audit still
+          #     runs unstressed on every other leg.
           #
           # (b) REAL BUGS THIS GATE FOUND ON ITS FIRST RUN -- excluded so the
           #     gate is green for everything else, exactly as the campaign
@@ -493,8 +499,8 @@ jobs:
           # cannot rot into a silent no-op.
           KAAPPI_GC_STRESS_SKIP: >-
             trampoline-polish-1375.scm srfi14.scm srfi264.scm
-            reader-port-refill-gaps.scm srfi178-segment-stack-2084.scm
-            srfi18-deepcopy-matrix-audit.scm
+            srfi166-audit.scm reader-port-refill-gaps.scm
+            srfi178-segment-stack-2084.scm srfi18-deepcopy-matrix-audit.scm
 
   riscv64-test:
     needs: format

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -747,6 +747,63 @@ view there too, which a literal R7RS vector cannot provide in portable Scheme
 documented scope reduction, unlike `array-flatten`, which the spec itself
 mandates as always a fresh copy regardless of source mode.
 
+### SRFI 166 — Monadic Formatting
+
+SRFI 166 ships as six libraries: `(srfi 166 base)` holds the entire state
+model and formatting core, and `(srfi 166)` re-exports base plus the four
+sub-libraries (`pretty`, `columnar`, `unicode`, `color`) from
+`lib/srfi/166/`. The #2292 rewrite put every state variable, `fn`/`with`
+macro, and formatter on one architecture: a state variable is a record
+carrying name/default/immutable (so `make-state-variable` is the real spec
+extension point, and `with!` errors on an immutable one because the spec
+allows "only dynamically bound with with"), the formatting state is a hash
+table keyed by the state-variable *object*, formatters mutate the state in
+place, and `with` restores exactly the variables it bound — which is why
+`col`/`row` survive a `with` while `forked`/`call-with-output` snapshot the
+whole table with `hash-table-copy`. Three constraints from that file that
+are invisible from the code and easy to break:
+
+1. **The writer streams token by token, and that is load-bearing.**
+   `%write-stream` calls `(emit string)` for every token ("(", each element,
+   separators, ")") rather than building one string; `written` and friends
+   thread each chunk through the `output` state variable. This is what makes
+   `trimmed/lazy` implementable at all: it installs a counting `output` hook
+   and, when the width budget is spent, unwinds the *generator itself* via a
+   `call/cc` escape — the spec's only mechanism that is "safe to use with an
+   infinite amount of output, e.g. from written-simply on an infinite
+   (circular) list". Regressing `%write-stream` back to whole-string
+   accumulation reinstates a hard KP3008 stack overflow on that case (the
+   audit pins it). Two related details: the list/vector spines are written
+   tail-recursively (a 50k-element list must not overflow), and
+   `trimmed/lazy` must restore the `output` binding on its escape path by
+   hand — a plain `with` skips its restore on a non-local exit, which would
+   strand the counting hook in the state for every later formatter.
+2. **`extract-shared-objects`' exit-event timing is the cycle/sharing
+   distinction.** The walk is an explicit enter/exit worklist (again so long
+   lists don't consume stack). An entry survives the `cyclic-only?` deletion
+   only if it was revisited *before* its first visit completed — that is a
+   cycle, kept for `written`'s datum labels; plain acyclic sharing re-visits
+   only after the exit event deleted the entry, so it re-counts from one and
+   `written` prints it duplicated, exactly like `write`, while
+   `written-shared` keeps it. Moving the delete earlier (e.g. to make the
+   cdr walk a tail call) misses cycles and hangs the writer on circular
+   data; moving it later labels sharing under plain `written`, which the
+   spec reserves for `-shared`.
+3. **Label numbers are assigned at first emission, not by the walk.** The
+   count stored in the shared table is a placeholder; `%gen-shared-ref`
+   overwrites it from a counter at the moment the label is first printed,
+   so numbering follows output order (`#0=` then `#0#`) regardless of hash
+   iteration order.
+
+A test-harness trap worth knowing: the library search order is explicit
+`--lib-path`, then the auto-added script dir, `~/.kaappi/lib`, and the
+exe-relative `zig-out/lib`, all *before* the cwd `lib/` fallback — so an
+installed or previously-built copy silently shadows edits to the source
+tree, and `zig build` (which re-installs `lib/` into `zig-out/lib`) must be
+rerun after every `.sld` edit. The shell suites isolate this with a temp
+`KAAPPI_HOME`; do the same when running
+`tests/scheme/srfi/srfi166-audit.scm` by hand.
+
 ### SRFI 63 — homogeneous and heterogeneous arrays
 
 SRFI 63 (homogeneous and heterogeneous arrays), the third piece of #1694's

--- a/lib/srfi/166/base.sld
+++ b/lib/srfi/166/base.sld
@@ -233,13 +233,18 @@
              st2)))))
 
     ;; with! is a procedure taking flat (state-var value) pairs and setting
-    ;; them permanently (the state variables are first-class values).
+    ;; them permanently (the state variables are first-class values).  An
+    ;; immutable state variable "can only be dynamically bound with with, and
+    ;; not set with with!" — with! on one is an error.
     (define (with! . bindings)
       (lambda (st)
         (let loop ((bs bindings))
           (if (null? bs)
               st
               (begin
+                (if (state-variable-immutable? (car bs))
+                    (error "with!: immutable state variable"
+                           (state-variable-name (car bs))))
                 (%st-set! st (car bs) (cadr bs))
                 (loop (cddr bs)))))))
 
@@ -449,10 +454,45 @@
     (define (fitted/both w . fmts)
       (padded/both w (apply trimmed/both (cons w fmts))))
 
-    ;; A non-lazy stand-in for trimmed/lazy: correct for finite output (the
-    ;; infinite-stream laziness has no observable effect for the finite tests).
+    ;; Spec: "a variant of trimmed which generates each fmt in left-to-right
+    ;; order, and truncates and terminates immediately if more than width
+    ;; characters are generated.  It does not output ellipsis.  Thus this is
+    ;; safe to use with an infinite amount of output, e.g. from
+    ;; written-simply on an infinite list."
+    ;;
+    ;; Laziness is realized through the `output` state variable: the writer
+    ;; streams one token at a time (see %write-stream), so a counting output
+    ;; hook sees each chunk as it is generated and, once the budget is spent,
+    ;; terminates the whole walk by invoking an escape continuation — no
+    ;; amount of further generation can follow.  The output binding is
+    ;; restored on both exit paths (a plain `with` would skip its restore on
+    ;; the escape path), and chunks are delegated to the output binding found
+    ;; on entry so nested uses compose.
     (define (trimmed/lazy w . fmts)
-      (apply trimmed/right (cons w fmts)))
+      (lambda (st)
+        (call/cc
+          (lambda (return)
+            (let ((kept 0)
+                  (saved (%st-ref st output)))
+              (define (finish st2)
+                (%st-set! st2 output saved)
+                (return st2))
+              (define (lazy-output str)
+                (lambda (st2)
+                  (let ((room (- w kept)))
+                    (cond
+                      ((<= room 0) (finish st2))
+                      ((<= (string-length str) room)
+                       (set! kept (+ kept (string-length str)))
+                       ((saved str) st2))
+                      (else
+                        (set! kept w)
+                        (finish ((saved (substring str 0 room)) st2)))))))
+              (let ((st2 (begin
+                           (%st-set! st output lazy-output)
+                           ((apply each fmts) st))))
+                (%st-set! st2 output saved)
+                st2))))))
 
     ;;; ================================================== escaping
 
@@ -689,27 +729,52 @@
 
     ;;; =============================================== shared structures
 
+    ;; Iterative depth-first walk (explicit enter/exit worklist) so a long
+    ;; list does not consume stack.  The `exit` event runs the same
+    ;; delete-if-not-revisited check the recursive original ran after a
+    ;; subtree completed -- and the timing of that check is exactly what
+    ;; distinguishes a cycle (revisited before its first visit completes, so
+    ;; the count is already 2 and the entry survives `cyclic-only?` deletion)
+    ;; from plain sharing (revisited only after the entry was deleted, so it
+    ;; is re-counted from 1 and is kept only when `cyclic-only?` is #f).
     (define (extract-shared-objects x cyclic-only?)
       (let ((seen (make-hash-table eq?)))
-        (let find ((x x))
-          (cond
-            ((or (pair? x) (vector? x))
-             (hash-table-update!/default seen x (lambda (n) (+ n 1)) 0)
-             (cond
-               ((> (hash-table-ref seen x) 1))
-               ((pair? x) (find (car x)) (find (cdr x)))
-               ((vector? x)
-                (let ((len (vector-length x)))
-                  (do ((i 0 (+ i 1))) ((= i len)) (find (vector-ref x i))))))
-             (if (and cyclic-only? (<= (hash-table-ref/default seen x 0) 1))
-                 (hash-table-delete! seen x)))))
-        (let ((res (make-hash-table eq?)) (count 0))
-          (hash-table-walk seen
-            (lambda (k v)
-              (cond ((> v 1)
-                     (hash-table-set! res k (cons count #f))
-                     (set! count (+ count 1))))))
-          (cons res 0))))
+        (let loop ((todo (list (cons 'enter x))))
+          (if (null? todo)
+              (let ((res (make-hash-table eq?)) (count 0))
+                (hash-table-walk seen
+                  (lambda (k v)
+                    (cond ((> v 1)
+                           (hash-table-set! res k (cons count #f))
+                           (set! count (+ count 1))))))
+                (cons res 0))
+              (let ((ev (car todo))
+                    (rest (cdr todo)))
+                (cond
+                  ((eq? (car ev) 'exit)
+                   (if (and cyclic-only?
+                            (<= (hash-table-ref/default seen (cdr ev) 0) 1))
+                       (hash-table-delete! seen (cdr ev)))
+                   (loop rest))
+                  ((not (or (pair? (cdr ev)) (vector? (cdr ev)))) (loop rest))
+                  (else
+                   (let ((x (cdr ev)))
+                     (hash-table-update!/default seen x (lambda (n) (+ n 1)) 0)
+                     (cond
+                       ((> (hash-table-ref seen x) 1) (loop rest))
+                       ((pair? x)
+                        (loop (cons (cons 'enter (car x))
+                                    (cons (cons 'enter (cdr x))
+                                          (cons (cons 'exit x) rest)))))
+                       (else
+                        (loop (let ((len (vector-length x)))
+                                (let build ((i (- len 1))
+                                            (acc (cons (cons 'exit x) rest)))
+                                  (if (< i 0)
+                                      acc
+                                      (build (- i 1)
+                                             (cons (cons 'enter (vector-ref x i))
+                                                   acc))))))))))))))))
 
     (define (%gen-shared-ref cell shares)
       (set-car! cell (cdr shares))
@@ -717,27 +782,16 @@
       (set-cdr! shares (+ (cdr shares) 1))
       (number->string (car cell)))
 
-    (define (%shared-ref-prefix obj shares proc)
-      (let ((cell (hash-table-ref/default (car shares) obj #f)))
-        (cond
-          ((and (pair? cell) (cdr cell))
-           (string-append "#" (number->string (car cell)) "#"))
-          ((pair? cell)
-           (string-append "#" (%gen-shared-ref cell shares) "=" (proc)))
-          (else (proc)))))
-
-    (define (%shared-ref-cdr obj shares proc)
-      (let ((cell (hash-table-ref/default (car shares) obj #f)))
-        (cond
-          ((and (pair? cell) (cdr cell))
-           (string-append ". #" (number->string (car cell)) "#"))
-          ((pair? cell)
-           (string-append ". #" (%gen-shared-ref cell shares) "=(" (proc) ")"))
-          (else (proc)))))
-
-    ;; Flatten obj to a string, labelling shared structure, with numbers
-    ;; formatted according to radix/precision.
-    (define (%write-flat obj shares radix precision)
+    ;; Stream obj to (emit string) one token at a time ("(", each element,
+    ;; separators, ")"), labelling shared structure per the `shares` table,
+    ;; with numbers formatted per radix/precision.  Chunked emission is what
+    ;; makes `trimmed/lazy` able to truncate and *terminate* an infinite
+    ;; generator such as written-simply on a circular list: emit runs after
+    ;; every token, so an `output` override observing the chunks can stop the
+    ;; walk.  The list/vector spines iterate tail-recursively so a long list
+    ;; does not consume stack (the previous whole-string builder recursed
+    ;; non-tail once per element).
+    (define (%write-stream obj shares radix precision emit)
       ;; Per the spec, `written` uses the radix only for 2/8/10/16 (the
       ;; readable radices), and fixed-point precision only when the radix is
       ;; 10.  Precision must not disable the radix branch for non-decimal
@@ -749,56 +803,84 @@
              (if precision (%number->string n 10 precision #f #f #f #f #f) (number->string n)))
             ((and cell (exact? n)) (string-append (cdr cell) (number->string n (car cell))))
             (else (%number->string n 10 precision #f #f #f #f #f)))))
-      (let wr ((obj obj))
-        (%shared-ref-prefix
-          obj shares
-          (lambda ()
-            (cond
-              ((pair? obj)
-               (string-append
-                 "("
-                 (let lp ((ls obj))
-                   (let ((rest (cdr ls)))
-                     (string-append
-                       (wr (car ls))
-                       (cond
-                         ((null? rest) "")
-                         ((pair? rest)
-                          (string-append " " (%shared-ref-cdr rest shares (lambda () (lp rest)))))
-                         (else (string-append " . " (wr rest)))))))
-                 ")"))
-              ((vector? obj)
-               (let ((len (vector-length obj)))
-                 (if (zero? len)
-                     "#()"
-                     (let loop ((i 0) (acc "#("))
-                       (if (= i len)
-                           (string-append acc ")")
-                           (loop (+ i 1)
-                                 (string-append acc (if (zero? i) "" " ")
-                                                (wr (vector-ref obj i)))))))))
-              ((number? obj) (write-number obj))
-              (else (%write-to-string obj)))))))
+      (define (emit-shared-cdr rest k)
+        ;; k continues the spine walk from rest's elements.
+        (let ((cell (hash-table-ref/default (car shares) rest #f)))
+          (cond
+            ((and (pair? cell) (cdr cell))
+             (emit (string-append ". #" (number->string (car cell)) "#")))
+            ((pair? cell)
+             (emit (string-append ". #" (%gen-shared-ref cell shares) "=("))
+             (k)
+             (emit ")"))
+            (else (k)))))
+      (define (wr obj)
+        (let ((cell (hash-table-ref/default (car shares) obj #f)))
+          (cond
+            ((and (pair? cell) (cdr cell))
+             (emit (string-append "#" (number->string (car cell)) "#")))
+            ((pair? cell)
+             (emit (string-append "#" (%gen-shared-ref cell shares) "="))
+             (wr-body obj))
+            (else (wr-body obj)))))
+      (define (wr-body obj)
+        (cond
+          ((pair? obj)
+           (emit "(")
+           (let lp ((ls obj))
+             (wr (car ls))
+             (let ((rest (cdr ls)))
+               (cond
+                 ((null? rest))
+                 ((pair? rest)
+                  (emit " ")
+                  (emit-shared-cdr rest (lambda () (lp rest))))
+                 (else (emit " . ") (wr rest)))))
+           (emit ")"))
+          ((vector? obj)
+           (emit "#(")
+           (let ((len (vector-length obj)))
+             (do ((i 0 (+ i 1)))
+                 ((= i len))
+               (if (positive? i) (emit " "))
+               (wr (vector-ref obj i))))
+           (emit ")"))
+          ((number? obj) (emit (write-number obj)))
+          (else (emit (%write-to-string obj)))))
+      (wr obj))
+
+    ;; Flatten obj to a single string: %write-stream accumulated in order.
+    ;; Used where a whole string is genuinely needed, e.g. pretty's
+    ;; does-it-fit decision.
+    (define (%write-flat obj shares radix precision)
+      (let ((acc '()))
+        (%write-stream obj shares radix precision
+                       (lambda (s) (set! acc (cons s acc))))
+        (apply string-append (reverse acc))))
+
+    ;; Stream obj's tokens through the `output` state variable, threading the
+    ;; state through each chunk.  `written` alone consults the `writer` state
+    ;; variable (it is the mapper for *automatic* formatting of non-string
+    ;; values via displayed's fallback; -shared/-simply are explicit).
+    (define (%write-to-state st obj shares)
+      (let ((cur (list st)))
+        (%write-stream obj shares (%st-ref st radix) (%st-ref st precision)
+                       (lambda (s) (set-car! cur (%output-string (car cur) s))))
+        (car cur)))
 
     (define (written obj)
       (lambda (st)
         (let ((w (%st-ref st writer)))
           (if w
               ((w obj) st)
-              (%output-string st
-                (%write-flat obj (extract-shared-objects obj #t)
-                             (%st-ref st radix) (%st-ref st precision)))))))
+              (%write-to-state st obj (extract-shared-objects obj #t))))))
 
     (define (written-shared obj)
       (lambda (st)
-        (%output-string st
-          (%write-flat obj (extract-shared-objects obj #f)
-                       (%st-ref st radix) (%st-ref st precision)))))
+        (%write-to-state st obj (extract-shared-objects obj #f))))
 
     (define (written-simply obj)
       (lambda (st)
-        (%output-string st
-          (%write-flat obj (extract-shared-objects #f #f)
-                       (%st-ref st radix) (%st-ref st precision)))))
+        (%write-to-state st obj (extract-shared-objects #f #f))))
 
     ))

--- a/tests/scheme/srfi/srfi166-audit.scm
+++ b/tests/scheme/srfi/srfi166-audit.scm
@@ -908,6 +908,154 @@
         (if (= i (string-length s)) n
             (loop (+ i 1) (if (char=? (string-ref s i) #\newline) (+ n 1) n)))))))
 
+;;; ================================ completing the #2292 rework
+
+;; Spec, (trimmed/lazy width fmt ...): "a variant of trimmed which generates
+;; each fmt in left-to-right order, and truncates and terminates immediately
+;; if more than width characters are generated.  It does not output ellipsis.
+;; Thus this is safe to use with an infinite amount of output, e.g. from
+;; written-simply on an infinite list."
+(test-equal "trimmed/lazy: truncates on the right like trimmed/right"
+  "abc" (show #f (trimmed/lazy 3 "abcdef")))
+(test-equal "trimmed/lazy: no ellipsis is output even when one is set"
+  "abc" (show #f (with (( ellipsis "...")) (trimmed/lazy 3 "abcdef"))))
+(test-equal "trimmed/lazy: a zero width outputs nothing"
+  "" (show #f (trimmed/lazy 0 "abc")))
+;; The defining property: the infinite generator must be TERMINATED, not just
+;; truncated after the fact -- a circular list under written-simply generates
+;; without end, so only lazy generation can answer at all.
+(test-equal "trimmed/lazy: terminates an infinite written-simply stream"
+  "(1 2 1 "
+  (let ((cyc (list 1 2)))
+    (set-cdr! (cdr cyc) cyc)
+    (show #f (trimmed/lazy 7 (written-simply cyc)))))
+;; ...and the output hook it rides on must be unbound again afterwards.
+(test-equal "trimmed/lazy: output after the form is not truncated"
+  "ab|z   " (show #f (trimmed/lazy 2 "abcdef") "|" (padded/right 4 "z")))
+
+;; Spec, (make-state-variable name default [immutable]): "Returns a new state
+;; variable suitable for use in fn and with, etc."; "If immutable is true, the
+;; state variable can only be dynamically bound with with, and not set with
+;; with!."
+(define %my-var (make-state-variable "my" 5))
+(test-equal "make-state-variable: the default is visible through fn"
+  "5" (show #f (fn ((v %my-var)) (displayed v))))
+(test-equal "make-state-variable: with binds and restores"
+  "9" (show #f (with (( %my-var 9)) (fn ((v %my-var)) (displayed v)))))
+(test-equal "make-state-variable: the binding does not escape with"
+  "95" (show #f (with (( %my-var 9)) (fn ((v %my-var)) (displayed v)))
+                  (fn ((v %my-var)) (displayed v))))
+(test-assert "make-state-variable: with! on an immutable variable is an error"
+  (not (ok? (lambda ()
+              (show #f (with! (make-state-variable "iv" 1 #t) 2) "x")))))
+(test-equal "make-state-variable: with may still bind an immutable variable"
+  "9"
+  (let ((iv (make-state-variable "iv" 1 #t)))
+    (show #f (with (( iv 9)) (fn ((v iv)) (displayed v))))))
+
+;; Spec, numeric/fitted: "Like numeric, but if the result doesn't fit in width
+;; using the current precision, output instead a string of hashes rather than
+;; showing an incorrectly truncated number."
+(test-equal "numeric/fitted: a value that fits is shown as is"
+  "1.25" (show #f (with (( precision 2)) (numeric/fitted 4 1.25))))
+(test-equal "numeric/fitted: an overflowing fixed-point value becomes hashes"
+  "#.##" (show #f (with (( precision 2)) (numeric/fitted 4 12.345))))
+(test-equal "numeric/fitted: precision 0 overflow is all hashes"
+  "##" (show #f (with (( precision 0)) (numeric/fitted 2 123.45))))
+
+;; Spec, joined/dot: "Like joined, but if the list is a dotted list, then
+;; formats the dotted value with dot-mapper instead."
+;; (show #f "(" (joined/dot displayed (lambda (dot) (each ". " dot))
+;;                          '(1 2 . 3) " ") ")")  =>  "(1 2 . 3)"
+(test-equal "joined/dot: the spec's dotted-list example"
+  "(1 2 . 3)"
+  (show #f "(" (joined/dot displayed (lambda (dot) (each ". " dot))
+                           '(1 2 . 3) " ") ")"))
+
+;; Spec, the writer state variable: "The mapper for automatic formatting of
+;; non-string/char values in top-level show, each and other formatters."
+(test-equal "writer: overriding it formats unhandled values"
+  "W" (show #f (with (( writer (lambda (x) (displayed "W")))) 42)))
+
+;; written labels cycles only -- plain (acyclic) sharing prints duplicated,
+;; like write.  Pins the exit-timing of the shared-object walk.
+(test-equal "written: plain acyclic sharing is not labelled"
+  "((1 2) (1 2))"
+  (let ((x (list 1 2))) (show #f (written (list x x)))))
+(test-equal "written: a cycle among sharing is labelled, the sharing is not"
+  "((1 2) ((1 2) #0=(#0#)))"
+  (let* ((y (list 1 2))
+         (c (list 0)))
+    (set-car! c c)
+    (show #f (written (list y (list y c))))))
+
+;; The shared-object walk and the token stream are both iterative: a long
+;; flat list neither overflows the stack nor has to fit in one string.
+;; KAAPPI_GC_STRESS_SKIP lists this file (reason (a), too slow under stress):
+;; this assertion streams 50,000 elements, each token allocating against the
+;; whole live list, which is quadratic under collection-on-every-allocation.
+(test-assert "written: a 50,000-element list does not overflow the stack"
+  (positive? (string-length (show #f (written (make-list 50000 'x))))))
+
+;; Spec, comma-sep: separators come from state variables too.
+(test-equal "numeric: the comma-sep state variable names the separator"
+  "1.234.567"
+  (show #f (with (( comma-rule 3) ( comma-sep #\.)) (numeric 1234567))))
+;; Spec, decimal-align: "an alignment for the decimal place ... useful for
+;; outputting tables of numbers" -- the points must land in one column.
+(test-equal "numeric: decimal-align aligns the decimal points"
+  "    1.50\n   22.50"
+  (show #f (with (( decimal-align 5) ( precision 2))
+                 (numeric 1.5) nl (numeric 22.5))))
+
+;; Spec, word-separator?: "A character predicate used to tokenize words for
+;; wrapped and justify", defaulting to char-whitespace?.
+(test-equal "wrapped: tokenizes on the word-separator? predicate"
+  "ab cd\nef gh"
+  (show #f (with (( width 5)
+                  ( word-separator? (lambda (c) (char=? c #\,))))
+                 (wrapped "ab,cd,ef,gh"))))
+
+;; Spec, escaped's renamer: "a procedure of one character which maps that
+;; character to its escape value".
+(test-equal "escaped: the renamer maps characters to their escape value"
+  "\\bbc"
+  (show #f (escaped "abc" #\" #\\ (lambda (c) (and (char=? c #\a) "b")))))
+
+;; Spec, string-terminal-width/wide: like string-terminal-width, "except the
+;; ambiguous-is-wide? parameter is treated as true" -- East Asian Ambiguous
+;; characters (here: Greek alpha) count as 2.
+(test-equal "string-terminal-width: an ambiguous character counts as 1"
+  1 (string-terminal-width "\x3b1;"))
+(test-equal "string-terminal-width/wide: an ambiguous character counts as 2"
+  2 (string-terminal-width/wide "\x3b1;"))
+(test-equal "substring-terminal-width/wide: wide-range selection"
+  "\xff41;\xff42;" (substring-terminal-width/wide fullwidth-abc 0 4))
+
+;; The SRFI's own worked example shape: a pretty-printed definition beside a
+;; justified docstring.  Every line carries the border, and the layout spans
+;; several lines at a narrow width.
+(test-assert "columnar: pretty beside justified, the spec's worked example"
+  (let ((s (show #f (with (( width 60))
+                          (columnar
+                            (pretty '(define (fold kons knil ls)
+                                       (if (null? ls)
+                                           knil
+                                           (fold kons (kons (car ls) knil)) (cdr ls))))
+                            " ; "
+                            (justified "The fundamental list recursion operator. kons is called for each element, knil is the seed."))))))
+    (and (> (count-lines s) 3)
+         (let every ((i 0) (ok #t))
+           (cond ((not ok) #f)
+                 ((= i (string-length s)) #t)
+                 ((and (char=? (string-ref s i) #\newline)
+                       (< (+ i 1) (string-length s)))
+                  (every (+ i 1)
+                         (contains? (substring s (+ i 1)
+                                               (min (string-length s) (+ i 61)))
+                                    " ; ")))
+                 (else (every (+ i 1) ok)))))))
+
 ;;; ============================================ export inventory (D1-shaped)
 
 ;; The spec's index lists names beyond the historical 50; each assertion below


### PR DESCRIPTION
## What remained broken after #2292, and what this fixes

#2292 restructured SRFI 166 into `lib/srfi/166/{base,pretty,columnar,unicode,color}.sld` and fixed the bulk of the v2 audit findings. Re-verifying all ten wave-2 issues against that tree (`origin/main` @ `645d2bba`, fresh ReleaseSafe build, isolated `KAAPPI_HOME`, cache cleared) shows **the audit already ran 259/259 green there** — the reported "~105 failures" reflects a pre-#2292 tree, not current main. Direct probes of every claim table in the ten issues found **two specified behaviors still missing**, both fixed here, plus under-covered spec examples now pinned.

### Fixed in this PR

1. **`trimmed/lazy` was a non-lazy alias of `trimmed/right`** (`lib/srfi/166/base.sld` had a comment admitting it). The spec's defining property — "safe to use with an infinite amount of output, e.g. from written-simply on an infinite list" — did not hold: `(show #f (trimmed/lazy 7 (written-simply circular-list)))` hit a hard, uncatchable **KP3008 stack overflow** inside the output capture. Now:
   - `%write-flat` was rewritten as a streaming `%write-stream` that emits one token at a time (`(`, each element, separators, `)`), and `written`/`written-shared`/`written-simply` thread each chunk through the `output` state variable. `%write-flat` survives as an accumulating wrapper for `pretty`'s fitting decision.
   - `trimmed/lazy` installs a counting `output` hook and, once the width budget is spent, **terminates the generator itself** via a `call/cc` escape — restoring the hook binding by hand on both exit paths (a plain `with` would skip its restore on the escape). No ellipsis is output, per spec.
   - Stack safety came with it: `extract-shared-objects` is now an explicit enter/exit worklist and the writer's spines are tail-recursive, so a 50,000-element list no longer overflows either (it did, pre-fix). The exit-event timing preserves the cycle-vs-sharing distinction exactly — `written` still labels only cycles, `written-shared` labels sharing (both now pinned by tests).
2. **`make-state-variable`'s `immutable` flag was stored but never enforced.** The spec: an immutable state variable "can only be dynamically bound with `with`, and not set with `with!`" — `with!` on one is now an error (and `with` still binds it, also pinned).

### Verify-and-close (already fixed by #2292 on main; evidence cited)

Every claim in these issues was re-verified against the new `lib/srfi/166/*` files before touching anything — via the 259 already-enabled audit assertions plus direct probes of each issue's full claim table:

- **#2066** (unicode stub): full EAW-wide/fullwidth=2, Mn/Cf=0, ANSI=0 model; `substring-terminal-width` returns a substring (all 8 spec examples); `terminal-aware` is a real `with` of `string-width`/`substring/width`/`substring/preserve`. This PR adds the `/wide` variant assertions the inventory-only checks missed.
- **#2065** (columnar): even width division, per-line borders, degenerate no-column case, `tabular` minimum widths, `wrapped` reads `width` and `word-separator?`, `wrapped/char` splits on characters, `justified` full-justifies, `line-numbers` streams through `columnar`/`from-file` (the nl(1) example). This PR adds a custom-`word-separator?` tokenization case.
- **#2064** (pretty): breaks datagrams across lines at `width`, round-trips, `written-shared`/`pretty-shared` label non-cyclic sharing. This PR adds the SRFI's own `columnar`+`pretty`+`justified` worked example (border on every line, multi-line layout).
- **#2063** (`displayed` on a formatter): returns it as is — audit case existed.
- **#2062** (ellipsis/string-width): all three ellipsis forms and the `string-width`-measured padding pass — audit cases existed.
- **#2061** (numeric family): radix+precision (`ff.00`), sign-rule `#t` and pair, comma-rule int/list, `decimal-sep`/`precision` state vars, all `numeric/comma` and `numeric/si` examples pass. This PR adds the `comma-sep` and `decimal-align` state-variable cases.
- **#2059** (escaped): no spurious delimiters, `esc-ch` `#f` doubling, `maybe-escaped` quoting on an embedded quote — all audit-pinned. This PR adds the `renamer` case.
- **#2058** (tab-to): on-a-stop no-op and zero width — audit cases existed.
- **#2056** (`with` restoring col/row): audit cases existed (with paired controls).
- **#2067**'s export inventory: all 15 names and `(srfi 166 base)` existed post-#2292; this PR completes the issue by making `trimmed/lazy` and `make-state-variable` behave as specified and pinning `numeric/fitted`'s three spec hash-examples, `joined/dot`'s spec example, the `writer` state variable, and `pretty-environment` reachability.

## Regression evidence

`tests/scheme/srfi/srfi166-audit.scm` grows 259 → **285 assertions**. On the pre-fix tree (`origin/main` @ `645d2bba` + this PR's tests, library change stashed) the audit **fails hard**: it aborts with an uncatchable KP3008 stack overflow at `trimmed/lazy: terminates an infinite written-simply stream`, after counted failures `trimmed/lazy: no ellipsis is output even when one is set` and `make-state-variable: with! on an immutable variable is an error` (the `written: a 50,000-element list` overflow abort follows the same way). With the fix: 285/285.

## Test results

- `tests/scheme/srfi/srfi166-audit.scm`: **285 pass, 0 fail**
- `bash tests/scheme/run-all.sh`: **717 scheme files pass, 0 fail** + R7RS suite **1395 pass, 0 fail**
- `zig build test`: **1744 pass, 7 skip** (unit) + 78 pass (thottam)
- `npx markdownlint-cli2` on the touched doc: clean

## Docs

`docs/dev/srfi-implementation-notes.md` gains a SRFI 166 section recording the constraints that are invisible from the code: the token-streaming writer as the foundation of `trimmed/lazy`, the exit-event timing that distinguishes cycles from sharing, emission-time label numbering, and the library search-order trap (`zig-out/lib` / `~/.kaappi/lib` shadow the source tree — rerun `zig build` after every `.sld` edit).

Closes #2067
Closes #2066
Closes #2065
Closes #2064
Closes #2063
Closes #2062
Closes #2061
Closes #2059
Closes #2058
Closes #2056

🤖 Generated with [Claude Code](https://claude.com/claude-code)
