### PR TITLE
records: carry field names on R7RS define-record-type rtds (#2088)

### DIFF
--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -907,12 +907,28 @@ pub fn compileDefineRecordType(self: *Compiler, args: Value, dst: u16) CompileEr
         forms = gc.allocPair(gc.makeList(&[_]Value{ define_sym, np, body }) catch return CompileError.OutOfMemory, forms) catch return CompileError.OutOfMemory;
     }
 
-    // Internal record type: (define __rt (%make-record-type "name" n))
+    // Internal record type: (define __rt (%make-record-type "name" n
+    //   (quote (("fname" . mutable?) ...)))) -- the quoted field-specs list
+    // carries the per-field metadata (#2088) in the same (name-string .
+    // mutable?) shape %make-record-type-descriptor uses, so the SRFI 237/240
+    // inspection layer sees this type's field names. Mutable iff the field's
+    // clause names a mutator (R7RS 5.5.1).
     {
         const mrt = globals_mod.baseBindingSymbol(gc, "%make-record-type") catch return CompileError.OutOfMemory;
         const ns = gc.allocString(spec.type_name) catch return CompileError.OutOfMemory;
         const nf = types.makeFixnum(@intCast(spec.field_count));
-        const init = gc.makeList(&[_]Value{ mrt, ns, nf }) catch return CompileError.OutOfMemory;
+
+        var spec_elems: [256]Value = undefined;
+        for (0..spec.field_count) |fi| {
+            const fname_str = gc.allocString(spec.field_names[fi]) catch return CompileError.OutOfMemory;
+            const fmut = if (spec.mutator_names[fi] != null) types.TRUE else types.FALSE;
+            spec_elems[fi] = gc.allocPair(fname_str, fmut) catch return CompileError.OutOfMemory;
+        }
+        const specs_list = gc.makeList(spec_elems[0..spec.field_count]) catch return CompileError.OutOfMemory;
+        const quote_sym = gc.allocSymbol("quote") catch return CompileError.OutOfMemory;
+        const quoted_specs = gc.makeList(&[_]Value{ quote_sym, specs_list }) catch return CompileError.OutOfMemory;
+
+        const init = gc.makeList(&[_]Value{ mrt, ns, nf, quoted_specs }) catch return CompileError.OutOfMemory;
         const rt_sym = gc.allocSymbol(internal_name) catch return CompileError.OutOfMemory;
         forms = gc.allocPair(gc.makeList(&[_]Value{ define_sym, rt_sym, init }) catch return CompileError.OutOfMemory, forms) catch return CompileError.OutOfMemory;
     }

--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -324,11 +324,14 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
             if (rt.parent == null and rt.own_field_count == 0 and rt.uid == null and
                 !rt.sealed and !rt.is_opaque and !rt.has_protocol)
             {
-                // Plain R7RS record type (the common case) -- no SRFI 237
-                // metadata to carry across. `has_protocol` joins the guard
-                // rather than being copied afterwards: allocRecordType makes
-                // a type with no SRFI 237 metadata at all, so a type that has
-                // any must take the slow path below.
+                // Count-only record type (%make-record-type with no field
+                // specs) -- no metadata of any kind to carry across. R7RS
+                // define-record-type types carry field names since #2088,
+                // so they take the slow path below, as SRFI 237 types
+                // always have. `has_protocol` joins the guard rather than
+                // being copied afterwards: allocRecordType makes a type
+                // with no metadata at all, so a type that has any must take
+                // the slow path below.
                 const new_val = try gc.allocRecordType(rt.name, rt.num_fields);
                 carryIdentity(rt, new_val);
                 try visited.put(src_ptr, new_val);

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -304,8 +304,10 @@ const core_specs = [_]PrimSpec{
     .{ .name = "symbol->string", .func = &symbolToString, .arity = .{ .exact = 1 }, .libs = BR },
     // The record substrate `define-record-type`'s desugarer emits and the
     // portable record SRFIs (57/131/136/150/237) call directly. Internal,
-    // not `(scheme base)` exports (kaappi#1856).
-    .{ .name = "%make-record-type", .func = &makeRecordTypeFn, .arity = .{ .exact = 2 }, .libs = INTERNAL_PUBLIC },
+    // not `(scheme base)` exports (kaappi#1856). %make-record-type's third
+    // argument (per-field metadata, #2088) is optional so count-only
+    // callers keep working.
+    .{ .name = "%make-record-type", .func = &makeRecordTypeFn, .arity = .{ .range = .{ .min = 2, .max = 3 } }, .libs = INTERNAL_PUBLIC },
     .{ .name = "%make-record", .func = &makeRecordFn, .arity = .{ .variadic = 1 }, .libs = INTERNAL_PUBLIC },
     .{ .name = RECORD_CHECK, .func = &recordCheckFn, .arity = .{ .exact = 2 }, .libs = INTERNAL_PUBLIC },
     .{ .name = "%record-ref", .func = &recordRefFn, .arity = .{ .exact = 3 }, .libs = INTERNAL_PUBLIC },
@@ -1249,12 +1251,57 @@ fn applyFn(args: []const Value) PrimitiveError!Value {
 
 fn makeRecordTypeFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    // args[0] = name (string), args[1] = num_fields (fixnum)
+    // args[0] = name (string), args[1] = num_fields (fixnum), and optionally
+    // args[2] = per-field metadata: a list of (name-string . mutable?) pairs,
+    // the same shape %make-record-type-descriptor's field-specs argument
+    // uses. Present exactly when the emitting define-record-type desugarer
+    // knows the field names (#2088 -- the R7RS paths joined the R6RS and
+    // procedural ones); absent for count-only callers.
     const name_data = try expectString("%make-record-type", args[0]);
     const nf = try expectFixnum("%make-record-type", args[1]);
     if (nf < 0 or nf > 255) return PrimitiveError.TypeError; // bare-ok: internal record primitive
     const num_fields: u8 = @intCast(nf);
-    return gc.allocRecordType(name_data, num_fields) catch return PrimitiveError.OutOfMemory;
+
+    if (args.len == 2) {
+        return gc.allocRecordType(name_data, num_fields) catch return PrimitiveError.OutOfMemory;
+    }
+
+    var field_names_buf: [256][]const u8 = undefined;
+    var field_mutable_buf: [256]bool = undefined;
+    var field_count: usize = 0;
+    var specs_cur = args[2];
+    while (specs_cur != types.NIL) {
+        if (!types.isPair(specs_cur)) return typeError("%make-record-type", "list", args[2]);
+        const entry = types.car(specs_cur);
+        if (!types.isPair(entry)) return typeError("%make-record-type", "(name . mutable?) pair", entry);
+        if (field_count >= 255) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+        field_names_buf[field_count] = try expectString("%make-record-type", types.car(entry));
+        field_mutable_buf[field_count] = types.cdr(entry) != types.FALSE;
+        field_count += 1;
+        specs_cur = types.cdr(specs_cur);
+    }
+    // The count and the specs describe one type; disagreeing is an invalid
+    // argument combination, not a type error.
+    if (field_count != nf) {
+        return argError(
+            "%make-record-type",
+            "field-specs list has {d} entries but the declared field count is {d}",
+            .{ field_count, nf },
+        );
+    }
+
+    // A parentless, generative, transparent type: %make-record-type has no
+    // way to ask for anything else, so TooManyFields is unreachable here
+    // (both the count and the specs list are capped at 255 above).
+    return gc.allocRecordTypeExtended(
+        name_data,
+        null,
+        field_names_buf[0..field_count],
+        field_mutable_buf[0..field_count],
+        null,
+        false,
+        false,
+    ) catch return PrimitiveError.OutOfMemory;
 }
 
 fn makeRecordFn(args: []const Value) PrimitiveError!Value {

--- a/src/tests_records.zig
+++ b/src/tests_records.zig
@@ -481,3 +481,65 @@ test "equal? records hash alike; different record types hash apart" {
     try std.testing.expectEqual(hashtable.valueHash(a1), hashtable.valueHash(a2));
     try std.testing.expect(hashtable.valueHash(a1) != hashtable.valueHash(b1));
 }
+
+// #2088: the R7RS positional define-record-type path populated no field
+// metadata, so record-type-field-names (SRFI 237/240 inspection) returned #()
+// and record-accessor/record-mutator/record-field-mutable? were unusable on
+// such rtds. The desugarer now records each field's name and mutability
+// (mutable iff the field's clause names a mutator, R7RS 5.5.1) on the rtd --
+// for the top-level handler AND the body-context desugarer below.
+test "R7RS define-record-type records field names and mutability on the rtd" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval(
+        \\(define-record-type <pt> (mk-pt x y) pt?
+        \\  (x pt-x) (y pt-y set-pt-y!))
+    );
+
+    const rt_val = vm.globals.get(" __record_type_<pt>") orelse
+        return error.TestUnexpectedResult;
+    const rt = types.toObject(rt_val).as(types.RecordType);
+    try std.testing.expectEqual(@as(usize, 2), rt.own_field_names.len);
+    try std.testing.expectEqualStrings("x", rt.own_field_names[0]);
+    try std.testing.expectEqualStrings("y", rt.own_field_names[1]);
+    try std.testing.expectEqual(@as(usize, 2), rt.own_field_mutable.len);
+    try std.testing.expect(!rt.own_field_mutable[0]);
+    try std.testing.expect(rt.own_field_mutable[1]);
+}
+
+test "body-local R7RS define-record-type records field names too" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // The lambda body's leading define-record-type goes through the
+    // body-scanning desugarer (expandRecordTypeDefines), whose generated
+    // %make-record-type call must carry the field specs as well. The
+    // accessors it defines are locals of the body, so the rtd is reached
+    // through an instance (the same route the SRFI 237 inspection layer
+    // takes).
+    _ = try vm.eval(
+        \\(define (make-lp a b)
+        \\  (define-record-type <lp> (mk-lp u v) lp? (u lp-u) (v lp-v))
+        \\  (mk-lp a b))
+    );
+    const result = try vm.eval(
+        \\(let ((rtd (%record-rtd (make-lp 1 2))))
+        \\  (list (%record-type-field-names rtd)
+        \\        (%record-field-mutable? rtd 0)
+        \\        (%record-field-mutable? rtd 1)))
+    );
+    try std.testing.expect(types.isPair(result));
+    const names = types.car(result);
+    try std.testing.expect(types.isSymbol(types.car(names)));
+    try std.testing.expectEqualStrings("u", types.symbolName(types.car(names)));
+    try std.testing.expect(types.isSymbol(types.car(types.cdr(names))));
+    try std.testing.expectEqualStrings("v", types.symbolName(types.car(types.cdr(names))));
+    try std.testing.expect(types.isNil(types.cdr(types.cdr(names))));
+    try std.testing.expectEqual(types.FALSE, types.car(types.cdr(result)));
+    try std.testing.expectEqual(types.FALSE, types.car(types.cdr(types.cdr(result))));
+}

--- a/src/types_record.zig
+++ b/src/types_record.zig
@@ -52,8 +52,11 @@ pub const RecordType = struct {
     /// RecordInstance.fields. Equals own_field_count for an R7RS record
     /// type (no parent).
     num_fields: u8,
-    /// Length of own_field_names / own_field_mutable below. 0 for a plain
-    /// R7RS record type, which doesn't track individual field metadata.
+    /// Length of own_field_names / own_field_mutable below. 0 only for a
+    /// count-only type (`%make-record-type` without field specs); every
+    /// define-record-type path -- the R7RS positional one included, since
+    /// #2088 -- records its fields, so the SRFI 237/240 inspection layer
+    /// sees them.
     own_field_count: u8 = 0,
     /// SRFI 237 inheritance. The only Value-bearing/heap-pointer field on
     /// this struct -- traced in gc_collect.zig's referencesYoung,

--- a/src/vm_records.zig
+++ b/src/vm_records.zig
@@ -26,10 +26,28 @@ pub fn handleDefineRecordType(vm: *VM, args: Value) VMError!Value {
     const all_field_count = spec.field_count;
     const ctor_field_count = spec.ctor_field_count;
 
-    const num_fields: u8 = @intCast(all_field_count);
+    // Field metadata (#2088): the rtd reports its field names/mutability to
+    // the SRFI 237/240 inspection layer exactly like the R6RS-clause and
+    // procedural paths do, so record-type-field-names answers the real
+    // names instead of #() and record-accessor/record-mutator work. R7RS
+    // 5.5.1: a field is mutable iff its clause names a mutator.
+    var field_mutable_buf: [256]bool = undefined;
+    for (0..all_field_count) |fi| {
+        field_mutable_buf[fi] = spec.mutator_names[fi] != null;
+    }
 
-    // Create the RecordType value
-    var rt_val = vm.gc.allocRecordType(type_name, num_fields) catch return VMError.OutOfMemory;
+    // Create the RecordType value (no parent/uid/sealed/opaque: an R7RS
+    // record type has none of those concepts, so this stays generative and
+    // transparent no matter what metadata it now carries).
+    var rt_val = vm.gc.allocRecordTypeExtended(
+        type_name,
+        null,
+        spec.field_names[0..all_field_count],
+        field_mutable_buf[0..all_field_count],
+        null,
+        false,
+        false,
+    ) catch return VMError.OutOfMemory;
     vm.gc.pushRoot(&rt_val);
     defer vm.gc.popRoot();
 
@@ -1040,12 +1058,30 @@ pub fn expandRecordTypeDefines(
     gc.no_collect += 1;
     errdefer gc.no_collect -= 1;
 
-    // 1. (define __rt (%make-record-type "name" num_fields))
+    // 1. (define __rt (%make-record-type "name" num_fields
+    //      (quote (("fname" . mutable?) ...))))
+    //
+    // The quoted field-specs list is the same (name-string . mutable?)
+    // shape %make-record-type-descriptor's fields argument uses, carrying
+    // this definition's per-field metadata (#2088) so the inspection layer
+    // sees the type's names. Mutable iff the field's clause names a
+    // mutator (R7RS 5.5.1).
     {
         const mrt_sym = globals_mod.baseBindingSymbol(gc, "%make-record-type") catch return CompileError.OutOfMemory;
         const name_str = gc.allocString(spec.type_name) catch return CompileError.OutOfMemory;
         const nf_val = types.makeFixnum(@intCast(spec.field_count));
-        def_inits[count.*] = gc.makeList(&[_]Value{ mrt_sym, name_str, nf_val }) catch return CompileError.OutOfMemory;
+
+        var spec_elems: [256]Value = undefined;
+        for (0..spec.field_count) |fi| {
+            const fname_str = gc.allocString(spec.field_names[fi]) catch return CompileError.OutOfMemory;
+            const fmut = if (spec.mutator_names[fi] != null) types.TRUE else types.FALSE;
+            spec_elems[fi] = gc.allocPair(fname_str, fmut) catch return CompileError.OutOfMemory;
+        }
+        const specs_list = gc.makeList(spec_elems[0..spec.field_count]) catch return CompileError.OutOfMemory;
+        const quote_sym = gc.allocSymbol("quote") catch return CompileError.OutOfMemory;
+        const quoted_specs = gc.makeList(&[_]Value{ quote_sym, specs_list }) catch return CompileError.OutOfMemory;
+
+        def_inits[count.*] = gc.makeList(&[_]Value{ mrt_sym, name_str, nf_val, quoted_specs }) catch return CompileError.OutOfMemory;
         def_names[count.*] = internal_name;
         extra_roots.append(gc.allocator, def_inits[count.*]) catch return CompileError.OutOfMemory;
         count.* += 1;

--- a/tests/scheme/audit/internal-primitives-audit.scm
+++ b/tests/scheme/audit/internal-primitives-audit.scm
@@ -123,9 +123,24 @@
 (test-assert "rt: valid"     (%record-type? (%make-record-type "T" 2)))
 (test-assert "rt: 0 fields"  (%record-type? (%make-record-type "T" 0)))
 (test-assert "rt: 255 max"   (%record-type? (%make-record-type "T" 255)))
-;; arity (KP3003)
+;; arity (KP3003). 3 arguments is legal since #2088 gave the primitive an
+;; optional per-field metadata list -- the same (name . mutable?) pair shape
+;; %make-record-type-descriptor's field-specs use -- so "too many" starts at 4.
 (test-assert "rt: too few"   (raises? (%make-record-type "T")))
-(test-assert "rt: too many"  (raises? (%make-record-type "T" 2 3)))
+(test-assert "rt: too many"  (raises? (%make-record-type "T" 2 '() 4)))
+;; the optional per-field metadata list (#2088)
+(test-assert "rt: field specs make an rtd"
+             (%record-type? (%make-record-type "T" 2 '(("a" . #f) ("b" . #t)))))
+(test-equal "rt: field specs record the names"
+            '(a b)
+            (%record-type-field-names (%make-record-type "T" 2 '(("a" . #f) ("b" . #t)))))
+(test-assert "rt: field specs record mutability"
+             (%record-field-mutable? (%make-record-type "T" 1 '(("a" . #t))) 0))
+(test-assert "rt: field specs see immutability"
+             (not (%record-field-mutable? (%make-record-type "T" 1 '(("a" . #f))) 0)))
+(test-assert "rt: specs disagreeing with the count rejected"
+             (raises? (%make-record-type "T" 2 '(("a" . #f)))))
+(test-assert "rt: specs not a list rejected" (raises? (%make-record-type "T" 2 3)))
 ;; type, each position independently
 (test-assert "rt: name not string" (raises? (%make-record-type 'T 2)))
 (test-assert "rt: count not int"   (raises? (%make-record-type "T" 'x)))

--- a/tests/scheme/srfi/srfi240-audit.scm
+++ b/tests/scheme/srfi/srfi240-audit.scm
@@ -7,12 +7,13 @@
 ;;; record types", with everything else inherited from SRFI 237.
 ;;;
 ;;; That interoperability claim is what this file tests, and it is where the
-;;; finding is: a record type created by R7RS positional `define-record-type`
-;;; reports ZERO field names to the SRFI 237/240 inspection layer, so
-;;; record-type-field-names lies (#() rather than the fields the type has) and
-;;; record-accessor / record-mutator / record-field-mutable? are unusable on
-;;; it. The R6RS-clause and procedural paths are both correct, which is the
-;;; discriminating control. Filed as #2088.
+;;; finding was: a record type created by R7RS positional `define-record-type`
+;;; reported ZERO field names to the SRFI 237/240 inspection layer, so
+;;; record-type-field-names lied (#() rather than the fields the type has) and
+;;; record-accessor / record-mutator / record-field-mutable? were unusable on
+;;; it. The R6RS-clause and procedural paths were both correct, which is the
+;;; discriminating control. Filed as #2088, fixed by populating the rtd's
+;;; field metadata on the R7RS path.
 ;;;
 ;;; The pre-existing tests/scheme/srfi/srfi240.scm has 12 assertions and never
 ;;; touches 17 of the 23 exports.
@@ -153,8 +154,8 @@
 
 ;;; ------------------------------------------------------------------
 ;;; R7RS positional syntax. `record?`, `record-rtd`, `record-type-name` and a
-;;; derived `record-constructor` all work, so the type IS visible to the
-;;; inspection layer — but its field metadata is empty.
+;;; derived `record-constructor` all work; since #2088's fix the rtd also
+;;; carries its field metadata, so the whole inspection layer works too.
 ;;; ------------------------------------------------------------------
 
 (define-record-type <r7> (make-r7 x y) r7? (x r7-x) (y r7-y set-r7-y!))
@@ -177,29 +178,44 @@
              (r7? ((record-constructor
                     (make-record-constructor-descriptor (record-rtd r7) #f #f)) 1 2)))
 
-;; FAIL: #2088 (an R7RS define-record-type produces an rtd with zero own field
-;;              names, so the SRFI 237/240 inspection layer cannot see its fields)
-;; (test-equal "an R7RS record reports its field names"
-;;             '#(x y) (record-type-field-names (record-rtd r7)))
-;; FAIL: #2088
-;; (test-equal "record-accessor works on an R7RS record"
-;;             1 ((record-accessor (record-rtd r7) 0) r7))
-;; FAIL: #2088
-;; (test-assert "record-field-mutable? works on an R7RS record"
-;;              (not (record-field-mutable? (record-rtd r7) 0)))
-;; FAIL: #2088
-;; (test-assert "record-mutator works on an R7RS record's mutable field"
-;;              (procedure? (record-mutator (record-rtd r7) 1)))
+;; #2088 (fixed): an R7RS define-record-type's rtd carries its field
+;; names/mutability, so the SRFI 237/240 inspection layer sees its fields.
+(test-equal "an R7RS record reports its field names"
+            '#(x y) (record-type-field-names (record-rtd r7)))
+(test-equal "record-accessor works on an R7RS record"
+            1 ((record-accessor (record-rtd r7) 0) r7))
+(test-equal "record-accessor reaches the second field of an R7RS record"
+            2 ((record-accessor (record-rtd r7) 1) r7))
+(test-assert "record-field-mutable? works on an R7RS record"
+             (not (record-field-mutable? (record-rtd r7) 0)))
+(test-assert "record-field-mutable? sees the mutable field of an R7RS record"
+             (record-field-mutable? (record-rtd r7) 1))
+(test-equal "record-mutator works on an R7RS record's mutable field"
+            9 (let ((m (record-mutator (record-rtd r7) 1))) (m r7 9) (r7-y r7)))
+(test-assert "record-mutator on an R7RS record's immutable field is rejected"
+             (raises? (lambda () (record-mutator (record-rtd r7) 0))))
+(test-assert "record-accessor by name works on an R7RS record"
+             (= 1 ((record-accessor (record-rtd r7) 'x) r7)))
+(test-assert "record-accessor with an out-of-range index is still rejected"
+             (raises? (lambda () (record-accessor (record-rtd r7) 5))))
 
-;; The observed behaviour, pinned so the fix flips these too.
-(test-equal "an R7RS record's rtd currently reports zero field names"
-            '#() (record-type-field-names (record-rtd r7)))
-(test-assert "record-accessor on an R7RS record's rtd currently raises"
-             (raises? (lambda () (record-accessor (record-rtd r7) 0))))
-(test-assert "record-field-mutable? on an R7RS record's rtd currently raises"
-             (raises? (lambda () (record-field-mutable? (record-rtd r7) 0))))
-(test-assert "record-mutator on an R7RS record's rtd currently raises"
-             (raises? (lambda () (record-mutator (record-rtd r7) 1))))
+;; A record type with zero fields legitimately reports zero names -- the
+;; fix must not invent any, and an empty #() stays empty for the right
+;; reason (there are no fields), not the wrong one (metadata was dropped).
+(define-record-type <empty> (make-empty) empty?)
+(test-equal "a zero-field R7RS record reports zero field names"
+            '#() (record-type-field-names (record-rtd (make-empty))))
+
+;; A body-local R7RS define-record-type (compiled through the body-scanning
+;; desugarer rather than the top-level handler) carries its field names too.
+(define (make-local-pair a b)
+  (define-record-type <lp> (mk-lp u v) lp? (u lp-u) (v lp-v))
+  (mk-lp a b))
+(define lp (make-local-pair 4 5))
+(test-equal "a body-local R7RS record reports its field names"
+            '#(u v) (record-type-field-names (record-rtd lp)))
+(test-equal "record-accessor works on a body-local R7RS record"
+            5 ((record-accessor (record-rtd lp) 1) lp))
 
 ;; Discriminating control: the same two-field, one-mutable shape built the two
 ;; other ways is fully introspectable, so the defect is specific to the R7RS


### PR DESCRIPTION
## What

An R7RS positional `define-record-type` produced an rtd with **zero own field names**, so the SRFI 237/240 inspection layer could not see its fields: `record-type-field-names` returned `#()` (a well-formed but false answer) and `record-accessor` / `record-mutator` / `record-field-mutable?` all failed with `index 0 out of range for length 0`. SRFI 240's entire content is a `define-record-type` accepting either syntax "both producing interoperable record types" — the R6RS-clause and `make-record-type-descriptor` paths already carried the metadata; only the R7RS positional path dropped it.

## Why it happened

`RecordType.own_field_names`/`own_field_mutable` were added for SRFI 237 and populated by the R6RS-clause desugarer and the procedural layer, but all three R7RS emit paths created the rtd count-only (`allocRecordType`) or emitted a count-only `(%make-record-type "name" n)` call.

## The fix

All three R7RS emit paths now record each field's name and mutability (mutable iff the field's clause names a mutator, R7RS 5.5.1):

- `handleDefineRecordType` (top level and library bodies): allocates via `allocRecordTypeExtended` — parentless, generative, transparent, i.e. exactly the shape `allocRecordType` built, plus the field metadata.
- `expandRecordTypeDefines` (leading-define body scanning) and `compileDefineRecordType` (general dispatch): emit the metadata through `%make-record-type`, which gains an **optional third argument** — a list of `(name-string . mutable?)` pairs, the same convention `%make-record-type-descriptor`'s field-specs already use. Count-only callers keep the two-argument form.

The rtd representation is unchanged: `own_field_names`/`own_field_mutable` already existed and are already handled by every GC switch (raw owned bytes, same category as `RecordType.name`); no new heap fields, no new tracing. `gc_deep_copy`'s metadata-ful slow path now carries R7RS field names across SRFI-18 thread boundaries (verified by the cross-thread-boundary audit). Stale comments documenting the old behavior (`types_record.zig`'s "0 for a plain R7RS record type", `gc_deep_copy.zig`'s fast-path rationale) are updated.

## Tests added

- `tests/scheme/srfi/srfi240-audit.scm` — the four assertions disabled under `;; FAIL: #2088` are enabled and the pinned broken-behavior set flipped to assert the fixed behavior; plus new coverage: by-name `record-accessor`, immutable-field mutator rejection, out-of-range index rejection, a zero-field type staying legitimately `#()`, and a body-local `define-record-type` carrying its names. **9 of these fail without the fix** (verified by stashing the `src/` changes and rebuilding).
- `src/tests_records.zig` — two unit tests asserting `own_field_names`/`own_field_mutable` on the rtd for the top-level and body-local desugarer paths.
- `tests/scheme/audit/internal-primitives-audit.scm` — `%make-record-type` arity assertions updated for the optional third argument (the old `rt: too many` 3-arg call now pins the specs-not-a-list rejection instead), plus positive/mismatch tests for the field-specs form.

## Evidence

- `srfi240-audit.scm`: 81/81 pass (72 pass + 9 unexpected failures without the fix)
- `internal-primitives-audit.scm`: 255/255
- srfi 9 / 57 / 131 / 136 / 137 / 150 / 237 / 240 suites: all pass
- R7RS suite: 1395 pass, 0 fail
- `zig build test`: green
- Native tier: a no-import record program through `kaappi compile` prints its field names (`(x y)`)

Closes #2088

🤖 Generated with [Claude Code](https://claude.com/claude-code)
