### PR TITLE
wasi: real compile gate for the wasm32-wasi unit suite, executed under wasmtime (kaappi#2153)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1273,6 +1273,20 @@ jobs:
       - name: Timer test (reactor poll_oneoff backend)
         run: wasmtime run --dir=. zig-out/bin/kaappi.wasm tests/wasm/timers.scm
 
+      # kaappi#2153: the wasm32-wasi unit suite as a compile gate (like
+      # `-Dtarget=<arch>-windows` — the foreign run skips, compilation must
+      # not) plus execution of the produced binary under wasmtime. The step
+      # runs everything the WASI target can run: VM/GC/reader/printer, the
+      # reactor's CLOCK path (timer tests in tests_reactor*), scheduler and
+      # fiber logic. fd-pair/thread/ffi/Scheme-file-I/O tests skip there
+      # with per-test comptime gates — WASI p1 under wasmtime cannot
+      # construct an EAGAIN-capable fd (no pipe/socketpair syscalls,
+      # sock_open unimplemented) — see docs/dev/porting.md Stage 3.
+      - name: WASI unit tests (compile gate + run under wasmtime, kaappi#2153)
+        run: |
+          zig build test -Dtarget=wasm32-wasi
+          wasmtime run --dir=. --dir=/tmp zig-out/bin/unit-tests.wasm
+
       - name: Parallel pool test (fiber-degraded, KEP-0002 Phase 5)
         run: wasmtime run --dir=. zig-out/bin/kaappi.wasm tests/wasm/parallel.scm
 

--- a/build.zig
+++ b/build.zig
@@ -8,11 +8,12 @@ pub fn build(b: *std.Build) void {
     // heavy workloads. ReleaseSafe matches ReleaseFast in throughput here while
     // keeping bounds/safety checks (fixnum overflow auto-promotes to bignum).
     // Override for development with `-Doptimize=Debug`.
-    const optimize = b.option(
+    const optimize_opt = b.option(
         std.builtin.OptimizeMode,
         "optimize",
         "Prioritize performance, safety, or binary size (default: ReleaseSafe)",
-    ) orelse .ReleaseSafe;
+    );
+    const optimize = optimize_opt orelse .ReleaseSafe;
 
     // Standalone binary: embed compiled bytecode via -Dbundle=path/to/program.sbc
     const bundle = b.option([]const u8, "bundle", "Path to .sbc bytecode file to embed for standalone binary");
@@ -419,10 +420,39 @@ pub fn build(b: *std.Build) void {
     fuzz_gen_step.dependOn(&b.addInstallArtifact(fuzz_gen_exe, .{}).step);
 
     // Unit tests
+    //
+    // wasm32-wasi test-module specifics (kaappi#2153), making
+    // `zig build test -Dtarget=wasm32-wasi` a compile gate like Windows:
+    //
+    //  * single_threaded, matching the wasm executable (wasm32-wasi has no
+    //    wasi-threads here; std's Io/poll plumbing otherwise analyzes its
+    //    futex paths, whose inline asm requires the atomics feature).
+    //  * The atomics CPU feature on the test target: that same std code
+    //    emits `memory.atomic.*` even single-threaded. Only atomic *waits*
+    //    require shared memory, and a single-threaded module never waits,
+    //    so wasmtime runs the binary unmodified. The shipped kaappi.wasm
+    //    keeps its plain baseline CPU — only the test module needs this.
+    //  * ReleaseSmall when `-Doptimize` was not passed explicitly: Debug
+    //    exceeds wasmtime's per-function locals limit in the comptime-
+    //    generated ffi.callFfiGeneric dispatchers (wasm32 halves the slot
+    //    count per local), and ReleaseSafe crashes the LLVM wasm32 backend
+    //    selecting a float constant-pool entry ("Cannot select: i32 =
+    //    ConstantPool<float ...>") in test-only code. ReleaseSmall compiles
+    //    the same Sema surface — every error class the gate exists for is
+    //    semantic, not codegen — and is what CI runs under wasmtime. An
+    //    explicit -Doptimize is always respected.
+    const wasm_test_target = if (is_wasm_target) b.resolveTargetQuery(.{
+        .cpu_arch = .wasm32,
+        .os_tag = .wasi,
+        .cpu_features_add = std.Target.wasm.featureSet(&.{.atomics}),
+    }) else target;
     const test_mod = kaappiModule(b, options_mod, .{
-        .target = target,
-        .optimize = optimize,
+        .target = wasm_test_target,
+        .optimize = if (is_wasm_target and optimize_opt == null) .ReleaseSmall else optimize,
         .embed = null_embed,
+        // Match the wasm executable's own threading model (see `main_mod`
+        // above): wasm32-wasi without wasi-threads is single-threaded.
+        .single_threaded = if (is_wasm_target) true else null,
     });
     const unit_tests = b.addTest(.{
         .name = "unit-tests",
@@ -439,6 +469,14 @@ pub fn build(b: *std.Build) void {
     run_unit_tests.skip_foreign_checks = true;
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);
+    if (is_wasm_target) {
+        // Install the cross-compiled test binary so a wasm runtime can
+        // execute it (the run step above skipped as foreign):
+        //   wasmtime run --dir=. zig-out/bin/unit-tests.wasm
+        // The wasm CI job does exactly that (kaappi#2153).
+        const install_wasm_tests = b.addInstallBinFile(unit_tests.getEmittedBin(), "unit-tests.wasm");
+        test_step.dependOn(&install_wasm_tests.step);
+    }
 
     const thottam_test_mod = kaappiModule(b, options_mod, .{
         .root = "src/thottam.zig",

--- a/docs/dev/porting.md
+++ b/docs/dev/porting.md
@@ -215,10 +215,25 @@ thottam → #1608 readiness), and it kept every intermediate PR shippable.
       `tests_reactor_parity.zig` is the one written *as* the
       cross-backend comparison: it names no backend, so a property that
       holds on kqueue/epoll/Windows and fails on the new one is a parity
-      defect by construction. Note that this criterion is currently
-      unmet for WASI — `zig build test -Dtarget=wasm32-wasi` does not
-      compile, so `WasiPollBackend`'s fd path is executed nowhere
-      (kaappi#2153).
+      defect by construction.
+      **WASI is a documented exception to the fd criterion, and the
+      boundary is the runtime, not us** (kaappi#2153): WASI p1 has no
+      pipe/socketpair creation syscalls, and wasmtime — the only runtime
+      CI has — leaves the nonstandard `sock_open` unimplemented, so a
+      guest cannot construct *any* EAGAIN-capable fd there (moreover,
+      `poll_oneoff` fails the whole call with `BADF` for an fd
+      subscription on every fd a guest *can* obtain). The fd suites skip
+      on wasm with per-test comptime gates, and
+      `testing_helpers.wasmNoFdPairs` panics if a test reaches a pair
+      constructor without its skip. What *is* required of the WASI leg —
+      and enforced by the `wasm` CI job — is: `zig build test
+      -Dtarget=wasm32-wasi` compiles (the same compile-gate discipline as
+      `-Dtarget=<arch>-windows`; the module also runs under `wasmtime
+      run --dir=. --dir=/tmp zig-out/bin/unit-tests.wasm`, executing the
+      suites' timer/scheduler halves — i.e. `WasiPollBackend`'s CLOCK
+      path). A future WASI runtime with working sockets should promote
+      the fd suites by giving `makeFdPair` a real WASI arm and deleting
+      the skips.
 
 ### Stage 4 — feature identifier, gates, degradations
 

--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -235,6 +235,7 @@ pub fn getSbcPath(allocator: std.mem.Allocator, src_path: []const u8) ![]u8 {
 // ---------------------------------------------------------------------------
 
 test "bytecode round-trip: simple function" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     const allocator = std.testing.allocator;
     var gc = GC.init(allocator);
     defer gc.deinit();
@@ -287,6 +288,7 @@ test "bytecode round-trip: simple function" {
 }
 
 test "bytecode round-trip: hash mismatch returns null" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     const allocator = std.testing.allocator;
     var gc = GC.init(allocator);
     defer gc.deinit();
@@ -313,6 +315,7 @@ test "bytecode round-trip: hash mismatch returns null" {
 }
 
 test "bytecode round-trip: various constant types" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     const allocator = std.testing.allocator;
     var gc = GC.init(allocator);
     defer gc.deinit();
@@ -389,6 +392,7 @@ test "bytecode round-trip: various constant types" {
 }
 
 test "bytecode round-trip: nested functions" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     const allocator = std.testing.allocator;
     var gc = GC.init(allocator);
     defer gc.deinit();
@@ -484,6 +488,7 @@ fn roundTrip(gc: *GC, func: *Function, path: [:0]const u8) !DeserializeResult {
 }
 
 test "bytecode round-trip: immutability flag preserved (kaappi#2110)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     // A literal's Object.flags.immutable must survive the codec, or a warm
     // run accepts a set-car! the cold run rejected. One immutable and one
     // mutable instance of each of the four types, so both flag values are
@@ -523,6 +528,7 @@ test "bytecode round-trip: immutability flag preserved (kaappi#2110)" {
 }
 
 test "bytecode round-trip: datum-label sharing preserved via backrefs (kaappi#2111)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     // '(#1=(1 2) #1#) and friends: an object reached twice must decode as the
     // SAME object (eq?), not a copy per reference.
     const allocator = std.testing.allocator;
@@ -573,6 +579,7 @@ test "bytecode round-trip: datum-label sharing preserved via backrefs (kaappi#21
 }
 
 test "bytecode round-trip: cyclic literal terminates and re-ties the knot (kaappi#2111)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     // '#0=(1 2 . #0#): before backrefs this recursed to the depth guard,
     // wrote a truncated entry, and the reader rejected it — a permanent miss.
     const allocator = std.testing.allocator;
@@ -612,6 +619,7 @@ test "bytecode round-trip: cyclic literal terminates and re-ties the knot (kaapp
 }
 
 test "bytecode round-trip: a long quoted list costs no nesting depth (kaappi#2113)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     // The cdr spine is iterative on both sides, so a 400-element list — well
     // past MAX_CONSTANT_DEPTH — writes and reads back. Before this, element
     // 257 hit the writer's depth guard and the entry never loaded.
@@ -647,6 +655,7 @@ test "bytecode round-trip: a long quoted list costs no nesting depth (kaappi#211
 }
 
 test "bytecode write: bundle sections refuse what the reader would reject too" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     // writeFileWithBundle's sections have the same refusal contract as the
     // constants: an oversized bundled file or preamble form fails the WRITE
     // with LimitExceeded, instead of producing a --compile artifact whose own
@@ -702,6 +711,7 @@ test "bytecode write: bundle sections refuse what the reader would reject too" {
 }
 
 test "bytecode write: refuses what the reader would reject (kaappi#2113)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     // The writer must never produce an entry the reader rejects — that is a
     // permanent, invisible cache miss. Nesting past MAX_CONSTANT_DEPTH and an
     // oversized string both fail the WRITE with LimitExceeded, and no file
@@ -839,6 +849,7 @@ test "dev rebuild (different build id) rejects cache" {
 }
 
 test "classifyEmbeddedRejection: foreign build id is distinguished from corrupt" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     // kaappi#1930: a bundled binary whose embedded .sbc came from a different
     // build must say so instead of "invalid embedded bytecode". The loader
     // refuses both cases with null, so the diagnostic classifier has to tell
@@ -893,6 +904,7 @@ test "classifyEmbeddedRejection: foreign build id is distinguished from corrupt"
 }
 
 test "readHeaderInfo round-trips build id and source path" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     const allocator = std.testing.allocator;
     var gc = GC.init(allocator);
     defer gc.deinit();
@@ -959,6 +971,7 @@ test "bytecode validation rejects oversized function count header" {
 }
 
 test "bytecode round-trip: vector pair bignum rational complex constants" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     const allocator = std.testing.allocator;
     var gc = GC.init(allocator);
     defer gc.deinit();
@@ -1056,6 +1069,7 @@ test "bytecode round-trip: vector pair bignum rational complex constants" {
 }
 
 test "bytecode round-trip: line table and source_line preserved" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     const allocator = std.testing.allocator;
     var gc = GC.init(allocator);
     defer gc.deinit();

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -465,6 +465,7 @@ fn writeTestCacheEntry(allocator: std.mem.Allocator, dir: []const u8, name: []co
 }
 
 test "renderStatus and clearDir over a temp cache dir" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the bytecode cache is disabled on wasm by design (cache.zig)
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -517,6 +518,7 @@ test "clearDir on a missing directory is a no-op" {
 }
 
 test "renderStatus reports a current-build entry the reader rejects as unloadable (kaappi#2113)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the bytecode cache is disabled on wasm by design (cache.zig)
     // A valid header over a body the loader rejects used to render as
     // "current" — documented as "a plain run would hit" — while every run
     // recompiled forever. The dry run must catch it. Corruption here is a

--- a/src/doctor.zig
+++ b/src/doctor.zig
@@ -619,6 +619,13 @@ fn smokeLink(r: *Report, lib_dir: []const u8) void {
             a.free(out);
             break :blk true;
         }
+        if (comptime platform.is_wasm) {
+            // No process creation on WASI p1 (kaappi#2153) — nothing to
+            // smoke-link. doctor itself is `!is_wasm`-gated in main.zig; this
+            // arm keeps the wasm test module linkable.
+            r.add("native-backend", "smoke-link", .pass, "skipped (no process spawning on WASI)", null);
+            return;
+        }
         const child = std.posix.system.fork();
         if (child < 0) {
             r.add("native-backend", "smoke-link", .pass, "skipped (fork failed)", null);

--- a/src/features.zig
+++ b/src/features.zig
@@ -288,8 +288,9 @@ test "features json is one object with the documented keys and limit values" {
     try testing.expect(obj.get("build_id").?.string.len > 0);
     try testing.expectEqualStrings(target_triple, obj.get("target").?.string);
     try testing.expect(obj.get("build_mode").?.string.len > 0);
-    // Unit tests never build for WASM, so sandbox is available here.
-    try testing.expect(obj.get("sandbox_available").?.bool);
+    // `--sandbox` is native-only (WASM is sandboxed by construction), and
+    // since kaappi#2153 the unit suite does build for wasm32-wasi.
+    try testing.expect(obj.get("sandbox_available").?.bool == sandbox_available);
 
     const limits = obj.get("limits").?.object;
     try testing.expectEqual(@as(i64, build_options.max_frames), limits.get("initial_frame_capacity").?.integer);

--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -777,7 +777,9 @@ test "marshalPointerReturn: small address returns fixnum" {
     const ptr: ?*anyopaque = @ptrCast(&dummy);
     const val = try marshalPointerReturn(ptr, &gc);
     const addr = @intFromPtr(&dummy);
-    if (addr <= @as(usize, @intCast(MAX_FIXNUM))) {
+    // MAX_FIXNUM (2^47-1) can exceed a 32-bit target's usize; on wasm32
+    // every address is small, so the fixnum expectation holds unconditionally.
+    if (addr <= @min(@as(usize, std.math.maxInt(usize)), MAX_FIXNUM)) {
         try std.testing.expect(types.isFixnum(val));
     }
 }
@@ -793,6 +795,9 @@ test "marshalToPointer: round-trips bignum pointer" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
 
+    // A pointer above MAX_FIXNUM needs 48 address bits, which a 32-bit
+    // target's usize cannot hold — the case is unreachable there.
+    if (comptime @bitSizeOf(usize) < 48) return error.SkipZigTest;
     const addr: usize = 0x1234_5678_9ABC;
     const limbs_buf = [1]u64{addr};
     const v = try gc.allocBignumFromLimbs(&limbs_buf, 1, true);

--- a/src/ffi_callback.zig
+++ b/src/ffi_callback.zig
@@ -324,6 +324,9 @@ test "marshalPtrArg: small address returns fixnum" {
 test "marshalPtrArg: large address returns bignum" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
+    // A pointer above MAX_FIXNUM needs 48 address bits, which a 32-bit
+    // target's usize cannot hold — the case is unreachable there.
+    if (comptime @bitSizeOf(usize) < 48) return error.SkipZigTest;
     const addr: usize = 0x0001_0000_0000_0000;
     const ptr: *anyopaque = @ptrFromInt(addr);
     const val = marshalPtrArg(ptr, &gc).?;

--- a/src/kaappi_paths.zig
+++ b/src/kaappi_paths.zig
@@ -251,6 +251,9 @@ test "siblingLibDir returns null when the result doesn't fit the buffer" {
 }
 
 test "getExeRelativeLibDir returns a lib dir sibling to the exe's bin dir" {
+    // WASI has no self-exe lookup (no /proc, no executable-path syscall)
+    // and getExeRelativeLibDir returns null there by design (kaappi#2153).
+    if (comptime platform.is_wasm) return error.SkipZigTest;
     // The test binary itself is always deeply nested (zig-cache output
     // dirs on every supported platform), so this must not return null —
     // asserting that keeps a regression in the platform probe from

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -745,6 +745,7 @@ fn tryLink(allocator: std.mem.Allocator, cc: []const u8, ll_path: []const u8, ou
             const code = platform.winSpawnPassthrough(allocator, argv_slices[0..argc], null) catch break :blk false;
             break :blk code == 0;
         }
+        if (comptime platform.is_wasm) break :blk false; // no process creation on WASI p1 (kaappi#2153)
         const pid = std.posix.system.fork();
         if (pid < 0) return false;
 

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -30,7 +30,7 @@ const builtin = @import("builtin");
 pub const is_windows = builtin.os.tag == .windows;
 pub const is_openbsd = builtin.os.tag == .openbsd;
 pub const is_netbsd = builtin.os.tag == .netbsd;
-const is_wasm = builtin.os.tag == .wasi;
+pub const is_wasm = builtin.os.tag == .wasi;
 
 /// CRT file descriptor on Windows; kernel fd elsewhere. i32 on every
 /// supported target (std.posix.fd_t is i32 on all POSIX platforms).
@@ -248,38 +248,136 @@ pub fn openRead(path: [:0]const u8) OpenError!fd_t {
     if (comptime is_windows) return winOpen(path, win.O_RDONLY, 0);
     if (comptime is_wasm) {
         // WASI has no AT.FDCWD: paths resolve only relative to a preopened
-        // directory fd. fd 3 is the first preopened dir — the working
-        // directory that both wasmtime `--dir=.` and the browser shim mount —
-        // the same convention file_utils.readWholeFile already uses. Without
-        // this branch, resolveLibraryPath's existence probe failed for every
-        // candidate path and no file-backed .sld was importable on wasm32
-        // even when the host mounted the directory (kaappi#2108).
+        // directory fd. Before #2153 this hardcoded fd 3 (the working
+        // directory that both wasmtime `--dir=.` and the browser shim mount,
+        // the same convention file_utils.readWholeFile uses — without it,
+        // resolveLibraryPath's existence probe failed for every candidate
+        // path and no file-backed .sld was importable on wasm32 even when
+        // the host mounted the directory, kaappi#2108). It now resolves
+        // through the preopen table like wasi-libc's open(), so absolute
+        // paths ("/tmp/...") reach the preopen that mounts them.
+        const resolved = wasiResolve(path) orelse return error.OpenFailed;
         var result_fd: std.os.wasi.fd_t = undefined;
-        const rc = std.os.wasi.path_open(3, .{ .SYMLINK_FOLLOW = true }, path.ptr, path.len, .{}, .{ .FD_READ = true, .FD_SEEK = true }, .{ .FD_READ = true }, .{}, &result_fd);
+        const rc = std.os.wasi.path_open(@intCast(resolved.dirfd), .{ .SYMLINK_FOLLOW = true }, resolved.path.ptr, resolved.path.len, .{}, .{ .FD_READ = true, .FD_SEEK = true }, .{ .FD_READ = true }, .{}, &result_fd);
         if (rc != .SUCCESS) return error.OpenFailed;
         return @as(fd_t, @intCast(result_fd));
     }
     return std.posix.openatZ(std.posix.AT.FDCWD, path, .{}, 0) catch |e| classifyOpenError(e);
 }
 
+/// WASI path resolution, the way wasi-libc's open() does it (kaappi#2153).
+/// Relative paths go to the first "."-named (or unnamed-root) preopen — the
+/// working directory `wasmtime --dir=.` and the browser shim mount, the old
+/// hardcoded fd 3. Absolute paths are matched against each preopen's *name*
+/// (its guest-side mount path), longest prefix first, and opened relative
+/// to that fd — so `wasmtime --dir=/tmp` (or `--dir=/abs/guest::/abs/host`)
+/// makes the absolute paths real programs and the unit suite spell
+/// ("/tmp/...") resolve instead of failing. The table is fixed for the
+/// process lifetime; the scan runs once and is cached.
+const WasiResolve = struct { dirfd: fd_t, path: []const u8 };
+
+var wasi_preopen_buf: [512]u8 = undefined;
+var wasi_preopen_names: ?[]const u8 = null; // packed "name\0" entries, fd implied by scan order
+var wasi_preopen_cwd: fd_t = -1;
+
+fn wasiPreopenScan() []const u8 {
+    if (wasi_preopen_names) |s| return s;
+    var used: usize = 0;
+    var fd: fd_t = 3;
+    // BADF arrives well before 64 on any real host; the cap bounds a
+    // hostile/odd table so the scan cannot walk the whole fd space.
+    while (fd < 64) : (fd += 1) {
+        var prestat: std.os.wasi.prestat_t = undefined;
+        if (std.os.wasi.fd_prestat_get(fd, &prestat) != .SUCCESS) break;
+        // Only DIR preopens exist in practice, and the resolve walk below
+        // pairs names to fds strictly by scan order — a non-DIR preopen
+        // would desynchronize that pairing, so treat one as the table's
+        // end rather than skip past it.
+        if (prestat.pr_type != .DIR) break;
+        const name_len = @min(prestat.u.dir.pr_name_len, wasi_preopen_buf.len - used - 1);
+        if (std.os.wasi.fd_prestat_dir_name(fd, wasi_preopen_buf[used..].ptr, name_len) != .SUCCESS) break;
+        if (wasi_preopen_cwd < 0 and (name_len == 0 or std.mem.eql(u8, wasi_preopen_buf[used .. used + name_len], "."))) {
+            wasi_preopen_cwd = fd;
+        }
+        used += name_len;
+        wasi_preopen_buf[used] = 0;
+        used += 1;
+    }
+    wasi_preopen_names = wasi_preopen_buf[0..used];
+    return wasi_preopen_names.?;
+}
+
+/// Resolve `path` (any spelling) to a preopen dirfd plus a path relative to
+/// it. Null when an absolute path matches no preopen name.
+fn wasiResolve(path: []const u8) ?WasiResolve {
+    const names = wasiPreopenScan();
+    if (path.len == 0 or path[0] != '/') {
+        // Relative: the CWD preopen, first DIR preopen when none is named
+        // "." — the fd 3 convention the pre-#2153 code relied on.
+        const cwd: fd_t = if (wasi_preopen_cwd >= 0) wasi_preopen_cwd else 3;
+        return .{ .dirfd = cwd, .path = path };
+    }
+    // Absolute: longest-prefix match over the preopen names.
+    var best: ?WasiResolve = null;
+    var best_len: usize = 0;
+    var fd: fd_t = 3;
+    var off: usize = 0;
+    while (off < names.len) : (fd += 1) {
+        const end = std.mem.indexOfScalarPos(u8, names, off, 0) orelse names.len;
+        const name = names[off..end];
+        off = end + 1;
+        const root_mount = name.len == 0 or std.mem.eql(u8, name, ".");
+        const matches = root_mount or
+            (std.mem.startsWith(u8, path, name) and
+                (path.len == name.len or path[name.len] == '/'));
+        if (matches and name.len >= best_len) {
+            const rest: []const u8 = if (path.len > name.len) path[name.len + 1 ..] else ".";
+            best = .{ .dirfd = fd, .path = rest };
+            best_len = name.len;
+        }
+    }
+    return best;
+}
+
+/// WASI write-open: resolved through the same preopen table as openRead's
+/// WASI arm (kaappi#2108, #2153) — there is no AT.FDCWD and no /dev/null,
+/// and `mode` has no counterpart in path_open, so the POSIX mode argument
+/// is ignored. Append is fdflags.APPEND (the open file description
+/// remembers it), not an oflag, exactly as on POSIX.
+fn wasiOpenWrite(path: [:0]const u8, oflags: std.os.wasi.oflags_t, append: bool) OpenError!fd_t {
+    const resolved = wasiResolve(path) orelse return error.OpenFailed;
+    var result_fd: std.os.wasi.fd_t = undefined;
+    const rc = std.os.wasi.path_open(@intCast(resolved.dirfd), .{ .SYMLINK_FOLLOW = true }, resolved.path.ptr, resolved.path.len, oflags, .{ .FD_WRITE = true, .FD_SEEK = true }, .{ .FD_WRITE = true }, if (append) .{ .APPEND = true } else .{}, &result_fd);
+    if (rc != .SUCCESS) return error.OpenFailed;
+    return @as(fd_t, @intCast(result_fd));
+}
+
 pub fn openWriteTrunc(path: [:0]const u8, mode: u16) OpenError!fd_t {
     if (comptime is_windows) return winOpen(path, win.O_WRONLY | win.O_CREAT | win.O_TRUNC, 0o600);
+    if (comptime is_wasm) return wasiOpenWrite(path, .{ .CREAT = true, .TRUNC = true }, false);
     return std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true }, mode) catch |e| classifyOpenError(e);
 }
 
 pub fn openWriteTruncExcl(path: [:0]const u8, mode: u16) OpenError!fd_t {
     if (comptime is_windows) return winOpen(path, win.O_WRONLY | win.O_CREAT | win.O_TRUNC | win.O_EXCL, 0o600);
+    if (comptime is_wasm) return wasiOpenWrite(path, .{ .CREAT = true, .TRUNC = true, .EXCL = true }, false);
     return std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true, .EXCL = true }, mode) catch error.OpenFailed;
 }
 
 pub fn openAppend(path: [:0]const u8, mode: u16) OpenError!fd_t {
     if (comptime is_windows) return winOpen(path, win.O_WRONLY | win.O_CREAT | win.O_APPEND, 0o600);
+    if (comptime is_wasm) return wasiOpenWrite(path, .{ .CREAT = true }, true);
     return std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .ACCMODE = .WRONLY, .CREAT = true, .APPEND = true }, mode) catch error.OpenFailed;
 }
 
 /// Write-only sink for discarding output (/dev/null, NUL).
 pub fn openNullSink() OpenError!fd_t {
     if (comptime is_windows) return winOpen("NUL", win.O_WRONLY, 0);
+    // WASI has no null device: nothing to open. Callers already treat the
+    // error as "no sink available" (doctor passes `catch -1`, the fuzz
+    // harness skips its fd-discarding mode), so a loud OpenFailed is the
+    // honest answer rather than substituting some real file.
+    if (comptime is_wasm) return error.OpenFailed;
     return std.posix.openatZ(std.posix.AT.FDCWD, "/dev/null", .{ .ACCMODE = .WRONLY }, 0) catch error.OpenFailed;
 }
 
@@ -602,7 +700,19 @@ pub const DirIter = struct {
         first_pending: bool,
         name_buf: [1024]u8,
     };
-    state: if (is_windows) WinState else *std.c.DIR,
+    /// WASI p1 has no libc DIR emulation here we can lean on (std.c.dirent
+    /// is void on wasi), so this arm drives fd_readdir directly: one batch
+    /// buffer, `cookie` tracking the last fully-consumed entry's `next`.
+    /// A name that cannot fit the batch buffer ends iteration — acceptable
+    /// for the directory listings this serves (library paths, cache dirs).
+    const WasiState = struct {
+        fd: std.os.wasi.fd_t,
+        buf: [4096]u8 = undefined,
+        len: usize = 0,
+        pos: usize = 0,
+        cookie: std.os.wasi.dircookie_t = std.os.wasi.DIRCOOKIE_START,
+    };
+    state: if (is_windows) WinState else if (is_wasm) WasiState else *std.c.DIR,
 
     pub fn open(path: [:0]const u8) ?DirIter {
         if (comptime is_windows) {
@@ -615,6 +725,16 @@ pub const DirIter = struct {
             if (st.handle == win.INVALID_HANDLE_VALUE) return null;
             st.first_pending = true;
             return .{ .state = st };
+        }
+        if (comptime is_wasm) {
+            // Same preopen resolution as openRead/openWriteTrunc's WASI
+            // arms: relative paths against the CWD preopen, absolute paths
+            // against whichever preopen's name mounts them.
+            const resolved = wasiResolve(path) orelse return null;
+            var result_fd: std.os.wasi.fd_t = undefined;
+            const rc = std.os.wasi.path_open(@intCast(resolved.dirfd), .{ .SYMLINK_FOLLOW = true }, resolved.path.ptr, resolved.path.len, .{ .DIRECTORY = true }, .{ .FD_READ = true }, .{}, .{}, &result_fd);
+            if (rc != .SUCCESS) return null;
+            return .{ .state = .{ .fd = result_fd } };
         }
         const dh = opendir_sys(path) orelse return null;
         return .{ .state = dh };
@@ -631,6 +751,37 @@ pub const DirIter = struct {
             const n = std.unicode.wtf16LeToWtf8(&st.name_buf, wname);
             return st.name_buf[0..n];
         }
+        if (comptime is_wasm) {
+            const st = &self.state;
+            while (true) {
+                if (st.pos == st.len) {
+                    // Refill from the last consumed entry's cookie.
+                    var used: usize = 0;
+                    const rc = std.os.wasi.fd_readdir(st.fd, &st.buf, st.buf.len, st.cookie, &used);
+                    if (rc != .SUCCESS or used == 0) return null;
+                    st.len = used;
+                    st.pos = 0;
+                }
+                const rest = st.buf[st.pos..st.len];
+                if (rest.len < @sizeOf(std.os.wasi.dirent_t)) {
+                    st.pos = st.len;
+                    continue;
+                }
+                const ent: *align(1) const std.os.wasi.dirent_t = @ptrCast(rest.ptr);
+                const total = @sizeOf(std.os.wasi.dirent_t) + @as(usize, ent.namlen);
+                if (rest.len < total) {
+                    // Entry straddles the batch end. fd_readdir only writes
+                    // whole entries, so this means the name cannot fit the
+                    // buffer at all — end iteration rather than loop.
+                    if (st.len == st.buf.len) return null;
+                    st.pos = st.len;
+                    continue;
+                }
+                st.pos += total;
+                st.cookie = ent.next;
+                return st.buf[st.pos - ent.namlen .. st.pos];
+            }
+        }
         const ent = readdir_sys(self.state) orelse return null;
         const name_ptr: [*:0]const u8 = @ptrCast(&ent.name);
         return std.mem.span(name_ptr);
@@ -639,6 +790,10 @@ pub const DirIter = struct {
     pub fn close(self: *DirIter) void {
         if (comptime is_windows) {
             _ = win.FindClose(self.state.handle);
+            return;
+        }
+        if (comptime is_wasm) {
+            _ = std.os.wasi.fd_close(self.state.fd);
             return;
         }
         _ = std.c.closedir(self.state);
@@ -1146,6 +1301,14 @@ pub fn dlOpen(path: ?[*:0]const u8) ?*anyopaque {
         if (handle == null) dl_error_pending = true;
         return handle;
     }
+    if (comptime is_wasm) {
+        // WASI p1 has no dynamic loading at all — no dlopen, no global
+        // symbol table to search. Fail through the same pending-error
+        // channel Windows uses so dlError() explains why.
+        dl_error_pending = true;
+        _ = std.fmt.bufPrintZ(&dl_error_buf, "dynamic loading unavailable on WASI", .{}) catch {};
+        return null;
+    }
     return std.c.dlopen(path, .{ .LAZY = true });
 }
 
@@ -1172,6 +1335,11 @@ pub fn dlSym(handle: *anyopaque, name: [*:0]const u8) ?*anyopaque {
         if (sym == null) dl_error_pending = true;
         return sym;
     }
+    if (comptime is_wasm) {
+        dl_error_pending = true;
+        _ = std.fmt.bufPrintZ(&dl_error_buf, "dynamic loading unavailable on WASI", .{}) catch {};
+        return null;
+    }
     return std.c.dlsym(handle, name);
 }
 
@@ -1181,6 +1349,10 @@ pub fn dlClose(handle: *anyopaque) void {
         // Windows; FreeLibrary on it would corrupt the exe module count.
         if (handle == win.GetModuleHandleW(null)) return;
         _ = win.FreeLibrary(handle);
+        return;
+    }
+    if (comptime is_wasm) {
+        // dlOpen can never succeed on WASI, so there is no handle to close.
         return;
     }
     _ = std.c.dlclose(handle);
@@ -1195,6 +1367,13 @@ pub fn dlError() ?[*:0]const u8 {
         dl_error_pending = false;
         const msg = std.fmt.bufPrintZ(&dl_error_buf, "Win32 error {d}", .{win.GetLastError()}) catch return null;
         return msg.ptr;
+    }
+    if (comptime is_wasm) {
+        // The failure arms above left the message in dl_error_buf; unlike
+        // Windows there is no per-call error code to reformat.
+        if (!dl_error_pending) return null;
+        dl_error_pending = false;
+        return @ptrCast(&dl_error_buf);
     }
     return std.c.dlerror();
 }
@@ -1212,6 +1391,14 @@ pub fn dlError() ?[*:0]const u8 {
 /// leak-tracking test allocators never see it.
 pub fn argsIterate(args: std.process.Args) std.process.Args.Iterator {
     if (comptime is_windows) {
+        return args.iterateAllocator(std.heap.c_allocator) catch @panic("out of memory parsing command line");
+    }
+    if (comptime is_wasm) {
+        // std's raw iterate() compile-errors on WASI (argv there must be
+        // wrapped by an allocator-initialized iterator). With libc linked —
+        // always, for us — the WASI iterator walks the raw argv block and
+        // never asks the allocator for anything, so this is the same
+        // process-lifetime-by-design shape as the Windows arm above.
         return args.iterateAllocator(std.heap.c_allocator) catch @panic("out of memory parsing command line");
     }
     return args.iterate();

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -580,6 +580,18 @@ pub inline fn fixnumIndexInBoundsInclusive(idx: i64, len: usize) bool {
     return idx >= 0 and @as(u64, @intCast(idx)) <= @as(u64, len);
 }
 
+/// Whether fixnum `k` (already known non-negative) fits the target's usize
+/// at all — the u64-domain check the `make-*` length conversions need
+/// before narrowing (kaappi#2153, the same #1912 class): on wasm32 a length
+/// like 10^14 would otherwise truncate inside `@intCast` and silently
+/// allocate a far smaller object than requested instead of raising. Callers
+/// report it as `OutOfMemory`, which is exactly what the 64-bit GC payload
+/// cap (gc_alloc.max_payload_bytes) raises for the same request, so
+/// `(guard ...)` sees one cross-platform condition.
+pub inline fn fixnumFitsUsize(k: i64) bool {
+    return @as(u64, @intCast(k)) <= @as(u64, std.math.maxInt(usize));
+}
+
 pub const Range = struct { start: usize, end: usize };
 
 pub fn parseOptionalRange(args: []const Value, arg_offset: usize, max_len: usize, proc_name: []const u8) PrimitiveError!Range {

--- a/src/primitives_bytevector.zig
+++ b/src/primitives_bytevector.zig
@@ -46,6 +46,7 @@ fn makeBytevector(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const k = types.toFixnum(args[0]);
     if (k < 0) return primitives.typeError("make-bytevector", "non-negative integer", args[0]);
+    if (!primitives.fixnumFitsUsize(k)) return PrimitiveError.OutOfMemory; // wasm32: would truncate (kaappi#2153)
     const size: usize = @intCast(k);
     const fill: u8 = if (args.len > 1) blk: {
         if (!types.isFixnum(args[1])) return primitives.typeError("make-bytevector", "exact integer 0-255", args[1]);

--- a/src/primitives_string.zig
+++ b/src/primitives_string.zig
@@ -128,6 +128,7 @@ fn makeStringFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[0])) return primitives.typeError("make-string", "exact integer", args[0]);
     const k = types.toFixnum(args[0]);
     if (k < 0) return primitives.typeError("make-string", "non-negative integer", args[0]);
+    if (!primitives.fixnumFitsUsize(k)) return PrimitiveError.OutOfMemory; // wasm32: would truncate (kaappi#2153)
     const count: usize = @intCast(k);
     const fill_cp: u21 = if (args.len > 1) blk: {
         if (!types.isChar(args[1])) return primitives.typeError("make-string", "character", args[1]);

--- a/src/primitives_vector.zig
+++ b/src/primitives_vector.zig
@@ -74,6 +74,7 @@ fn makeVectorFn(args: []const Value) PrimitiveError!Value {
     if (!types.isFixnum(args[0])) return primitives.typeError("make-vector", "exact non-negative integer", args[0]);
     const k = types.toFixnum(args[0]);
     if (k < 0) return primitives.typeError("make-vector", "exact non-negative integer", args[0]);
+    if (!primitives.fixnumFitsUsize(k)) return PrimitiveError.OutOfMemory; // wasm32: would truncate (kaappi#2153)
     const size: usize = @intCast(k);
     const fill: Value = if (args.len > 1) args[1] else types.UNDEFINED;
     return gc.allocVectorFill(size, fill) catch return PrimitiveError.OutOfMemory;

--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -781,6 +781,9 @@ fn spawnWorker(allocator: std.mem.Allocator, exe_path: []const u8, file: []const
         };
         return .{ .output = res.output, .exit_code = res.exit_code, .signaled = false };
     }
+    // No process creation on WASI p1 (kaappi#2153) — `kaappi test` is a
+    // hosted-CLI feature; this arm keeps the wasm test module linkable.
+    if (comptime platform.is_wasm) return error.ForkFailed;
 
     const argv_z = try allocator.alloc(?[*:0]const u8, argv.items.len + 1);
     @memset(argv_z, null);

--- a/src/test_selection.zig
+++ b/src/test_selection.zig
@@ -462,6 +462,9 @@ fn runCapture(arena: std.mem.Allocator, argv: []const []const u8) ?CaptureResult
         };
         return .{ .stdout = stdout, .ok = true };
     }
+    // No process creation on WASI p1 (kaappi#2153) — the git-based selection
+    // helpers read "unavailable", which their callers already handle.
+    if (comptime platform.is_wasm) return null;
 
     var pipe: [2]c_int = undefined;
     if (std.c.pipe(&pipe) != 0) return null;

--- a/src/testing_helpers.zig
+++ b/src/testing_helpers.zig
@@ -16,7 +16,15 @@ pub const Value = types.Value;
 /// every platform. std.testing places tmp dirs at `.zig-cache/tmp/<sub_path>`
 /// relative to the cwd (see `std.testing.tmpDir`), which realpath
 /// canonicalizes. Caller owns the returned slice.
+///
+/// On WASI the realpath is *dropped* instead (kaappi#2153): an absolute
+/// host path can resolve only against a same-named preopen, and the test
+/// binary's runner mounts just the working directory (`wasmtime --dir=.`),
+/// so the relative spelling is the one the preopen table can actually open.
 pub fn tmpDirRealPathAlloc(tmp: *std.testing.TmpDir, allocator: std.mem.Allocator) ![]const u8 {
+    if (comptime platform.is_wasm) {
+        return std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp.sub_path});
+    }
     var rel_buf: [platform.PATH_MAX]u8 = undefined;
     const rel = try std.fmt.bufPrintZ(&rel_buf, ".zig-cache/tmp/{s}", .{tmp.sub_path});
     var out_buf: [platform.PATH_MAX]u8 = undefined;
@@ -108,7 +116,10 @@ pub fn expectEvalVoid(source: []const u8) !void {
 // (#1608), so there every pair is a loopback TCP pair wrapped in CRT fds —
 // exactly the object the port layer's socket bridge expects — and the raw
 // read/write helpers route through sockRecv/sockSend (CRT _read/_write
-// cannot operate on SOCKET handles).
+// cannot operate on SOCKET handles). WASI p1 constructs no pairs at all:
+// the proposal has no pipe/socketpair creation syscalls and wasmtime
+// leaves sock_open unimplemented, so the pair constructors panic there and
+// every fd-suite test skips on wasm before its first call (kaappi#2153).
 // ---------------------------------------------------------------------------
 
 /// Winsock externs only the loopback-pair construction needs; test-only,
@@ -136,6 +147,7 @@ const winsock_test = if (platform.is_windows) struct {
 /// which satisfies every unidirectional use).
 pub fn makeFdPair() [2]platform.fd_t {
     if (comptime platform.is_windows) return makeWinLoopbackPair();
+    if (comptime platform.is_wasm) wasmNoFdPairs();
     var fds: [2]std.c.fd_t = undefined;
     if (std.c.pipe(&fds) != 0) unreachable;
     return fds;
@@ -146,6 +158,7 @@ pub fn makeFdPair() [2]platform.fd_t {
 /// Windows. For tests that need two-way traffic or socket buffer tuning.
 pub fn makeBidiFdPair() [2]platform.fd_t {
     if (comptime platform.is_windows) return makeWinLoopbackPair();
+    if (comptime platform.is_wasm) wasmNoFdPairs();
     var fds: [2]std.c.fd_t = undefined;
     if (std.c.socketpair(std.c.AF.UNIX, std.c.SOCK.STREAM, 0, &fds) != 0) unreachable;
     return fds;
@@ -160,9 +173,22 @@ pub fn makeBidiFdPair() [2]platform.fd_t {
 /// I/O on these fds must use platform.read/platform.write, not
 /// fdRead/fdWrite (whose Windows routing is socket-only).
 pub fn makePipeFdPair() [2]platform.fd_t {
+    if (comptime platform.is_wasm) wasmNoFdPairs();
     var fds: [2]platform.fd_t = undefined;
     std.debug.assert(platform.pipe(&fds) == 0);
     return fds;
+}
+
+/// WASI p1 cannot construct fd pairs, and no runtime remedy exists: the
+/// proposal has no pipe(2)/socketpair(2) creation syscalls, and wasmtime
+/// (the CI runtime) leaves the nonstandard sock_open unimplemented — there
+/// is no EAGAIN-capable fd a guest can create at all (kaappi#2153; the
+/// same reason poll_oneoff rejects fd subscriptions on every obtainable
+/// fd there). Every fd-suite test skips on wasm *before* its first
+/// makeFdPair/makeBidiFdPair/makePipeFdPair call; reaching this panic is
+/// a missing skip, not a runtime failure to tolerate.
+fn wasmNoFdPairs() noreturn {
+    @panic("fd pairs are not constructible on WASI p1 (kaappi#2153) — the fd suite test is missing its wasm skip");
 }
 
 fn makeWinLoopbackPair() [2]platform.fd_t {
@@ -224,10 +250,18 @@ pub fn fdReadRetry(fd: platform.fd_t, buf: []u8) isize {
     return -1;
 }
 
-/// Flips a pair fd to non-blocking: fcntl(O_NONBLOCK) / ioctlsocket(FIONBIO).
+/// Flips a pair fd to non-blocking: fcntl(O_NONBLOCK) / ioctlsocket(FIONBIO)
+/// / WASI fd_fdstat_set_flags(NONBLOCK).
 pub fn setFdNonblocking(fd: platform.fd_t) void {
     if (comptime platform.is_windows) {
         std.debug.assert(platform.setSockNonblockingFd(fd));
+        return;
+    }
+    if (comptime platform.is_wasm) {
+        // No fcntl on WASI — the fd's flags live in fd_fdstat_set_flags,
+        // the same call primitives_io's maybeSetNonblocking capability
+        // probe issues (KEP-0001 Phase 4).
+        std.debug.assert(std.os.wasi.fd_fdstat_set_flags(fd, .{ .NONBLOCK = true }) == .SUCCESS);
         return;
     }
     const flags = std.c.fcntl(fd, std.posix.F.GETFL, @as(c_int, 0));
@@ -247,6 +281,11 @@ pub fn setSockBufSize(fd: platform.fd_t, which: SockBuf, size: c_int) void {
         const sock = platform.sockFromFd(fd) orelse unreachable;
         std.debug.assert(winsock_test.setsockopt(sock, platform.win.SOL_SOCKET, opt, @ptrCast(&size), @sizeOf(c_int)) == 0);
         return;
+    }
+    if (comptime platform.is_wasm) {
+        // Only socket-pair fds are worth tuning, and those cannot exist on
+        // WASI p1 — the callers are wasm-skipped fd-suite tests.
+        wasmNoFdPairs();
     }
     const opt: u32 = if (which == .snd) std.posix.SO.SNDBUF else std.posix.SO.RCVBUF;
     std.posix.setsockopt(fd, std.posix.SOL.SOCKET, opt, std.mem.asBytes(&size)) catch unreachable;

--- a/src/tests_advanced.zig
+++ b/src/tests_advanced.zig
@@ -571,7 +571,11 @@ test "cond-expand library check for srfi 18" {
         \\  ((library (srfi 18)) 'yes)
         \\  (else 'no))
     );
-    try std.testing.expectEqualStrings("yes", types.symbolName(result));
+    // (srfi 18) is wasm-gated (Lib.wasmAvailable's srfi_18 => false, no OS
+    // threads on wasm32-wasi) — expect each platform's correct answer
+    // (kaappi#2153: the unit suite now builds for wasm too).
+    const want: []const u8 = if (comptime platform.is_wasm) "no" else "yes";
+    try std.testing.expectEqualStrings(want, types.symbolName(result));
 }
 
 // KEP-0004 Phase 1: bare feature identifiers for the KEP subsystems.
@@ -603,9 +607,10 @@ test "cond-expand kaappi-reactor feature" {
     try std.testing.expectEqualStrings("yes", types.symbolName(result));
 }
 
-// Native unit-test builds are never wasm32-wasi, so kaappi-threads is always
-// present here; its absence on wasm is covered by Lib.wasmAvailable's
-// existing srfi_18 => false gate, not separately unit-testable on this host.
+// Since kaappi#2153 the unit suite builds for wasm32-wasi too, so the
+// platform-correct answer is assertable on both: kaappi-threads is present
+// natively and absent on wasm (types.zig platform_features omits it there,
+// matching Lib.wasmAvailable's srfi_18 => false gate — no OS threads).
 test "cond-expand kaappi-threads feature" {
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -617,7 +622,8 @@ test "cond-expand kaappi-threads feature" {
         \\  (kaappi-threads 'yes)
         \\  (else 'no))
     );
-    try std.testing.expectEqualStrings("yes", types.symbolName(result));
+    const want: []const u8 = if (comptime platform.is_wasm) "no" else "yes";
+    try std.testing.expectEqualStrings(want, types.symbolName(result));
 }
 
 // Regression: libraryIsAvailable must not let cond-expand report a

--- a/src/tests_bytecode_cache.zig
+++ b/src/tests_bytecode_cache.zig
@@ -58,6 +58,7 @@ fn gcHoldsObject(gc: *GC, obj: *types.Object) bool {
 }
 
 test "bytecode cache: deserialized top-level functions survive a mid-run GC" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     const allocator = std.testing.allocator;
     var gc = GC.init(allocator);
     defer gc.deinit();
@@ -182,26 +183,32 @@ fn expectSbcEquivalence(source: []const u8) !void {
 }
 
 test "sbc equiv: fixnum arithmetic" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     try expectSbcEquivalence("(+ (* 3 4) 5)");
 }
 
 test "sbc equiv: conditional" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     try expectSbcEquivalence("(if (< 1 2) 10 20)");
 }
 
 test "sbc equiv: let binding" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     try expectSbcEquivalence("(let ((x 5) (y 3)) (+ x y))");
 }
 
 test "sbc equiv: boolean logic" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     try expectSbcEquivalence("(and (or #f #t) (not #f))");
 }
 
 test "sbc equiv: list operations" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     try expectSbcEquivalence("(car (cons 42 '()))");
 }
 
 test "sbc equiv: tail-recursive loop" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     try expectSbcEquivalence(
         \\(define (loop n acc) (if (= n 0) acc (loop (- n 1) (+ acc 1))))
         \\(loop 1000 0)

--- a/src/tests_endian.zig
+++ b/src/tests_endian.zig
@@ -48,6 +48,7 @@
 //! little-endian *limb* order, with each limb serialized through
 //! `writeU64`; and SRFI 178 bit order is spec-defined, not host-defined.
 
+const platform = @import("platform.zig");
 const std = @import("std");
 const builtin = @import("builtin");
 const build_options = @import("build_options");
@@ -247,6 +248,7 @@ test "endian: readHeaderInfo rejects a big-endian-spelled version field" {
 // ---------------------------------------------------------------------------
 
 test "endian: a written .sbc file carries VERSION and source_hash little-endian" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the golden .sbc write path is gated off on wasm (bytecode_file_write.zig)
     const allocator = std.testing.allocator;
     var gc = GC.init(allocator);
     defer gc.deinit();
@@ -519,6 +521,7 @@ fn buildGoldenGraph(gc: *GC, allocator: std.mem.Allocator, roots: *[2]types.Valu
 }
 
 test "endian: the serializer reproduces the golden .sbc byte sequence" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the golden .sbc write path is gated off on wasm (bytecode_file_write.zig)
     const allocator = std.testing.allocator;
     var gc = GC.init(allocator);
     defer gc.deinit();

--- a/src/tests_ffi.zig
+++ b/src/tests_ffi.zig
@@ -121,6 +121,7 @@ fn expectStringValue(expected: []const u8, v: types.Value) !void {
 }
 
 test "ffi callback error is re-raised after the C call returns (#1185)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the FFI surface is unregistered on wasm (primitives.zig wasm gating)
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
@@ -137,6 +138,7 @@ test "ffi callback error is re-raised after the C call returns (#1185)" {
 }
 
 test "ffi callback non-integer return raises instead of coercing to 0 (#1185)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the FFI surface is unregistered on wasm (primitives.zig wasm gating)
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
@@ -152,6 +154,7 @@ test "ffi callback non-integer return raises instead of coercing to 0 (#1185)" {
 }
 
 test "ffi callback error state is consumed by the failing call (#1185)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the FFI surface is unregistered on wasm (primitives.zig wasm gating)
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
@@ -193,6 +196,7 @@ fn ffiOpenErrorMessage(ctx: *th.TestContext, target: []const u8) ![]const u8 {
 }
 
 test "ffi-open: existing unloadable file's own error is reported, not a probe's" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the FFI surface is unregistered on wasm (primitives.zig wasm gating)
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
@@ -220,6 +224,7 @@ test "ffi-open: existing unloadable file's own error is reported, not a probe's"
 }
 
 test "ffi-open: bare name hitting an unloadable file under KAAPPI_HOME/lib reports that file's error" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the FFI surface is unregistered on wasm (primitives.zig wasm gating)
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
@@ -254,6 +259,7 @@ test "ffi-open: bare name hitting an unloadable file under KAAPPI_HOME/lib repor
 }
 
 test "ffi-open: name not found anywhere reports the requested name plus probe note" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the FFI surface is unregistered on wasm (primitives.zig wasm gating)
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
@@ -264,6 +270,7 @@ test "ffi-open: name not found anywhere reports the requested name plus probe no
 }
 
 test "ffi-open: a path with separators is not re-searched under home lib" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the FFI surface is unregistered on wasm (primitives.zig wasm gating)
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();

--- a/src/tests_fibers.zig
+++ b/src/tests_fibers.zig
@@ -100,6 +100,7 @@ test "channel-receive deadlock error is catchable by guard" {
 }
 
 test "kaappi#1742: channel-receive deadlock names the other thread when one is alive but never shared this channel" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the #1742 deadlock diagnostic needs real OS threads, unavailable on wasm
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
@@ -501,6 +502,7 @@ fn ringAfter(flag: *std.atomic.Value(bool), n: *reactor_mod.ThreadNotifier) void
 }
 
 test "an expired timer popped by the dispatch tick ends the wait instead of parking unbounded" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no OS threads on wasm32-wasi (single-threaded target)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);

--- a/src/tests_filesystem.zig
+++ b/src/tests_filesystem.zig
@@ -5,6 +5,7 @@ const types = @import("types.zig");
 const memory = @import("memory.zig");
 
 test "file-info returns file-info object" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -14,6 +15,7 @@ test "file-info returns file-info object" {
 }
 
 test "file-info:size returns non-negative fixnum" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -23,6 +25,7 @@ test "file-info:size returns non-negative fixnum" {
 }
 
 test "file-info:inode returns positive fixnum" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -37,6 +40,7 @@ test "file-info:inode returns positive fixnum" {
 }
 
 test "file-info:nlinks returns positive fixnum" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -46,6 +50,7 @@ test "file-info:nlinks returns positive fixnum" {
 }
 
 test "file-info:device returns fixnum" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -55,6 +60,7 @@ test "file-info:device returns fixnum" {
 }
 
 test "file-info:uid and :gid return fixnums" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -65,6 +71,7 @@ test "file-info:uid and :gid return fixnums" {
 }
 
 test "file-info:atime and :ctime return fixnums" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -75,6 +82,7 @@ test "file-info:atime and :ctime return fixnums" {
 }
 
 test "file-info:blksize and :blocks" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -90,6 +98,7 @@ test "file-info:blksize and :blocks" {
 }
 
 test "file-info predicates on directory" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -104,6 +113,7 @@ test "file-info predicates on directory" {
 }
 
 test "file-info on regular file" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     if (!platform.pathExists("build.zig")) return error.SkipZigTest;
 
     var gc = memory.GC.init(std.testing.allocator);
@@ -116,6 +126,7 @@ test "file-info on regular file" {
 }
 
 test "pid returns positive integer" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -125,6 +136,7 @@ test "pid returns positive integer" {
 }
 
 test "current-directory returns non-empty string" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -135,6 +147,7 @@ test "current-directory returns non-empty string" {
 }
 
 test "umask returns non-negative integer" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     if (comptime platform.is_windows) return error.SkipZigTest; // POSIX identity/umask
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -145,6 +158,7 @@ test "umask returns non-negative integer" {
 }
 
 test "user-uid and user-gid return fixnums" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     if (comptime platform.is_windows) return error.SkipZigTest; // POSIX identity/umask
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -156,6 +170,7 @@ test "user-uid and user-gid return fixnums" {
 }
 
 test "user-effective-uid and user-effective-gid" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     if (comptime platform.is_windows) return error.SkipZigTest; // POSIX identity/umask
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -167,6 +182,7 @@ test "user-effective-uid and user-effective-gid" {
 }
 
 test "user-supplementary-gids returns list" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     if (comptime platform.is_windows) return error.SkipZigTest; // POSIX identity/umask
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -177,6 +193,7 @@ test "user-supplementary-gids returns list" {
 }
 
 test "real-path resolves current directory" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -187,6 +204,7 @@ test "real-path resolves current directory" {
 }
 
 test "user-info for current user" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     if (comptime platform.is_windows) return error.SkipZigTest; // POSIX-only, raises on Windows
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -202,6 +220,7 @@ test "user-info for current user" {
 }
 
 test "user-info by name" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     if (comptime platform.is_windows) return error.SkipZigTest; // POSIX-only, raises on Windows
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -215,6 +234,7 @@ test "user-info by name" {
 }
 
 test "user-info? predicate" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -225,6 +245,7 @@ test "user-info? predicate" {
 }
 
 test "group-info for current group" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     if (comptime platform.is_windows) return error.SkipZigTest; // POSIX-only, raises on Windows
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -237,6 +258,7 @@ test "group-info for current group" {
 }
 
 test "group-info? predicate" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -246,6 +268,7 @@ test "group-info? predicate" {
 }
 
 test "directory-files returns list" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -256,6 +279,7 @@ test "directory-files returns list" {
 }
 
 test "open-directory read-directory close-directory cycle" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -270,6 +294,7 @@ test "open-directory read-directory close-directory cycle" {
 }
 
 test "terminal? on file port returns #f" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     if (!platform.pathExists("build.zig")) return error.SkipZigTest;
 
     var gc = memory.GC.init(std.testing.allocator);
@@ -286,6 +311,7 @@ test "terminal? on file port returns #f" {
 }
 
 test "set-environment-variable! and get-environment-variable roundtrip" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -299,6 +325,7 @@ test "set-environment-variable! and get-environment-variable roundtrip" {
 }
 
 test "delete-environment-variable! removes variable" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -313,6 +340,7 @@ test "delete-environment-variable! removes variable" {
 }
 
 test "posix-time returns SRFI-19 time object" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -327,6 +355,7 @@ test "posix-time returns SRFI-19 time object" {
 }
 
 test "monotonic-time returns SRFI-19 time object" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -341,6 +370,7 @@ test "monotonic-time returns SRFI-19 time object" {
 }
 
 test "rename-file works" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -361,6 +391,7 @@ test "rename-file works" {
 }
 
 test "set-file-mode changes permissions" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     if (comptime platform.is_windows) return error.SkipZigTest; // POSIX-only, raises on Windows
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
@@ -387,6 +418,7 @@ test "set-file-mode changes permissions" {
 // discriminating control: a *directory* with st_rdev = 0 that still aborted,
 // pinning the fault on st_dev rather than rdev or the file type.
 test "file-info on devfs paths does not abort (#1976)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the SRFI-170/system surface is unregistered on wasm (primitives.zig wasm gating)
     if (comptime platform.is_windows) return error.SkipZigTest;
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();

--- a/src/tests_fuzz.zig
+++ b/src/tests_fuzz.zig
@@ -292,6 +292,11 @@ fn evalNormalized(input: []const u8, optimize: bool, gpa: std.mem.Allocator) Nor
     // Redirect fd 1 to /dev/null for the duration: generated programs can
     // call (display ...), and the test binary's stdout is the build-runner
     // IPC pipe — a stray write there deadlocks the run.
+    // WASI has neither dup nor a null device (kaappi#2153): bail before any
+    // of those calls so the module never imports the missing symbols. The
+    // generated programs still run under wasmtime — only with output left
+    // on the runner's stdout instead of discarded.
+    if (comptime platform.is_wasm) return .harness_unavailable;
     const saved_stdout = platform.dup(1);
     if (saved_stdout < 0) return .harness_unavailable;
     defer _ = platform.close(saved_stdout);

--- a/src/tests_io.zig
+++ b/src/tests_io.zig
@@ -85,6 +85,7 @@ test "eof-object and eof-object?" {
 }
 
 test "write to file and read back with read-line" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -117,6 +118,7 @@ test "write to file and read back with read-line" {
 }
 
 test "write-char and read-char" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -153,6 +155,7 @@ test "write-char and read-char" {
 }
 
 test "peek-char does not consume" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -184,6 +187,7 @@ test "peek-char does not consume" {
 }
 
 test "close-port marks port as closed" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -198,6 +202,7 @@ test "close-port marks port as closed" {
 }
 
 test "file-exists?" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -218,6 +223,7 @@ test "file-exists?" {
 }
 
 test "file-exists? returns #t for unreadable files" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     // POSIX permission bits; Windows ACLs don't map to chmod(0o000).
     if (comptime platform.is_windows) return error.SkipZigTest;
     var gc = memory.GC.init(std.testing.allocator);
@@ -259,6 +265,7 @@ test "file-exists? returns #t for FIFOs" {
 }
 
 test "read datum from file" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -287,6 +294,7 @@ test "read datum from file" {
 }
 
 test "display and write with port argument" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -318,6 +326,7 @@ test "display and write with port argument" {
 }
 
 test "open-input-file on port is an input port" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -339,6 +348,7 @@ test "open-input-file on port is an input port" {
 }
 
 test "read-line returns eof on empty file" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -359,6 +369,7 @@ test "read-line returns eof on empty file" {
 }
 
 test "read-line with multiple lines" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -397,6 +408,7 @@ test "read-line with multiple lines" {
 }
 
 test "write to port with write procedure" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);

--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -529,6 +529,7 @@ test "cond-expand (library ...) detects an unloaded .sld on the lib path" {
 // include-library-declarations or nested in cond-expand, so the import
 // succeeded with no bindings. .sbc files are now ignored for .sld libraries.
 test "stale .sbc next to .sld must not drop include-library-declarations exports" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try tmp.dir.createDirPath(std.testing.io, "cachedlib");

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -32,6 +32,7 @@ fn definePortGlobal(vm: *th.VM, name: []const u8, fd: platform.fd_t, is_input: b
 }
 
 test "two fibers reading two pipes park and interleave through the reactor" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -63,6 +64,7 @@ test "two fibers reading two pipes park and interleave through the reactor" {
 }
 
 test "main fiber read drives the scheduler while it waits" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -84,6 +86,7 @@ test "main fiber read drives the scheduler while it waits" {
 }
 
 test "write larger than the pipe buffer parks the writer; a reader fiber drains it losslessly" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -120,6 +123,7 @@ test "write larger than the pipe buffer parks the writer; a reader fiber drains 
 }
 
 test "(read) parked mid-datum resumes with the buffered prefix" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -146,6 +150,7 @@ test "(read) parked mid-datum resumes with the buffered prefix" {
 }
 
 test "closing a port with a parked reader raises a clean error in that fiber" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -170,6 +175,7 @@ test "closing a port with a parked reader raises a clean error in that fiber" {
 }
 
 test "#1959: a reader inside dynamic-wind, map or sort parks; only native frames drive" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -238,6 +244,7 @@ test "#1959: a reader inside dynamic-wind, map or sort parks; only native frames
 }
 
 test "#1625: guard reader's idle drive unwinds instead of wedging a resolved join" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -283,6 +290,7 @@ test "#1625: guard reader's idle drive unwinds instead of wedging a resolved joi
 }
 
 test "#1625: guard reader pinned under an expired thread-sleep! unwinds too" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -314,6 +322,7 @@ test "#1625: guard reader pinned under an expired thread-sleep! unwinds too" {
 }
 
 test "#1625: same ordering over an OS pipe unwinds identically" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -337,6 +346,7 @@ test "#1625: same ordering over an OS pipe unwinds identically" {
 }
 
 test "thread-terminate! pulls a parked reader off the reactor; the fd stays usable" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -365,6 +375,7 @@ test "thread-terminate! pulls a parked reader off the reactor; the fd stays usab
 }
 
 test "port write buffer holds bytes until flush; close-port flushes the remainder" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -390,6 +401,7 @@ test "port write buffer holds bytes until flush; close-port flushes the remainde
 }
 
 test "a read on the same port flushes its pending writes first" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -416,6 +428,7 @@ test "a read on the same port flushes its pending writes first" {
 }
 
 test "(read) must not lose read_buf when its write drain parks" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -458,6 +471,7 @@ test "(read) must not lose read_buf when its write drain parks" {
 }
 
 test "binary read-u8 drains bytes a prior (read) left in the port buffer" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -480,6 +494,7 @@ test "binary read-u8 drains bytes a prior (read) left in the port buffer" {
 }
 
 test "lazy non-blocking flip: only for fd > 2 and only once a scheduler exists" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -527,6 +542,7 @@ test "flush-output-port accepts string ports and the default port" {
 }
 
 test "file I/O with fibers active stays correct (files never EAGAIN)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -554,6 +570,7 @@ test "file I/O with fibers active stays correct (files never EAGAIN)" {
 // busy-polling the fd with a 1ms sleep.
 
 test "#1478: fd->port read parks the fiber on the reactor until the peer writes" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -583,6 +600,7 @@ test "#1478: fd->port read parks the fiber on the reactor until the peer writes"
 }
 
 test "#1478: fd->port rejects the standard streams and non-fixnums" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -605,6 +623,7 @@ test "#1478: fd->port rejects the standard streams and non-fixnums" {
 // than one per byte.
 
 test "readOneByte batches an available burst into read_buf, not one syscall per byte" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -631,6 +650,7 @@ test "readOneByte batches an available burst into read_buf, not one syscall per 
 }
 
 test "read-bytevector over a large file preserves byte order across batched chunk boundaries" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -660,6 +680,7 @@ test "read-bytevector over a large file preserves byte order across batched chun
 }
 
 test "read-bytevector composes read_buf left by a prior (read) with fresh fd reads" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -690,6 +711,7 @@ test "read-bytevector composes read_buf left by a prior (read) with fresh fd rea
 }
 
 test "read-bytevector after peek-char includes the peeked byte in order" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // Scheme-level file I/O is deliberately gated off on wasm (kaappi#1972: this WebAssembly build has no filesystem access)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -715,6 +737,7 @@ test "read-bytevector after peek-char includes the peeked byte in order" {
 }
 
 test "a parked mid-read-bytevector retry over a pipe loses no bytes" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -764,6 +787,7 @@ test "a parked mid-read-bytevector retry over a pipe loses no bytes" {
 // ---------------------------------------------------------------------------
 
 test "#1608: two fibers reading two OS-pipe ports park and interleave" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -803,6 +827,7 @@ test "#1608: two fibers reading two OS-pipe ports park and interleave" {
 }
 
 test "#1608: OS-pipe write beyond the pipe buffer parks the writer; a reader fiber drains it" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -840,6 +865,7 @@ test "#1608: OS-pipe write beyond the pipe buffer parks the writer; a reader fib
 }
 
 test "#1608: OS-pipe port stays blocking sequentially; enters non-blocking mode under a scheduler" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -873,6 +899,7 @@ test "#1608: OS-pipe port stays blocking sequentially; enters non-blocking mode 
 }
 
 test "#1608: closing an OS-pipe port with a parked reader raises a clean error in that fiber" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -904,6 +931,7 @@ test "#1608: closing an OS-pipe port with a parked reader raises a clean error i
 }
 
 test "#1608: GC finalization of an abandoned pipe port with a full pipe drops the remainder instead of blocking" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);

--- a/src/tests_reactor.zig
+++ b/src/tests_reactor.zig
@@ -68,6 +68,7 @@ fn writeByte(fd: platform.fd_t, byte: u8) void {
 }
 
 test "register + poll wakes the fiber when the fd becomes readable" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var reactor = try Reactor.init(std.testing.allocator);
     defer reactor.deinit();
 
@@ -90,6 +91,7 @@ test "register + poll wakes the fiber when the fd becomes readable" {
 }
 
 test "poll times out with an empty ready list when nothing fires" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var reactor = try Reactor.init(std.testing.allocator);
     defer reactor.deinit();
 
@@ -109,6 +111,7 @@ test "poll times out with an empty ready list when nothing fires" {
 }
 
 test "multiple waiters on one fd direction are all woken (wake-all)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var reactor = try Reactor.init(std.testing.allocator);
     defer reactor.deinit();
 
@@ -140,6 +143,7 @@ test "multiple waiters on one fd direction are all woken (wake-all)" {
 }
 
 test "a write end is immediately ready for write interest" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var reactor = try Reactor.init(std.testing.allocator);
     defer reactor.deinit();
 
@@ -187,6 +191,7 @@ test "addTimer fires when its deadline passes" {
 }
 
 test "the nearer of an fd timeout and a timer deadline bounds the wait" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var reactor = try Reactor.init(std.testing.allocator);
     defer reactor.deinit();
 
@@ -245,6 +250,7 @@ test "removeTimer cancels a pending timer so it never fires" {
 }
 
 test "unregister drops the registration; a later write wakes nobody" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var reactor = try Reactor.init(std.testing.allocator);
     defer reactor.deinit();
 
@@ -267,6 +273,7 @@ test "unregister drops the registration; a later write wakes nobody" {
 }
 
 test "isEmpty is true after a fired oneshot drains its waiters, even though the fd is still tracked" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var reactor = try Reactor.init(std.testing.allocator);
     defer reactor.deinit();
 
@@ -291,6 +298,7 @@ test "isEmpty is true after a fired oneshot drains its waiters, even though the 
 }
 
 test "re-registering a fd after a fired oneshot re-arms correctly" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // Exercises the epoll first_time bookkeeping directly: a second
     // register() on the same fd after a prior fire must use CTL_MOD, not
     // CTL_ADD (which would fail EEXIST on an already-tracked fd). On
@@ -325,6 +333,7 @@ test "re-registering a fd after a fired oneshot re-arms correctly" {
 }
 
 test "a recycled fd number registers cleanly over a stale Reg left by a close without unregister" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // A port freed by the GC closes its fd without reactor.unregister —
     // the kernel silently drops the fd from the epoll set, but the Reg
     // (kernel_registered=true, empty waiter lists) survives in the map.
@@ -382,6 +391,7 @@ test "a recycled fd number registers cleanly over a stale Reg left by a close wi
 }
 
 test "two fds: only the one that becomes ready wakes its fiber" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var reactor = try Reactor.init(std.testing.allocator);
     defer reactor.deinit();
 
@@ -412,6 +422,7 @@ test "two fds: only the one that becomes ready wakes its fiber" {
 const makeSocketPair = th.makeBidiFdPair;
 
 test "one fd with both read and write interest: a fired direction re-arms the other" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // Regression guard for the epoll-specific bug this design is most at
     // risk of: EPOLLONESHOT disarms the *entire* fd registration on any
     // fire, not just the direction that fired. Without the re-arm-on-
@@ -450,6 +461,7 @@ test "one fd with both read and write interest: a fired direction re-arms the ot
 }
 
 test "closing the peer wakes a parked read waiter (EOF/HUP mapped to broken)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // Exercises the `broken` mapping on both backends (kqueue's EV_EOF,
     // epoll's EPOLLHUP|EPOLLERR): a peer close must be reported as read
     // (and write) readiness so the parked fiber wakes to observe EOF,
@@ -478,6 +490,7 @@ test "closing the peer wakes a parked read waiter (EOF/HUP mapped to broken)" {
 }
 
 test "data already buffered when the read interest is registered still wakes" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // The condition predates the arm. kqueue/epoll report a pre-existing
     // condition on a fresh ONESHOT registration natively; the Windows
     // backend must catch it via arm()'s post-WSAEventSelect readiness
@@ -505,6 +518,7 @@ test "data already buffered when the read interest is registered still wakes" {
 }
 
 test "a peer closed before the read interest is registered still wakes" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // Same pre-arm race as above but for the hangup edge: FD_CLOSE is
     // edge-recorded on Windows, so a peer that closed before the arm
     // would never re-fire — only arm()'s probe can observe it. On
@@ -569,6 +583,7 @@ fn drainSocket(fd: platform.fd_t) void {
 }
 
 test "a stale ONESHOT fire on one direction re-arms the fd for the surviving waiter (#1462)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // removeWaiter only edits the waiter lists — it never touches the
     // kernel registration (see its doc comment). If the removed waiter's
     // direction fires before the surviving direction does, epoll's
@@ -658,6 +673,7 @@ test "retainNotifier keeps the notifier alive past Reactor.deinit; releasing the
 }
 
 test "notify() from another OS thread interrupts a blocking poll()" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no OS threads on wasm32-wasi (single-threaded target)
     var reactor = try Reactor.init(std.testing.allocator);
     defer reactor.deinit();
 
@@ -694,6 +710,7 @@ test "notify() from another OS thread interrupts a blocking poll()" {
 // ---------------------------------------------------------------------------
 
 test "#1608: pipe pair — register + poll wakes the fiber when the pipe becomes readable" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var reactor = try Reactor.init(std.testing.allocator);
     defer reactor.deinit();
 
@@ -723,6 +740,7 @@ test "#1608: pipe pair — register + poll wakes the fiber when the pipe becomes
 }
 
 test "#1608: pipe pair — poll times out empty while the pipe is silent" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var reactor = try Reactor.init(std.testing.allocator);
     defer reactor.deinit();
 
@@ -744,6 +762,7 @@ test "#1608: pipe pair — poll times out empty while the pipe is silent" {
 }
 
 test "#1608: pipe pair — a write end with buffer space is ready for write interest" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var reactor = try Reactor.init(std.testing.allocator);
     defer reactor.deinit();
 

--- a/src/tests_reactor_parity.zig
+++ b/src/tests_reactor_parity.zig
@@ -46,12 +46,17 @@
 //! kqueue (the `macos` matrix leg, plus the FreeBSD/OpenBSD/NetBSD VM legs,
 //! which execute the cross-compiled binary), epoll (`ubuntu-latest`), and
 //! Windows (`windows-arm-test`/`windows-x64-test` run `unit-tests.exe`).
-//! WASI does not: `zig build test -Dtarget=wasm32-wasi` does not compile at
-//! all, so `WasiPollBackend`'s fd path is executed by nothing anywhere —
-//! kaappi#2153. `msFromNs` below is the one exception in the other
-//! direction, a backend-specific rule any host can check; its Windows
-//! twin is a hand-written second copy that no test can reach —
-//! kaappi#2154.
+//! WASI is the half-covered fourth: since kaappi#2153 the suite compiles
+//! and RUNS for wasm32-wasi (the `wasm` CI job executes the unit-tests
+//! binary under wasmtime), so the timer-heap assertions below and
+//! `msFromNs` really do run against `WasiPollBackend`'s CLOCK path — but
+//! the fd assertions skip there, because WASI p1 under wasmtime cannot
+//! construct an EAGAIN-capable fd at all (no pipe/socketpair syscalls,
+//! `sock_open` unimplemented; see docs/dev/porting.md Stage 3), so
+//! `WasiPollBackend`'s fd branch is still executed by nothing anywhere.
+//! `msFromNs` below is the one exception in the other direction, a
+//! backend-specific rule any host can check; its Windows twin is a
+//! hand-written second copy that no test can reach — kaappi#2154.
 //!
 //! Both halves of the kqueue/epoll comparison were executed when this file
 //! landed, not inferred: macOS aarch64 natively, and aarch64 Linux by
@@ -157,6 +162,7 @@ test "parity: timers fire in deadline order, not insertion order" {
 }
 
 test "parity: an already-due timer floors the wait at zero instead of blocking" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // `effectiveTimeout` reduces a past deadline to 0, so `poll` must return
     // the expired fiber without ever blocking — even with an fd registered
     // that will never fire and a multi-second cap. Asserted as ordering
@@ -271,6 +277,7 @@ test "parity: removeTimer cancels only the named fiber; a sibling timer still fi
 // ---------------------------------------------------------------------------
 
 test "parity: poll's documented duplicate wake — one fiber, fd and timer, listed twice" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // `Reactor.poll`'s doc comment: "`ready` may contain the same fiber
     // twice in one call ... Callers must tolerate a duplicate wake". The
     // reactor's half of that contract had no test, so a change that
@@ -305,6 +312,7 @@ test "parity: poll's documented duplicate wake — one fiber, fd and timer, list
 // ---------------------------------------------------------------------------
 
 test "parity: a hangup wakes waiters on both directions, not only the read side" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // Every backend maps a broken fd to *both* directions — kqueue's EV_EOF
     // (`readable = is_read or broken`, `writable = !is_read or broken`),
     // epoll's `EPOLLERR|EPOLLHUP`, WASI's per-subscription error/HANGUP,
@@ -342,6 +350,7 @@ test "parity: a hangup wakes waiters on both directions, not only the read side"
 }
 
 test "parity: both directions of one ready fd wake in a single poll" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // A socket that is simultaneously readable and writable must wake both
     // waiters. kqueue delivers two independent knotes that `wait` merges by
     // fd; epoll delivers one event with `IN|OUT`; the merge and the split
@@ -374,6 +383,7 @@ test "parity: both directions of one ready fd wake in a single poll" {
 }
 
 test "parity: removeWaiter silences the removed fiber and keeps the co-waiter" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // `removeWaiter`'s contract is "without waking it or disturbing other
     // waiters". #1462's test covers the *kernel* consequence of a stale
     // fire; this covers the bookkeeping half on the same direction — two
@@ -405,6 +415,7 @@ test "parity: removeWaiter silences the removed fiber and keeps the co-waiter" {
 }
 
 test "parity: removeWaiter for a fiber that was never registered is a no-op" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // The unwind path (`waitForFd`'s error exit) calls this on fds whose
     // lists may already have been cleared by a fired ONESHOT. It must not
     // disturb the surviving registration.
@@ -435,6 +446,7 @@ test "parity: removeWaiter for a fiber that was never registered is a no-op" {
 }
 
 test "parity: a zero timeout polls without blocking on every backend" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // `effectiveTimeout` floors an already-due deadline at 0 and the
     // scheduler's per-tick probe relies on a 0 wait being a *probe*: kqueue
     // passes a zeroed timespec, epoll `timeout_ms == 0`, WASI a CLOCK
@@ -472,6 +484,7 @@ test "parity: a zero timeout polls without blocking on every backend" {
 }
 
 test "parity: a cross-thread notify interrupts the wait without consuming a timer or an fd arming" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no OS threads on wasm32-wasi (single-threaded target)
     // tests_reactor.zig pins that `notify()` interrupts an otherwise idle
     // `poll`. What nothing pinned is that it interrupts a wait which has
     // *real* work pending without disturbing it — the case that actually

--- a/src/tests_robustness.zig
+++ b/src/tests_robustness.zig
@@ -832,6 +832,7 @@ test "profile: resetProfileCounters reaches functions promoted to the old genera
 }
 
 test "profile: JSON report includes functions promoted to the old generation" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // the JSON profile report is written to a file, and file writes are gated off on wasm
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();

--- a/src/tests_scheduler.zig
+++ b/src/tests_scheduler.zig
@@ -65,6 +65,7 @@ test "hasRunnableFibers reports io_waiting as alive but not a merely-running anc
 }
 
 test "parkOnReactor wakes a manually io_waiting fiber when its fd becomes readable" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -292,6 +293,7 @@ test "runSchedulerStep sets driving for its whole extent and clears it on return
 }
 
 test "review regression: mutex-lock! contended through a 3-level nested dispatch does not corrupt an unrelated fiber's result" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // these drive thread-start!/mutex contention on real OS threads, unavailable on wasm
     // Confirmed VM corruption without the driving guard (git-stash A/B, see
     // tests/scheme/smoke/mutex-nested-dispatch-dirty-snapshot-1487.scm):
     // fiber b sets .waiting on m1 and starts its own nested drive
@@ -507,6 +509,7 @@ test "#1530: a broadcast wakes every enrolled waiter on the object and frees the
 }
 
 test "#1530: a hand-off wakes exactly one waiter and leaves the rest enrolled" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // these drive thread-start!/mutex contention on real OS threads, unavailable on wasm
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
@@ -559,6 +562,7 @@ test "#1530: a terminated (.errored) waiter still in the index is skipped, not r
 }
 
 test "#1530: tail dedup bounds a same-object re-park; a wake+re-park re-indexes" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // these drive thread-start!/mutex contention on real OS threads, unavailable on wasm
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();

--- a/src/tests_shared_channel.zig
+++ b/src/tests_shared_channel.zig
@@ -1107,6 +1107,7 @@ test "Motivation Path 2 regression: a channel reached through a shared global ra
 // ---------------------------------------------------------------------------
 
 test "KEP-0002 Phase 2: thunk snapshot -- mutation after thread-start! returns is not visible to the child" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // cross-OS-thread channels need thread-start!, unregistered on wasm
     // The envelope copy runs synchronously inside thread-start!, before it
     // ever returns -- so this is deterministic, not a race the test might
     // get lucky on. Before Phase 2, the child deepCopy'd fiber.thunk at some
@@ -1122,6 +1123,7 @@ test "KEP-0002 Phase 2: thunk snapshot -- mutation after thread-start! returns i
 }
 
 test "KEP-0002 Phase 2: Motivation Path 1 -- a channel captured in the thread thunk now works end-to-end" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // cross-OS-thread channels need thread-start!, unregistered on wasm
     // Before Phase 1+2: the child errored with "thread thunk contains
     // uncopyable type" (deepCopy rejected channels outright). Now: `ch` is
     // promoted on the parent thread as part of the envelope build (the only
@@ -1139,6 +1141,7 @@ test "KEP-0002 Phase 2: Motivation Path 1 -- a channel captured in the thread th
 }
 
 test "KEP-0002 Phase 2: a channel created and returned by the child promotes correctly" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // cross-OS-thread channels need thread-start!, unregistered on wasm
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
@@ -1162,6 +1165,7 @@ test "KEP-0002 Phase 2: a channel created and returned by the child promotes cor
 }
 
 test "KEP-0002 Phase 2: a thunk returning an uncopyable value raises the .failed path at thread-join!" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // cross-OS-thread channels need thread-start!, unregistered on wasm
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
@@ -1184,6 +1188,7 @@ test "KEP-0002 Phase 2: a thunk returning an uncopyable value raises the .failed
 }
 
 test "KEP-0002 Phase 2: uncopyable thunk is detected synchronously in thread-start!, never spawns an OS thread" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // cross-OS-thread channels need thread-start!, unregistered on wasm
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
@@ -1216,6 +1221,7 @@ test "KEP-0002 Phase 2: uncopyable thunk is detected synchronously in thread-sta
 }
 
 test "kaappi#1742: thread-join! surfaces the child's real failure reason in the default error detail" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // cross-OS-thread channels need thread-start!, unregistered on wasm
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
@@ -1241,6 +1247,7 @@ test "kaappi#1742: thread-join! surfaces the child's real failure reason in the 
 }
 
 test "KEP-0002 Phase 2: thread churn -- repeated cross-thread channel round trips leave no refcount leak" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // cross-OS-thread channels need thread-start!, unregistered on wasm
     const baseline = shared_object.liveCount();
     {
         var ctx: th.TestContext = undefined;
@@ -1287,6 +1294,7 @@ test "KEP-0002 Phase 2: thread churn -- repeated cross-thread channel round trip
 }
 
 test "KEP-0002 Phase 2: an exception raised in the child carrying a channel promotes via the exception envelope" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // cross-OS-thread channels need thread-start!, unregistered on wasm
     const baseline = shared_object.liveCount();
     {
         var ctx: th.TestContext = undefined;
@@ -1344,6 +1352,7 @@ test "KEP-0002 Phase 2: an exception raised in the child carrying a channel prom
 // ---------------------------------------------------------------------------
 
 test "review regression: two spawned fibers each parked on their own promoted channel do not corrupt each other's result" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // cross-OS-thread channels need thread-start!, unregistered on wasm
     // Confirmed VM corruption before this fix (PR #1485 review): drive-
     // parking a scheduler-dispatched fiber (setting .waiting and continuing
     // to nest runSchedulerStep in the same native frame) makes its mid-call
@@ -1381,6 +1390,7 @@ test "review regression: two spawned fibers each parked on their own promoted ch
 }
 
 test "review regression: local sibling send still wakes a receiver after the channel is only transiently promoted" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // cross-OS-thread channels need thread-start!, unregistered on wasm
     // Confirmed false-positive deadlock before this fix (PR #1485 review):
     // channelReceiveShared raised immediately whenever sharedWakeupPossible()
     // was false, even for a dispatched fiber -- breaking ordinary local
@@ -1420,6 +1430,7 @@ test "review regression: local sibling send still wakes a receiver after the cha
 }
 
 test "required regression: park locally -> promote -> remote send wakes (§2 step 4)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // cross-OS-thread channels need thread-start!, unregistered on wasm
     const baseline = shared_object.liveCount();
     const notifier_baseline = reactor_mod.notifierLiveCount();
     {
@@ -1518,6 +1529,7 @@ test "required regression: a rung receiver that loses the pop race re-parks and 
 }
 
 test "N producers / M consumers stress on the raw SharedChannel/ThreadNotifier primitives: no lost or duplicated deliveries, no leaks" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no OS threads on wasm32-wasi (single-threaded target)
     const n_producers = 4;
     const m_consumers = 4;
     const per_producer: usize = if (@import("build_options").gc_stress) 25 else 250;
@@ -1618,6 +1630,7 @@ test "N producers / M consumers stress on the raw SharedChannel/ThreadNotifier p
 }
 
 test "KEP-0002 Phase 3 (#1468): main thread receives values sent concurrently by several real OS threads" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // cross-OS-thread channels need thread-start!, unregistered on wasm
     const baseline = shared_object.liveCount();
     const notifier_baseline = reactor_mod.notifierLiveCount();
     {

--- a/src/tests_shared_channel_rendezvous.zig
+++ b/src/tests_shared_channel_rendezvous.zig
@@ -97,6 +97,7 @@ test "shared rendezvous: timed-out receive withdraws demand on the promoted chan
 }
 
 test "shared rendezvous: cross-thread handoff both directions" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // cross-OS-thread rendezvous needs thread-start!, unregistered on wasm
     // The #1600 scenario on real OS threads, channel captured by the thunk
     // (the KEP-0002 §2 legal sharing path — a top-level global would fail
     // the foreign-owner check instead of promoting).
@@ -191,6 +192,7 @@ test "shared rendezvous: tryTimeoutWithdraw is one lock section (finding 6)" {
 }
 
 test "shared rendezvous: close wakes a parked child-thread receiver (deterministic)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // cross-OS-thread rendezvous needs thread-start!, unregistered on wasm
     // #1604 review: the Scheme twin of this test synchronizes with
     // thread-sleep!, which cannot prove the child parked before the close.
     // Here the parent polls sc.rv_demand — the child's commitment is

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform = @import("platform.zig");
 const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
@@ -64,6 +65,7 @@ test "child VM globals view survives parent-side rehash (#958)" {
 // blocking forever in pthread_join. The child VM polls fiber.terminated at
 // the dispatch-loop safepoint.
 test "thread-terminate! stops busy OS thread and join raises terminated" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // OS threads are unregistered on wasm (thread-start! is native-only)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -91,6 +93,7 @@ test "thread-terminate! stops busy OS thread and join raises terminated" {
 // any allocation is leaked, so the many distinct child-only symbols below must
 // all be reclaimed.
 test "child thread interning distinct new symbols does not leak" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // OS threads are unregistered on wasm (thread-start! is native-only)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -340,6 +343,7 @@ test "abandonFiberMutexes abandons a mutex from another GC heap (#1458)" {
 }
 
 test "thread-terminate! on current thread abandons held mutex" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // OS threads are unregistered on wasm (thread-start! is native-only)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -368,6 +372,7 @@ test "thread-terminate! on current thread abandons held mutex" {
 }
 
 test "mutex-lock! on abandoned mutex raises abandoned-mutex-exception" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // OS threads are unregistered on wasm (thread-start! is native-only)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -399,6 +404,7 @@ test "mutex-lock! on abandoned mutex raises abandoned-mutex-exception" {
 }
 
 test "top-level define with yielding body (scheduler created mid-form)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // OS threads are unregistered on wasm (thread-start! is native-only)
     // Regression: spawn creates the scheduler lazily *during* the form's
     // run, so run() had already committed to the non-scheduler path and the
     // subsequent thread-yield! escaped as error.Yielded, aborting the define.
@@ -421,6 +427,7 @@ test "top-level define with yielding body (scheduler created mid-form)" {
 }
 
 test "top-level form value is the main fiber's result after nested resume" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // OS threads are unregistered on wasm (thread-start! is native-only)
     // Regression: when the main fiber yields and the spawned fiber then
     // blocks in a native primitive (mutex-lock!), the main fiber's form
     // completes inside that primitive's nested scheduler loop. The form's
@@ -511,6 +518,7 @@ test "marking skips objects owned by another GC (#958)" {
 // on the parent heap — between collections every mark bit is false, and the
 // parent's next cycle relies on that to trace its full object graph.
 test "child thread collections leave no stale marks on parent heap (#958)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // OS threads are unregistered on wasm (thread-start! is native-only)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -558,6 +566,7 @@ test "child thread collections leave no stale marks on parent heap (#958)" {
 // procedure to a boxed local, so nothing a child thread runs may leave
 // child-owned values in the shared globals map.
 test "child thread leaves no child-heap values in shared globals (#958)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // OS threads are unregistered on wasm (thread-start! is native-only)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -619,6 +628,7 @@ test "a joined child's freed slots pass to the parent's quarantine (#2127)" {
 // a raw pointer across the copy (issue #958 follow-up). The joined procedures
 // must be fresh parent-heap objects that are still callable.
 test "thread result containing primitive procedures is callable after join" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // OS threads are unregistered on wasm (thread-start! is native-only)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -639,6 +649,7 @@ test "thread result containing primitive procedures is callable after join" {
 // (sched_yield). This test verifies that the yield path coexists with
 // thread-terminate! without leaking error.Yielded (#948).
 test "thread-yield! in child OS thread does not busy-spin or leak Yielded" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // OS threads are unregistered on wasm (thread-start! is native-only)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -665,6 +676,7 @@ test "thread-yield! in child OS thread does not busy-spin or leak Yielded" {
 // pre-fix nesting would run deep; it must complete promptly rather than
 // crash or stall.
 test "concurrent thread-sleep! retries across fibers resolve without unbounded stack growth (#1463)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // OS threads are unregistered on wasm (thread-start! is native-only)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -741,6 +753,7 @@ test "concurrent thread-sleep! retries across fibers resolve without unbounded s
 // instead, because "so far out it never fires" is the legal SRFI-18 reading
 // of a huge deadline (+inf.0 conventionally means "never time out").
 test "seconds->time rejects unrepresentable seconds catchably (#1983)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // OS threads are unregistered on wasm (thread-start! is native-only)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -772,6 +785,7 @@ test "seconds->time rejects unrepresentable seconds catchably (#1983)" {
 }
 
 test "huge and infinite timeouts saturate instead of aborting (#1983)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // OS threads are unregistered on wasm (thread-start! is native-only)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);

--- a/src/tests_waitforfd.zig
+++ b/src/tests_waitforfd.zig
@@ -102,6 +102,7 @@ fn settleSpawnedFibers(vm: *th.VM) !void {
 // ===========================================================================
 
 test "waitForFd cell (idx!=0, dispatched): parks — Yielded, io_waiting, retry armed" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -136,6 +137,7 @@ test "waitForFd cell (idx!=0, dispatched): parks — Yielded, io_waiting, retry 
 }
 
 test "waitForFd cell (idx==0, dispatched): drives — control for the my_idx term" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -165,6 +167,7 @@ test "waitForFd cell (idx==0, dispatched): drives — control for the my_idx ter
 }
 
 test "waitForFd cell (idx!=0, not dispatched): drives — control for the dispatched term" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -193,6 +196,7 @@ test "waitForFd cell (idx!=0, not dispatched): drives — control for the dispat
 }
 
 test "waitForFd cell (idx==0, not dispatched): drives — the sequential main-fiber path" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -214,6 +218,7 @@ test "waitForFd cell (idx==0, not dispatched): drives — the sequential main-fi
 }
 
 test "waitForFd's park branch ignores fd readiness entirely" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // The mirror of the park cell above: an fd with nothing to read parks
     // identically. Together the two pin that the branch is chosen by
     // dispatch state alone — readiness is never consulted before the
@@ -239,6 +244,7 @@ test "waitForFd's park branch ignores fd readiness entirely" {
 }
 
 test "waitForFd parks on write interest with the same selector" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // .write is the second interest the port layer uses (drainWriteBuffer);
     // the selector is interest-independent, and the registration must land
     // in the write list, not the read one.
@@ -266,6 +272,7 @@ test "waitForFd parks on write interest with the same selector" {
 }
 
 test "waitForFd restores status and unregisters when reactor registration fails" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // The one pre-branch failure path: register() rejects the fd (EBADF on
     // a closed one). Neither branch has run yet, so the fiber must be left
     // exactly as it was found — not stranded in .io_waiting with a dangling
@@ -548,6 +555,7 @@ test "an empty driving_waits stack never reports a resolved ancestor" {
 // ===========================================================================
 
 test "yield-retry: a park mid-UTF-8-sequence stashes the consumed prefix" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -587,6 +595,7 @@ test "yield-retry: a park mid-UTF-8-sequence stashes the consumed prefix" {
 }
 
 test "yield-retry: a park mid-line stashes the partial line" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -619,6 +628,7 @@ test "yield-retry: a park mid-line stashes the partial line" {
 }
 
 test "yield-retry: a park mid-CRLF stashes the bare carriage return" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // read-line's CR lookahead consumes a byte it has not appended. If the
     // lookahead parks and the CR is not re-stashed, the retry never reaches
     // the same decision point and the line boundary silently moves.
@@ -650,6 +660,7 @@ test "yield-retry: a park mid-CRLF stashes the bare carriage return" {
 }
 
 test "yield-retry: a park mid-datum stashes the partial datum for (read)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -676,6 +687,7 @@ test "yield-retry: a park mid-datum stashes the partial datum for (read)" {
 }
 
 test "yield-retry: a park at an item boundary stashes nothing" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // The control for the four tests above: with no partial progress to
     // preserve, the park must leave read_buf empty. A stash-everything
     // implementation would pass those and fail this.
@@ -702,6 +714,7 @@ test "yield-retry: a park at an item boundary stashes nothing" {
 }
 
 test "yield-retry: a write-side park resumes from write_buf_start without duplicating" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // The write half of the contract takes a different route from the read
     // half: portWriteBytes drains BEFORE appending, and drainWriteBuffer
     // records how far it got in the port's own `write_buf_start`. Nothing is
@@ -777,6 +790,7 @@ test "yield-retry: a write-side park resumes from write_buf_start without duplic
 // ===========================================================================
 
 test "which frames force the drive branch: guard does; map and dynamic-wind do not" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // waitForFd's doc comment names "guard, dynamic-wind, callbacks" as the
     // re-entrant native frames that make a spawned fiber drive rather than
     // park, and vm.in_custom_port_callback's own comment lists
@@ -839,6 +853,7 @@ test "which frames force the drive branch: guard does; map and dynamic-wind do n
 }
 
 test "close-port on a parked fd wakes the waiter and its retry raises cleanly" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // wakeIoWaitersOnFd's contract on the PARK path (the existing
     // tests_port_io close test covers the drive path, where the wait
     // returns into waitPortFd's own is_open re-check). Here the retry is
@@ -890,6 +905,7 @@ test "close-port on a parked fd wakes the waiter and its retry raises cleanly" {
 }
 
 test "a custom-port callback is refused before the drive, even on a ready fd" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // vm.in_custom_port_callback is checked BEFORE runSchedulerStep, so the
     // rejection does not depend on the fd being unready — a callback that
     // would have succeeded by luck still gets the documented error rather
@@ -927,6 +943,7 @@ test "a custom-port callback is refused before the drive, even on a ready fd" {
 }
 
 test "a stale timed_out does not degrade an fd wait into an abandonment" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // waitForFd clears me.timed_out before driving. Without that, an fd
     // wait inheriting a leftover deadline flag from an earlier timed wait
     // exits runSchedulerStep's loop immediately with done == false — which
@@ -952,6 +969,7 @@ test "a stale timed_out does not degrade an fd wait into an abandonment" {
 }
 
 test "#1625 unwind leaves the fd unregistered and the port usable" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // The abandonment path's cleanup half, which the existing single #1625
     // test does not assert: the raise happens after waitForFd's defer, so
     // the reactor must hold no waiter for the fd afterwards — otherwise
@@ -992,6 +1010,7 @@ test "#1625 unwind leaves the fd unregistered and the port usable" {
 }
 
 test "two fibers parked on the same fd are both listed and both woken by close" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
     // waitForFd registers per-fiber, not per-fd, and wakeIoWaitersOnFd
     // iterates every fiber rather than the reactor's list — the two must
     // agree, or a second waiter is silently stranded.

--- a/src/thottam_proc.zig
+++ b/src/thottam_proc.zig
@@ -34,6 +34,12 @@ pub fn runCapture(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?
         const trimmed = std.mem.trim(u8, raw, "\n\r");
         return allocator.dupe(u8, trimmed) catch return error.OutOfMemory;
     }
+    // WASI p1 has no process creation — and wasi-libc does not even provide
+    // pipe/fork/execve as symbols, so the POSIX tail below would leave the
+    // module with imports no host can resolve (kaappi#2153). Thottam does
+    // not ship in the wasm build; this arm exists so the unit-test module
+    // compiles as a gate.
+    if (comptime platform.is_wasm) return error.ForkFailed;
 
     const argv_z = try allocator.alloc(?[*:0]const u8, argv.len + 1);
     @memset(argv_z, null);
@@ -117,6 +123,7 @@ pub fn runPassthrough(allocator: std.mem.Allocator, argv: []const []const u8, cw
             else => return error.ForkFailed,
         };
     }
+    if (comptime platform.is_wasm) return error.ForkFailed; // no process creation on WASI p1 (see runCapture)
 
     const argv_z = try allocator.alloc(?[*:0]const u8, argv.len + 1);
     @memset(argv_z, null);

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -40,11 +40,14 @@ test {
     _ = @import("tests_native.zig");
     _ = @import("tests_native_dispatch.zig");
     _ = @import("tests_native_gate.zig");
-    // The fd-readiness suites run everywhere: their fds come from
-    // testing_helpers' cross-platform pairs — pipes/socketpairs on POSIX,
-    // loopback socket pairs on Windows, where these suites cover the
-    // WSAEventSelect socket backend, and their "#1608:" pipe-pair tests
-    // cover the polled pipe backend (stage 2).
+    // The fd-readiness suites run on every hosted target: their fds come
+    // from testing_helpers' cross-platform pairs — pipes/socketpairs on
+    // POSIX, loopback socket pairs on Windows, where these suites cover
+    // the WSAEventSelect socket backend, and their "#1608:" pipe-pair
+    // tests cover the polled pipe backend (stage 2). WASI is the one
+    // exception — no constructible fd pairs there, the fd tests skip
+    // (kaappi#2153) while the timer/scheduler halves still run under
+    // wasmtime.
     _ = @import("tests_reactor.zig");
     // Audit v2 Phase 5G: the backend-parity contracts. Same per-OS legs, so
     // the assertions run against whichever of the four backends the target


### PR DESCRIPTION
## Direction chosen

The issue's **(a)** — fix the compile errors so `zig build test -Dtarget=wasm32-wasi` becomes a compile gate like Windows and run the produced binary under wasmtime in the existing `wasm` job — with **(b)**'s documentation for the one piece no runtime can host: the fd-readiness criterion.

I probed the boundary empirically on wasmtime 48 (the CI runner is v46.0.1, same p1 implementation): `sock_open` is an unresolvable import even with `-S inherit-network`/`-S tcp`, the legacy p1 (`-S preview2=n`) is gone, and `poll_oneoff` with an FD subscription fails the whole call with `BADF` on every fd a guest *can* obtain (closed fd, stdout pipe end, preopened dir). So a WASI guest cannot construct any EAGAIN-capable fd under the CI runtime — the fd suites cannot execute there at any cost, which is exactly what (b)'s Stage 3 note is for. Everything else the issue asks for is delivered as execution, not documentation.

## What changed

**The compile gate (the headline).** `zig build test -Dtarget=wasm32-wasi` exits 0 and installs `zig-out/bin/unit-tests.wasm`:
- WASI arms across the platform facade: write-open family + `openNullSink` (`path_open`), `DirIter` (`fd_readdir`), the `dl*` family, `argsIterate`; process-spawn sites (`thottam_proc`, `test_runner`, `test_selection`, `doctor`, `native_compiler`) return their spawn errors comptime-gated so the module never imports wasi-libc's missing `pipe`/`fork`/`execve` symbols; `testing_helpers`' fd-pair family grows honest WASI arms; FFI test constants made 32-bit-safe.
- `build.zig`: the wasm test module is single-threaded (matching the wasm executable — std's Io/futex plumbing otherwise emits `memory.atomic.wait` inline asm), carries the atomics CPU feature (only waits need shared memory; this module never waits), defaults to ReleaseSmall (Debug exceeds wasmtime's per-function locals limit in the comptime-generated FFI dispatchers; ReleaseSafe crashes the LLVM wasm32 backend selecting a float constant pool — explicit `-Doptimize` is always respected), and installs the test binary for a wasm runtime.

**Execution under wasmtime.** `wasmtime run --dir=. --dir=/tmp zig-out/bin/unit-tests.wasm` → **1542 passed, 209 skipped, 0 failed, of 1751 — the same test count as the native suite**. This genuinely executes `WasiPollBackend`'s CLOCK path (`addTimer`, `removeTimer`, `popExpiredTimers`, `msFromNs`, the scheduler/fiber halves), which previously ran only in `tests/wasm/timers.scm` via the CLI.

**The fd boundary, documented.** fd-pair/thread/ffi/Scheme-file-I/O tests skip on wasm with per-test comptime gates naming their reason; `testing_helpers.wasmNoFdPairs` panics if an fd test reaches a pair constructor without its skip (a missing gate is loud, never silent). `docs/dev/porting.md` Stage 3 states the boundary and what IS required of a WASI leg, replacing the self-contradiction the issue called out.

**A real bug the gate found immediately** (the issue's own 32-bit-`usize` class, sibling of #1912): `(make-bytevector 100000000000000)` and `(make-string ...)` with absurd lengths **silently allocated a truncated, far smaller object** on wasm32 — the i64 length truncated inside `@intCast` before the GC payload cap could see it (verified on the shipped `kaappi.wasm`: the call returned normally). `primitives.fixnumFitsUsize` now compares in u64 before narrowing at the three `make-*` sites and raises the same `OutOfMemory` the 64-bit payload cap would, so `guard` sees one cross-platform condition. The pre-existing absurd-payload regression test now *runs on wasm and fails without the fix* — it could never run before this PR.

**Also:**
- `platform.zig`'s WASI opens now resolve through the **preopen table** the way wasi-libc does (relative → CWD preopen, absolute → longest preopen-name prefix match) instead of hardcoding fd 3 — the unit tests' `/tmp/...` paths resolve under `--dir=/tmp`, and Zig-level reads keep the #2108 relative convention.
- Three assertions that assumed "unit tests never build for WASM" (`kaappi-threads`, `(library (srfi 18))`, `features`' `sandbox_available`) now expect each platform's correct answer instead of an unconditional native one.
- CI: the `wasm` job gains `WASI unit tests (compile gate + run under wasmtime)` — the runner was already installed there. The bare-error BASELINE line is untouched.

## Verification

- `zig build test -Dtarget=wasm32-wasi` → exit 0 (compile gate; run auto-skips as foreign), installs `unit-tests.wasm`.
- `wasmtime run --dir=. --dir=/tmp zig-out/bin/unit-tests.wasm` → exit 0, **1542 passed; 209 skipped; 0 failed** (wasmtime 48.0.0, macOS aarch64 host).
- Native `zig build test` → exit 0, **Build Summary: 11/11 steps succeeded; 1822/1829 tests passed (7 skipped)** (unit-tests 1744 pass/7 skip, thottam-tests 78 pass).
- `zig build wasm` (shipped binary) → exit 0; its smoke surface unchanged.
- `zig fmt --check` clean on every touched file; `ci.yml` parses; skips are visible in the wasm run output (`...SKIP` per test), not silent.

Closes #2153

🤖 Generated with [Claude Code](https://claude.com/claude-code)
