### PR TITLE
io: gate fd->port off on WASM like its ffi-* siblings (#2018)

### DIFF
--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -385,6 +385,18 @@ comptime {
                     lib.canonicalName() ++ "; use `.internal` (see Lib.internal) or a *_primitives sub-library");
         }
     }
+    // Every `(kaappi ffi)` primitive is native-only. Unlike SRFI 18 — whose
+    // OS-thread library is WASM-unavailable yet keeps the fiber-safe
+    // `thread-sleep!` registered as a working global — (kaappi ffi) has no
+    // WASM-viable subset: nothing behind these names can ever succeed on
+    // wasm32-wasi. A spec that omits `.wasm = false` would register a global
+    // that exists solely to refuse (kaappi#2018), so require it here rather
+    // than let the next FFI primitive silently reintroduce the divergence.
+    for (all_specs) |spec| {
+        if (spec.libs.contains(.kaappi_ffi) and spec.wasm)
+            @compileError("`.kaappi_ffi` spec \"" ++ spec.name ++
+                "\" must set `.wasm = false`: (kaappi ffi) has no WASM-viable subset (kaappi#2018)");
+    }
 }
 
 pub fn registerAll(vm: *vm_mod.VM) !void {

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -65,7 +65,7 @@ pub const specs = [_]primitives.PrimSpec{
     // already imports — so a raw fd from an FFI call can be given reactor-
     // integrated non-blocking I/O (#1478). Not in sandbox: it is a raw
     // capability over an arbitrary descriptor.
-    .{ .name = "fd->port", .func = &fdToPort, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_ffi), .sandbox = false },
+    .{ .name = "fd->port", .func = &fdToPort, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_ffi), .sandbox = false, .wasm = false },
 };
 
 // ---------------------------------------------------------------------------

--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -698,6 +698,12 @@ test "every spec name resolves in globals (drift guard)" {
     defer vm.deinit();
 
     for (&primitives_mod.all_specs) |spec| {
+        // A `.wasm = false` spec is deliberately not registered on wasm32-wasi
+        // — registerAll gates it with `if (!is_wasm or spec.wasm)`, so on this
+        // target its absence is the rule, not drift (kaappi#2018).
+        if (comptime platform.is_wasm) {
+            if (!spec.wasm) continue;
+        }
         // The helpers vm_bootstrap.install() removes from globals after the
         // bootstrapped closures capture them (#1375) must NOT resolve —
         // calling %push-wind or a %promise-* mutator out of sequence

--- a/tests/wasm/platform-gates.scm
+++ b/tests/wasm/platform-gates.scm
@@ -23,6 +23,10 @@
   (newline)
   (if (not ok) (set! failures (+ failures 1))))
 
+(define (starts-with? s prefix)
+  (and (>= (string-length s) (string-length prefix))
+       (string=? (substring s 0 (string-length prefix)) prefix)))
+
 (define (classify thunk)
   (guard (e (#t (list (cond ((file-error? e) 'file-error)
                             ((error-object? e) 'error)
@@ -69,14 +73,19 @@
               (open-input-file "gate.txt"))))
 
 ;; --- fd->port ---------------------------------------------------------------
-;; A Kaappi extension over (kaappi ffi) — which is itself unavailable on WASM,
-;; though the primitive stays registered as a global, so the gate is reachable.
-;; No file is involved and nothing here satisfies file-error?, so this one is an
-;; argument fault (KP3007) rather than a borrowed file error.
+;; A Kaappi extension over (kaappi ffi), which has no WASM-viable subset — so,
+;; unlike SRFI 18's thread-sleep!, fd->port carries `.wasm = false` like its
+;; seven ffi-* siblings and is not registered at all on this target
+;; (kaappi#2018). The name genuinely does not exist here, so a reference is an
+;; undefined-variable fault, not a global that exists solely to refuse. (A
+;; "Did you mean …?" tail may follow, so match the prefix rather than the
+;; whole message.)
 
-(check "fd->port reports the platform, not the descriptor"
-       (equal? (classify (lambda () (fd->port 5)))
-               '(error "fd->port: raw file descriptors are unavailable in this WebAssembly build" ())))
+(check "fd->port is not registered on WASM (undefined, not a refusing global)"
+       (let ((c (classify (lambda () (fd->port 5)))))
+         (and (eq? (car c) 'error)
+              (string? (cadr c))
+              (starts-with? (cadr c) "undefined variable 'fd->port'"))))
 
 ;; --- controls ---------------------------------------------------------------
 ;; Without these the fix could have flattened every failure into a file error
@@ -85,10 +94,6 @@
 (check "CONTROL: a non-string argument is still a type error"
        (equal? (classify (lambda () (open-input-file 42)))
                '(error "type error in 'open-input-file': expected string, got 42" ())))
-
-(check "CONTROL: fd->port still type-checks its argument first"
-       (equal? (classify (lambda () (fd->port 'not-a-fixnum)))
-               '(error "type error in 'fd->port': expected file descriptor, got not-a-fixnum" ())))
 
 ;; file-exists? is the one filesystem procedure with a value to degrade to, so
 ;; it answers #f rather than raising anything at all — deliberately unlike the


### PR DESCRIPTION
## Summary

`fd->port` was the only `.kaappi_ffi` spec without `.wasm = false`. Because `PrimSpec.wasm` defaults to `true`, it was registered in `vm.globals` on the `wasm32-wasi` build while its seven siblings (`ffi-open`, `ffi-fn`, `ffi-close`, `ffi-callback`, `ffi-callback-release`, `ffi-callback?`, `ffi-bytevector-ptr`) were not. The `(kaappi ffi)` library is itself `wasmAvailable = false`, and `fdToPort`'s `comptime is_wasm` gate can only refuse — so the registered global existed solely to say "no".

Unlike SRFI 18 (whose OS-thread library is WASM-unavailable but keeps the fiber-safe `thread-sleep!` as a working global), `(kaappi ffi)` has **no** WASM-viable subset. The honest state is that the name does not exist there, which is what `.wasm = false` gives — `(fd->port …)` becomes an undefined-variable fault, consistent with the siblings.

## Changes

- `src/primitives_io.zig`: add `.wasm = false` to the `fd->port` spec.
- `src/primitives.zig`: comptime assertion that **every** `.kaappi_ffi` spec sets `.wasm = false`. Comptime blocks run on every target, so the native build alone now fails to compile if a future FFI primitive reintroduces the divergence.
- `tests/wasm/platform-gates.scm` (run under wasmtime in the `wasm` CI job): the two `fd->port` assertions now check that the name is undefined on WASM rather than a refusing global.

The in-body `comptime is_wasm` gate in `fdToPort` is kept intentionally: `.wasm = false` only skips *runtime registration*, so `fdToPort` is still compiled into the wasm binary and the gate remains load-bearing for comptime analysis (mirrors `primitives_srfi18.zig`'s `threadStartImpl` guard).

## Verification

- `zig build` and `zig build test` (native): pass — 1841 tests. The successful native build already proves the comptime invariant holds (fd->port has `.wasm = false`).
- `zig build test -Dtarget=wasm32-wasi`: compiles (`unit-tests.wasm` builds).
- `zig build wasm` + `wasmtime run zig-out/bin/kaappi.wasm tests/wasm/platform-gates.scm`: all 9 platform-gate checks pass, including the new "fd->port is not registered on WASM" assertion.
- Native `fd->port` still registered and type-checks (`type error in 'fd->port': expected file descriptor, got x`).

Note: `zig build -Dtarget=wasm32-wasi` (the ReleaseSafe exe) fails locally on a pre-existing LLVM "Cannot select" float-constant bug in `primitives_numeric.angleFn` (reproduces on clean `origin/main`, unrelated to this change; `zig build wasm` uses ReleaseSmall and is unaffected).

Closes #2018

🤖 Generated with [Claude Code](https://claude.com/claude-code)