### PR TITLE
Route internal record primitives' range failures through the taxonomy helpers (#1914)

### DIFF
--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -1286,7 +1286,7 @@ fn makeRecordTypeFn(args: []const Value) PrimitiveError!Value {
     // procedural ones); absent for count-only callers.
     const name_data = try expectString("%make-record-type", args[0]);
     const nf = try expectFixnum("%make-record-type", args[1]);
-    if (nf < 0 or nf > 255) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+    if (nf < 0 or nf > 255) return argError("%make-record-type", "field count {d} is out of range (must be 0 to 255)", .{nf});
     const num_fields: u8 = @intCast(nf);
 
     if (args.len == 2) {
@@ -1301,7 +1301,7 @@ fn makeRecordTypeFn(args: []const Value) PrimitiveError!Value {
         if (!types.isPair(specs_cur)) return typeError("%make-record-type", "list", args[2]);
         const entry = types.car(specs_cur);
         if (!types.isPair(entry)) return typeError("%make-record-type", "(name . mutable?) pair", entry);
-        if (field_count >= 255) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+        if (field_count >= 255) return argError("%make-record-type", "record type would have more than 255 fields, but the limit is 255", .{});
         field_names_buf[field_count] = try expectString("%make-record-type", types.car(entry));
         field_mutable_buf[field_count] = types.cdr(entry) != types.FALSE;
         field_count += 1;
@@ -1357,7 +1357,7 @@ fn recordRefFn(args: []const Value) PrimitiveError!Value {
     if (!types.sameRecordType(ri.record_type, rt)) return typeError("%record-ref", rt.name, args[0]);
     if (!types.isFixnum(args[1])) return typeError("%record-ref", "exact integer", args[1]);
     const raw_idx = types.toFixnum(args[1]);
-    if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+    if (raw_idx < 0) return indexError("%record-ref", raw_idx, ri.fields.len);
     // u64 comparison before narrowing (kaappi#1912): see fixnumIndexInBounds.
     if (!fixnumIndexInBounds(raw_idx, ri.fields.len)) return indexError("%record-ref", raw_idx, ri.fields.len);
     const idx: usize = @intCast(raw_idx);
@@ -1373,7 +1373,7 @@ fn recordSetFn(args: []const Value) PrimitiveError!Value {
     if (!types.sameRecordType(ri.record_type, rt)) return typeError("%record-set!", rt.name, args[0]);
     if (!types.isFixnum(args[1])) return typeError("%record-set!", "exact integer", args[1]);
     const raw_idx = types.toFixnum(args[1]);
-    if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+    if (raw_idx < 0) return indexError("%record-set!", raw_idx, ri.fields.len);
     // u64 comparison before narrowing (kaappi#1912): see fixnumIndexInBounds.
     if (!fixnumIndexInBounds(raw_idx, ri.fields.len)) return indexError("%record-set!", raw_idx, ri.fields.len);
     const idx: usize = @intCast(raw_idx);

--- a/src/primitives_srfi237.zig
+++ b/src/primitives_srfi237.zig
@@ -257,7 +257,10 @@ fn makeRecordTypeDescriptorFn(args: []const Value) PrimitiveError!Value {
         if (!types.isPair(specs_cur)) return typeError(MAKE_RTD, "list", args[5]);
         const entry = types.car(specs_cur);
         if (!types.isPair(entry)) return typeError(MAKE_RTD, "(name . mutable?) pair", entry);
-        if (field_count >= 255) return PrimitiveError.TypeError; // bare-ok: internal record primitive; own_field_count is u8
+        // own_field_count is a u8: a 256th own field cannot be represented.
+        // Report it the same way as the post-alloc TooManyFields path, which
+        // also names the inherited count (the issue's "sharpest instance").
+        if (field_count >= 255) return tooManyFieldsError(MAKE_RTD, field_count + 1, parent);
         field_names_buf[field_count] = try expectString(MAKE_RTD, types.car(entry));
         field_mutable_buf[field_count] = types.cdr(entry) != types.FALSE;
         field_count += 1;
@@ -335,7 +338,7 @@ fn recordRefInheritFn(args: []const Value) PrimitiveError!Value {
     if (!isOrDescendsFrom(ri.record_type, rt)) return typeError("%record-ref/inherit", rt.name, args[0]);
     if (!types.isFixnum(args[1])) return typeError("%record-ref/inherit", "exact integer", args[1]);
     const raw_idx = types.toFixnum(args[1]);
-    if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+    if (raw_idx < 0) return indexError("%record-ref/inherit", raw_idx, ri.fields.len);
     // u64 comparison before narrowing (kaappi#1912): see primitives.fixnumIndexInBounds.
     if (!primitives.fixnumIndexInBounds(raw_idx, ri.fields.len)) return indexError("%record-ref/inherit", raw_idx, ri.fields.len);
     const idx: usize = @intCast(raw_idx);
@@ -355,13 +358,13 @@ fn recordRefInheritFn(args: []const Value) PrimitiveError!Value {
 fn recordSplitArgsFn(args: []const Value) PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
     const suffix_len_raw = try expectFixnum("%record-split-args", args[1]);
-    if (suffix_len_raw < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+    if (suffix_len_raw < 0) return argError("%record-split-args", "suffix length {d} must be non-negative", .{suffix_len_raw});
     var buf: [256]Value = undefined;
     var n: usize = 0;
     var cur = args[0];
     while (cur != types.NIL) {
         if (!types.isPair(cur)) return typeError("%record-split-args", "list", args[0]);
-        if (n >= 256) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+        if (n >= 256) return argError("%record-split-args", "argument list has more than {d} elements, the maximum this desugarer supports", .{buf.len});
         buf[n] = types.car(cur);
         n += 1;
         cur = types.cdr(cur);
@@ -370,7 +373,7 @@ fn recordSplitArgsFn(args: []const Value) PrimitiveError!Value {
     // suffix would truncate and pass the check against a short list, or panic
     // @intCast on a safety-checked build.  The narrowing runs only after the
     // check passes.
-    if (!primitives.fixnumIndexInBoundsInclusive(suffix_len_raw, n)) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+    if (!primitives.fixnumIndexInBoundsInclusive(suffix_len_raw, n)) return argError("%record-split-args", "cannot take the last {d} elements of a {d}-element list", .{ suffix_len_raw, n });
     const suffix_len: usize = @intCast(suffix_len_raw);
     const split = n - suffix_len;
 
@@ -390,7 +393,7 @@ fn recordSetInheritFn(args: []const Value) PrimitiveError!Value {
     if (!isOrDescendsFrom(ri.record_type, rt)) return typeError("%record-set!/inherit", rt.name, args[0]);
     if (!types.isFixnum(args[1])) return typeError("%record-set!/inherit", "exact integer", args[1]);
     const raw_idx = types.toFixnum(args[1]);
-    if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+    if (raw_idx < 0) return indexError("%record-set!/inherit", raw_idx, ri.fields.len);
     // u64 comparison before narrowing (kaappi#1912): see primitives.fixnumIndexInBounds.
     if (!primitives.fixnumIndexInBounds(raw_idx, ri.fields.len)) return indexError("%record-set!/inherit", raw_idx, ri.fields.len);
     const idx: usize = @intCast(raw_idx);
@@ -462,7 +465,7 @@ fn recordFieldMutableFn(args: []const Value) PrimitiveError!Value {
     if (!types.isRecordType(args[0])) return typeError("%record-field-mutable?", "record-type", args[0]);
     const rt = asRecordType(args[0]);
     const raw_idx = try expectFixnum("%record-field-mutable?", args[1]);
-    if (raw_idx < 0) return PrimitiveError.TypeError; // bare-ok: internal record primitive
+    if (raw_idx < 0) return indexError("%record-field-mutable?", raw_idx, rt.own_field_mutable.len);
     // u64 comparison before narrowing (kaappi#1912): see primitives.fixnumIndexInBounds.
     if (!primitives.fixnumIndexInBounds(raw_idx, rt.own_field_mutable.len)) return indexError("%record-field-mutable?", raw_idx, rt.own_field_mutable.len);
     const idx: usize = @intCast(raw_idx);

--- a/tests/scheme/audit/error-taxonomy-audit.scm
+++ b/tests/scheme/audit/error-taxonomy-audit.scm
@@ -33,10 +33,14 @@
 ;;; message text). `raises?`-only assertions pin nothing -- a documented lesson
 ;;; from #1944, and the central hazard of this unit specifically.
 ;;;
+;;; #1914 is FIXED: the ten internal `%` record primitives that returned a bare
+;;; TypeError on a range/limit failure (blaming a valid args[0]) now route
+;;; through indexError (KP3006) for out-of-range indices and argError (KP3007)
+;;; for rejected-but-well-typed values. Pinned in PART 8.
+;;;
 ;;; Related, already filed -- not re-tested here:
 ;;;   #1899 primitives.safeValueDescription renders heap values opaquely (F10)
 ;;;        (fixed; its assertions remain live in PART 5)
-;;;   #1914 internal `%` primitives return bare TypeError on range failures
 ;;;   #1944 / #1972 primitives_io.zig taxonomy
 ;;;   #1978 SRFI-170 errno / filesystem range errors
 ;;;   #2002 fibers: make-channel range error claims a type error
@@ -610,6 +614,110 @@
             'KP3002 (code-of (lambda () (+ 1 'x))))
 (test-equal "clean: apply with a non-procedure is KP3005, not KP3002"
             'KP3005 (code-of (lambda () (apply 42 '()))))
+
+;; ===========================================================================
+;; PART 8 -- internal `%` record primitives: range failures        [FIXED: #1914]
+;;
+;; Ten sites in primitives.zig / primitives_srfi237.zig returned a bare
+;; PrimitiveError.TypeError on a range/limit failure. mapNativeError then
+;; synthesized "type error in '<proc>': got <args[0]>" -- naming the FIRST
+;; argument, which is valid in every one of these cases (the record, the name,
+;; the whole input list), and omitting the expected type. All ten carried a
+;; misapplied `// bare-ok:` annotation, so the CI gate waved them through.
+;;
+;; These primitives are ambient globals (%-prefixed, exported by nothing), so
+;; they are reachable here by name without an import.
+;; ===========================================================================
+
+;; A field-spec list of `n` entries for %make-record-type-descriptor / the
+;; 3-arg %make-record-type.
+(define (specs-1914 n)
+  (let loop ((i 0) (acc '()))
+    (if (= i n) (reverse acc)
+        (loop (+ i 1) (cons (cons (string-append "f" (number->string i)) #f) acc)))))
+(define (rtd-1914 name parent uid sealed opaque fields)
+  (%make-record-type-descriptor name parent uid sealed opaque fields))
+
+;; -- Negative indices are KP3006, naming the real index, not args[0] ---------
+;; The control (a POSITIVE out-of-range index) was already correct; the issue's
+;; discriminating test is that the NEGATIVE one used to degrade to a type error.
+(test-equal "%record-ref with a negative index is KP3006"
+            'KP3006
+            (code-of (lambda ()
+                       (let ((rt (%make-record-type "T" 2)))
+                         (%record-ref (%make-record rt 1 2) -1 rt)))))
+(test-equal "%record-ref: positive and negative out-of-range agree on the code"
+            (code-of (lambda ()
+                       (let ((rt (%make-record-type "T" 2)))
+                         (%record-ref (%make-record rt 1 2) 2 rt))))
+            (code-of (lambda ()
+                       (let ((rt (%make-record-type "T" 2)))
+                         (%record-ref (%make-record rt 1 2) -1 rt)))))
+(test-assert "%record-ref's negative-index message names the index, not the record"
+             (contains? (msg-of (lambda ()
+                                  (let ((rt (%make-record-type "T" 2)))
+                                    (%record-ref (%make-record rt 1 2) -1 rt))))
+                        "-1"))
+(test-assert "%record-ref's negative-index message no longer says 'type error'"
+             (not (contains? (msg-of (lambda ()
+                                       (let ((rt (%make-record-type "T" 2)))
+                                         (%record-ref (%make-record rt 1 2) -1 rt))))
+                             "type error")))
+(test-equal "%record-set! with a negative index is KP3006"
+            'KP3006
+            (code-of (lambda ()
+                       (let ((rt (%make-record-type "T" 2)))
+                         (%record-set! (%make-record rt 1 2) -1 9 rt)))))
+(test-equal "%record-field-mutable? with a negative index is KP3006"
+            'KP3006
+            (code-of (lambda () (%record-field-mutable? (%make-record-type "T" 1 '(("a" . #t))) -1))))
+(test-equal "%record-ref/inherit with a negative index is KP3006"
+            'KP3006
+            (code-of (lambda ()
+                       (let* ((p (rtd-1914 "P" #f #f #f #f '(("a" . #f))))
+                              (c (rtd-1914 "C" p #f #f #f '(("b" . #f)))))
+                         (%record-ref/inherit (%make-record c 1 2) -1 c)))))
+(test-equal "%record-set!/inherit with a negative index is KP3006"
+            'KP3006
+            (code-of (lambda ()
+                       (let* ((p (rtd-1914 "P" #f #f #f #f '(("a" . #f))))
+                              (c (rtd-1914 "C" p #f #f #f '(("b" . #t)))))
+                         (%record-set!/inherit (%make-record c 1 2) -1 9 c)))))
+
+;; -- Field-count / size limits are KP3007, naming the count, not the name ----
+(test-equal "%make-record-type with 256 fields is KP3007"
+            'KP3007 (code-of (lambda () (%make-record-type "T" 256))))
+(test-equal "%make-record-type with a negative field count is KP3007"
+            'KP3007 (code-of (lambda () (%make-record-type "T" -1))))
+(test-assert "%make-record-type's field-count message names 256, not the type name"
+             (contains? (msg-of (lambda () (%make-record-type "T" 256))) "256"))
+(test-assert "%make-record-type's field-count message no longer says 'type error'"
+             (not (contains? (msg-of (lambda () (%make-record-type "T" 256))) "type error")))
+(test-equal "%make-record-type with more than 255 field-specs is KP3007"
+            'KP3007 (code-of (lambda () (%make-record-type "T" 2 (specs-1914 256)))))
+;; The issue's "sharpest instance": the 255-field limit reached via OWN fields
+;; now reports the same symmetric message the inherited path already did.
+(test-equal "%make-record-type-descriptor with 256 own fields is KP3007"
+            'KP3007 (code-of (lambda () (rtd-1914 "T" #f #f #f #f (specs-1914 256)))))
+(test-assert "...and its message names the field count and the limit"
+             (let ((m (msg-of (lambda () (rtd-1914 "T" #f #f #f #f (specs-1914 256))))))
+               (and (contains? m "256") (contains? m "255"))))
+
+;; -- %record-split-args: negative, over-cap, and over-length are KP3007 ------
+;; The over-length message must NOT dump the whole input list (the old bare
+;; TypeError did); it names the two counts instead.
+(test-equal "%record-split-args with a negative suffix length is KP3007"
+            'KP3007 (code-of (lambda () (%record-split-args '(1 2) -1))))
+(test-equal "%record-split-args with a suffix longer than the list is KP3007"
+            'KP3007 (code-of (lambda () (%record-split-args '(1 2) 3))))
+(test-assert "%record-split-args' over-length message names both counts, not the list"
+             (let ((m (msg-of (lambda () (%record-split-args '(1 2) 3)))))
+               (and (contains? m "3") (contains? m "2"))))
+
+;; The control: a WORKING split still works, so the guards above are guarding
+;; a real failure, not rejecting everything.
+(test-equal "control: %record-split-args splits a valid request"
+            '((1) . (2 3)) (%record-split-args '(1 2 3) 2))
 
 (let ((runner (test-runner-current)))
   (test-end "error taxonomy audit")

--- a/tests/scheme/audit/primitives_srfi237-audit.scm
+++ b/tests/scheme/audit/primitives_srfi237-audit.scm
@@ -647,21 +647,24 @@
                     (string-search m "200 inherited")
                     (string-search m "255"))))
 
-;; The own-fields path reports a bare TypeError naming args[0] (the type
-;; NAME, which is perfectly valid) instead of the field count.
-;; FAIL: #1914 (own-field 255-limit overflow reports a bare TypeError blaming args[0])
-;; (test-assert "255 limit: the own-fields path reports the same limit as precisely"
-;;              (let ((m (message-of (lambda ()
-;;                                     (make-record-type-descriptor 'OWN256 #f #f #f #f
-;;                                                                  (fields-vector 256))))))
-;;                (and (string? m) (string-search m "255"))))
-
-;; Enabled: the current, asymmetric wording, so #1914's fix has a pinned "before".
-(test-assert "255 limit: the own-fields path currently reports a type error naming the rtd name"
+;; #1914 FIXED: the own-fields path used to report a bare TypeError naming
+;; args[0] (the type NAME, which is perfectly valid) instead of the field
+;; count. It now reports the SAME symmetric limit message the inherited path
+;; does, through argError (KP3007) rather than a bare TypeError.
+(test-assert "255 limit: the own-fields path reports the limit as precisely (#1914)"
              (let ((m (message-of (lambda ()
                                     (make-record-type-descriptor 'OWN256 #f #f #f #f
                                                                  (fields-vector 256))))))
-               (and (string? m) (string-search m "type error"))))
+               (and (string? m)
+                    (string-search m "256 fields")
+                    (string-search m "256 of its own")
+                    (string-search m "0 inherited")
+                    (string-search m "255"))))
+(test-assert "255 limit: the own-fields path no longer blames the rtd name with a type error (#1914)"
+             (let ((m (message-of (lambda ()
+                                    (make-record-type-descriptor 'OWN256 #f #f #f #f
+                                                                 (fields-vector 256))))))
+               (and (string? m) (not (string-search m "type error")))))
 
 
 ;;; ===================================================================


### PR DESCRIPTION
## What

Ten `%`-prefixed internal record primitives guarded a range or size limit with a bare `PrimitiveError.TypeError`. `mapNativeError` then synthesized `type error in '<proc>': got <args[0]>` — naming the **first** argument, which is valid in every one of these cases (the record, the type name, the whole input list), and omitting the expected type. All ten carried a **misapplied** `// bare-ok:` annotation, so the CI bare-error gate waved them through even though each has both a real procedure name and a specific offending value.

## The fix

Each site now uses the taxonomy helper that fits the failure:

| Site (`src/`) | Procedure | Failure | Now |
|---|---|---|---|
| `primitives.zig` ×2 | `%record-ref`, `%record-set!` | negative index | `indexError` (KP3006) |
| `primitives.zig` ×2 | `%make-record-type` | field count out of range / >255 specs | `argError` (KP3007) |
| `primitives_srfi237.zig` ×3 | `%record-ref/inherit`, `%record-set!/inherit`, `%record-field-mutable?` | negative index | `indexError` (KP3006) |
| `primitives_srfi237.zig` ×1 | `%make-record-type-descriptor` | 256th own field | `tooManyFieldsError` → `argError` (KP3007) |
| `primitives_srfi237.zig` ×3 | `%record-split-args` | negative / over-256-cap / over-length suffix | `argError` (KP3007) |

The own-fields 255-limit overflow now reuses `tooManyFieldsError`, so it reports the same symmetric "N of its own plus M inherited" message the inherited path already did — the issue's *sharpest instance*.

### Before / after (from the issue's reproductions)

```
(%make-record-type "T" 256)
  before: type error in '%make-record-type': got "T"            (blames the name)
  after:  KP3007 %make-record-type: field count 256 is out of range (must be 0 to 255)

(%record-ref r -1 rt)
  before: type error in '%record-ref': got #<T 1 2>             (blames the record)
  after:  KP3006 %record-ref: index -1 out of range for length 2

(make-record-type-descriptor 'OWN256 #f #f #f #f <256 fields>)
  before: type error in '%make-record-type-descriptor': got "T"
  after:  KP3007 ...record type would have 256 fields (256 of its own plus 0 inherited), but the limit is 255
```

## BASELINE (the ratchet)

`.github/workflows/ci.yml`'s `BASELINE=9` counts **unannotated** bare `TypeError|IndexOutOfBounds|InvalidArgument` returns — the gate command excludes `// bare-ok:` lines. These ten sites were `bare-ok`-annotated, so they were **already excluded** from the counted total. Converting them to helpers removes the (misapplied) annotations without changing the count:

```
before: 9
after:  9
```

**BASELINE stays 9** — no `ci.yml` change. (It may only go down; nothing *counted* was removed, since these were hidden behind `bare-ok` rather than counted. The value of the fix is removing the misapplied annotations and naming the real cause.)

## Regression tests

- **`tests/scheme/audit/error-taxonomy-audit.scm`** — new **PART 8** pins every fixed site to its KP code and asserts the message names the real cause (the index / the count), not `args[0]`; includes a "no longer says 'type error'" guard and a working-split control. Fails before the fix (bare TypeError → KP3002), passes after. (183 assertions, all pass.)
- **`tests/scheme/audit/primitives_srfi237-audit.scm`** — the existing "before" pin of the own-fields path (`… currently reports a type error naming the rtd name`) is replaced with the fixed symmetric-message assertion. (217 assertions, all pass.)

## Verification

- `zig build test` — passes (exit 0).
- `zig fmt` — clean on both touched Zig files.
- No bare `PrimitiveError.TypeError` introduced; gate count recomputed at 9.

Closes #1914

🤖 Generated with [Claude Code](https://claude.com/claude-code)
