### PR TITLE
Make SRFI 1 fold/filter/any/every/unfold and hash-table-walk resumable (#2060)

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,22 @@ captured in tight inner loops. Continuations captured in one top-level REPL
 expression cannot re-enter subsequent top-level expressions (standard behavior
 shared by Guile, Chibi, Chicken, Chez, and Racket).
 
+A continuation captured inside the callback of a **native driver** — a
+higher-order procedure implemented in Zig that re-enters the VM once per
+element — cannot be resumed once that driver's call has returned, because the
+driver's state lives on the Zig stack, not in the copied VM state. This is the
+restriction [CONFORMANCE.md](CONFORMANCE.md) refers to. It is why a
+continuation-backed value (e.g. a SRFI 158 coroutine generator, which captures
+a continuation on every `yield`) breaks when consumed inside such a driver. As
+of #2060 the SRFI-1 `fold`, `filter`, `any`, `every`, `unfold` and SRFI-69
+`hash-table-walk` run in the bytecode dispatch loop and are exempt — a coroutine
+generator can be folded, filtered, or walked freely. The remaining native
+SRFI-1 drivers still carry the restriction: `fold-right`, `reduce`,
+`reduce-right`, `find`, `find-tail`, `count`, `partition`, `remove`,
+`take-while`, `drop-while`, `delete`, `delete-duplicates`, `filter-map`,
+`append-map`, `pair-for-each`, `pair-fold`, the `lset-*` family, and
+`assoc`/`member` with a custom predicate, among others.
+
 SRFI 248's delimited continuations (`with-unwind-handler`, and the extended
 `guard`) are built on this `call/cc` via a sticky exception handler, with three
 observable caveats:
@@ -438,11 +454,12 @@ own, whose separate timing caveat is above.
 ### Fibers
 
 Callbacks driven by `map`, `for-each`, `vector-map`, `vector-for-each`,
-`string-map`, `string-for-each`, `dynamic-wind`, and `force` run in the
-bytecode dispatch loop, so a fiber can park inside them (e.g. block on an
-empty channel) and resume later. Other higher-order procedures are still
-native drivers — SRFI-1 (`fold`, `filter`, `find`, `any`, `every`, ...),
-`hash-table-walk`/`hash-table-update!`, `assoc`/`member` with a custom
+`string-map`, `string-for-each`, `dynamic-wind`, `force`, and — since #2060 —
+SRFI-1 `fold`, `filter`, `any`, `every`, `unfold` and SRFI-69 `hash-table-walk`
+run in the bytecode dispatch loop, so a fiber can park inside them (e.g. block
+on an empty channel) and resume later. Other higher-order procedures are still
+native drivers — SRFI-1 (`fold-right`, `reduce`, `find`, `count`, `partition`,
+`remove`, ...), `hash-table-update!`, `assoc`/`member` with a custom
 predicate, `string-index`, `eval`, ... — and a fiber that blocks on
 an empty channel inside one of those callbacks cannot be parked: the native
 call's state lives on the Zig stack and cannot be suspended. If other fibers

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -23,7 +23,10 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "hash-table-size", .func = &hashTableSizeFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_69) },
     .{ .name = "hash-table-keys", .func = &hashTableKeysFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_69) },
     .{ .name = "hash-table-values", .func = &hashTableValuesFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_69) },
-    .{ .name = "hash-table-walk", .func = &hashTableWalkFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_69) },
+    // hash-table-walk is implemented in Scheme (src/vm_bootstrap.zig, over
+    // hash-table->alist) so a continuation captured inside its callback can
+    // resume — the native driver's returned C frame could not (kaappi#2060).
+    .{ .name = "hash-table-walk", .func = primitives.bootstrapStub("hash-table-walk"), .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_69) },
     .{ .name = "hash-table->alist", .func = &hashTableToAlistFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_69) },
     .{ .name = "alist->hash-table", .func = &alistToHashTableFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_69) },
     .{ .name = "hash-table-copy", .func = &hashTableCopyFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_69) },
@@ -744,33 +747,10 @@ fn hashTableValuesFn(args: []const Value) PrimitiveError!Value {
     return result;
 }
 
-// (hash-table-walk ht proc) — call (proc key value) for each entry
-fn hashTableWalkFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const ht = try getHashTable("hash-table-walk", args[0]);
-    const proc = args[1];
-
-    const snapshot = snapshotLiveEntries(gc, ht) orelse return PrimitiveError.OutOfMemory;
-    defer memory.freeSliceNoFill(gc.allocator, HashEntry, snapshot);
-
-    // Root all entries up front: the first callback can delete+allocate and
-    // free a not-yet-visited entry's key/value that only the snapshot holds.
-    const scope = gc.rootedScope();
-    defer scope.release();
-    for (snapshot) |entry| {
-        gc.extra_roots.append(gc.allocator, entry.key) catch return PrimitiveError.OutOfMemory;
-        gc.extra_roots.append(gc.allocator, entry.value) catch return PrimitiveError.OutOfMemory;
-    }
-
-    for (snapshot) |entry| {
-        const call_args = [2]Value{ entry.key, entry.value };
-        _ = vm.callWithArgs(proc, &call_args) catch |err| {
-            return err;
-        };
-    }
-    return types.VOID;
-}
+// hash-table-walk is implemented in Scheme (src/vm_bootstrap.zig) so a
+// continuation captured inside its callback can resume (kaappi#2060). It
+// snapshots via hash-table->alist, matching the native snapshot-then-call
+// order this used to do.
 
 // (hash-table->alist ht)
 fn hashTableToAlistFn(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_srfi1.zig
+++ b/src/primitives_srfi1.zig
@@ -9,17 +9,21 @@ const PrimitiveError = primitives.PrimitiveError;
 const LS = primitives.LibSet;
 
 pub const specs = [_]primitives.PrimSpec{
-    .{ .name = "fold", .func = &foldFn, .arity = .{ .variadic = 3 }, .libs = LS.initOne(.srfi_1) },
+    // fold/filter/any/every/unfold are implemented in Scheme (src/vm_bootstrap.zig)
+    // so a continuation captured inside their callback can be resumed — the native
+    // driver's returned C frame could not be re-entered (kaappi#2060). The stub
+    // errors only if vm_bootstrap.install() has not run.
+    .{ .name = "fold", .func = primitives.bootstrapStub("fold"), .arity = .{ .variadic = 3 }, .libs = LS.initOne(.srfi_1) },
     .{ .name = "fold-right", .func = &foldRightFn, .arity = .{ .variadic = 3 }, .libs = LS.initOne(.srfi_1) },
     .{ .name = "reduce", .func = &reduceFn, .arity = .{ .exact = 3 }, .libs = LS.initOne(.srfi_1) },
     .{ .name = "reduce-right", .func = &reduceRightFn, .arity = .{ .exact = 3 }, .libs = LS.initOne(.srfi_1) },
-    .{ .name = "filter", .func = &filterFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_1) },
+    .{ .name = "filter", .func = primitives.bootstrapStub("filter"), .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_1) },
     .{ .name = "remove", .func = &removeFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_1) },
     .{ .name = "partition", .func = &partitionFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_1) },
     .{ .name = "find", .func = &findFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_1) },
     .{ .name = "find-tail", .func = &findTailFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_1) },
-    .{ .name = "any", .func = &anyFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_1) },
-    .{ .name = "every", .func = &everyFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_1) },
+    .{ .name = "any", .func = primitives.bootstrapStub("any"), .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_1) },
+    .{ .name = "every", .func = primitives.bootstrapStub("every"), .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_1) },
     .{ .name = "count", .func = &countFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_1) },
     .{ .name = "iota", .func = &iotaFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_1) },
     .{ .name = "zip", .func = &zipFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.srfi_1) },
@@ -70,7 +74,7 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "alist-cons", .func = &alistConsFn, .arity = .{ .exact = 3 }, .libs = LS.initOne(.srfi_1) },
     .{ .name = "alist-copy", .func = &alistCopyFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_1) },
     .{ .name = "alist-delete", .func = &alistDeleteFn, .arity = .{ .variadic = 2 }, .libs = LS.initOne(.srfi_1) },
-    .{ .name = "unfold", .func = &unfoldFn, .arity = .{ .variadic = 4 }, .libs = LS.initOne(.srfi_1) },
+    .{ .name = "unfold", .func = primitives.bootstrapStub("unfold"), .arity = .{ .variadic = 4 }, .libs = LS.initOne(.srfi_1) },
     .{ .name = "unfold-right", .func = &unfoldRightFn, .arity = .{ .variadic = 4 }, .libs = LS.initOne(.srfi_1) },
     .{ .name = "append-reverse", .func = &appendReverseFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.srfi_1) },
     .{ .name = "length+", .func = &lengthPlusFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.srfi_1) },
@@ -165,24 +169,8 @@ const MultiListIter = struct {
 // Folds
 // ---------------------------------------------------------------------------
 
-// (fold proc init list1 ...)
-fn foldFn(args: []const Value) PrimitiveError!Value {
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const proc = args[0];
-    var acc = args[1];
-    std.debug.assert(args.len >= 3);
-
-    gc.pushRoot(&acc);
-    defer gc.popRoot();
-
-    var iter = MultiListIter.init(args[2..], false);
-    while (try iter.next("fold")) |_| {
-        iter.call_args[iter.list_count] = acc;
-        acc = try callVM(proc, iter.call_args[0 .. iter.list_count + 1]);
-        iter.advance();
-    }
-    return acc;
-}
+// `fold` is implemented in Scheme (src/vm_bootstrap.zig) so continuations
+// captured inside its callback can resume (kaappi#2060).
 
 // (fold-right proc init list1 ...)
 fn foldRightFn(args: []const Value) PrimitiveError!Value {
@@ -296,28 +284,8 @@ fn reduceRightFn(args: []const Value) PrimitiveError!Value {
 // Filtering
 // ---------------------------------------------------------------------------
 
-// (filter pred list)
-fn filterFn(args: []const Value) PrimitiveError!Value {
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const pred = args[0];
-    var current = args[1];
-
-    var results: std.ArrayList(Value) = .empty;
-    defer results.deinit(gc.allocator);
-
-    while (current != types.NIL) {
-        if (!types.isPair(current)) return primitives.typeError("filter", "pair", current);
-        const elem = types.car(current);
-        const call_args_buf = [1]Value{elem};
-        const result = try callVM(pred, &call_args_buf);
-        if (isTruthyResult(result)) {
-            results.append(gc.allocator, elem) catch return PrimitiveError.OutOfMemory;
-        }
-        current = types.cdr(current);
-    }
-
-    return buildList(gc, results.items, types.NIL);
-}
+// `filter` is implemented in Scheme (src/vm_bootstrap.zig) so continuations
+// captured inside its callback can resume (kaappi#2060).
 
 // (remove pred list) — opposite of filter
 fn removeFn(args: []const Value) PrimitiveError!Value {
@@ -410,35 +378,8 @@ fn findTailFn(args: []const Value) PrimitiveError!Value {
     return types.FALSE;
 }
 
-// (any pred list1 ...) — returns first truthy pred result
-fn anyFn(args: []const Value) PrimitiveError!Value {
-    const pred = args[0];
-    std.debug.assert(args.len >= 2);
-
-    var iter = MultiListIter.init(args[1..], false);
-    while (try iter.next("any")) |call_args| {
-        const result = try callVM(pred, call_args);
-        if (isTruthyResult(result)) return result;
-        iter.advance();
-    }
-    return types.FALSE;
-}
-
-// (every pred list1 ...) — returns last truthy result or #f
-fn everyFn(args: []const Value) PrimitiveError!Value {
-    const pred = args[0];
-    std.debug.assert(args.len >= 2);
-
-    var iter = MultiListIter.init(args[1..], false);
-    var last_result: Value = types.TRUE;
-    while (try iter.next("every")) |call_args| {
-        const result = try callVM(pred, call_args);
-        if (!isTruthyResult(result)) return types.FALSE;
-        last_result = result;
-        iter.advance();
-    }
-    return last_result;
-}
+// `any` and `every` are implemented in Scheme (src/vm_bootstrap.zig) so
+// continuations captured inside their callback can resume (kaappi#2060).
 
 // (count pred list1 ...) — count satisfying elements
 fn countFn(args: []const Value) PrimitiveError!Value {
@@ -1539,42 +1480,8 @@ fn lsetXorFn(args: []const Value) PrimitiveError!Value {
 // Unfold
 // ---------------------------------------------------------------------------
 
-// (unfold p f g seed [tail-gen]) — fundamental list constructor
-fn unfoldFn(args: []const Value) PrimitiveError!Value {
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const p = args[0]; // stop predicate
-    const f = args[1]; // map function
-    const g = args[2]; // successor
-    var seed = args[3];
-    const has_tail = args.len > 4;
-
-    var elems: std.ArrayList(Value) = .empty;
-    defer elems.deinit(gc.allocator);
-    const scope = gc.rootedScope();
-    defer scope.release();
-    gc.pushRoot(&seed);
-    defer gc.popRoot();
-
-    while (true) {
-        const stop_args = [1]Value{seed};
-        const stop = try callVM(p, &stop_args);
-        if (isTruthyResult(stop)) break;
-
-        const map_args = [1]Value{seed};
-        const val = try callVM(f, &map_args);
-        try appendRooted(gc, &elems, val);
-
-        const succ_args = [1]Value{seed};
-        seed = try callVM(g, &succ_args);
-    }
-
-    var tail: Value = types.NIL;
-    if (has_tail) {
-        const tail_args = [1]Value{seed};
-        tail = try callVM(args[4], &tail_args);
-    }
-    return buildList(gc, elems.items, tail);
-}
+// `unfold` is implemented in Scheme (src/vm_bootstrap.zig) so continuations
+// captured inside its p/f/g/tail-gen callbacks can resume (kaappi#2060).
 
 // (unfold-right p f g seed [tail]) — build list from right
 fn unfoldRightFn(args: []const Value) PrimitiveError!Value {

--- a/src/vm_bootstrap.zig
+++ b/src/vm_bootstrap.zig
@@ -80,6 +80,19 @@ const definitions = [_][]const u8{
     string_map_src,
     dynamic_wind_src,
     force_src,
+    // SRFI 1 / SRFI 69 higher-order drivers whose callbacks may capture and
+    // resume a continuation (e.g. a SRFI 158 coroutine-backed generator). The
+    // native versions re-entered the VM under a Zig frame, so a continuation
+    // captured in the callback could not be resumed once that frame returned
+    // (kaappi#2060). Scoped to the six the SRFI 158 spec examples flow through;
+    // the remaining native SRFI 1 drivers keep the restriction (see README
+    // "Known limitations -> Continuations").
+    fold_src,
+    filter_src,
+    any_src,
+    every_src,
+    unfold_src,
+    hash_table_walk_src,
 };
 
 const for_each_src =
@@ -355,4 +368,151 @@ const force_src =
     \\                                        (%promise-set-forcing! current #f)
     \\                                        (%promise-complete! current result)
     \\                                        result))))))))))))))
+;
+
+// (fold kons knil list1 ...) — matches the native driver it replaces: stops at
+// the first exhausted (null) list, raises on a non-pair tail, and does not
+// pre-check kons (a non-procedure surfaces as the VM's own "not a procedure"
+// when first applied). Multi-list form calls (kons e1 e2 ... acc) via apply.
+const fold_src =
+    \\(define fold
+    \\  (let ((null? null?) (pair? pair?) (car car) (cdr cdr) (cons cons)
+    \\        (apply apply) (error error))
+    \\    (lambda (kons knil list1 . lists)
+    \\      (if (null? lists)
+    \\          (let loop ((lst list1) (acc knil))
+    \\            (if (pair? lst)
+    \\                (loop (cdr lst) (kons (car lst) acc))
+    \\                (if (null? lst) acc (error "fold: not a proper list"))))
+    \\          (let loop ((lsts (cons list1 lists)) (acc knil))
+    \\            (let ((go (let check ((l lsts))
+    \\                        (if (null? l) #t
+    \\                            (if (null? (car l)) #f
+    \\                                (if (not (pair? (car l)))
+    \\                                    (error "fold: not a proper list")
+    \\                                    (check (cdr l))))))))
+    \\              (if go
+    \\                  (loop
+    \\                    (let cdrs ((l lsts))
+    \\                      (if (null? l) '()
+    \\                          (cons (cdr (car l)) (cdrs (cdr l)))))
+    \\                    (apply kons
+    \\                      (let cars ((l lsts))
+    \\                        (if (null? l) (cons acc '())
+    \\                            (cons (car (car l)) (cars (cdr l)))))))
+    \\                  acc)))))))
+;
+
+// (filter pred list) — keeps elements for which pred is true, in order.
+// An empty list never calls pred (so a non-procedure pred is not reached),
+// matching the native driver.
+const filter_src =
+    \\(define filter
+    \\  (let ((null? null?) (pair? pair?) (car car) (cdr cdr) (cons cons)
+    \\        (reverse reverse) (error error))
+    \\    (lambda (pred lst)
+    \\      (let loop ((lst lst) (acc '()))
+    \\        (if (pair? lst)
+    \\            (let ((x (car lst)))
+    \\              (loop (cdr lst) (if (pred x) (cons x acc) acc)))
+    \\            (if (null? lst) (reverse acc)
+    \\                (error "filter: not a proper list")))))))
+;
+
+// (any pred list1 ...) — first truthy (pred e ...) value, else #f. Short-
+// circuits, so a truthy hit before a non-pair tail returns without error.
+const any_src =
+    \\(define any
+    \\  (let ((null? null?) (pair? pair?) (car car) (cdr cdr) (cons cons)
+    \\        (apply apply) (not not) (error error))
+    \\    (lambda (pred list1 . lists)
+    \\      (if (null? lists)
+    \\          (let loop ((lst list1))
+    \\            (if (pair? lst)
+    \\                (let ((r (pred (car lst))))
+    \\                  (if r r (loop (cdr lst))))
+    \\                (if (null? lst) #f (error "any: not a proper list"))))
+    \\          (let loop ((lsts (cons list1 lists)))
+    \\            (let ((go (let check ((l lsts))
+    \\                        (if (null? l) #t
+    \\                            (if (null? (car l)) #f
+    \\                                (if (not (pair? (car l)))
+    \\                                    (error "any: not a proper list")
+    \\                                    (check (cdr l))))))))
+    \\              (if go
+    \\                  (let ((r (apply pred
+    \\                             (let cars ((l lsts))
+    \\                               (if (null? l) '()
+    \\                                   (cons (car (car l)) (cars (cdr l))))))))
+    \\                    (if r r
+    \\                        (loop
+    \\                          (let cdrs ((l lsts))
+    \\                            (if (null? l) '()
+    \\                                (cons (cdr (car l)) (cdrs (cdr l))))))))
+    \\                  #f)))))))
+;
+
+// (every pred list1 ...) — #f as soon as pred is false, else the last pred
+// result (#t over an empty list). Short-circuits like any.
+const every_src =
+    \\(define every
+    \\  (let ((null? null?) (pair? pair?) (car car) (cdr cdr) (cons cons)
+    \\        (apply apply) (not not) (error error))
+    \\    (lambda (pred list1 . lists)
+    \\      (if (null? lists)
+    \\          (let loop ((lst list1) (last #t))
+    \\            (if (pair? lst)
+    \\                (let ((r (pred (car lst))))
+    \\                  (if r (loop (cdr lst) r) #f))
+    \\                (if (null? lst) last (error "every: not a proper list"))))
+    \\          (let loop ((lsts (cons list1 lists)) (last #t))
+    \\            (let ((go (let check ((l lsts))
+    \\                        (if (null? l) #t
+    \\                            (if (null? (car l)) #f
+    \\                                (if (not (pair? (car l)))
+    \\                                    (error "every: not a proper list")
+    \\                                    (check (cdr l))))))))
+    \\              (if go
+    \\                  (let ((r (apply pred
+    \\                             (let cars ((l lsts))
+    \\                               (if (null? l) '()
+    \\                                   (cons (car (car l)) (cars (cdr l))))))))
+    \\                    (if r
+    \\                        (loop
+    \\                          (let cdrs ((l lsts))
+    \\                            (if (null? l) '()
+    \\                                (cons (cdr (car l)) (cdrs (cdr l)))))
+    \\                          r)
+    \\                        #f))
+    \\                  last)))))))
+;
+
+// (unfold p f g seed [tail-gen]) — builds (f seed0) (f seed1) ... in order,
+// then appends (tail-gen final-seed) or '(). Only a 5th argument is consulted,
+// matching the native driver.
+const unfold_src =
+    \\(define unfold
+    \\  (let ((null? null?) (car car) (cdr cdr) (cons cons))
+    \\    (lambda (p f g seed . tail-gen)
+    \\      (let loop ((seed seed) (acc '()))
+    \\        (if (p seed)
+    \\            (let ((tail (if (null? tail-gen) '() ((car tail-gen) seed))))
+    \\              (let rev ((a acc) (r tail))
+    \\                (if (null? a) r (rev (cdr a) (cons (car a) r)))))
+    \\            (loop (g seed) (cons (f seed) acc)))))))
+;
+
+// (hash-table-walk ht proc) — calls (proc key value) for every entry. Walks a
+// hash-table->alist snapshot so the callback may capture and resume a
+// continuation; the native version snapshotted the same way before calling.
+const hash_table_walk_src =
+    \\(define hash-table-walk
+    \\  (let ((null? null?) (car car) (cdr cdr)
+    \\        (hash-table->alist hash-table->alist))
+    \\    (lambda (ht proc)
+    \\      (let loop ((es (hash-table->alist ht)))
+    \\        (if (null? es)
+    \\            (if #f #f)
+    \\            (begin (proc (car (car es)) (cdr (car es)))
+    \\                   (loop (cdr es))))))))
 ;

--- a/tests/scheme/srfi/srfi158-audit.scm
+++ b/tests/scheme/srfi/srfi158-audit.scm
@@ -994,11 +994,16 @@
 ;;       (generator-unfold (make-for-each-generator string-for-each "abc") unfold)
 ;;                                                              => (#\a #\b #\c)
 ;;
-;;     and it does not run: SRFI 1's `unfold` is a native driver, and every
-;;     coroutine-backed generator — make-coroutine-generator,
-;;     make-for-each-generator, make-unfold-generator, and gtake — resumes a
-;;     continuation captured under it.  See #2060.
-;;     The controls below isolate the mechanism to the driver, not the SRFI.
+;;     It now runs: #2060 moved SRFI 1's `fold`, `filter`, `any`, `every`,
+;;     `unfold` and SRFI 69's `hash-table-walk` to bytecode-driven Scheme
+;;     (src/vm_bootstrap.zig), so a continuation captured inside their callback
+;;     — as every coroutine-backed generator (make-coroutine-generator,
+;;     make-for-each-generator, make-unfold-generator, gtake) does on yield —
+;;     can be resumed.  The controls below isolate the mechanism to the driver,
+;;     not the SRFI.  The remaining native SRFI 1 drivers (fold-right, find,
+;;     reduce, count, partition, remove, take-while, assoc/member with a
+;;     predicate, ...) keep the restriction — see #2060 and README
+;;     "Known limitations -> Continuations".
 ;; ---------------------------------------------------------------------------
 
 (define (portable-unfold stop? mapper successor seed . rest)
@@ -1030,37 +1035,36 @@
 (test-equal "CONTROL driver: a plain let* sequence resumes a coroutine freely"
             '(1 2 3) (let* ((g (fresh-coroutine)) (a (g)) (b (g)) (c (g))) (list a b c)))
 
-(test-assert "driver: SRFI 158's own generator-unfold example raises (see #2060)"
-             (raises? (lambda ()
-                        (generator-unfold (make-for-each-generator string-for-each "abc") unfold))))
-(test-assert "driver: gtake under SRFI 1 unfold raises (see #2060)"
-             (raises? (lambda () (generator-unfold (gtake (string->generator "abcdef") 3) unfold))))
-(test-assert "driver: make-unfold-generator under SRFI 1 unfold raises (see #2060)"
-             (raises? (lambda ()
-                        (generator-unfold
-                         (make-unfold-generator (lambda (s) (> s 2)) (lambda (s) s)
-                                                (lambda (s) (+ s 1)) 0)
-                         unfold))))
-(test-assert "driver: a coroutine generator under SRFI 1 fold raises (see #2060)"
-             (raises? (lambda () (let ((g (fresh-coroutine)))
-                                   (fold (lambda (i acc) (cons (g) acc)) '() '(a b c))))))
-(test-assert "driver: a coroutine generator under SRFI 1 filter raises (see #2060)"
-             (raises? (lambda () (let ((g (fresh-coroutine))) (filter (lambda (i) (g)) '(a b c))))))
-(test-assert "driver: a coroutine generator under SRFI 1 any raises (see #2060)"
-             (raises? (lambda () (let ((g (fresh-coroutine)))
-                                   (any (lambda (i) (eq? 99 (g))) '(a b c))))))
-(test-assert "driver: a coroutine generator under SRFI 1 every raises (see #2060)"
-             (raises? (lambda () (let ((g (fresh-coroutine))) (every (lambda (i) (g)) '(a b c))))))
-(test-assert "driver: a coroutine generator under hash-table-walk raises (see #2060)"
-             (raises? (lambda ()
-                        (let ((g (fresh-coroutine)) (h (make-hash-table equal?)) (acc '()))
-                          (hash-table-set! h 'a 1) (hash-table-set! h 'b 2) (hash-table-set! h 'c 3)
-                          (hash-table-walk h (lambda (k v) (set! acc (cons (g) acc))))
-                          acc))))
-(test-assert "driver: a gtake generator under SRFI 1 fold raises (see #2060)"
-             (raises? (lambda ()
-                        (let ((g (gtake (make-range-generator 0 100) 5)))
-                          (fold (lambda (i acc) (cons (g) acc)) '() '(a b c))))))
+(test-equal "driver: SRFI 158's own generator-unfold example resumes (see #2060)"
+            '(#\a #\b #\c)
+            (generator-unfold (make-for-each-generator string-for-each "abc") unfold))
+(test-equal "driver: gtake under SRFI 1 unfold resumes (see #2060)"
+            '(#\a #\b #\c) (generator-unfold (gtake (string->generator "abcdef") 3) unfold))
+(test-equal "driver: make-unfold-generator under SRFI 1 unfold resumes (see #2060)"
+            '(0 1 2)
+            (generator-unfold
+             (make-unfold-generator (lambda (s) (> s 2)) (lambda (s) s)
+                                    (lambda (s) (+ s 1)) 0)
+             unfold))
+(test-equal "driver: a coroutine generator under SRFI 1 fold resumes (see #2060)"
+            '(3 2 1) (let ((g (fresh-coroutine)))
+                       (fold (lambda (i acc) (cons (g) acc)) '() '(a b c))))
+(test-equal "driver: a coroutine generator under SRFI 1 filter resumes (see #2060)"
+            '(a b c) (let ((g (fresh-coroutine))) (filter (lambda (i) (g)) '(a b c))))
+(test-equal "driver: a coroutine generator under SRFI 1 any resumes (see #2060)"
+            #f (let ((g (fresh-coroutine))) (any (lambda (i) (eq? 99 (g))) '(a b c))))
+(test-equal "driver: a coroutine generator under SRFI 1 every resumes (see #2060)"
+            3 (let ((g (fresh-coroutine))) (every (lambda (i) (g)) '(a b c))))
+(test-equal "driver: a coroutine generator under hash-table-walk resumes (see #2060)"
+            '(3 2 1)
+            (let ((g (fresh-coroutine)) (h (make-hash-table equal?)) (acc '()))
+              (hash-table-set! h 'a 1) (hash-table-set! h 'b 2) (hash-table-set! h 'c 3)
+              (hash-table-walk h (lambda (k v) (set! acc (cons (g) acc))))
+              acc))
+(test-equal "driver: a gtake generator under SRFI 1 fold resumes (see #2060)"
+            '(2 1 0)
+            (let ((g (gtake (make-range-generator 0 100) 5)))
+              (fold (lambda (i acc) (cons (g) acc)) '() '(a b c))))
 (test-equal "CONTROL driver: the same gtake generator under map succeeds"
             '(0 1 2) (let ((g (gtake (make-range-generator 0 100) 5)))
                        (map (lambda (i) (g)) '(a b c))))
@@ -1072,46 +1076,43 @@
 
 ;; make-for-each-generator's stated job is to convert ANY collection: "converts
 ;; any collection obj to a generator that returns its elements using a for-each
-;; procedure appropriate for obj".  It works only when that for-each is one of
-;; the eight bytecode-driven primitives; a hash table or any SRFI 1-shaped
-;; walker cannot be converted at all.  Its very first item does come back — the
-;; failure is on resumption — so the damage is not visible until the second call.
+;; procedure appropriate for obj".  Since #2060 it works for a hash table and
+;; any SRFI 1-shaped walker built on the six converted drivers, not only the
+;; eight core bytecode-driven for-each primitives — the yield's continuation
+;; now resumes, so a multi-element collection drains instead of breaking on the
+;; second demand.
 (test-equal "driver: make-for-each-generator over hash-table-walk yields item 1"
             1 ((make-for-each-generator hash-walk (one-entry-table))))
-(test-assert "driver: ... but its second call raises (see #2060)"
-             (raises? (lambda ()
-                        (let* ((g (make-for-each-generator hash-walk (one-entry-table))) (a (g)))
-                          (g)))))
-(test-assert "driver: make-for-each-generator over hash-table-walk cannot be drained (see #2060)"
-             (raises? (lambda ()
-                        (generator->list (make-for-each-generator hash-walk (one-entry-table))))))
-(test-assert "driver: make-for-each-generator over an SRFI 1 walker cannot be drained (see #2060)"
-             (raises? (lambda () (generator->list (make-for-each-generator fold-walk '(1 2 3))))))
-(test-assert "driver: gtake over a hash-table-backed generator raises (see #2060)"
-             (raises? (lambda ()
-                        (generator->list
-                         (gtake (make-for-each-generator hash-walk (one-entry-table)) 2)))))
+(test-assert "driver: ... and its second call reaches eof (see #2060)"
+             (eof-object?
+              (let* ((g (make-for-each-generator hash-walk (one-entry-table))) (a (g)))
+                (g))))
+(test-equal "driver: make-for-each-generator over hash-table-walk drains (see #2060)"
+            '(1) (generator->list (make-for-each-generator hash-walk (one-entry-table))))
+(test-equal "driver: make-for-each-generator over an SRFI 1 walker drains (see #2060)"
+            '(1 2 3) (generator->list (make-for-each-generator fold-walk '(1 2 3))))
+(test-equal "driver: gtake over a hash-table-backed generator resumes (see #2060)"
+            '(1)
+            (generator->list
+             (gtake (make-for-each-generator hash-walk (one-entry-table)) 2)))
 (test-equal "CONTROL driver: the same walker shape over a bytecode-driven for-each works"
             '(1 2 3) (generator->list (make-for-each-generator for-each '(1 2 3))))
 
-;; FAIL: #2060 (SRFI 1's native unfold cannot resume a coroutine generator)
-;; (test-equal "spec example: generator-unfold over make-for-each-generator"
-;;             '(#\a #\b #\c)
-;;             (generator-unfold (make-for-each-generator string-for-each "abc") unfold))
-;; FAIL: #2060 (SRFI 1's native fold cannot resume a coroutine generator)
-;; (test-equal "driver: a coroutine generator drives SRFI 1 fold"
-;;             '(3 2 1) (let ((g (fresh-coroutine)))
-;;                        (fold (lambda (i acc) (cons (g) acc)) '() '(a b c))))
-;; FAIL: #2060 (SRFI 1's native fold cannot resume a gtake generator)
-;; (test-equal "driver: a gtake generator drives SRFI 1 fold"
-;;             '(2 1 0) (let ((g (gtake (make-range-generator 0 100) 5)))
-;;                        (fold (lambda (i acc) (cons (g) acc)) '() '(a b c))))
-;; FAIL: #2060 (hash-table-walk is a native driver, so its yield cannot resume)
-;; (test-equal "seam: a hash table becomes a generator through make-for-each-generator"
-;;             '(1) (generator->list (make-for-each-generator hash-walk (one-entry-table))))
-;; FAIL: #2060 (SRFI 1 fold is a native driver, so its yield cannot resume)
-;; (test-equal "driver: an SRFI 1-shaped walker becomes a generator"
-;;             '(1 2 3) (generator->list (make-for-each-generator fold-walk '(1 2 3))))
+;; Fixed by #2060 (formerly ;; FAIL): the six converted drivers resume a
+;; coroutine-backed generator, so these spec-shaped examples now run.
+(test-equal "spec example: generator-unfold over make-for-each-generator"
+            '(#\a #\b #\c)
+            (generator-unfold (make-for-each-generator string-for-each "abc") unfold))
+(test-equal "driver: a coroutine generator drives SRFI 1 fold"
+            '(3 2 1) (let ((g (fresh-coroutine)))
+                       (fold (lambda (i acc) (cons (g) acc)) '() '(a b c))))
+(test-equal "driver: a gtake generator drives SRFI 1 fold"
+            '(2 1 0) (let ((g (gtake (make-range-generator 0 100) 5)))
+                       (fold (lambda (i acc) (cons (g) acc)) '() '(a b c))))
+(test-equal "seam: a hash table becomes a generator through make-for-each-generator"
+            '(1) (generator->list (make-for-each-generator hash-walk (one-entry-table))))
+(test-equal "driver: an SRFI 1-shaped walker becomes a generator"
+            '(1 2 3) (generator->list (make-for-each-generator fold-walk '(1 2 3))))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi158-audit")

--- a/tests/scheme/srfi/srfi190.scm
+++ b/tests/scheme/srfi/srfi190.scm
@@ -204,9 +204,12 @@
 ;;; --- resumption across a returned native frame (#2060).
 ;;;
 ;;; make-coroutine-generator is built on call/cc, so a resume that has to
-;;; cross a native driver's already-returned frame raises. SRFI 1's
-;;; higher-order procedures are still native drivers; (scheme base)'s
-;;; map/for-each were trampolined by #1347 and are the control. ---
+;;; cross a native driver's already-returned frame raises. #2060 moved SRFI 1's
+;;; fold/filter/any/every/unfold (and SRFI 69 hash-table-walk) into the
+;;; bytecode dispatch loop, so a coroutine generator resumes freely inside
+;;; those; (scheme base)'s map/for-each were trampolined by #1347 and are the
+;;; control. The remaining native SRFI 1 drivers (find, reduce, fold-right,
+;;; ...) still raise on resumption. ---
 
 (test-equal "control: a coroutine generator resumes under (scheme base) map"
   '(1 2 3)
@@ -217,20 +220,14 @@
   '(1 2 3)
   (generator->list (coroutine-generator (for-each yield '(1 2 3)))))
 
-;; FAIL: #2060 (SRFI 1 procedures are native drivers; a resume cannot cross them)
-;; (test-equal "a coroutine generator resumes under SRFI 1 fold"
-;;   '(3 2 1)
-;;   (let ((g (coroutine-generator (yield 1) (yield 2) (yield 3))))
-;;     (fold (lambda (i acc) (cons (g) acc)) '() '(a b c))))
-;; FAIL: #2060 (same, with the yield itself inside the native driver)
-;; (test-equal "yield inside a SRFI 1 driver"
-;;   '(1 2 3)
-;;   (generator->list (coroutine-generator (any (lambda (x) (yield x) #f) '(1 2 3)))))
-
-(test-error "a coroutine generator cannot resume under SRFI 1 fold (see #2060)"
+;; Fixed by #2060: fold and any are now bytecode-driven, so a coroutine
+;; generator resumes inside them.
+(test-equal "a coroutine generator resumes under SRFI 1 fold (see #2060)"
+  '(3 2 1)
   (let ((g (coroutine-generator (yield 1) (yield 2) (yield 3))))
     (fold (lambda (i acc) (cons (g) acc)) '() '(a b c))))
-(test-error "yield inside a SRFI 1 driver cannot resume (see #2060)"
+(test-equal "yield inside a SRFI 1 driver resumes (see #2060)"
+  '(1 2 3)
   (generator->list (coroutine-generator (any (lambda (x) (yield x) #f) '(1 2 3)))))
 
 ;;; --- the derived cond-expand feature id (#1649) ---


### PR DESCRIPTION
## Summary

SRFI 158's coroutine-backed generators (`make-coroutine-generator`,
`make-for-each-generator`, `make-unfold-generator`, `gtake`) capture a
continuation on every `yield`. Consuming one inside a **native** higher-order
driver raised `KP3000: continuation cannot resume across a returned native
call` — the driver re-entered the VM under a Zig frame, so the captured
continuation could not be reinstated once that frame returned. SRFI 158's own
27th documented example did not run, and `gtake` could not be resumed inside
`fold`/`filter`/`any`/`every` or `hash-table-walk`.

This extends the #1347 trampoline approach to the six drivers the SRFI 158 spec
examples flow through: SRFI 1 `fold`, `filter`, `any`, `every`, `unfold` and
SRFI 69 `hash-table-walk` now run in the bytecode dispatch loop as
closure-guarded Scheme definitions in `src/vm_bootstrap.zig`, so a continuation
captured in their callback can resume. The native Zig implementations are
removed and their specs point at `bootstrapStub`, exactly as `map`/`for-each`
do. `hash-table-walk` drives a `hash-table->alist` snapshot, matching the
native snapshot-then-call order.

### Before / after (issue repros)

| repro | before | after |
|---|---|---|
| `(generator-unfold (make-for-each-generator string-for-each "abc") unfold)` | raises | `(#\a #\b #\c)` |
| `gtake` inside `fold` | raises | `(2 1 0)` |
| `make-for-each-generator` over `hash-table-walk` | raises on 2nd call | drains to `(1)` |

## Scope

Limited to the six drivers the issue's tests pin. The remaining native SRFI 1
drivers (`fold-right`, `reduce`, `find`, `count`, `partition`, `remove`,
`take-while`, `assoc`/`member` with a predicate, ...) keep the
continuation-across-native-call restriction. This is now documented in README
"Known limitations → Continuations" — where `CONFORMANCE.md` already pointed but
the restriction was never actually stated (the issue's doc-truth half) — and the
Fibers section's driver lists are corrected.

## Semantics preserved

The Scheme reimplementations faithfully match the native drivers: stop at the
first exhausted list, raise on a non-pair tail, no procedure pre-check (a bad
callback surfaces as the VM's own "not a procedure"), multi-list
`fold`/`any`/`every` via `apply` (with the accumulator last for `fold`), and
`unfold`'s optional 5th tail-gen argument.

## Tests

`tests/scheme/srfi/srfi158-audit.scm`: the 13 `raises?` pins are flipped to
positive assertions and the 5 `;; FAIL: #2060` tests are enabled — all fail
pre-fix, pass post-fix (360 passes, 0 failures).

## Validation

- `zig fmt --check` clean; `zig build test` exits 0
- SRFI-1 suites green (`srfi1.scm` 13/0, `srfi1-ext.scm` 66/0, `srfi1-gc-stress.scm` 37/0)
- SRFI-158 audit 360/0; R7RS suite 1395/0; continuations + SRFI-69/113 suites clean

Closes #2060

🤖 Generated with [Claude Code](https://claude.com/claude-code)