### PR TITLE
Make the minor collection's mark generational

### DIFF
--- a/.claude/rules/gc-safety.md
+++ b/.claude/rules/gc-safety.md
@@ -9,8 +9,16 @@ When mutating heap objects (set-car!, set-cdr!, vector-set!, hash-table-set!,
 string-set!, record field mutation):
 
 - **Write barrier required**: call `gc.writeBarrier(container, new_val)` after
-  storing a Value into a heap object field. Omitting this corrupts the
-  generational GC during minor collections.
+  storing a Value into a heap object field. Since #1961 the minor mark is
+  generational: it stops at old objects and reaches their young referents
+  only through the remembered set, so the barrier is load-bearing — omitting
+  it means the young referent is swept while the old container still points
+  at it (a use-after-free, not a leak). Edges created while the container is
+  still young need no barrier at the store; the GC's promotion scan records
+  them when the container is promoted. Bulk stores into a container the GC
+  re-traces wholesale (a fiber's saved execution state, the root-marked
+  globals/library maps) are covered by explicit root marking instead — when
+  in doubt, add the barrier; it is cheap and deduplicated.
 
 - **Root before allocating**: if you hold a pointer to a heap object and then
   allocate (which may trigger GC), root the value first with

--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -99,24 +99,64 @@ keeps it alive.
 
 ### The write barrier
 
-Because the collector is generational, minor collections scan only the
-young generation plus a remembered set of old objects that point into
-it. Mutating a field of a heap object (set-car!, set-cdr!, vector-set!,
-hash-table-set!, record field mutation) can create an old→young
-reference the minor collection would otherwise never see — the young
-object would be freed while still reachable.
+Minor collections are generational (#1961): the minor mark traces roots
+into the young generation and treats old objects as opaque (`GC.minor_marking`
+gates the check in `markValueInner`), so it costs O(live young) rather than
+O(live heap). An old→young reference — a field of an old heap object holding
+a young object — is therefore invisible to that mark unless it is recorded.
+The remembered set is that record, and it is fed two ways:
 
-After storing a Value into a heap object field, call:
+- `gc.writeBarrier(container, new_val)` after storing a Value into a heap
+  object field (set-car!, set-cdr!, vector-set!, hash-table-set!, record
+  field mutation, guardian registration, …). The barrier is load-bearing:
+  a missing one is a **use-after-free** — the young referent is swept while
+  the old container still points at it — not a leak.
+- The **promotion scan** in `sweepYoung`: the barrier only fires for a
+  container that is *already* old, so an edge created while the container
+  was young (a barrier there is a correct no-op) is recorded when the
+  container is promoted, by scanning it with `referencesYoung` at that
+  moment. The dual **full-collect re-scan** in `sweepOld` re-records every
+  surviving old→young edge after a full collection, whose up-front drain
+  would otherwise leave the next minor without the entry (full collections
+  never promote, so the referent is still young).
 
-```zig
-gc.writeBarrier(container, new_val);
-```
+During the minor mark, the remembered-set walk (`markObjectContents`) marks
+the young referents of every remembered container; `pruneRememberedSet`
+drops entries whose referents have all aged into the old generation, so a
+later old→young write re-queues the container (the write barrier does).
 
-where `container` is the heap object being mutated. The barrier records
-the old→young edge in the remembered set. Omitting it does not fail
-immediately — it corrupts the heap only when a minor collection happens
-to run before the next full collection, which is why these bugs surface
-as rare, allocation-pattern-sensitive crashes.
+Two things deliberately do **not** rely on the barrier:
+
+- Bulk state the GC re-traces wholesale: every resident fiber — the running
+  one included — gets an explicit `markFiberState` pass from
+  `FiberScheduler.markRoots` each collection. That covers a suspended
+  fiber's saved registers/frames (written by `saveCurrentFiber`'s memcpy,
+  with no per-slot barriers) and, for a running fiber, both its mutable
+  fields (`waiting_on`, parameter overrides, held mutexes, …) and its
+  *stale* saved snapshot — which must stay traced because full collections
+  still walk it through `markValueInner`'s `.fiber` arm, and a value freed
+  by an intervening minor would turn that walk into a use-after-free.
+- The root-marked maps (`vm.globals`, library `lib_env`s): their values are
+  marked directly as roots every collection, so `set!`/`define` into them
+  needs no barrier. A *mutable* `SchemeEnvironment` (the `eval`/
+  `environment` objects) is a heap object, not a root-marked map — the
+  `define`/`set!`/`define-syntax` stores into its map carry a write barrier
+  on the wrapper object.
+
+Weak structures follow the same rule with one addition: a guardian's
+`registered` list grows at every registration, so `invokeGuardian` barriers
+the append, and `processWeakRefs` re-queues an old guardian that still
+references young objects after a full collection (which drains the set).
+The weak probes (`keptAlive`/`weakReachable`) treat every old object as
+alive during a minor collection — the old generation is never swept by one,
+so an ephemeron with an old key must not break and a guardian watching an
+old object must not resurrect; the decision is deferred to the next full
+collection, where old garbage is unmarked and visible.
+
+Omitting a barrier does not fail immediately — it corrupts the heap only
+when a minor collection happens to run before the next full collection,
+which is why these bugs surface as rare, allocation-pattern-sensitive
+crashes.
 
 ### Stress testing
 

--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -108,9 +108,15 @@ The remembered set is that record, and it is fed two ways:
 
 - `gc.writeBarrier(container, new_val)` after storing a Value into a heap
   object field (set-car!, set-cdr!, vector-set!, hash-table-set!, record
-  field mutation, guardian registration, …). The barrier is load-bearing:
-  a missing one is a **use-after-free** — the young referent is swept while
-  the old container still points at it — not a leak.
+  field mutation, guardian registration, a function's `global_cache`
+  slots, …). The barrier is load-bearing: a missing one is a
+  **use-after-free** — the young referent is swept while the old container
+  still points at it — not a leak. Two shared funnels keep the discipline
+  in one place: `GC.appendFunctionConstant` (every `Function.constants`
+  append — compiler, `.sbc` deserializer, tests) and `GC.rememberObject`
+  (every wholesale enrollment of an owned container outside the
+  store+barrier pattern — `writeBarrier`'s owned branch, both sweep-phase
+  scans, `saveCurrentFiber`'s bulk snapshot).
 - The **promotion scan** in `sweepYoung`: the barrier only fires for a
   container that is *already* old, so an edge created while the container
   was young (a barrier there is a correct no-op) is recorded when the
@@ -129,29 +135,38 @@ Two things deliberately do **not** rely on the barrier:
 
 - Bulk state the GC re-traces wholesale: every resident fiber — the running
   one included — gets an explicit `markFiberState` pass from
-  `FiberScheduler.markRoots` each collection. That covers a suspended
-  fiber's saved registers/frames (written by `saveCurrentFiber`'s memcpy,
-  with no per-slot barriers) and, for a running fiber, both its mutable
-  fields (`waiting_on`, parameter overrides, held mutexes, …) and its
-  *stale* saved snapshot — which must stay traced because full collections
-  still walk it through `markValueInner`'s `.fiber` arm, and a value freed
-  by an intervening minor would turn that walk into a use-after-free.
+  `FiberScheduler.markRoots` each collection (authoritative; the fiber-field
+  barriers are belt-and-braces). That covers a suspended fiber's saved
+  registers/frames and, for a running fiber, both its mutable fields
+  (`waiting_on`, parameter overrides, held mutexes, …) and its *stale* saved
+  snapshot — which must stay traced because full collections still walk it
+  through `markValueInner`'s `.fiber` arm, and a value freed by an
+  intervening minor would turn that walk into a use-after-free. A fiber
+  retired from its scheduler slot loses that pass while staying
+  heap-reachable, so `saveCurrentFiber` also enrolls an old fiber in the
+  remembered set wholesale (`GC.rememberObject`): its bulk snapshot has no
+  per-field barriers, and `pruneRememberedSet` drops the entry once the
+  snapshot has aged.
 - The root-marked maps (`vm.globals`, library `lib_env`s): their values are
   marked directly as roots every collection, so `set!`/`define` into them
-  needs no barrier. A *mutable* `SchemeEnvironment` (the `eval`/
-  `environment` objects) is a heap object, not a root-marked map — the
-  `define`/`set!`/`define-syntax` stores into its map carry a write barrier
-  on the wrapper object.
+  needs no barrier — nor into the interaction-environment wrapper, whose
+  map *is* `vm.globals` (the `.owned == false` case the handlers skip). A
+  *mutable* `SchemeEnvironment` (the `eval`/`environment` objects) is a
+  heap object, not a root-marked map — the `define`/`set!`/`define-syntax`
+  stores into its map carry a write barrier on the wrapper object, and the
+  compiler's `def_env_val`/`let_syntax_peer_vals` stores into a
+  possibly-promoted aliased transformer (SRFI 147/211) carry one on the
+  transformer.
 
 Weak structures follow the same rule with one addition: a guardian's
 `registered` list grows at every registration, so `invokeGuardian` barriers
-the append, and `processWeakRefs` re-queues an old guardian that still
-references young objects after a full collection (which drains the set).
-The weak probes (`keptAlive`/`weakReachable`) treat every old object as
-alive during a minor collection — the old generation is never swept by one,
-so an ephemeron with an old key must not break and a guardian watching an
-old object must not resurrect; the decision is deferred to the next full
-collection, where old garbage is unmarked and visible.
+the append (the old "weak structures never enter the remembered set" claim
+was wrong for guardians). The weak probes (`keptAlive`/`weakReachable`)
+treat every old object as alive during a minor collection — the old
+generation is never swept by one, so an ephemeron with an old key must not
+break and a guardian watching an old object must not resurrect; the
+decision is deferred to the next full collection, where old garbage is
+unmarked and visible.
 
 Omitting a barrier does not fail immediately — it corrupts the heap only
 when a minor collection happens to run before the next full collection,

--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -150,10 +150,11 @@ Two things deliberately do **not** rely on the barrier:
 - The root-marked maps (`vm.globals`, library `lib_env`s): their values are
   marked directly as roots every collection, so `set!`/`define` into them
   needs no barrier — nor into the interaction-environment wrapper, whose
-  map *is* `vm.globals` (the `.owned == false` case the handlers skip). A
-  *mutable* `SchemeEnvironment` (the `eval`/`environment` objects) is a
-  heap object, not a root-marked map — the `define`/`set!`/`define-syntax`
-  stores into its map carry a write barrier on the wrapper object, and the
+  map *is* `vm.globals`. That exclusion and the barrier it gates live once,
+  in `GC.envStoreBarrier`: a *mutable* `SchemeEnvironment` (the `eval`/
+  `environment` objects) is a heap object, not a root-marked map, so the
+  `define`/`set!`/`define-syntax` stores into its map carry a write barrier
+  on the wrapper object — the `.owned == false` wrapper does not. The
   compiler's `def_env_val`/`let_syntax_peer_vals` stores into a
   possibly-promoted aliased transformer (SRFI 147/211) carry one on the
   transformer.

--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -101,8 +101,10 @@ keeps it alive.
 
 Minor collections are generational (#1961): the minor mark traces roots
 into the young generation and treats old objects as opaque (`GC.minor_marking`
-gates the check in `markValueInner`), so it costs O(live young) rather than
-O(live heap). An old→young reference — a field of an old heap object holding
+gates the check in `markValueInner`). Its cost is O(live young) plus the
+fields scanned in remembered containers — a large old container with one
+young referent still costs its full capacity to re-scan each minor, which
+is why the dedup and pruning below matter — not O(live heap). An old→young reference — a field of an old heap object holding
 a young object — is therefore invisible to that mark unless it is recorded.
 The remembered set is that record, and it is fed two ways:
 

--- a/docs/dev/gc-safety-and-error-handling.md
+++ b/docs/dev/gc-safety-and-error-handling.md
@@ -154,8 +154,9 @@ Two things deliberately do **not** rely on the barrier:
   in `GC.envStoreBarrier`: a *mutable* `SchemeEnvironment` (the `eval`/
   `environment` objects) is a heap object, not a root-marked map, so the
   `define`/`set!`/`define-syntax` stores into its map carry a write barrier
-  on the wrapper object — the `.owned == false` wrapper does not. The
-  compiler's `def_env_val`/`let_syntax_peer_vals` stores into a
+  on the wrapper object — the `.owned == false` wrapper does not, and
+  `referencesYoung` answers false for it too, so neither scan enrolls it.
+  The compiler's `def_env_val`/`let_syntax_peer_vals` stores into a
   possibly-promoted aliased transformer (SRFI 147/211) carry one on the
   transformer.
 

--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -381,23 +381,31 @@ test "bytecode round-trip: various constant types" {
     // Add various constant types
     func.constants.append(allocator, types.makeFixnum(-100)) catch unreachable;
     func.constants.append(allocator, types.TRUE) catch unreachable;
+    gc.writeBarrier(&func.header, types.TRUE); // #1961: func may be promoted already
     func.constants.append(allocator, types.FALSE) catch unreachable;
+    gc.writeBarrier(&func.header, types.FALSE); // #1961: func may be promoted already
     func.constants.append(allocator, types.NIL) catch unreachable;
+    gc.writeBarrier(&func.header, types.NIL); // #1961: func may be promoted already
     func.constants.append(allocator, types.VOID) catch unreachable;
+    gc.writeBarrier(&func.header, types.VOID); // #1961: func may be promoted already
     func.constants.append(allocator, types.makeChar('Z')) catch unreachable;
 
     const sym = try gc.allocSymbol("hello");
     func.constants.append(allocator, sym) catch unreachable;
+    gc.writeBarrier(&func.header, sym); // #1961: func may be promoted already
 
     const str = try gc.allocString("world");
     func.constants.append(allocator, str) catch unreachable;
+    gc.writeBarrier(&func.header, str); // #1961: func may be promoted already
 
     const flo = types.makeFlonum(3.14);
     func.constants.append(allocator, flo) catch unreachable;
+    gc.writeBarrier(&func.header, flo); // #1961: func may be promoted already
 
     const bv_data = [_]u8{ 1, 2, 3 };
     const bv = try gc.allocBytevector(&bv_data);
     func.constants.append(allocator, bv) catch unreachable;
+    gc.writeBarrier(&func.header, bv); // #1961: func may be promoted already
 
     func.arity = 0;
     func.locals_count = 1;
@@ -467,6 +475,7 @@ test "bytecode round-trip: nested functions" {
     parent_func.code.append(allocator, 0) catch unreachable; // src high
     parent_func.code.append(allocator, 0) catch unreachable; // src low
     parent_func.constants.append(allocator, types.makePointer(&child_func.header)) catch unreachable;
+    gc.writeBarrier(&parent_func.header, types.makePointer(&child_func.header)); // #1961: func may be promoted already
     parent_func.arity = 0;
     parent_func.locals_count = 1;
 
@@ -592,6 +601,7 @@ test "bytecode round-trip: datum-label sharing preserved via backrefs (kaappi#21
     gc.pushRoot(&tail);
     const outer = try gc.allocPair(shared_pair, tail);
     func.constants.append(allocator, outer) catch unreachable;
+    gc.writeBarrier(&func.header, outer); // #1961: func may be promoted already
 
     var shared_str = try gc.allocString("s");
     gc.pushRoot(&shared_str);
@@ -603,6 +613,7 @@ test "bytecode round-trip: datum-label sharing preserved via backrefs (kaappi#21
     gc.writeBarrier(types.toObject(vec), shared_pair);
     gc.writeBarrier(types.toObject(vec), shared_str);
     func.constants.append(allocator, vec) catch unreachable;
+    gc.writeBarrier(&func.header, vec); // #1961: func may be promoted already
     gc.popRoot(); // shared_str
     gc.popRoot(); // tail
     gc.popRoot(); // shared_pair
@@ -642,6 +653,7 @@ test "bytecode round-trip: cyclic literal terminates and re-ties the knot (kaapp
     types.toObject(head).as(types.Pair).cdr = second;
     gc.writeBarrier(types.toObject(head), second);
     func.constants.append(allocator, head) catch unreachable;
+    gc.writeBarrier(&func.header, head); // #1961: func may be promoted already
     gc.popRoot();
 
     // A self-referential vector too: #0=#(1 #0#).
@@ -650,6 +662,7 @@ test "bytecode round-trip: cyclic literal terminates and re-ties the knot (kaapp
     types.toVector(cyc_vec).data[1] = cyc_vec;
     gc.writeBarrier(types.toObject(cyc_vec), cyc_vec);
     func.constants.append(allocator, cyc_vec) catch unreachable;
+    gc.writeBarrier(&func.header, cyc_vec); // #1961: func may be promoted already
     gc.popRoot();
 
     var loaded = try roundTrip(&gc, func, "/tmp/kaappi_test_cycle.sbc");
@@ -684,6 +697,7 @@ test "bytecode round-trip: a long quoted list costs no nesting depth (kaappi#211
         list = try gc.allocPair(types.makeFixnum(i), list);
     }
     func.constants.append(allocator, list) catch unreachable;
+    gc.writeBarrier(&func.header, list); // #1961: func may be promoted already
     gc.popRoot();
 
     var loaded = try roundTrip(&gc, func, "/tmp/kaappi_test_longlist.sbc");
@@ -778,6 +792,7 @@ test "bytecode write: refuses what the reader would reject (kaappi#2113)" {
         nested = try gc.allocPair(nested, types.NIL);
     }
     func.constants.append(allocator, nested) catch unreachable;
+    gc.writeBarrier(&func.header, nested); // #1961: func may be promoted already
     gc.popRoot();
 
     var funcs_arr = [_]*Function{func};
@@ -792,7 +807,9 @@ test "bytecode write: refuses what the reader would reject (kaappi#2113)" {
     const big = allocator.alloc(u8, MAX_STRING_BYTES + 1) catch unreachable;
     defer allocator.free(big);
     @memset(big, 'x');
-    func.constants.append(allocator, try gc.allocString(big)) catch unreachable;
+    const big_str = try gc.allocString(big);
+    func.constants.append(allocator, big_str) catch unreachable;
+    gc.writeBarrier(&func.header, big_str); // #1961: func may be promoted already
     try std.testing.expectError(BytecodeError.LimitExceeded, writeFileWithTopLevel(allocator, &funcs_arr, 0x1234, "test.scm", path));
 
     // And exactly AT the cap still round-trips — the two halves agree on the
@@ -805,6 +822,7 @@ test "bytecode write: refuses what the reader would reject (kaappi#2113)" {
         at_cap = try gc.allocPair(at_cap, types.NIL);
     }
     func.constants.append(allocator, at_cap) catch unreachable;
+    gc.writeBarrier(&func.header, at_cap); // #1961: func may be promoted already
     gc.popRoot();
     var loaded = try roundTrip(&gc, func, path);
     read.freeDeserializeResult(allocator, &loaded);
@@ -1037,21 +1055,26 @@ test "bytecode round-trip: vector pair bignum rational complex constants" {
     const vec_data = [_]Value{ types.makeFixnum(10), types.makeFixnum(20), types.makeFixnum(30) };
     const vec = try gc.allocVector(&vec_data);
     func.constants.append(allocator, vec) catch unreachable;
+    gc.writeBarrier(&func.header, vec); // #1961: func may be promoted already
 
     const pair = try gc.allocPair(types.makeFixnum(1), types.makeFixnum(2));
     func.constants.append(allocator, pair) catch unreachable;
+    gc.writeBarrier(&func.header, pair); // #1961: func may be promoted already
 
     const limbs = [_]u64{ 0xDEADBEEF, 0xCAFEBABE };
     const bn = try gc.allocBignumFromLimbs(&limbs, 2, true);
     func.constants.append(allocator, bn) catch unreachable;
+    gc.writeBarrier(&func.header, bn); // #1961: func may be promoted already
 
     const rat_num = types.makeFixnum(22);
     const rat_den = types.makeFixnum(7);
     const rat = try gc.allocRational(rat_num, rat_den);
     func.constants.append(allocator, rat) catch unreachable;
+    gc.writeBarrier(&func.header, rat); // #1961: func may be promoted already
 
     const cx = try gc.allocComplex(types.makeFlonum(3.0), types.makeFlonum(4.0));
     func.constants.append(allocator, cx) catch unreachable;
+    gc.writeBarrier(&func.header, cx); // #1961: func may be promoted already
 
     // Exact components (bignum real, rational imag) must survive the .sbc
     // round trip digit-exactly (kaappi#2166). The bignum must stay rooted
@@ -1062,6 +1085,7 @@ test "bytecode round-trip: vector pair bignum rational complex constants" {
     defer gc.popRoot();
     const cx_exact = try gc.allocComplex(cx_bn_root, try gc.allocRational(types.makeFixnum(3), types.makeFixnum(4)));
     func.constants.append(allocator, cx_exact) catch unreachable;
+    gc.writeBarrier(&func.header, cx_exact); // #1961: func may be promoted already
 
     func.arity = 0;
     func.locals_count = 1;

--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -298,7 +298,7 @@ test "bytecode round-trip: simple function" {
     func.code.append(allocator, 0) catch unreachable; // src low
 
     // Add a fixnum constant
-    func.constants.append(allocator, types.makeFixnum(42)) catch unreachable;
+    try gc.appendFunctionConstant(func, types.makeFixnum(42));
     func.arity = 0;
     func.locals_count = 1;
 
@@ -379,33 +379,25 @@ test "bytecode round-trip: various constant types" {
     func.code.append(allocator, 0) catch unreachable; // src low
 
     // Add various constant types
-    func.constants.append(allocator, types.makeFixnum(-100)) catch unreachable;
-    func.constants.append(allocator, types.TRUE) catch unreachable;
-    gc.writeBarrier(&func.header, types.TRUE); // #1961: func may be promoted already
-    func.constants.append(allocator, types.FALSE) catch unreachable;
-    gc.writeBarrier(&func.header, types.FALSE); // #1961: func may be promoted already
-    func.constants.append(allocator, types.NIL) catch unreachable;
-    gc.writeBarrier(&func.header, types.NIL); // #1961: func may be promoted already
-    func.constants.append(allocator, types.VOID) catch unreachable;
-    gc.writeBarrier(&func.header, types.VOID); // #1961: func may be promoted already
-    func.constants.append(allocator, types.makeChar('Z')) catch unreachable;
+    try gc.appendFunctionConstant(func, types.makeFixnum(-100));
+    try gc.appendFunctionConstant(func, types.TRUE);
+    try gc.appendFunctionConstant(func, types.FALSE);
+    try gc.appendFunctionConstant(func, types.NIL);
+    try gc.appendFunctionConstant(func, types.VOID);
+    try gc.appendFunctionConstant(func, types.makeChar('Z'));
 
     const sym = try gc.allocSymbol("hello");
-    func.constants.append(allocator, sym) catch unreachable;
-    gc.writeBarrier(&func.header, sym); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, sym);
 
     const str = try gc.allocString("world");
-    func.constants.append(allocator, str) catch unreachable;
-    gc.writeBarrier(&func.header, str); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, str);
 
     const flo = types.makeFlonum(3.14);
-    func.constants.append(allocator, flo) catch unreachable;
-    gc.writeBarrier(&func.header, flo); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, flo);
 
     const bv_data = [_]u8{ 1, 2, 3 };
     const bv = try gc.allocBytevector(&bv_data);
-    func.constants.append(allocator, bv) catch unreachable;
-    gc.writeBarrier(&func.header, bv); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, bv);
 
     func.arity = 0;
     func.locals_count = 1;
@@ -460,7 +452,7 @@ test "bytecode round-trip: nested functions" {
     child_func.code.append(allocator, @intFromEnum(types.OpCode.@"return")) catch unreachable;
     child_func.code.append(allocator, 0) catch unreachable; // src high
     child_func.code.append(allocator, 0) catch unreachable; // src low
-    child_func.constants.append(allocator, types.makeFixnum(99)) catch unreachable;
+    try gc.appendFunctionConstant(child_func, types.makeFixnum(99));
     child_func.arity = 1;
     child_func.locals_count = 1;
 
@@ -474,8 +466,7 @@ test "bytecode round-trip: nested functions" {
     parent_func.code.append(allocator, @intFromEnum(types.OpCode.@"return")) catch unreachable;
     parent_func.code.append(allocator, 0) catch unreachable; // src high
     parent_func.code.append(allocator, 0) catch unreachable; // src low
-    parent_func.constants.append(allocator, types.makePointer(&child_func.header)) catch unreachable;
-    gc.writeBarrier(&parent_func.header, types.makePointer(&child_func.header)); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(parent_func, types.makePointer(&child_func.header));
     parent_func.arity = 0;
     parent_func.locals_count = 1;
 
@@ -600,8 +591,7 @@ test "bytecode round-trip: datum-label sharing preserved via backrefs (kaappi#21
     var tail = try gc.allocPair(shared_pair, types.NIL);
     gc.pushRoot(&tail);
     const outer = try gc.allocPair(shared_pair, tail);
-    func.constants.append(allocator, outer) catch unreachable;
-    gc.writeBarrier(&func.header, outer); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, outer);
 
     var shared_str = try gc.allocString("s");
     gc.pushRoot(&shared_str);
@@ -612,8 +602,7 @@ test "bytecode round-trip: datum-label sharing preserved via backrefs (kaappi#21
     vecp.data[2] = shared_str;
     gc.writeBarrier(types.toObject(vec), shared_pair);
     gc.writeBarrier(types.toObject(vec), shared_str);
-    func.constants.append(allocator, vec) catch unreachable;
-    gc.writeBarrier(&func.header, vec); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, vec);
     gc.popRoot(); // shared_str
     gc.popRoot(); // tail
     gc.popRoot(); // shared_pair
@@ -652,8 +641,7 @@ test "bytecode round-trip: cyclic literal terminates and re-ties the knot (kaapp
     const second = try gc.allocPair(types.makeFixnum(2), head);
     types.toObject(head).as(types.Pair).cdr = second;
     gc.writeBarrier(types.toObject(head), second);
-    func.constants.append(allocator, head) catch unreachable;
-    gc.writeBarrier(&func.header, head); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, head);
     gc.popRoot();
 
     // A self-referential vector too: #0=#(1 #0#).
@@ -661,8 +649,7 @@ test "bytecode round-trip: cyclic literal terminates and re-ties the knot (kaapp
     gc.pushRoot(&cyc_vec);
     types.toVector(cyc_vec).data[1] = cyc_vec;
     gc.writeBarrier(types.toObject(cyc_vec), cyc_vec);
-    func.constants.append(allocator, cyc_vec) catch unreachable;
-    gc.writeBarrier(&func.header, cyc_vec); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, cyc_vec);
     gc.popRoot();
 
     var loaded = try roundTrip(&gc, func, "/tmp/kaappi_test_cycle.sbc");
@@ -696,8 +683,7 @@ test "bytecode round-trip: a long quoted list costs no nesting depth (kaappi#211
     while (i > 0) : (i -= 1) {
         list = try gc.allocPair(types.makeFixnum(i), list);
     }
-    func.constants.append(allocator, list) catch unreachable;
-    gc.writeBarrier(&func.header, list); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, list);
     gc.popRoot();
 
     var loaded = try roundTrip(&gc, func, "/tmp/kaappi_test_longlist.sbc");
@@ -791,8 +777,7 @@ test "bytecode write: refuses what the reader would reject (kaappi#2113)" {
     while (d < MAX_CONSTANT_DEPTH + 2) : (d += 1) {
         nested = try gc.allocPair(nested, types.NIL);
     }
-    func.constants.append(allocator, nested) catch unreachable;
-    gc.writeBarrier(&func.header, nested); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, nested);
     gc.popRoot();
 
     var funcs_arr = [_]*Function{func};
@@ -808,8 +793,7 @@ test "bytecode write: refuses what the reader would reject (kaappi#2113)" {
     defer allocator.free(big);
     @memset(big, 'x');
     const big_str = try gc.allocString(big);
-    func.constants.append(allocator, big_str) catch unreachable;
-    gc.writeBarrier(&func.header, big_str); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, big_str);
     try std.testing.expectError(BytecodeError.LimitExceeded, writeFileWithTopLevel(allocator, &funcs_arr, 0x1234, "test.scm", path));
 
     // And exactly AT the cap still round-trips — the two halves agree on the
@@ -821,8 +805,7 @@ test "bytecode write: refuses what the reader would reject (kaappi#2113)" {
     while (d2 < MAX_CONSTANT_DEPTH) : (d2 += 1) {
         at_cap = try gc.allocPair(at_cap, types.NIL);
     }
-    func.constants.append(allocator, at_cap) catch unreachable;
-    gc.writeBarrier(&func.header, at_cap); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, at_cap);
     gc.popRoot();
     var loaded = try roundTrip(&gc, func, path);
     read.freeDeserializeResult(allocator, &loaded);
@@ -1054,27 +1037,22 @@ test "bytecode round-trip: vector pair bignum rational complex constants" {
 
     const vec_data = [_]Value{ types.makeFixnum(10), types.makeFixnum(20), types.makeFixnum(30) };
     const vec = try gc.allocVector(&vec_data);
-    func.constants.append(allocator, vec) catch unreachable;
-    gc.writeBarrier(&func.header, vec); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, vec);
 
     const pair = try gc.allocPair(types.makeFixnum(1), types.makeFixnum(2));
-    func.constants.append(allocator, pair) catch unreachable;
-    gc.writeBarrier(&func.header, pair); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, pair);
 
     const limbs = [_]u64{ 0xDEADBEEF, 0xCAFEBABE };
     const bn = try gc.allocBignumFromLimbs(&limbs, 2, true);
-    func.constants.append(allocator, bn) catch unreachable;
-    gc.writeBarrier(&func.header, bn); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, bn);
 
     const rat_num = types.makeFixnum(22);
     const rat_den = types.makeFixnum(7);
     const rat = try gc.allocRational(rat_num, rat_den);
-    func.constants.append(allocator, rat) catch unreachable;
-    gc.writeBarrier(&func.header, rat); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, rat);
 
     const cx = try gc.allocComplex(types.makeFlonum(3.0), types.makeFlonum(4.0));
-    func.constants.append(allocator, cx) catch unreachable;
-    gc.writeBarrier(&func.header, cx); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, cx);
 
     // Exact components (bignum real, rational imag) must survive the .sbc
     // round trip digit-exactly (kaappi#2166). The bignum must stay rooted
@@ -1084,8 +1062,7 @@ test "bytecode round-trip: vector pair bignum rational complex constants" {
     gc.pushRoot(&cx_bn_root);
     defer gc.popRoot();
     const cx_exact = try gc.allocComplex(cx_bn_root, try gc.allocRational(types.makeFixnum(3), types.makeFixnum(4)));
-    func.constants.append(allocator, cx_exact) catch unreachable;
-    gc.writeBarrier(&func.header, cx_exact); // #1961: func may be promoted already
+    try gc.appendFunctionConstant(func, cx_exact);
 
     func.arity = 0;
     func.locals_count = 1;
@@ -1152,7 +1129,7 @@ test "bytecode round-trip: line table and source_line preserved" {
     func.code.append(allocator, @intFromEnum(types.OpCode.@"return")) catch unreachable;
     func.code.append(allocator, 0) catch unreachable;
     func.code.append(allocator, 0) catch unreachable;
-    func.constants.append(allocator, types.makeFixnum(42)) catch unreachable;
+    try gc.appendFunctionConstant(func, types.makeFixnum(42));
     func.arity = 1;
     func.locals_count = 2;
     func.source_line = 5;

--- a/src/bytecode_file_read.zig
+++ b/src/bytecode_file_read.zig
@@ -631,6 +631,12 @@ fn deserializeFromBufferImpl(gc: *GC, data: []const u8, expected_hash: ?u64) Byt
         for (0..const_count) |_| {
             const val = readConstant(&r, gc, all_funcs, &shared, 0) catch return null;
             func.constants.append(allocator, val) catch return BytecodeError.OutOfMemory;
+            // #1961: all_funcs are extra-rooted from the start of
+            // deserialization, so by now `func` is long promoted — an old
+            // container whose constants list is still growing. The
+            // generational minor mark reaches the freshly appended young
+            // constants only through the remembered set.
+            gc.writeBarrier(&func.header, val);
         }
 
         // Debug info: source_line and line_table (added in v7; col added in v9)

--- a/src/bytecode_file_read.zig
+++ b/src/bytecode_file_read.zig
@@ -630,13 +630,11 @@ fn deserializeFromBufferImpl(gc: *GC, data: []const u8, expected_hash: ?u64) Byt
         if (const_count > bf.MAX_CONSTANTS_PER_FUNCTION) return null;
         for (0..const_count) |_| {
             const val = readConstant(&r, gc, all_funcs, &shared, 0) catch return null;
-            func.constants.append(allocator, val) catch return BytecodeError.OutOfMemory;
-            // #1961: all_funcs are extra-rooted from the start of
-            // deserialization, so by now `func` is long promoted — an old
-            // container whose constants list is still growing. The
-            // generational minor mark reaches the freshly appended young
-            // constants only through the remembered set.
-            gc.writeBarrier(&func.header, val);
+            // #1961: appendFunctionConstant write-barriers the store —
+            // all_funcs are extra-rooted from the start of deserialization,
+            // so by now `func` is long promoted while its constants list is
+            // still growing.
+            gc.appendFunctionConstant(func, val) catch return BytecodeError.OutOfMemory;
         }
 
         // Debug info: source_line and line_table (added in v7; col added in v9)

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -288,6 +288,11 @@ pub const Compiler = struct {
         }
         if (self.func.constants.items.len >= 65536) return CompileError.TooManyConstants;
         self.func.constants.append(self.gc.allocator, value) catch return CompileError.OutOfMemory;
+        // #1961: compiling a large body spans collections, so `func` may
+        // already be promoted while its constants list is still growing —
+        // an old container taking young values, which the generational
+        // minor mark reaches only through the remembered set.
+        self.gc.writeBarrier(&self.func.header, value);
         return @intCast(self.func.constants.items.len - 1);
     }
 

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -287,12 +287,10 @@ pub const Compiler = struct {
             if (c == value) return @intCast(i);
         }
         if (self.func.constants.items.len >= 65536) return CompileError.TooManyConstants;
-        self.func.constants.append(self.gc.allocator, value) catch return CompileError.OutOfMemory;
-        // #1961: compiling a large body spans collections, so `func` may
-        // already be promoted while its constants list is still growing —
-        // an old container taking young values, which the generational
-        // minor mark reaches only through the remembered set.
-        self.gc.writeBarrier(&self.func.header, value);
+        // #1961: appendFunctionConstant write-barriers the store — compiling
+        // a large body spans collections, so `func` may already be promoted
+        // while its constants list is still growing.
+        self.gc.appendFunctionConstant(self.func, value) catch return CompileError.OutOfMemory;
         return @intCast(self.func.constants.items.len - 1);
     }
 

--- a/src/compiler_define_syntax.zig
+++ b/src/compiler_define_syntax.zig
@@ -700,6 +700,11 @@ fn resolveTransformerSpecRec(self: *Compiler, spec_in: Value, merged_macros: *st
                 if (self.body_macro_depth == 0) {
                     if (self.lib_env) |env| {
                         env.put(def_name, def_transformer) catch return CompileError.OutOfMemory;
+                        // #1961: same old→young edge on a mutable
+                        // SchemeEnvironment as compileDefineSyntax's own
+                        // lib_env store above.
+                        if (types.isEnvironment(self.lib_env_val))
+                            self.gc.writeBarrier(types.toObject(self.lib_env_val), def_transformer);
                     }
                 }
                 rest = types.cdr(rest);

--- a/src/compiler_define_syntax.zig
+++ b/src/compiler_define_syntax.zig
@@ -84,6 +84,13 @@ pub fn compileDefineSyntax(self: *Compiler, args: Value, dst: u16) CompileError!
     if (self.body_macro_depth == 0) {
         if (self.lib_env) |env| {
             env.put(name, transformer) catch return CompileError.OutOfMemory;
+            // #1961: for a mutable SchemeEnvironment (eval/environment
+            // objects — assertEnvMapInvariant's env_val case) this store is
+            // an old→young edge on that heap object once it promotes; the
+            // VM-rooted library lib_envs (env_val NIL) are marked as roots
+            // every collection, where the barrier is simply a no-op.
+            if (types.isEnvironment(self.lib_env_val))
+                self.gc.writeBarrier(types.toObject(self.lib_env_val), transformer);
         }
     }
 

--- a/src/compiler_define_syntax.zig
+++ b/src/compiler_define_syntax.zig
@@ -65,6 +65,14 @@ pub fn compileDefineSyntax(self: *Compiler, args: Value, dst: u16) CompileError!
     if (self.lib_env) |env| {
         tx.def_env = env;
         tx.def_env_val = self.lib_env_val;
+        // #1961 (review): resolveTransformerSpec can return a pre-existing
+        // (possibly promoted) transformer via the SRFI 147/211 alias paths,
+        // so this store may write a young environment into an OLD
+        // transformer — an old→young edge the minor mark reaches only
+        // through the remembered set. No isEnvironment guard needed:
+        // writeBarrier no-ops on the immediate NIL the library-rooted case
+        // carries.
+        self.gc.writeBarrier(types.toObject(transformer), self.lib_env_val);
         globals_mod.assertEnvMapInvariant(env, self.lib_env_val); // #1962
         // #1812: pairs with def_env so renameForHygiene can build a
         // def_env_binding_prefix-marked reference that survives being
@@ -269,6 +277,14 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
         };
         tx.let_syntax_peer_names = new_peer_names;
         tx.let_syntax_peer_vals = new_peer_vals;
+        // #1961 (review): resolveTransformerSpec can hand back a
+        // PRE-EXISTING transformer (SRFI 147 alias/bare-symbol specs, SRFI
+        // 211 globals) that was promoted long before this let-syntax — the
+        // peers_computed guard above does not prove freshness, since plain
+        // define-syntax transformers never compute peers. The snapshot is a
+        // fresh bundle of old→young edges on such a transformer; barrier
+        // each value so the generational minor mark can still reach them.
+        for (new_peer_vals) |pv| self.gc.writeBarrier(types.toObject(transformer), pv);
         // Only NOW, once both slices are durably stored, mark this
         // transformer's snapshot complete (CodeRabbit): setting the flag
         // any earlier -- before the fallible appends/dupes above -- would
@@ -692,6 +708,10 @@ fn resolveTransformerSpecRec(self: *Compiler, spec_in: Value, merged_macros: *st
                     const def_tx = types.toObject(def_transformer).as(types.Transformer);
                     def_tx.def_env = env;
                     def_tx.def_env_val = self.lib_env_val;
+                    // #1961 (review): same old→young edge on the transformer
+                    // as compileDefineSyntax's own def_env_val store above —
+                    // begin-wrapped helper definitions are just as aliased.
+                    self.gc.writeBarrier(types.toObject(def_transformer), self.lib_env_val);
                     globals_mod.assertEnvMapInvariant(env, self.lib_env_val); // #1962
                 }
                 try finalizeTransformer(self, def_transformer);

--- a/src/compiler_define_syntax.zig
+++ b/src/compiler_define_syntax.zig
@@ -92,13 +92,10 @@ pub fn compileDefineSyntax(self: *Compiler, args: Value, dst: u16) CompileError!
     if (self.body_macro_depth == 0) {
         if (self.lib_env) |env| {
             env.put(name, transformer) catch return CompileError.OutOfMemory;
-            // #1961: for a mutable SchemeEnvironment (eval/environment
-            // objects — assertEnvMapInvariant's env_val case) this store is
-            // an old→young edge on that heap object once it promotes; the
-            // VM-rooted library lib_envs (env_val NIL) are marked as roots
-            // every collection, where the barrier is simply a no-op.
-            if (types.isEnvironment(self.lib_env_val))
-                self.gc.writeBarrier(types.toObject(self.lib_env_val), transformer);
+            // #1961: the shared envStoreBarrier (mutable eval/environment
+            // objects only — the interaction-environment wrapper's map is
+            // the root-marked globals and enrolls nothing).
+            self.gc.envStoreBarrier(self.lib_env_val, transformer);
         }
     }
 
@@ -720,11 +717,9 @@ fn resolveTransformerSpecRec(self: *Compiler, spec_in: Value, merged_macros: *st
                 if (self.body_macro_depth == 0) {
                     if (self.lib_env) |env| {
                         env.put(def_name, def_transformer) catch return CompileError.OutOfMemory;
-                        // #1961: same old→young edge on a mutable
-                        // SchemeEnvironment as compileDefineSyntax's own
-                        // lib_env store above.
-                        if (types.isEnvironment(self.lib_env_val))
-                            self.gc.writeBarrier(types.toObject(self.lib_env_val), def_transformer);
+                        // #1961: same shared rule as compileDefineSyntax's
+                        // own lib_env store above.
+                        self.gc.envStoreBarrier(self.lib_env_val, def_transformer);
                     }
                 }
                 rest = types.cdr(rest);

--- a/src/disassembler.zig
+++ b/src/disassembler.zig
@@ -360,6 +360,7 @@ test "disassemble all opcodes" {
 
     const sym = try gc.allocSymbol("test-sym");
     func.constants.append(allocator, sym) catch unreachable;
+    gc.writeBarrier(&func.header, sym); // #1961: func may be promoted already
     func.constants.append(allocator, types.makeFixnum(42)) catch unreachable;
 
     const emit = struct {

--- a/src/disassembler.zig
+++ b/src/disassembler.zig
@@ -359,9 +359,8 @@ test "disassemble all opcodes" {
     func.name = "test-all-opcodes";
 
     const sym = try gc.allocSymbol("test-sym");
-    func.constants.append(allocator, sym) catch unreachable;
-    gc.writeBarrier(&func.header, sym); // #1961: func may be promoted already
-    func.constants.append(allocator, types.makeFixnum(42)) catch unreachable;
+    try gc.appendFunctionConstant(func, sym);
+    try gc.appendFunctionConstant(func, types.makeFixnum(42));
 
     const emit = struct {
         fn op(f: *types.Function, a: std.mem.Allocator, opcode: OpCode) void {

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -606,6 +606,22 @@ pub const FiberScheduler = struct {
         fiber.current_exception = vm.current_exception;
         fiber.continuation_invoked = vm.continuation_invoked;
         fiber.continuation_value = vm.continuation_value;
+        // #1961 (review): the retire paths (vm_calls.zig, fiber_wait.zig)
+        // run this save AFTER retireSlot has queued the slot for reuse, so
+        // the fiber may stop being scheduler-resident — losing the
+        // unconditional markFiberState pass in FiberScheduler.markRoots —
+        // while staying heap-reachable through a joiner's waiting_on or any
+        // variable holding the handle. This save writes a whole snapshot
+        // (memcpy'd registers/frames/handlers/winds, current_exception,
+        // continuation_value) with no per-field barriers, so an old fiber's
+        // fresh snapshot is otherwise an unrecorded bundle of old→young
+        // edges; the errored path's young ErrorObject is exactly one. Enroll
+        // the whole container: the remembered-set walk re-traces the
+        // snapshot, and pruneRememberedSet drops the entry once every
+        // snapshot value has aged into the old generation. Resident fibers
+        // keep their markFiberState pass regardless — this is additive.
+        if (fiber.header.flags.generation == 1)
+            vm.gc.rememberObject(&fiber.header);
     }
 
     pub fn restoreFiber(self: *FiberScheduler, idx: usize) VMError!void {

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -1032,7 +1032,17 @@ pub const FiberScheduler = struct {
         for (self.fibers.items) |f| {
             if (f) |fiber| {
                 gc.markValue(types.makePointer(&fiber.header));
-                if (fiber.status == .running) continue;
+                // #1961: once promoted, a fiber is opaque to the generational
+                // minor mark — markValue above no longer traces it — so every
+                // resident fiber gets this explicit pass, the running one
+                // included. For a running fiber the saved registers/frames are
+                // stale (the VM holds the live copies, marked by markVmRoots),
+                // but they must stay *traced* anyway: markValueInner's .fiber
+                // arm still walks them during full collections, and a value
+                // freed by a minor in between would turn that walk into a
+                // use-after-free. Retaining the stale snapshot until the next
+                // save overwrites it is the same conservatism the pre-#1961
+                // full transitive minor mark provided.
                 markFiberState(gc, fiber);
             }
         }

--- a/src/gc_alloc.zig
+++ b/src/gc_alloc.zig
@@ -177,6 +177,19 @@ pub fn allocFunction(self: *GC) !*Function {
     return func;
 }
 
+/// Append `v` to `func.constants`, write-barriering the store (#1961): a
+/// function can already be promoted while its constants list is still
+/// growing — compiling a large body spans collections, and the .sbc
+/// deserializer extra-roots its functions from the start — so the appended
+/// value may be a young referent only the remembered set can reach. Shared
+/// by the compiler, the deserializer, and the tests so the barrier is a
+/// property of adding a constant rather than of each call site. The barrier
+/// no-ops for immediates.
+pub fn appendFunctionConstant(self: *GC, func: *Function, v: Value) error{OutOfMemory}!void {
+    try func.constants.append(self.allocator, v);
+    self.writeBarrier(&func.header, v);
+}
+
 pub fn allocClosure(self: *GC, func: *Function) !Value {
     self.rootArgs1(types.makePointer(&func.header));
     try self.maybeCollect();

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -56,7 +56,7 @@ pub fn collect(gc: *GC) void {
 fn minorCollect(gc: *GC) void {
     // #1961: the minor mark is generational. `minor_marking` makes
     // markValueInner treat the old generation as opaque, so this mark costs
-    // O(live young) — roots plus remembered-set entries — instead of
+    // O(live young) plus the remembered containers' scanned fields — not
     // O(live heap). Mark-bit invariant, which is why no clearOldMarks pass
     // exists anywhere: the only writes of flags.marked are inside
     // markValueInner (young objects only during a minor — the opacity check

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -294,6 +294,18 @@ pub fn referencesYoung(gc: *GC, obj: *Object) bool {
         },
         .scheme_environment => {
             const se = obj.as(types.SchemeEnvironment);
+            // #1961 (review): an .owned == false wrapper's map IS the
+            // owning VM's root-marked globals map (interaction-environment
+            // is the only such constructor) — every value in it is marked
+            // each collection by markVmRoots regardless, so the wrapper
+            // never carries a remembered-set-relevant young edge; for a
+            // child-thread wrapper the values are foreign to this GC and
+            // isYoungPointer would skip them anyway. Returning false here
+            // keeps the promotion scan and the full-collect re-scan from
+            // enrolling the wrapper, which would otherwise re-walk all of
+            // globals (mark + prune) once per minor while any global value
+            // stays young.
+            if (!se.owned) return false;
             var vit = se.env.valueIterator();
             while (vit.next()) |val| {
                 if (isYoungPointer(gc, val.*)) return true;

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -57,11 +57,14 @@ fn minorCollect(gc: *GC) void {
     // #1961: the minor mark is generational. `minor_marking` makes
     // markValueInner treat the old generation as opaque, so this mark costs
     // O(live young) — roots plus remembered-set entries — instead of
-    // O(live heap). No clearOldMarks here: nothing marks an old object while
-    // minor_marking is set, and every sweep (sweepYoung/sweep/sweepOld)
-    // clears the marks it observes, so old marks are always false between
-    // collections.
+    // O(live heap). Mark-bit invariant, which is why no clearOldMarks pass
+    // exists anywhere: the only writes of flags.marked are inside
+    // markValueInner (young objects only during a minor — the opacity check
+    // returns before marking an old one — and both generations during a
+    // full), and every sweep clears the marks it observes before the
+    // collection ends, so no collection ever sees a stale mark.
     gc.minor_marking = true;
+    defer gc.minor_marking = false;
     markRoots(gc);
     for (gc.remembered_set.items) |obj| {
         markObjectContents(gc, obj);
@@ -72,15 +75,6 @@ fn minorCollect(gc: *GC) void {
     gc.quarantineReleaseToCap();
     sweepYoung(gc);
     pruneRememberedSet(gc);
-    gc.minor_marking = false;
-}
-
-fn clearOldMarks(gc: *GC) void {
-    var obj = gc.old_objects;
-    while (obj) |o| {
-        o.flags.marked = false;
-        obj = o.next;
-    }
 }
 
 fn pruneRememberedSet(gc: *GC) void {
@@ -346,8 +340,9 @@ fn isYoungPointer(gc: *GC, val: Value) bool {
 
 pub fn fullCollect(gc: *GC) void {
     // #1961: a full collection marks both generations — old objects are
-    // traced and swept here, so they must not be opaque. Also the defensive
-    // reset if a panic path ever left the flag set.
+    // traced and swept here, so they must not be opaque. minorCollect's
+    // defer guarantees the flag is already false; this makes the
+    // requirement local instead of transitive.
     gc.minor_marking = false;
     // #2196: drain the remembered_set up front. A full collect marks from
     // roots over both generations, so it never consults the set — and doing
@@ -356,7 +351,8 @@ pub fn fullCollect(gc: *GC) void {
     // use-after-free). Every surviving old container is then free to re-queue
     // itself on its next old->young write.
     drainRememberedSet(gc);
-    clearOldMarks(gc);
+    // No clearOldMarks here either — see minorCollect's mark-bit invariant:
+    // the previous collection (minor or full) left every mark clear.
     markRoots(gc);
     processWeakRefs(gc);
     // #1687: see minorCollect.

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -54,7 +54,14 @@ pub fn collect(gc: *GC) void {
 }
 
 fn minorCollect(gc: *GC) void {
-    clearOldMarks(gc);
+    // #1961: the minor mark is generational. `minor_marking` makes
+    // markValueInner treat the old generation as opaque, so this mark costs
+    // O(live young) — roots plus remembered-set entries — instead of
+    // O(live heap). No clearOldMarks here: nothing marks an old object while
+    // minor_marking is set, and every sweep (sweepYoung/sweep/sweepOld)
+    // clears the marks it observes, so old marks are always false between
+    // collections.
+    gc.minor_marking = true;
     markRoots(gc);
     for (gc.remembered_set.items) |obj| {
         markObjectContents(gc, obj);
@@ -65,6 +72,7 @@ fn minorCollect(gc: *GC) void {
     gc.quarantineReleaseToCap();
     sweepYoung(gc);
     pruneRememberedSet(gc);
+    gc.minor_marking = false;
 }
 
 fn clearOldMarks(gc: *GC) void {
@@ -92,7 +100,11 @@ fn pruneRememberedSet(gc: *GC) void {
     gc.remembered_set.shrinkRetainingCapacity(write_idx);
 }
 
-fn referencesYoung(gc: *GC, obj: *Object) bool {
+/// True iff `obj` (an old container) directly references a young object of
+/// this GC. Drives `pruneRememberedSet` and — since #1961 — the promotion
+/// scan in `sweepYoung`: this is the predicate that decides whether a freshly
+/// promoted object carries old→young edges the remembered set must record.
+pub fn referencesYoung(gc: *GC, obj: *Object) bool {
     switch (obj.tag) {
         .pair => {
             const pair = obj.as(Pair);
@@ -293,9 +305,13 @@ fn referencesYoung(gc: *GC, obj: *Object) bool {
                 if (isYoungPointer(gc, val.*)) return true;
             }
         },
-        // Weak structures never actually enter the remembered set (they are
-        // never mutated after allocation), but for completeness these report
-        // any young field: an over-approximation is always safe here.
+        // Weak structures reach the remembered set only via the promotion
+        // scan and — for guardians, whose `registered` list grows at every
+        // registration — the writeBarrier in invokeGuardian (an old guardian
+        // registering a young object is an old→young edge like any other,
+        // #1961). Ephemerons and transport cells are immutable after
+        // allocation, so for them the promotion scan is the only route; an
+        // over-approximation is always safe here.
         .ephemeron => {
             const eph = obj.as(Ephemeron);
             if (isYoungPointer(gc, eph.key) or isYoungPointer(gc, eph.value)) return true;
@@ -329,6 +345,10 @@ fn isYoungPointer(gc: *GC, val: Value) bool {
 }
 
 pub fn fullCollect(gc: *GC) void {
+    // #1961: a full collection marks both generations — old objects are
+    // traced and swept here, so they must not be opaque. Also the defensive
+    // reset if a panic path ever left the flag set.
+    gc.minor_marking = false;
     // #2196: drain the remembered_set up front. A full collect marks from
     // roots over both generations, so it never consults the set — and doing
     // this before sweepOld frees any old object means every entry is still
@@ -562,6 +582,14 @@ fn keptAlive(gc: *GC, v: Value) bool {
             @panic("GC: marking freed object (use-after-free)");
     }
     if (obj.owner != gc.id) return true;
+    // #1961: a minor collection never sweeps the old generation, so every
+    // old object trivially survives one — and none of them carries a mark
+    // (markValueInner leaves the old generation opaque). Answer alive and
+    // defer the weak decision to the next full collection, where old garbage
+    // is unmarked and visible; breaking an ephemeron or resurrecting a
+    // guardian entry over an old key during a minor would be destructive and
+    // wrong.
+    if (gc.minor_marking and obj.flags.generation == 1) return true;
     return obj.flags.marked or gc.weak_resurrected.contains(obj);
 }
 
@@ -582,6 +610,10 @@ fn weakReachable(gc: *GC, v: Value) bool {
             @panic("GC: marking freed object (use-after-free)");
     }
     if (obj.owner != gc.id) return true;
+    // #1961: same as keptAlive — an old object survives every minor
+    // collection, so a guardian entry watching one must stay registered
+    // here instead of being resurrected early.
+    if (gc.minor_marking and obj.flags.generation == 1) return true;
     return obj.flags.marked;
 }
 
@@ -924,6 +956,17 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
         // "already marked" object, skip tracing its children, and sweep live
         // descendants (#958).
         if (obj.owner != gc.id) return;
+        // #1961: during a minor collection the old generation is opaque. Old
+        // objects are never swept by sweepYoung, so they need no mark — and
+        // not tracing them is what makes the minor mark cheap. Every live
+        // old→young edge reaches this phase through the remembered-set walk
+        // instead (writeBarrier at each mutation site plus the promotion
+        // scan in sweepYoung), which is exactly why a missing barrier is a
+        // use-after-free here, not a retention miss.
+        if (gc.minor_marking and obj.flags.generation == 1) {
+            gc.stats.minor_old_skips += 1;
+            return;
+        }
         if (obj.flags.marked) return;
         obj.flags.marked = true;
 

--- a/src/gc_sweep.zig
+++ b/src/gc_sweep.zig
@@ -13,6 +13,7 @@ const builtin = @import("builtin");
 const types = @import("types.zig");
 const types_port = @import("types_port.zig");
 const memory_mod = @import("memory.zig");
+const gc_collect = @import("gc_collect.zig");
 const shared_channel = @import("shared_channel.zig");
 const shared_buffer = @import("shared_buffer.zig");
 const instrument = @import("channel_instrument.zig");
@@ -68,6 +69,20 @@ pub fn sweepYoung(gc: *GC) void {
                 o.flags.survive_count = 0;
                 o.next = gc.old_objects;
                 gc.old_objects = o;
+                // #1961 promotion scan: the write barrier only fires for a
+                // container that is *already* old, so an old→young edge
+                // created while the container was young (a barrier there is
+                // a correct no-op) would go unrecorded at promotion — and
+                // since the minor mark stopped tracing through old objects,
+                // that edge is the referent's only route to survival. Scan
+                // at promotion and remember the container. The flag is
+                // provably clear here: this object was young a moment ago,
+                // and writeBarrier only ever enqueues old containers.
+                if (gc_collect.referencesYoung(gc, o)) {
+                    o.flags.in_remembered_set = true;
+                    gc.remembered_set.append(gc.allocator, o) catch
+                        @panic("GC promotion scan: remembered set OOM");
+                }
                 obj = next;
             } else {
                 prev = o;
@@ -98,6 +113,21 @@ pub fn sweepOld(gc: *GC) void {
     while (obj) |o| {
         if (o.flags.marked) {
             o.flags.marked = false;
+            // #1961 full-collect re-scan: the drain at the top of this
+            // collection emptied the remembered set, and a full collection
+            // never promotes (young survivors stay generation 0), so an old
+            // container whose young referent just survived this full would
+            // otherwise face the next minor with no remembered-set entry —
+            // and the generational minor mark would sweep the referent.
+            // Re-record every surviving old→young edge here, where the old
+            // heap is already being walked. Objects freed below never had a
+            // live referent to protect. All owned flags were cleared by the
+            // drain, so the dedup guard is exact.
+            if (!o.flags.in_remembered_set and gc_collect.referencesYoung(gc, o)) {
+                o.flags.in_remembered_set = true;
+                gc.remembered_set.append(gc.allocator, o) catch
+                    @panic("GC full-collect re-scan: remembered set OOM");
+            }
             prev = o;
             obj = o.next;
         } else {

--- a/src/gc_sweep.zig
+++ b/src/gc_sweep.zig
@@ -75,13 +75,11 @@ pub fn sweepYoung(gc: *GC) void {
                 // a correct no-op) would go unrecorded at promotion — and
                 // since the minor mark stopped tracing through old objects,
                 // that edge is the referent's only route to survival. Scan
-                // at promotion and remember the container. The flag is
+                // at promotion and remember the container. The dedup flag is
                 // provably clear here: this object was young a moment ago,
                 // and writeBarrier only ever enqueues old containers.
                 if (gc_collect.referencesYoung(gc, o)) {
-                    o.flags.in_remembered_set = true;
-                    gc.remembered_set.append(gc.allocator, o) catch
-                        @panic("GC promotion scan: remembered set OOM");
+                    gc.rememberObject(o);
                 }
                 obj = next;
             } else {
@@ -122,11 +120,9 @@ pub fn sweepOld(gc: *GC) void {
             // Re-record every surviving old→young edge here, where the old
             // heap is already being walked. Objects freed below never had a
             // live referent to protect. All owned flags were cleared by the
-            // drain, so the dedup guard is exact.
-            if (!o.flags.in_remembered_set and gc_collect.referencesYoung(gc, o)) {
-                o.flags.in_remembered_set = true;
-                gc.remembered_set.append(gc.allocator, o) catch
-                    @panic("GC full-collect re-scan: remembered set OOM");
+            // drain, so rememberObject's dedup guard is exact.
+            if (gc_collect.referencesYoung(gc, o)) {
+                gc.rememberObject(o);
             }
             prev = o;
             obj = o.next;

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -398,6 +398,18 @@ pub const GC = struct {
             @panic("GC rememberObject: remembered set OOM");
     }
 
+    /// #1961: barrier a store into a mutable SchemeEnvironment's map (the
+    /// eval/environment objects) — an old→young edge on the wrapper once it
+    /// promotes. The interaction-environment wrapper (.owned == false) is
+    /// excluded: its map IS the root-marked globals map, and enrolling it
+    /// would re-walk every global once per minor, forever. Shared by the
+    /// set_global/define_global handlers and the compiler's define-syntax
+    /// env stores, so the exclusion rule lives in exactly one place.
+    pub fn envStoreBarrier(self: *GC, env_val: Value, val: Value) void {
+        if (types.isEnvironment(env_val) and types.toEnvironment(env_val).owned)
+            self.writeBarrier(types.toObject(env_val), val);
+    }
+
     pub fn writeBarrier(self: *GC, container: *Object, new_val: Value) void {
         if (container.flags.generation == 1 and types.isPointer(new_val)) {
             const child = types.toObject(new_val);

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -382,6 +382,22 @@ pub const GC = struct {
         self.source_spans.deinit();
     }
 
+    /// #1961: enroll an OWNED container in the remembered set, idempotently
+    /// (the #2196 dedup flag is the in-set mark for owned objects: set iff
+    /// present, cleared by pruneRememberedSet/drainRememberedSet on exit).
+    /// Shared by writeBarrier's owned path, the promotion scan and
+    /// full-collect re-scan in gc_sweep, and saveCurrentFiber's bulk
+    /// snapshot — every site that creates or re-creates an old→young edge
+    /// outside the ordinary store+barrier pattern. Callers must have
+    /// established `obj.owner == self.id`; foreign containers carry no flag
+    /// and stay in writeBarrier's unconditional-append branch.
+    pub fn rememberObject(self: *GC, obj: *Object) void {
+        if (obj.flags.in_remembered_set) return;
+        obj.flags.in_remembered_set = true;
+        self.remembered_set.append(self.allocator, obj) catch
+            @panic("GC rememberObject: remembered set OOM");
+    }
+
     pub fn writeBarrier(self: *GC, container: *Object, new_val: Value) void {
         if (container.flags.generation == 1 and types.isPointer(new_val)) {
             const child = types.toObject(new_val);
@@ -404,9 +420,8 @@ pub const GC = struct {
                 // written here and no reference this GC must track is dropped.
                 if (container.owner != self.id) {
                     self.remembered_set.append(self.allocator, container) catch @panic("GC writeBarrier: remembered set OOM");
-                } else if (!container.flags.in_remembered_set) {
-                    self.remembered_set.append(self.allocator, container) catch @panic("GC writeBarrier: remembered set OOM");
-                    container.flags.in_remembered_set = true;
+                } else {
+                    self.rememberObject(container);
                 }
             }
         }
@@ -465,6 +480,7 @@ pub const GC = struct {
     pub const allocUninternedSymbol = gc_alloc.allocUninternedSymbol;
     pub const allocString = gc_alloc.allocString;
     pub const allocFunction = gc_alloc.allocFunction;
+    pub const appendFunctionConstant = gc_alloc.appendFunctionConstant;
     pub const allocClosure = gc_alloc.allocClosure;
     pub const allocNativeFn = gc_alloc.allocNativeFn;
     pub const allocNativeClosure = gc_alloc.allocNativeClosure;

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -234,7 +234,8 @@ pub const GC = struct {
     /// #1961: set for the duration of a minor collection's mark phase. While
     /// set, `markValueInner` treats the old generation as opaque — an old
     /// object is never marked or traced, because `sweepYoung` never frees it —
-    /// so the minor mark costs O(live young), not O(live heap). Every live
+    /// so the minor mark costs O(live young) plus the remembered containers'
+    /// scanned fields, not O(live heap). Every live
     /// old→young edge is supplied by the remembered-set walk instead (the
     /// `writeBarrier` calls at each mutation site plus the promotion scan in
     /// `sweepYoung`). False outside a collection and during every full

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -52,6 +52,10 @@ pub const GcStats = struct {
     peak_bytes_allocated: usize = 0,
     allocs_by_type: [64]usize = .{0} ** 64,
     no_collect_deferred: usize = 0,
+    /// #1961: times a minor collection's mark phase stopped at an old object
+    /// (the generational boundary). Watching this stay > 0 while a large old
+    /// heap exists is how tests pin that a minor mark really is generational.
+    minor_old_skips: usize = 0,
 };
 
 pub var symbol_mutex: std.atomic.Mutex = .unlocked;
@@ -227,6 +231,18 @@ pub const GC = struct {
     source_spans: std.AutoHashMap(Value, types.Span) = undefined,
     stats: GcStats = .{},
     minor_cycle_count: u32 = 0,
+    /// #1961: set for the duration of a minor collection's mark phase. While
+    /// set, `markValueInner` treats the old generation as opaque — an old
+    /// object is never marked or traced, because `sweepYoung` never frees it —
+    /// so the minor mark costs O(live young), not O(live heap). Every live
+    /// old→young edge is supplied by the remembered-set walk instead (the
+    /// `writeBarrier` calls at each mutation site plus the promotion scan in
+    /// `sweepYoung`). False outside a collection and during every full
+    /// collection. The weak-reference probes (`keptAlive`/`weakReachable`)
+    /// also read it: an old object trivially survives a minor collection, so
+    /// it must answer "alive" there and defer its weak fate to the next full
+    /// collection.
+    minor_marking: bool = false,
     mark_worklist: std.ArrayList(Value) = .empty,
     marking: bool = false,
     /// SRFI-254 weak references reached during the current mark phase. Filled

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -1546,6 +1546,11 @@ fn trackOwnedMutex(fiber: *fiber_mod.Fiber, m_val: Value) void {
     // The lock itself already succeeded, so failing the primitive now would
     // be worse — the caller would believe the lock failed while it is held.
     fiber.owned_mutexes.append(gc.allocator, m_val) catch {};
+    // #1961: this list is also an old→young edge when a promoted fiber locks
+    // a fresh mutex — FiberScheduler.markRoots' explicit markFiberState pass
+    // covers it as a root, and this keeps the remembered set complete for it
+    // like every other Value store into an old container.
+    gc.writeBarrier(&fiber.header, m_val);
 }
 
 fn mutexLockFn(args: []const Value) PrimitiveError!Value {

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -922,3 +922,54 @@ test "255-argument calls work on every dispatch path; 256 params reject cleanly 
         try std.testing.expectError(vm_mod.VMError.CompileError, vm.eval(def));
     }
 }
+
+// #1961: define/set! into a mutable SchemeEnvironment's map is an old→young
+// edge on the wrapper object once promoted; the opcode handlers barrier it
+// (vm_dispatch.zig). This drives the real opcode path: promote the env, then
+// define and set! a fresh young vector through eval, force a minor
+// collection while the vector's only reference is the env's map, and read it
+// back intact. Without the barrier the minor sweeps the vector (the old env
+// is opaque to the mark) and the read-back dereferences freed memory.
+test "define/set! into a promoted mutable env survive a minor collection (#1961)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // Same construction as the #1269 test above: a mutable env with the
+    // globals' bindings but a distinct map, reachable from Scheme.
+    const env_map = try ctx.gc.allocator.create(std.StringHashMap(types.Value));
+    env_map.* = std.StringHashMap(types.Value).init(ctx.gc.allocator);
+    var git = ctx.vm.globals.iterator();
+    while (git.next()) |entry| {
+        try env_map.put(entry.key_ptr.*, entry.value_ptr.*);
+    }
+    var env_val = try ctx.gc.allocEnvironment(env_map, true, false);
+    ctx.gc.pushRoot(&env_val);
+    defer ctx.gc.popRoot();
+    try ctx.vm.globals.put("__test-mut-env", env_val);
+
+    // Promote the env wrapper: two manual minors, marked through the global.
+    ctx.gc.enabled = false;
+    ctx.gc.minor_cycle_count = 0;
+    ctx.gc.collect();
+    ctx.gc.minor_cycle_count = 0;
+    ctx.gc.collect();
+    try std.testing.expectEqual(@as(u1, 1), types.toEnvironment(env_val).header.flags.generation);
+
+    // Real define_global: a fresh young vector stored into the promoted
+    // env's map, then a minor collection with the map as its only anchor.
+    _ = try ctx.vm.eval("(eval '(define reg-box-1961 (vector 42)) __test-mut-env)");
+    ctx.gc.minor_cycle_count = 0;
+    ctx.gc.collect();
+    try std.testing.expectEqual(@as(i64, 42), types.toFixnum(try ctx.vm.eval(
+        "(eval '(vector-ref reg-box-1961 0) __test-mut-env)",
+    )));
+
+    // Real set_global through the same env.
+    _ = try ctx.vm.eval("(eval '(set! reg-box-1961 (vector 43)) __test-mut-env)");
+    ctx.gc.minor_cycle_count = 0;
+    ctx.gc.collect();
+    try std.testing.expectEqual(@as(i64, 43), types.toFixnum(try ctx.vm.eval(
+        "(eval '(vector-ref reg-box-1961 0) __test-mut-env)",
+    )));
+}

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -977,9 +977,12 @@ test "define/set! into a promoted mutable env survive a minor collection (#1961)
 // #1961 (review follow-up): define-syntax through the interaction-
 // environment must NOT enroll its wrapper in the remembered set — the
 // wrapper's map is the root-marked globals map, and enrolling it would
-// re-walk every global once per minor until process exit. GC.envStoreBarrier
-// is the one place that exclusion lives; this is the reviewer's reachable
-// path (mutable wrapper, top-level depth, lib_env = vm.globals).
+// re-walk every global once per minor until process exit. Both routes are
+// pinned: GC.envStoreBarrier owns the barrier-side exclusion, and
+// referencesYoung's .scheme_environment arm returns false for .owned ==
+// false wrappers so the promotion scan and the full-collect re-scan cannot
+// enroll it either. The young global defined between the two promotion
+// collections is what makes the scan route fire deterministically.
 test "define-syntax via interaction-environment does not enroll the wrapper (#1961)" {
     var ctx: th.TestContext = undefined;
     try ctx.init();
@@ -988,14 +991,21 @@ test "define-syntax via interaction-environment does not enroll the wrapper (#19
     _ = try ctx.vm.eval("(define ie (interaction-environment))");
     const ie_val = try ctx.vm.eval("ie");
 
-    // A fresh wrapper per call; promote this one.
+    // A fresh wrapper per call. First survival...
     ctx.gc.enabled = false;
     ctx.gc.minor_cycle_count = 0;
     ctx.gc.collect();
+    // ...then a young value lands in the wrapper's (root-marked) map...
+    _ = try ctx.vm.eval("(define pin-young-global-1961 (vector 7))");
+    // ...and the second collection promotes the wrapper with that young
+    // value still in the map — exactly the shape that made the promotion
+    // scan enroll the wrapper before referencesYoung learned to skip
+    // .owned == false maps.
     ctx.gc.minor_cycle_count = 0;
     ctx.gc.collect();
     try std.testing.expectEqual(@as(u1, 1), types.toEnvironment(ie_val).header.flags.generation);
 
+    // The barrier route: a top-level define-syntax through the wrapper.
     _ = try ctx.vm.eval("(eval '(define-syntax k-1961 (syntax-rules () ((_) 1))) ie)");
 
     const wrapper = types.toObject(ie_val);

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -973,3 +973,35 @@ test "define/set! into a promoted mutable env survive a minor collection (#1961)
         "(eval '(vector-ref reg-box-1961 0) __test-mut-env)",
     )));
 }
+
+// #1961 (review follow-up): define-syntax through the interaction-
+// environment must NOT enroll its wrapper in the remembered set — the
+// wrapper's map is the root-marked globals map, and enrolling it would
+// re-walk every global once per minor until process exit. GC.envStoreBarrier
+// is the one place that exclusion lives; this is the reviewer's reachable
+// path (mutable wrapper, top-level depth, lib_env = vm.globals).
+test "define-syntax via interaction-environment does not enroll the wrapper (#1961)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(define ie (interaction-environment))");
+    const ie_val = try ctx.vm.eval("ie");
+
+    // A fresh wrapper per call; promote this one.
+    ctx.gc.enabled = false;
+    ctx.gc.minor_cycle_count = 0;
+    ctx.gc.collect();
+    ctx.gc.minor_cycle_count = 0;
+    ctx.gc.collect();
+    try std.testing.expectEqual(@as(u1, 1), types.toEnvironment(ie_val).header.flags.generation);
+
+    _ = try ctx.vm.eval("(eval '(define-syntax k-1961 (syntax-rules () ((_) 1))) ie)");
+
+    const wrapper = types.toObject(ie_val);
+    for (ctx.gc.remembered_set.items) |o| {
+        try std.testing.expect(o != wrapper);
+    }
+    // The store itself happened — only the enrollment is skipped.
+    try std.testing.expectEqual(@as(i64, 1), types.toFixnum(try ctx.vm.eval("(eval '(k-1961) ie)")));
+}

--- a/src/tests_gc_tracing.zig
+++ b/src/tests_gc_tracing.zig
@@ -1310,23 +1310,17 @@ test "gc write barrier: an entry whose young referent is gone is pruned" {
     try expectDead(&gc, ref(a, 1));
 }
 
-// Pins a property that is easy to assume the other way round, and that
-// decides how dangerous a *missing* `gc.writeBarrier` call is anywhere in
-// the tree: a minor collection here is a **full transitive mark** from the
-// roots. `minorCollect` calls `clearOldMarks` and then `markRoots`, and
-// `markValueInner` never stops at the young/old boundary — only the *sweep*
-// is generational (`sweepYoung` vs `sweep` + `sweepOld`).
-//
-// So an old object that is reachable from any root has its young children
-// traced whether or not it is in the remembered set, and the remembered set
-// only ever adds young children of old objects that are *not* root-reachable
-// — floating garbage a minor collection cannot free anyway. A forgotten
-// barrier is therefore a conservative-retention miss, not a lost live object.
-//
-// If `minorCollect` ever becomes a true generational mark that stops at old
-// objects, this test flips to failing — which is exactly the moment every
-// heap-mutation site in the tree needs auditing for a missing barrier.
-test "gc write barrier: a minor collection marks through an old object with no remembered-set entry" {
+// Pins the property #1961 established: a minor collection is a
+// **generational** mark. `markValueInner` treats the old generation as
+// opaque, so an old container is traced by a minor collection only through
+// the remembered set — which makes `gc.writeBarrier` (plus the promotion
+// scan in sweepYoung) load-bearing. A forgotten barrier is a
+// use-after-free: the young referent is swept while the old container still
+// points at it. (Before #1961 the minor mark was a full transitive mark, and
+// this test asserted the exact opposite — that the referent survived — which
+// is what told whoever made the mark generational that every mutation site
+// needed auditing first.)
+test "gc write barrier: a minor collection does not mark through an old object with no remembered-set entry" {
     var gc = newGc();
     defer gc.deinit();
     const c = try gc.allocPair(types.NIL, types.NIL);
@@ -1341,7 +1335,166 @@ test "gc write barrier: a minor collection marks through an old object with no r
     try std.testing.expect(!inRemembered(&gc, types.toObject(c)));
 
     forceMinor(&gc);
+    // The root keeps `c` itself alive (old objects survive every minor),
+    // but the old generation is opaque to the mark and `c` is not
+    // remembered, so `a` has no route to survival. It is freed, not merely
+    // unmarked — reading it back here would be the use-after-free this test
+    // exists to pin, so liveness is checked by list membership only.
+    try expectDead(&gc, ref(a, 1));
+}
+
+// The companion to the case above: the same store WITH the barrier keeps the
+// referent alive — the remembered-set walk (markObjectContents) is its only
+// route to survival, since the container is old and unrooted-reachable.
+test "gc write barrier: a remembered old container keeps its young referent through a minor collection" {
+    var gc = newGc();
+    defer gc.deinit();
+    const c = try gc.allocPair(types.NIL, types.NIL);
+    try promoteToOld(&gc, c);
+
+    var root = c;
+    gc.pushRoot(&root);
+
+    const a = try young(&gc, 1);
+    types.toObject(c).as(types.Pair).car = a;
+    gc.writeBarrier(types.toObject(c), a);
+    try std.testing.expect(inRemembered(&gc, types.toObject(c)));
+
+    gc.popRoot();
+    forceMinor(&gc);
     try expectAlive(&gc, ref(a, 1));
+}
+
+// #1961 promotion scan: the write barrier only fires for a container that is
+// already old, so an old→young edge created while the container was young (a
+// barrier there is a correct no-op) would go unrecorded when sweepYoung
+// promotes it. The scan at promotion records it, keeping the remembered set
+// complete without any barrier change at the mutation sites.
+test "gc promotion scan: a promoted container with young referents enters the remembered set" {
+    var gc = newGc();
+    defer gc.deinit();
+    const c = try gc.allocPair(types.NIL, types.NIL);
+    var root = c;
+    gc.pushRoot(&root);
+
+    // One survival leaves c young with survive_count 1...
+    forceMinor(&gc);
+    // ...then a fresh young referent is stored (still correctly barrier-less:
+    // c is young, so a minor collection traces it from the root anyway)...
+    const a = try young(&gc, 1);
+    types.toObject(c).as(types.Pair).car = a;
+    // ...and the next minor promotes c while a — one survival so far — stays
+    // young. The promotion scan must record the edge.
+    forceMinor(&gc);
+    try std.testing.expectEqual(@as(u1, 1), types.toObject(c).flags.generation);
+    try std.testing.expectEqual(@as(u1, 0), types.toObject(a).flags.generation);
+    try std.testing.expect(inRemembered(&gc, types.toObject(c)));
+
+    // With the root dropped, the remembered-set walk is a's only anchor.
+    gc.popRoot();
+    forceMinor(&gc);
+    try expectAlive(&gc, ref(a, 1));
+
+    // a survived that minor, so both ends of the edge are now old and
+    // referencesYoung says no — the entry is pruned and the flag cleared, so
+    // a later old→young write to c is free to re-queue it (#2196).
+    try std.testing.expect(!inRemembered(&gc, types.toObject(c)));
+    try std.testing.expect(!types.toObject(c).flags.in_remembered_set);
+}
+
+// #1961: the whole point of the generational minor mark, pinned directly off
+// the skip counter — a minor collection whose roots reach old objects must
+// not trace them, while a full collection (which sweeps the old generation)
+// still must.
+test "gc minor mark: skips the old generation, full mark does not (#1961)" {
+    var gc = newGc();
+    defer gc.deinit();
+    // A chain of old pairs hanging off one old head.
+    var head = try gc.allocPair(types.NIL, types.NIL);
+    gc.pushRoot(&head);
+    var tail = head;
+    for (0..64) |i| {
+        const next = try gc.allocPair(types.makeFixnum(@intCast(i)), types.NIL);
+        types.toObject(tail).as(types.Pair).cdr = next;
+        tail = next;
+    }
+    try promoteToOld(&gc, head);
+
+    const skips_before = gc.stats.minor_old_skips;
+    forceMinor(&gc);
+    // The root walk reached `head` (and only `head` — the cdr chain is old
+    // and opaque), so the boundary fired at least once...
+    try std.testing.expect(gc.stats.minor_old_skips > skips_before);
+    // ...and exactly once per old object the walk attempted: the head only,
+    // because the chain behind it is never entered.
+    try std.testing.expectEqual(skips_before + 1, gc.stats.minor_old_skips);
+
+    forceFull(&gc);
+    // A full collection marks both generations — no new skips.
+    try std.testing.expectEqual(skips_before + 1, gc.stats.minor_old_skips);
+    gc.popRoot();
+}
+
+// #1961: a minor collection never sweeps the old generation, so the weak
+// probes must treat every old object as alive — an ephemeron whose key is
+// old must not break (breaking is destructive: both fields are cleared)
+// just because the key carries no mark during a minor.
+test "gc weak refs: an old ephemeron key does not break in a minor collection (#1961)" {
+    var gc = newGc();
+    defer gc.deinit();
+    const key = try young(&gc, 1);
+    try promoteToOld(&gc, key);
+
+    const val = try young(&gc, 2);
+    const eph_val = try gc.allocEphemeron(key, val);
+    const eph = types.toEphemeron(eph_val);
+    var root = eph_val;
+    gc.pushRoot(&root);
+
+    // The key is old garbage-in-waiting (only the ephemeron's weak field
+    // references it), but a minor collection cannot free it — so the
+    // ephemeron must not break and the value must stay retained.
+    forceMinor(&gc);
+    try std.testing.expect(!eph.broken);
+    try expectAlive(&gc, ref(val, 2));
+
+    // Control: the next FULL collection sweeps the old generation, sees the
+    // key as the garbage it is, and breaks the ephemeron — proving the minor
+    // above deferred the decision rather than losing it.
+    forceFull(&gc);
+    try std.testing.expect(eph.broken);
+    gc.popRoot();
+}
+
+// #1961: same rule for guardians — a registered element watching an old
+// object must stay registered through a minor collection (the object cannot
+// die in one), instead of being resurrected early.
+test "gc weak refs: a guardian watching an old object does not resurrect in a minor collection (#1961)" {
+    var gc = newGc();
+    defer gc.deinit();
+    const watched = try young(&gc, 1);
+    try promoteToOld(&gc, watched);
+
+    const rep = try young(&gc, 2);
+    const g_val = try gc.allocGuardian(false);
+    const g = types.toGuardian(g_val);
+    try g.registered.append(gc.allocator, .{ .watched = watched, .payload = rep });
+    gc.writeBarrier(types.toObject(g_val), watched);
+    gc.writeBarrier(types.toObject(g_val), rep);
+
+    var root = g_val;
+    gc.pushRoot(&root);
+    forceMinor(&gc);
+    try std.testing.expectEqual(@as(usize, 0), g.ready.items.len);
+    try std.testing.expectEqual(@as(usize, 1), g.registered.items.len);
+
+    // Control: the next FULL collection sees the old watched object as the
+    // garbage it is and resurrects the element — the deferred decision,
+    // taken exactly when the object can actually die.
+    forceFull(&gc);
+    try std.testing.expectEqual(@as(usize, 1), g.ready.items.len);
+    try std.testing.expectEqual(@as(usize, 0), g.registered.items.len);
+    gc.popRoot();
 }
 
 // ---------------------------------------------------------------------------
@@ -1913,10 +2066,12 @@ test "gc remembered set (#2196): a full collect drain resets every dedup flag" {
     gc.writeBarrier(&vec.header, a);
     try std.testing.expect(vec.header.flags.in_remembered_set);
 
-    // fullCollect drains the whole remembered_set. The flag must be cleared
-    // there too -- otherwise a surviving container that keeps its stale flag
-    // would refuse to re-queue, silently dropping a later old->young write.
-    // Root the container so the full collect keeps it.
+    // Repoint at an immediate so the #1961 sweepOld re-scan has no old→young
+    // edge to re-record. fullCollect drains the whole remembered_set and the
+    // flag must be cleared there too — otherwise a surviving container that
+    // keeps its stale flag would refuse to re-queue, silently dropping a
+    // later old->young write. Root the container so the full collect keeps it.
+    vec.data[0] = types.makeFixnum(0);
     var root = c;
     gc.pushRoot(&root);
     forceFull(&gc);
@@ -1930,6 +2085,36 @@ test "gc remembered set (#2196): a full collect drain resets every dedup flag" {
     gc.writeBarrier(&vec.header, b);
     try std.testing.expectEqual(@as(usize, 1), gc.remembered_set.items.len);
     try std.testing.expect(vec.header.flags.in_remembered_set);
+}
+
+// #1961: a full collection drains the remembered set before marking but
+// never promotes — young survivors stay generation 0 — so an old container
+// whose young referent just survived the full would face the next minor
+// with no entry. sweepOld re-records every surviving old→young edge while
+// it already walks the old generation.
+test "gc remembered set (#1961): a full collect re-records surviving old→young edges" {
+    var gc = newGc();
+    defer gc.deinit();
+    const c = try gc.allocVectorFill(1, types.NIL);
+    try promoteToOld(&gc, c);
+    const vec = types.toObject(c).as(types.Vector);
+
+    const a = try young(&gc, 1);
+    vec.data[0] = a;
+    gc.writeBarrier(&vec.header, a);
+
+    var root = c;
+    gc.pushRoot(&root);
+    forceFull(&gc);
+    // The vector survived the full still referencing young `a`, so the
+    // re-scan must have re-queued it: the next minor's mark reaches `a` only
+    // through that entry.
+    try std.testing.expectEqual(@as(usize, 1), gc.remembered_set.items.len);
+    try std.testing.expect(vec.header.flags.in_remembered_set);
+
+    gc.popRoot();
+    forceMinor(&gc);
+    try expectAlive(&gc, ref(a, 1));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests_gc_tracing.zig
+++ b/src/tests_gc_tracing.zig
@@ -1402,6 +1402,114 @@ test "gc promotion scan: a promoted container with young referents enters the re
     try std.testing.expect(!types.toObject(c).flags.in_remembered_set);
 }
 
+// #1961 (review): an old function's constants list is a barriered container.
+// The compiler's addConstant, the .sbc deserializer, and the bytecode-file
+// tests all funnel through GC.appendFunctionConstant, so this drives the
+// real mechanism; the control half pins why it must — a function can be
+// promoted long before its constants list stops growing.
+test "gc: an old function's constants list is a barriered container (#1961)" {
+    var gc = newGc();
+    defer gc.deinit();
+    const f1 = try gc.allocFunction();
+    const f1_val = types.makePointer(&f1.header);
+    try promoteToOld(&gc, f1_val);
+    const f2 = try gc.allocFunction();
+    const f2_val = types.makePointer(&f2.header);
+    try promoteToOld(&gc, f2_val);
+
+    // The store every producer makes: append + barrier on the function.
+    const a = try young(&gc, 1);
+    try gc.appendFunctionConstant(f1, a);
+    // The old function survives every minor unrooted; the barrier's entry is
+    // a's only route to survival.
+    forceMinor(&gc);
+    try expectAlive(&gc, ref(a, 1));
+
+    // Control — the same store without the barrier (the pre-#1961 shape)
+    // loses the referent.
+    const b = try young(&gc, 2);
+    f2.constants.append(gc.allocator, b) catch unreachable;
+    forceMinor(&gc);
+    try expectDead(&gc, ref(b, 2));
+}
+
+// #1961 (review): a function's global_cache is a barriered container for the
+// same reason — a cached value can be orphaned by a later rebinding before
+// this function's own next global op clears the slot, and the minor mark
+// reaches the orphan only through the remembered set. The opcode handlers
+// barrier each cache store; this pins that store shape at the mechanism
+// level (the dispatch path itself is exercised end-to-end by gc-stress).
+test "gc: an old function's global_cache is a barriered container (#1961)" {
+    var gc = newGc();
+    defer gc.deinit();
+    const f1 = try gc.allocFunction();
+    const f1_val = types.makePointer(&f1.header);
+    try promoteToOld(&gc, f1_val);
+    const f2 = try gc.allocFunction();
+    const f2_val = types.makePointer(&f2.header);
+    try promoteToOld(&gc, f2_val);
+
+    const cache1 = try gc.allocator.alloc(Value, 1);
+    @memset(cache1, types.VOID);
+    f1.global_cache = cache1;
+    const a = try young(&gc, 1);
+    cache1[0] = a;
+    gc.writeBarrier(types.toObject(f1_val), a); // the handlers' store shape
+    forceMinor(&gc);
+    try expectAlive(&gc, ref(a, 1));
+
+    const cache2 = try gc.allocator.alloc(Value, 1);
+    @memset(cache2, types.VOID);
+    f2.global_cache = cache2;
+    const b = try young(&gc, 2);
+    cache2[0] = b; // no barrier — the pre-fix shape
+    forceMinor(&gc);
+    try expectDead(&gc, ref(b, 2));
+}
+
+// #1961 (review): a fiber retired from its scheduler slot (retireSlot queues
+// the slot for reuse, then the retire paths run saveCurrentFiber AFTER it)
+// loses the unconditional markFiberState pass while staying heap-reachable
+// through a joiner's waiting_on or any handle. saveCurrentFiber's answer is
+// to enroll an old fiber in the remembered set wholesale — its bulk snapshot
+// (memcpy'd registers/frames/handlers/winds, current_exception,
+// continuation_value) has no per-field barriers. This pins that mechanism:
+// an unbarriered snapshot store into a non-resident old fiber survives only
+// via rememberObject.
+test "gc: a retired old fiber's snapshot survives via the remembered set (#1961)" {
+    var gc = newGc();
+    defer gc.deinit();
+    const fiber = try gc.allocFiber(types.NIL, 1);
+    const fiber_val = types.makePointer(&fiber.header);
+    try promoteToOld(&gc, fiber_val);
+
+    // Simulate the retire-path save: young values written straight into the
+    // fiber's snapshot fields, no per-field barriers (saveCurrentFiber's
+    // memcpy shape), then the wholesale enrollment.
+    const exc = try young(&gc, 1);
+    fiber.current_exception = exc;
+    fiber.registers[3] = try young(&gc, 2);
+    fiber.frames[0] = .{ .closure = null, .code = &.{}, .ip = 0, .base = 0, .dst = 0 };
+    fiber.frame_count = 1;
+    gc.rememberObject(types.toObject(fiber_val));
+
+    // The fiber is not scheduler-resident and nothing roots it; it survives
+    // every minor anyway (old), and the remembered entry keeps the snapshot
+    // values alive with it.
+    forceMinor(&gc);
+    try expectAlive(&gc, ref(exc, 1));
+
+    // Control: the same snapshot store without the enrollment loses the
+    // values — the old fiber is opaque and nothing else references them.
+    const fiber2 = try gc.allocFiber(types.NIL, 2);
+    const fiber2_val = types.makePointer(&fiber2.header);
+    try promoteToOld(&gc, fiber2_val);
+    const lost = try young(&gc, 3);
+    fiber2.current_exception = lost; // no rememberObject
+    forceMinor(&gc);
+    try expectDead(&gc, ref(lost, 3));
+}
+
 // #1961: the whole point of the generational minor mark, pinned directly off
 // the skip counter — a minor collection whose roots reach old objects must
 // not trace them, while a full collection (which sweeps the old generation)

--- a/src/tests_scheduler.zig
+++ b/src/tests_scheduler.zig
@@ -466,6 +466,58 @@ test "fiber suspend does not save stale gap registers (#1529)" {
     try std.testing.expectEqual(@as(i64, 16), types.toFixnum(result));
 }
 
+// #1961: a generational minor mark treats a promoted fiber as opaque, so
+// every resident fiber — the running one included — gets an explicit
+// markFiberState pass in FiberScheduler.markRoots. The store below
+// deliberately skips the write barrier its real mutation sites carry: the
+// explicit pass, not remembered-set bookkeeping, is what must keep the young
+// value alive. Without it the value is swept and the field dangles — the
+// use-after-free shape the pre-#1961 full transitive minor mark used to
+// absorb silently.
+test "a running old fiber's mutable state survives a minor collection (#1961)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try fiber_mod.ensureScheduler(vm);
+    const main_fiber = vm.current_fiber.?;
+    const main_val = types.makePointer(&main_fiber.header);
+
+    // Manual collections only, so the promotion below is deterministic.
+    gc.enabled = false;
+    gc.minor_cycle_count = 0;
+    gc.collect();
+    gc.minor_cycle_count = 0;
+    gc.collect();
+    try std.testing.expectEqual(@as(u1, 1), types.toObject(main_val).flags.generation);
+
+    const skips_before = gc.stats.minor_old_skips;
+    const held = try gc.allocPair(types.makeFixnum(42), types.NIL);
+    main_fiber.waiting_on = held; // no writeBarrier, on purpose
+
+    gc.minor_cycle_count = 0;
+    gc.collect();
+
+    // The fiber itself was skipped as opaque — proof the minor mark really
+    // stopped at the generational boundary instead of tracing the fiber.
+    try std.testing.expect(gc.stats.minor_old_skips > skips_before);
+
+    // Yet the young value survived: markFiberState reached it through
+    // the scheduler's root pass. Liveness by list membership only — reading
+    // the value back would be the dangling-read this test pins.
+    var live = false;
+    var cur = gc.objects;
+    while (cur) |o| : (cur = o.next) {
+        if (o == types.toObject(held)) live = true;
+    }
+    cur = gc.old_objects;
+    while (cur) |o| : (cur = o.next) {
+        if (o == types.toObject(held)) live = true;
+    }
+    try std.testing.expect(live);
+}
+
 // #1530: the by-object waiter index (waiter_index / enrollWaiter). These
 // drive the index directly — parking a spawned fiber is simulated by setting
 // its status/waiting_on and calling enrollWaiter, exactly as the real park

--- a/src/tests_srfi254.zig
+++ b/src/tests_srfi254.zig
@@ -562,3 +562,43 @@ test "srfi 254: component libraries import in isolation" {
     // reference-barrier is exported by both ephemerons and guardians.
     _ = try ctx.vm.eval("(reference-barrier 'x)");
 }
+
+// #1961: invokeGuardian's registration barrier, driven through the real
+// primitive path (the mirror-level pin lives above, next to its
+// "resurrects a young object registered on an old guardian" sibling). An old
+// guardian registering a fresh young object is an old→young edge the
+// generational minor mark reaches only through the remembered set; without
+// the barrier the next minor never even probes the entry (an old guardian is
+// opaque unless remembered), the young object is swept, and the guardian
+// yields #f instead of resurrecting it.
+test "guardian: registration through the real primitive survives a minor collection (#1961)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(import (srfi 254)) (define g (make-guardian))");
+    const g_val = try ctx.vm.eval("g");
+
+    // Promote the guardian: two manual minors, marked through the global.
+    ctx.gc.enabled = false;
+    ctx.gc.minor_cycle_count = 0;
+    ctx.gc.collect();
+    ctx.gc.minor_cycle_count = 0;
+    ctx.gc.collect();
+    try expectEqual(@as(u1, 1), types.toObject(g_val).flags.generation);
+
+    // Real registration path: a fresh young object through invokeGuardian.
+    _ = try ctx.vm.eval("(g (vector 'a 'b 'c))");
+
+    // The vector is now unreachable except through the guardian's weak
+    // queue; the minor must probe the entry and resurrect it.
+    ctx.gc.minor_cycle_count = 0;
+    ctx.gc.collect();
+
+    const g = types.toGuardian(g_val);
+    try expectEqual(@as(usize, 1), g.ready.items.len);
+    // Retrieve through the real API; contents must be intact, and the queue
+    // must drain.
+    try expectEqual(try ctx.vm.eval("'b"), try ctx.vm.eval("(vector-ref (g) 1)"));
+    try expect(!types.isTruthy(try ctx.vm.eval("(g)")));
+}

--- a/src/tests_srfi254.zig
+++ b/src/tests_srfi254.zig
@@ -160,13 +160,13 @@ test "guardian: keeps a still-reachable registered object registered" {
 }
 
 test "guardian: resurrects a young object registered on an old guardian" {
-    // Promote the guardian into the old generation, then register a fresh young
-    // object and run a minor collection. No write barrier is applied on
-    // registration (the registered list is weak and reprocessed every cycle);
-    // this passes only because a minor collection re-traces every reachable
-    // guardian, so the old->young reference is seen without a remembered-set
-    // entry. If that invariant regressed, the young object would be swept
-    // instead of resurrected.
+    // Promote the guardian into the old generation, then register a fresh
+    // young object and run a minor collection. Since #1961 the minor mark
+    // treats the old guardian as opaque, so registration is an ordinary
+    // old→young edge: invokeGuardian barriers it into the remembered set,
+    // which is the mark's only route to the entry. The store+barrier pair
+    // below mirrors invokeGuardian's; without the barrier the young object
+    // would be swept instead of resurrected.
     var gc = GC.init(std.testing.allocator);
     defer gc.deinit();
     gc.enabled = false;
@@ -175,7 +175,8 @@ test "guardian: resurrects a young object registered on an old guardian" {
     gc.pushRoot(&g);
     defer gc.popRoot();
 
-    // Two surviving collections promote the guardian to the old generation.
+    // Two surviving collections promote the guardian to the old generation
+    // (with an empty registered list, so the promotion scan adds nothing).
     gc.collect();
     gc.collect();
     try expect(types.toObject(g).flags.generation == 1);
@@ -184,11 +185,12 @@ test "guardian: resurrects a young object registered on an old guardian" {
     {
         const obj = try gc.allocPair(fix(7), types.NIL); // young, weak-only ref
         try types.toGuardian(g).registered.append(gc.allocator, .{ .watched = obj, .payload = obj });
+        gc.writeBarrier(types.toObject(g), obj);
     }
-    // Registration took no write barrier, so the remembered set is still empty.
-    try expectEqual(@as(usize, 0), gc.remembered_set.items.len);
+    // The barrier recorded the old→young edge.
+    try expectEqual(@as(usize, 1), gc.remembered_set.items.len);
 
-    gc.collect(); // minor: old guardian, young registered object
+    gc.collect(); // minor: remembered old guardian, young registered object
 
     try expectEqual(@as(usize, 1), types.toGuardian(g).ready.items.len);
     const readied = types.toGuardian(g).ready.items[0].payload;

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -946,10 +946,14 @@ pub const VM = struct {
         const key = @intFromPtr(param);
         if (self.current_fiber) |fiber| {
             fiber.param_overrides.put(key, val) catch return VMError.OutOfMemory;
-            // #1961: an old running fiber's override map holding a young
-            // value is an old→young edge the generational minor mark reaches
-            // only through the remembered set (FiberScheduler.markRoots'
-            // explicit markFiberState pass is the belt-and-braces backstop).
+            // #1961: belt-and-braces, matching the other fiber-field
+            // barriers. The authoritative mechanism for a resident fiber's
+            // override map is FiberScheduler.markRoots' unconditional
+            // markFiberState pass (see gc_collect.zig's .fiber arm of
+            // referencesYoung, which states this invariant); this barrier
+            // keeps the remembered set complete for the non-resident window
+            // — a retired fiber whose slot was reused — the same way
+            // saveCurrentFiber's enrollment does for the bulk snapshot.
             self.gc.writeBarrier(&fiber.header, val);
         } else {
             self.param_overrides.put(key, val) catch return VMError.OutOfMemory;

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -946,6 +946,11 @@ pub const VM = struct {
         const key = @intFromPtr(param);
         if (self.current_fiber) |fiber| {
             fiber.param_overrides.put(key, val) catch return VMError.OutOfMemory;
+            // #1961: an old running fiber's override map holding a young
+            // value is an old→young edge the generational minor mark reaches
+            // only through the remembered set (FiberScheduler.markRoots'
+            // explicit markFiberState pass is the belt-and-braces backstop).
+            self.gc.writeBarrier(&fiber.header, val);
         } else {
             self.param_overrides.put(key, val) catch return VMError.OutOfMemory;
         }

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -70,6 +70,11 @@ pub fn invokeGuardian(vm: *VM, guardian: Value, args: []const Value) VMError!Val
         }
         const cell = vm.gc.allocTransportCell(args[0], args[1]) catch return VMError.OutOfMemory;
         g.registered.append(vm.gc.allocator, .{ .watched = cell, .payload = types.NIL }) catch return VMError.OutOfMemory;
+        // #1961: `registered` grows at every registration, so a guardian is
+        // a mutated container like any other — an old guardian registering a
+        // fresh young cell is an old→young edge the minor mark reaches only
+        // through the remembered set.
+        vm.gc.writeBarrier(&g.header, cell);
         return cell;
     }
 
@@ -84,6 +89,9 @@ pub fn invokeGuardian(vm: *VM, guardian: Value, args: []const Value) VMError!Val
         return VMError.InvalidArgument;
     }
     g.registered.append(vm.gc.allocator, .{ .watched = obj, .payload = rep }) catch return VMError.OutOfMemory;
+    // #1961: same old→young edge as the transport-cell branch above.
+    vm.gc.writeBarrier(&g.header, obj);
+    vm.gc.writeBarrier(&g.header, rep);
     return types.VOID;
 }
 

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -337,6 +337,14 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     break :blk null;
                 };
                 if (ptr) |p| p.* = val;
+                // #1961: when the target map belongs to a mutable
+                // SchemeEnvironment (func.env_val — the eval/environment
+                // objects), this store is an old→young edge on that heap
+                // object once it promotes. The VM-rooted maps (globals,
+                // library lib_envs — env_val NIL there) are marked as roots
+                // every collection and need no barrier.
+                if (types.isEnvironment(func.env_val))
+                    self.gc.writeBarrier(types.toObject(func.env_val), val);
                 self.unlockGlobalsShared();
                 if (ptr == null) {
                     self.setErrorDetail("set!: unbound variable '{s}'", .{name});
@@ -389,6 +397,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     env.put(name, val) catch return VMError.OutOfMemory;
                 } else {
                     env.put(name, val) catch return VMError.OutOfMemory;
+                    // #1961: same as set_global — a define into a mutable
+                    // SchemeEnvironment's map is an old→young edge on the
+                    // wrapper object once promoted.
+                    if (types.isEnvironment(func.env_val))
+                        self.gc.writeBarrier(types.toObject(func.env_val), val);
                 }
                 if (func.env == null) {
                     self.global_version +%= 1;

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -350,16 +350,13 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     // #1961: when the target map belongs to a mutable
                     // SchemeEnvironment (func.env_val — the eval/environment
                     // objects), this store is an old→young edge on that heap
-                    // object once it promotes. The VM-rooted maps (globals,
-                    // library lib_envs — env_val NIL there) are marked as
-                    // roots every collection and need no barrier; so does the
-                    // interaction-environment wrapper, whose .owned == false
-                    // map IS the root-marked globals map (enrolling it would
-                    // re-walk every global once per minor, forever). Nothing
-                    // allocates between the store and the barrier, so this
-                    // order is as safe as barrier-first.
-                    if (types.isEnvironment(func.env_val) and types.toEnvironment(func.env_val).owned)
-                        self.gc.writeBarrier(types.toObject(func.env_val), val);
+                    // object once it promotes. envStoreBarrier applies the
+                    // one exclusion rule: the interaction-environment wrapper
+                    // and the root-marked maps (globals, library lib_envs)
+                    // are marked as roots every collection and enroll
+                    // nothing. Nothing allocates between the store and the
+                    // barrier, so this order is as safe as barrier-first.
+                    self.gc.envStoreBarrier(func.env_val, val);
                 }
                 self.unlockGlobalsShared();
                 if (ptr == null) {
@@ -416,14 +413,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     env.put(name, val) catch return VMError.OutOfMemory;
                 } else {
                     env.put(name, val) catch return VMError.OutOfMemory;
-                    // #1961: same as set_global — a define into a mutable
-                    // SchemeEnvironment's map is an old→young edge on the
-                    // wrapper object once promoted (the .owned guard skips
-                    // the interaction-environment wrapper, which borrows the
-                    // root-marked globals map; this branch can't see it, but
-                    // the guard keeps the two opcodes' rule identical).
-                    if (types.isEnvironment(func.env_val) and types.toEnvironment(func.env_val).owned)
-                        self.gc.writeBarrier(types.toObject(func.env_val), val);
+                    // #1961: same rule as set_global, via the shared helper
+                    // (envStoreBarrier) so the exclusion lives once.
+                    self.gc.envStoreBarrier(func.env_val, val);
                 }
                 if (func.env == null) {
                     self.global_version +%= 1;

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -336,15 +336,19 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     }
                     break :blk null;
                 };
-                if (ptr) |p| p.* = val;
-                // #1961: when the target map belongs to a mutable
-                // SchemeEnvironment (func.env_val — the eval/environment
-                // objects), this store is an old→young edge on that heap
-                // object once it promotes. The VM-rooted maps (globals,
-                // library lib_envs — env_val NIL there) are marked as roots
-                // every collection and need no barrier.
-                if (types.isEnvironment(func.env_val))
-                    self.gc.writeBarrier(types.toObject(func.env_val), val);
+                if (ptr) |p| {
+                    p.* = val;
+                    // #1961: when the target map belongs to a mutable
+                    // SchemeEnvironment (func.env_val — the eval/environment
+                    // objects), this store is an old→young edge on that heap
+                    // object once it promotes. The VM-rooted maps (globals,
+                    // library lib_envs — env_val NIL there) are marked as roots
+                    // every collection and need no barrier. Nothing allocates
+                    // between the store and the barrier, so this order is as
+                    // safe as barrier-first.
+                    if (types.isEnvironment(func.env_val))
+                        self.gc.writeBarrier(types.toObject(func.env_val), val);
+                }
                 self.unlockGlobalsShared();
                 if (ptr == null) {
                     self.setErrorDetail("set!: unbound variable '{s}'", .{name});

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -271,6 +271,15 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         func.global_cache = cache;
                         func.cache_version = self.global_version;
                     }
+                    // #1961 (review): the cached value is root-marked right
+                    // now (it is also in the globals map), but a later
+                    // rebinding by another function orphans this slot — only
+                    // this function's own next global op clears it — and the
+                    // generational minor mark reaches the orphaned young
+                    // value only through the remembered set. The function
+                    // itself may already be promoted, including on the
+                    // fresh-cache path.
+                    self.gc.writeBarrier(&func.header, val);
                 }
             },
             .set_global => {
@@ -342,11 +351,14 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     // SchemeEnvironment (func.env_val — the eval/environment
                     // objects), this store is an old→young edge on that heap
                     // object once it promotes. The VM-rooted maps (globals,
-                    // library lib_envs — env_val NIL there) are marked as roots
-                    // every collection and need no barrier. Nothing allocates
-                    // between the store and the barrier, so this order is as
-                    // safe as barrier-first.
-                    if (types.isEnvironment(func.env_val))
+                    // library lib_envs — env_val NIL there) are marked as
+                    // roots every collection and need no barrier; so does the
+                    // interaction-environment wrapper, whose .owned == false
+                    // map IS the root-marked globals map (enrolling it would
+                    // re-walk every global once per minor, forever). Nothing
+                    // allocates between the store and the barrier, so this
+                    // order is as safe as barrier-first.
+                    if (types.isEnvironment(func.env_val) and types.toEnvironment(func.env_val).owned)
                         self.gc.writeBarrier(types.toObject(func.env_val), val);
                 }
                 self.unlockGlobalsShared();
@@ -366,6 +378,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         @memset(cache, types.VOID);
                         if (sym_idx < cache.len) cache[sym_idx] = val;
                         func.cache_version = self.global_version;
+                        // #1961 (review): same orphaned-slot hazard as
+                        // get_global's cache fill.
+                        self.gc.writeBarrier(&func.header, val);
                     }
                 }
             },
@@ -403,8 +418,11 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     env.put(name, val) catch return VMError.OutOfMemory;
                     // #1961: same as set_global — a define into a mutable
                     // SchemeEnvironment's map is an old→young edge on the
-                    // wrapper object once promoted.
-                    if (types.isEnvironment(func.env_val))
+                    // wrapper object once promoted (the .owned guard skips
+                    // the interaction-environment wrapper, which borrows the
+                    // root-marked globals map; this branch can't see it, but
+                    // the guard keeps the two opcodes' rule identical).
+                    if (types.isEnvironment(func.env_val) and types.toEnvironment(func.env_val).owned)
                         self.gc.writeBarrier(types.toObject(func.env_val), val);
                 }
                 if (func.env == null) {
@@ -416,6 +434,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         @memset(cache, types.VOID);
                         if (sym_idx < cache.len) cache[sym_idx] = val;
                         func.cache_version = self.global_version;
+                        // #1961 (review): same orphaned-slot hazard as
+                        // get_global's cache fill.
+                        self.gc.writeBarrier(&func.header, val);
                     }
                 }
             },
@@ -995,6 +1016,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                                 vm_mod.globals_mod.parseDefEnvBindingSymbolName(name) == null)
                             {
                                 if (sym_idx < cache.len) cache[sym_idx] = val;
+                                // #1961 (review): same orphaned-slot hazard
+                                // as get_global's cache fill.
+                                self.gc.writeBarrier(&the_func.header, val);
                             }
                         }
                     } else {
@@ -1021,6 +1045,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             cache[sym_idx] = val;
                             the_func.global_cache = cache;
                             the_func.cache_version = self.global_version;
+                            // #1961 (review): fresh caches too — the function
+                            // can already be promoted by its first global op.
+                            self.gc.writeBarrier(&the_func.header, val);
                         }
                     }
                 } else {
@@ -1120,6 +1147,9 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             func.global_cache = cache;
                             func.cache_version = self.global_version;
                         }
+                        // #1961 (review): same orphaned-slot hazard as
+                        // get_global's cache fill.
+                        self.gc.writeBarrier(&func.header, callee);
                     }
                 }
 

--- a/tests/scheme/smoke/gc-generational-minor-1961.scm
+++ b/tests/scheme/smoke/gc-generational-minor-1961.scm
@@ -1,0 +1,68 @@
+;; GC generational minor mark (#1961): a minor collection marks only the
+;; young generation plus the remembered set of old objects that point into
+;; it. End-to-end guards for the three loads that makes load-bearing —
+;; guardian registration (an old guardian holding a young entry), the
+;; running main fiber's parameter overrides, and a large old heap left
+;; intact while young garbage churns. The deterministic pins live in
+;; src/tests_gc_tracing.zig and src/tests_scheduler.zig.
+(import (scheme base) (scheme write) (kaappi fibers) (srfi 254))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+;; Allocation churn: enough transient pairs to drive several collections
+;; (the initial threshold is 8192 objects), promoting whatever survives.
+(define (churn n)
+  (let loop ((i 0))
+    (when (< i n) (cons i i) (loop (+ i 1)))))
+
+;; 1. An old guardian registering a young object (#1961 Gap 1): the
+;; registration barrier puts the guardian in the remembered set, so the
+;; minor mark still probes the entry, resurrects the dead object, and keeps
+;; it alive until retrieval — with its contents intact.
+(define g (make-guardian))
+(churn 30000) ; promote the guardian before registering anything
+(let ((obj (vector 'a 'b 'c)))
+  (g obj)
+  (set! obj #f)) ; the guardian's weak entry is now the only reference
+(churn 30000) ; minors while an old guardian holds a young entry
+(let ((got (g)))
+  (check "guardian entry resurrected intact across minors"
+    (and (vector? got) (vector-ref got 1))
+    'b))
+(check "guardian queue drained" (g) #f)
+
+;; 2. The running main fiber's parameter overrides (#1961 Gap 3): with a
+;; scheduler present, parameterize stores into the (by now promoted) main
+;; fiber's override map — reachable in a minor collection only through the
+;; fiber's explicit mutable-state marking and the store's write barrier.
+(define p (make-parameter 1))
+(churn 30000) ; promote the main fiber
+(parameterize ((p (vector 42)))
+  (churn 30000) ; minors while the override holds a young vector
+  (check "parameterized value survives minor collections"
+    (vector-ref (p) 0)
+    42))
+(check "parameter restored after dynamic extent" (p) 1)
+
+;; 3. A large old heap stays intact while young garbage churns around it.
+(define old-data
+  (let loop ((i 0) (acc '()))
+    (if (= i 50000) acc (loop (+ i 1) (cons i acc)))))
+(churn 60000)
+(check "old heap length intact" (length old-data) 50000)
+(check "old heap contents intact" (car old-data) 49999)
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(if (> fail 0) (error "gc-generational-minor-1961 tests failed" fail))


### PR DESCRIPTION
Fixes #1961.

## What changed

A minor collection used to perform a **full transitive mark** — `markValueInner` had no generation check, so minor and full collections cost the same to mark (only the sweep differed). This PR makes the minor mark actually generational, following the design in the issue's audit comment, plus the additional edge-audit the `-Dgc-stress=true` suite demanded.

### Core

- **`GC.minor_marking`**: while set, `markValueInner` treats the old generation as opaque — old objects are never swept by `sweepYoung`, so they need no mark. The minor mark now costs O(live young) instead of O(live heap). `clearOldMarks` is dropped from `minorCollect` (nothing marks an old object during a minor; every sweep clears the marks it observes).
- **Weak predicates** (`keptAlive`/`weakReachable`): an old object answers *alive* during a minor — the old generation survives every minor, so an ephemeron with an old key must not break (destructive!) and a guardian watching an old object must not resurrect early. The decision defers to the next full collection, where old garbage is unmarked and visible.

### Remembered-set completeness — what makes the above safe

The issue's comment identified two gaps (guardian registration barrier, promotion scan) and one coverage question (running-fiber fields). All three are here, plus three more the stress suite surfaced:

1. **Promotion scan** (`sweepYoung`): the write barrier only fires for containers *already* old, so an edge created while the container was young is recorded when the container is promoted, via a `referencesYoung` scan.
2. **Full-collect re-scan** (`sweepOld`): a full collection drains the remembered set up front and never promotes, so an old container whose young referent just survived the full would face the next minor with no entry. Surviving old→young edges are re-recorded while the old heap is walked anyway — found by gc-stress; every container type is affected, not just guardians.
3. **Missing write barriers** found by the audit and fixed:
   - guardian registration in `invokeGuardian` (`registered` grows at every registration — the old comment claiming weak structures never enter the remembered set was wrong for guardians),
   - `Function.constants` appends into a possibly-promoted function (`compiler.addConstant`, the `.sbc` deserializer, gc-stress test helpers),
   - `define`/`set!`/`define-syntax` into a **mutable `SchemeEnvironment`**'s map (opcode handlers + `compileDefineSyntax`; the root-marked globals/lib_env maps need no barrier),
   - the running fiber's `param_overrides` put (`VM.setParameterValue`),
   - `trackOwnedMutex`'s append (belt-and-braces; the explicit fiber marking already covers it).
4. **`FiberScheduler.markRoots`** now calls `markFiberState` for *every* resident fiber, the running one included. A promoted fiber is opaque to the minor mark, and a running fiber's stale saved snapshot must stay *traced* because full collections still walk it through `markValueInner`'s `.fiber` arm — a value freed by an intervening minor would turn that walk into a use-after-free. *(Deviation from the issue comment's design, which proposed marking only the non-swapped fields — that variant crashes under gc-stress; the full explicit pass is both simpler and matches the pre-#1961 retention semantics for the snapshot.)*

### Tests

- The old sentinel (`a minor collection marks through an old object with no remembered-set entry`) flips to pin the opposite — exactly the signal it was written to give. Its companion proves the remembered walk keeps the referent alive.
- New pins: the promotion scan (promote-then-kept-young), the full-collect re-scan, the weak-predicate deferral (old ephemeron key not broken / old watched object not resurrected during a minor, both decided at the next full), the running old fiber, and `stats.minor_old_skips` proving the minor mark stops at the generational boundary while a full mark does not.
- End-to-end smoke test (`tests/scheme/smoke/gc-generational-minor-1961.scm`): an old guardian's registered entry across churn, a `parameterize`d value on the promoted main fiber, and a large old heap under young churn.

### Docs

`.claude/rules/gc-safety.md` and `docs/dev/gc-safety-and-error-handling.md` previously read as though the barrier were already load-bearing; they now describe the mechanisms that actually make it so (barrier + promotion scan + full-collect re-scan, the two wholesale-marked exceptions, and the mutable-environment case).

## Validation

- `zig build test` — green
- `zig build test -Dgc-stress=true` — green (this is the suite that caught gaps 2 and 3)
- R7RS suite 1395/1395 — including under a `-Dgc-stress=true` binary
- `bash tests/scheme/run-all.sh` — 2115 pass, 0 fail
- markdownlint — clean