### PR TITLE
Document that ~/.kaappi/lib shadows a checkout's lib/ for .sld work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,6 +326,25 @@ bash tools/run-r7rs-suite.sh zig-out/bin/kaappi         # R7RS suite (1,395 test
 bash tests/scheme/run-all.sh                            # everything (build FIRST)
 ```
 
+**An installed `~/.kaappi/lib` shadows the checkout's `lib/` for `.sld`
+resolution.** The library search order is (1) the script's own dir, (2)
+`$KAAPPI_HOME/lib` (default `~/.kaappi/lib`), (3) the exe-relative
+`<exe>/../lib` (= `zig-out/lib`, which `zig build` populates from the checkout).
+Step 2 before step 3 is deliberate — a from-source binary must never shadow a
+user's install (kaappi#1523) — but it means that if you have ever installed
+Kaappi, `~/.kaappi/lib` wins over your working-tree edits, so a change to
+`lib/**/*.sld` tested with a bare `zig-out/bin/kaappi file.scm` can look like a
+no-op no matter how many times you rebuild or `kaappi cache clear` (kaappi#2352).
+Run local `.sld` work with an isolated home so the checkout wins:
+
+```bash
+KAAPPI_HOME=$(mktemp -d) zig-out/bin/kaappi file.scm
+```
+
+`tests/scheme/run-all.sh` already does this (a fresh `mktemp` home per run), so
+the suite always exercises the working tree; only ad-hoc invocations need the
+prefix.
+
 The unit suite must also stay green under `zig build test -Dgc-stress=true`
 (collection on every allocation — kaappi#1401). Tests holding heap values in
 Zig locals across allocations must root them; loop-heavy tests should scale

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -219,6 +219,37 @@ bash tests/scheme/run-all.sh
 bash tools/run-r7rs-suite.sh zig-out/bin/kaappi
 ```
 
+### An installed `~/.kaappi/lib` shadows the checkout's `lib/`
+
+The library search order is (1) the script's own directory, (2)
+`$KAAPPI_HOME/lib` (default `~/.kaappi/lib`), (3) the exe-relative
+`<exe>/../lib` — which is `zig-out/lib`, populated from the checkout by
+`zig build`. Step 2 is checked before step 3 on purpose, so a from-source
+binary never shadows a real install (kaappi#1523).
+
+The trap for library development (kaappi#2352) falls straight out of that
+order: if you have ever installed Kaappi, `~/.kaappi/lib` holds the last
+release's `.sld` files, and it wins over your working tree. So editing, say,
+`lib/srfi/231/views.sld` and running
+
+```bash
+zig build && zig-out/bin/kaappi /tmp/t.scm
+```
+
+loads the **old** installed copy — the edit looks like a no-op, and neither
+another rebuild nor `kaappi cache clear` helps, because it is the wrong source
+file being read, not a stale cache of the right one. Run local `.sld` work with
+an isolated home so the checkout's `lib/` (via `zig-out/lib`) wins:
+
+```bash
+KAAPPI_HOME=$(mktemp -d) zig-out/bin/kaappi /tmp/t.scm
+```
+
+`run-all.sh` already exports a fresh `mktemp` `KAAPPI_HOME` for the whole run,
+so the suite always exercises the working tree — this only bites ad-hoc
+`zig-out/bin/kaappi file.scm` invocations. CI never has a `~/.kaappi/lib`, which
+is why the hazard is local-only and easy to miss.
+
 ### The official SRFI 231 conformance suite
 
 `tests/scheme/srfi/srfi231-official.scm` is the SRFI's **official** test

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -42,6 +42,17 @@ fi
 # Isolate ~/.kaappi so the suite is hermetic: plain `kaappi <file>` runs write a
 # bytecode cache under $KAAPPI_HOME/cache (kaappi#1516), and we don't want the
 # suite reading or polluting the developer's real cache (or history/config).
+#
+# The fresh (empty) home is also what keeps the suite exercising THIS working
+# tree's `.sld` libraries rather than a stale install: the library search order
+# is (1) the script's own dir, (2) $KAAPPI_HOME/lib, (3) the exe-relative
+# <exe>/../lib (= zig-out/lib, which `zig build` populates from the checkout).
+# Step 2 is checked before step 3 by design, so a from-source binary never
+# shadows a real install (kaappi#1523) — but that means a developer's own
+# ~/.kaappi/lib would silently shadow their checkout edits (kaappi#2352). A
+# throwaway home has no lib/, so step 3 wins and the corpus runs against the
+# tree under test. Do NOT narrow this to a cache-only isolation.
+#
 # Tests that need their own HOME (e.g. exe-relative-lib-1523) override this.
 KAAPPI_HOME_TMP=$(mktemp -d /tmp/kaappi-test-home-XXXXXX)
 export KAAPPI_HOME="$KAAPPI_HOME_TMP"


### PR DESCRIPTION
## The hazard (#2352)
The library search order checks `$KAAPPI_HOME/lib` (default `~/.kaappi/lib`) **before** the exe-relative `<exe>/../lib` (= `zig-out/lib`, populated from the checkout by `zig build`). That order is deliberate — a from-source binary must never shadow a user's install (#1523) — but it means a developer who has ever installed Kaappi has their working-tree `.sld` edits silently shadowed by the last release. A bare `zig-out/bin/kaappi file.scm` loads the *old* installed copy, so the edit looks like a no-op, and neither a rebuild nor `kaappi cache clear` helps, because it's the wrong source file being read — not a stale cache of the right one.

## Scope of the fix
This is a **doc-truth** close. The issue's suggested option 1 (isolate the suite's `KAAPPI_HOME`) turned out to be **already done** on `main`: `run-all.sh` exports a fresh `mktemp` home for the whole run (added for cache isolation, #1516), so the suite already exercises the working tree. The remaining gap was documentation of the hazard for ad-hoc interactive `.sld` work, plus making sure the suite's existing isolation isn't later narrowed to cache-only.

Changes:
- **`CLAUDE.md`** and **`docs/dev/testing.md`** — document the search order, the trap, and the `KAAPPI_HOME=$(mktemp -d) zig-out/bin/kaappi file.scm` workaround; note that the suite already isolates so only ad-hoc invocations need the prefix, and that CI never has a `~/.kaappi/lib` (why it's local-only and easy to miss).
- **`tests/scheme/run-all.sh`** — comment only: pin the existing isolation as load-bearing for #2352 ("Do NOT narrow this to a cache-only isolation").

The search order itself is **not** changed — reordering would reintroduce #1523. No `.zig` touched.

## Verification
- `markdownlint-cli2` (the CI `format` gate): 0 issues.
- Confirmed against `origin/main` that `run-all.sh` already exports a throwaway `KAAPPI_HOME` with a cleanup trap, so the suite half of the issue is already resolved.

Closes #2352

🤖 Generated with [Claude Code](https://claude.com/claude-code)