### PR TITLE
Wire up kaappi.pkg name: and source:; drop version: from the grammar

### DIFF
--- a/docs/dev/thottam.md
+++ b/docs/dev/thottam.md
@@ -74,7 +74,12 @@ manifest would mean nothing; it is dropped like any unknown key (kaappi#2138).
   trailing `/` and a `.git` suffix — those are cosmetic spellings of one
   remote — but a scheme difference (`http` vs `https`) is a real downgrade and
   still warns. In `--locked` mode the lockfile is authoritative and the
-  manifest's `source:` is ignored (#2137).
+  manifest's `source:` is ignored (#2137). Because a manifest is
+  attacker-controlled and its `source:` is later handed to `git clone`, a
+  declared source that uses a git remote-helper transport (`ext::<cmd>` runs a
+  command) or is option-shaped (leading `-`) is refused rather than recorded;
+  the clone itself also runs with `protocol.ext.allow=never`, so the
+  OS-command-injection vector is closed at both ends (CWE-78).
 - `depends` is space-separated, and may carry an inline custom URL:
   `depends: kaappi-net kaappi-auth::https://github.com/bob/kaappi-auth`.
 - Version constraints use `>=`, `>`, `<=`, `<`, `^` (compatible), `~`

--- a/docs/dev/thottam.md
+++ b/docs/dev/thottam.md
@@ -20,7 +20,8 @@ thottam remove kaappi-web                                        # uninstall
 
 - Clones from `github.com/kaappi/<package>` (or a custom `::url`) into
   `$KAAPPI_HOME/src/` (`~/.kaappi/src/` by default).
-- Reads `kaappi.pkg` for dependencies and build commands.
+- Reads `kaappi.pkg` for the package name, dependencies, build command, and
+  declared source.
 - Copies `.sld` files to `~/.kaappi/lib/`, preserving directory structure.
 - Copies `.dylib`/`.so` to `~/.kaappi/lib/`.
 - Records source URLs in the lockfile `~/.kaappi/thottam.lock`, for provenance.
@@ -43,17 +44,31 @@ directory. See the LLVM backend section of `CLAUDE.md`.
 ## The `kaappi.pkg` manifest
 
 ```text
+name: kaappi-web
 depends: kaappi-http kaappi-json
 build: make
+source: https://github.com/someone/kaappi-web
 ```
 
-Only these two fields are read. `name:`, `version:`, `source:` and any other
-key are ignored — a package is identified by the name it is installed under,
-the version is whatever tag or SHA the install requested, and a third-party
-source is given on the command line (`thottam install pkg::url`) or in a
-`depends:` spec, never in the package's own manifest (which thottam can only
-read after it has already cloned the repo) (kaappi#2138).
+Four keys are read: `name:`, `depends:`, `build:`, and `source:`. There is no
+`version:` field — thottam locks by git SHA, so a version written in the
+manifest would mean nothing; it is dropped like any unknown key (kaappi#2138).
 
+- `name`, when present, must match the package being installed. A manifest that
+  names a different package is a packaging error, and the install refuses
+  before recording anything. It is optional — a manifest may omit it — but a
+  mismatching `name:` is never accepted.
+- `source` declares where the package is canonically hosted. On a bare-name
+  install (no `::url` on the command line) it is recorded as the lockfile's
+  provenance, so `thottam list` shows `(from: …)` and a later `--locked`
+  install fetches from it — surfaced with a one-line note at record time, since
+  the manifest is then steering where the package comes from. It **cannot**
+  redirect the *first* clone: thottam can only read the manifest after cloning
+  the repo, so the initial fetch URL is always the `::url` given on the command
+  line or the `KAAPPI_ORG` default. When a `::url` *is* given and disagrees with
+  `source:`, thottam warns (a fork or mirror is legitimate) and records the URL
+  it actually fetched from, never the manifest's claim. In `--locked` mode the
+  lockfile is authoritative and the manifest's `source:` is ignored (#2137).
 - `depends` is space-separated, and may carry an inline custom URL:
   `depends: kaappi-net kaappi-auth::https://github.com/bob/kaappi-auth`.
 - Version constraints use `>=`, `>`, `<=`, `<`, `^` (compatible), `~`

--- a/docs/dev/thottam.md
+++ b/docs/dev/thottam.md
@@ -56,8 +56,11 @@ manifest would mean nothing; it is dropped like any unknown key (kaappi#2138).
 
 - `name`, when present, must match the package being installed. A manifest that
   names a different package is a packaging error, and the install refuses
-  before recording anything. It is optional — a manifest may omit it — but a
-  mismatching `name:` is never accepted.
+  before recording anything (removing the checkout it just cloned, so nothing
+  unrecorded is left for a later install to reuse). It is optional — a manifest
+  may omit it — but a mismatching `name:` is never accepted. The check is scoped
+  to unlocked installs: in `--locked` mode the lockfile already vouches for the
+  exact SHA, so the manifest at that SHA is not re-litigated.
 - `source` declares where the package is canonically hosted. On a bare-name
   install (no `::url` on the command line) it is recorded as the lockfile's
   provenance, so `thottam list` shows `(from: …)` and a later `--locked`
@@ -67,8 +70,11 @@ manifest would mean nothing; it is dropped like any unknown key (kaappi#2138).
   the repo, so the initial fetch URL is always the `::url` given on the command
   line or the `KAAPPI_ORG` default. When a `::url` *is* given and disagrees with
   `source:`, thottam warns (a fork or mirror is legitimate) and records the URL
-  it actually fetched from, never the manifest's claim. In `--locked` mode the
-  lockfile is authoritative and the manifest's `source:` is ignored (#2137).
+  it actually fetched from, never the manifest's claim. The comparison ignores a
+  trailing `/` and a `.git` suffix — those are cosmetic spellings of one
+  remote — but a scheme difference (`http` vs `https`) is a real downgrade and
+  still warns. In `--locked` mode the lockfile is authoritative and the
+  manifest's `source:` is ignored (#2137).
 - `depends` is space-separated, and may carry an inline custom URL:
   `depends: kaappi-net kaappi-auth::https://github.com/bob/kaappi-auth`.
 - Version constraints use `>=`, `>`, `<=`, `<`, `^` (compatible), `~`

--- a/src/tests_thottam.zig
+++ b/src/tests_thottam.zig
@@ -509,6 +509,22 @@ test "sourcesEquivalent ignores trailing slash and .git, keeps scheme (#2138)" {
     try std.testing.expect(!eq("https://h/p", "https://h/q"));
 }
 
+test "isRecordableSource refuses remote-helper transports and option-shaped URLs (#2138)" {
+    const ok = thottam.isRecordableSource;
+    // Ordinary remotes and local paths are recordable.
+    try std.testing.expect(ok("https://github.com/foo/bar.git"));
+    try std.testing.expect(ok("git@github.com:foo/bar.git"));
+    try std.testing.expect(ok("/srv/git/bar.git"));
+    // A `<transport>::<address>` remote helper runs a command -> refused.
+    try std.testing.expect(!ok("ext::sh -c 'touch /tmp/pwned'"));
+    try std.testing.expect(!ok("fd::17"));
+    try std.testing.expect(!ok("transport::whatever"));
+    // A leading '-' would be read by `git clone` as an option -> refused.
+    try std.testing.expect(!ok("--upload-pack=evil"));
+    // Empty is not a source.
+    try std.testing.expect(!ok(""));
+}
+
 test "parsePkgManifest tolerates CRLF line endings" {
     // thottam runs on Windows under Git Bash; a manifest checked out with
     // core.autocrlf=true has \r before every \n.

--- a/src/tests_thottam.zig
+++ b/src/tests_thottam.zig
@@ -496,6 +496,19 @@ test "parsePkgManifest treats empty name: and source: as absent (#2138)" {
     try std.testing.expectEqualStrings("dep", m.depends.?);
 }
 
+test "sourcesEquivalent ignores trailing slash and .git, keeps scheme (#2138)" {
+    const eq = thottam.sourcesEquivalent;
+    // Cosmetic differences — the same remote — do not warn.
+    try std.testing.expect(eq("https://h/p", "https://h/p.git"));
+    try std.testing.expect(eq("https://h/p", "https://h/p/"));
+    try std.testing.expect(eq("https://h/p.git", "https://h/p/"));
+    try std.testing.expect(eq("https://h/p", "https://h/p"));
+    // A scheme downgrade is NOT cosmetic — it still warns.
+    try std.testing.expect(!eq("https://h/p", "http://h/p"));
+    // A genuinely different repository still warns.
+    try std.testing.expect(!eq("https://h/p", "https://h/q"));
+}
+
 test "parsePkgManifest tolerates CRLF line endings" {
     // thottam runs on Windows under Git Bash; a manifest checked out with
     // core.autocrlf=true has \r before every \n.

--- a/src/tests_thottam.zig
+++ b/src/tests_thottam.zig
@@ -466,20 +466,34 @@ test "isValidPkgName accepts the shapes the ecosystem actually uses" {
 // kaappi.pkg manifest parsing
 // ---------------------------------------------------------------------------
 
-test "parsePkgManifest reads the two read fields and ignores the rest" {
-    // Only depends and build are read. name, source and version are
-    // documented as ignored — a manifest that lies about its identity or
-    // hosting must not change the install (issue #2138).
+test "parsePkgManifest reads name, depends, build and source; version is ignored" {
+    // Since #2138 the parser reads four fields: `name:` (consistency-checked
+    // against the package being installed), `depends:`, `build:`, and
+    // `source:` (recorded as provenance). `version:` is not a field — thottam
+    // locks by git SHA, so a manifest version means nothing and is dropped
+    // like any unknown key.
     const m = state.parsePkgManifest(
         \\name: kaappi-web
-        \\source: https://evil.example.com/not-this-repo
+        \\source: https://github.com/someone/kaappi-web
         \\version: 99.99.99
         \\depends: kaappi-http kaappi-json
         \\build: make
         \\
     );
+    try std.testing.expectEqualStrings("kaappi-web", m.name.?);
     try std.testing.expectEqualStrings("kaappi-http kaappi-json", m.depends.?);
     try std.testing.expectEqualStrings("make", m.build_cmd.?);
+    try std.testing.expectEqualStrings("https://github.com/someone/kaappi-web", m.source.?);
+}
+
+test "parsePkgManifest treats empty name: and source: as absent (#2138)" {
+    // An empty value is an absence, not a claim — the same rule `build:`
+    // already follows — so a blank `name:`/`source:` does not trigger the
+    // install-time mismatch check or a provenance record.
+    const m = state.parsePkgManifest("name:\nsource:  \ndepends: dep\n");
+    try std.testing.expect(m.name == null);
+    try std.testing.expect(m.source == null);
+    try std.testing.expectEqualStrings("dep", m.depends.?);
 }
 
 test "parsePkgManifest tolerates CRLF line endings" {
@@ -503,6 +517,8 @@ test "parsePkgManifest ignores unknown keys and near-miss key names" {
         \\depends: real-dep
         \\
     );
+    try std.testing.expectEqualStrings("real", m.name.?);
+    try std.testing.expectEqualStrings("https://h/real", m.source.?);
     try std.testing.expectEqualStrings("real-dep", m.depends.?);
     try std.testing.expect(m.build_cmd == null);
 }

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -602,6 +602,19 @@ pub fn sourcesEquivalent(a: []const u8, b: []const u8) bool {
     return std.mem.eql(u8, canonicalSource(a), canonicalSource(b));
 }
 
+/// Whether a manifest-declared `source:` is safe to record in the lockfile and
+/// later hand to `git clone` under --locked. It is attacker-controlled (it
+/// comes from the cloned repo), and git's remote-helper transports use the
+/// `<transport>::<address>` form to run an arbitrary command (`ext::<cmd>`,
+/// `fd::…`), so any `::` is refused; so is a leading `-`, which `git clone`
+/// would read as an option (kaappi#2138, CWE-78). A command-line `::url` is
+/// user-chosen and not gated here; the clone itself disables `ext` regardless.
+pub fn isRecordableSource(s: []const u8) bool {
+    if (s.len == 0 or s[0] == '-') return false;
+    if (std.mem.indexOf(u8, s, "::") != null) return false;
+    return true;
+}
+
 fn doInstall(
     allocator: std.mem.Allocator,
     config: Config,
@@ -788,7 +801,14 @@ fn doInstall(
         writeStdout("...\n");
         const url_copy = try allocator.dupe(u8, clone_url);
         defer allocator.free(url_copy);
-        runGit(allocator, &.{ "clone", "--quiet", "--", url_copy, pkg_dir }) catch |err| switch (err) {
+        // `protocol.ext.allow=never` disables git's `ext::` remote helper,
+        // which runs an arbitrary command from a `ext::<cmd>` URL. A clone URL
+        // can reach here from a manifest's `source:` (recorded in the lockfile
+        // and cloned under --locked), so this closes the OS-command-injection
+        // vector at the git call regardless of where the URL came from
+        // (kaappi#2138, CWE-78). Local file paths use the `file` transport and
+        // are unaffected.
+        runGit(allocator, &.{ "-c", "protocol.ext.allow=never", "clone", "--quiet", "--", url_copy, pkg_dir }) catch |err| switch (err) {
             error.GitNotFound => return missingGit("install packages"),
             else => {
                 printErrColor(Color.red, "  Failed to clone repository\n");
@@ -876,7 +896,7 @@ fn doInstall(
                     const msg = std.fmt.bufPrint(&w, "{s} declares source '{s}' but was fetched from '{s}'\n", .{ pkg, declared, supplied }) catch "declared source differs from fetch URL\n";
                     writeStderr(msg);
                 }
-            } else {
+            } else if (isRecordableSource(declared)) {
                 // Installed by bare name: record the declared home as
                 // provenance so `thottam list` shows it and a later --locked
                 // install fetches from it. Surfaced on stderr, alongside the
@@ -886,6 +906,15 @@ fn doInstall(
                 writeStderr("  note: recording declared source ");
                 writeStderr(declared);
                 writeStderr("\n");
+            } else {
+                // A manifest source that could execute a command as a git
+                // remote helper (or inject a clone option) is refused rather
+                // than recorded; the package still installs from where it was
+                // actually fetched (kaappi#2138, CWE-78).
+                var w: [640]u8 = undefined;
+                printErrColor(Color.yellow, "  warning: ");
+                const msg = std.fmt.bufPrint(&w, "{s} declares an unsupported source transport '{s}'; not recording it\n", .{ pkg, declared }) catch "unsupported source transport in manifest\n";
+                writeStderr(msg);
             }
         }
     };

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -280,8 +280,10 @@ fn getPkgManifest(allocator: std.mem.Allocator, src_dir: []const u8, pkg: []cons
     const content = readFile(allocator, pkg_file) catch return null;
     defer allocator.free(content);
     var m = parsePkgManifest(content);
+    m.name = if (m.name) |n| allocator.dupe(u8, n) catch null else null;
     m.depends = if (m.depends) |d| allocator.dupe(u8, d) catch null else null;
     m.build_cmd = if (m.build_cmd) |b| allocator.dupe(u8, b) catch null else null;
+    m.source = if (m.source) |s| allocator.dupe(u8, s) catch null else null;
     m.owned = true;
     return m;
 }
@@ -799,9 +801,65 @@ fn doInstall(
         }
     }
 
-    if (getPkgManifest(allocator, config.src_dir, pkg)) |manifest| {
-        defer manifest.deinit(allocator);
-        if (manifest.depends) |deps| {
+    // The manifest is read only now, because it lives in the checkout we just
+    // cloned — so a package's own `source:` can never redirect its *first*
+    // clone (that URL is settled above). It is kept alive until after the
+    // lockfile is written, because `record_source` may alias `manifest.source`.
+    const manifest = getPkgManifest(allocator, config.src_dir, pkg);
+    defer if (manifest) |m| m.deinit(allocator);
+
+    // Provenance to record in the lockfile. In --locked mode the lockfile's own
+    // source is authoritative and must survive the check (#2137); otherwise a
+    // command-line `::url` wins, and absent one the manifest's declared
+    // `source:` is recorded so `thottam list` shows where the package is
+    // hosted (kaappi#2138).
+    var record_source: ?[]const u8 = if (locked_mode) locked_source else parsed.source;
+
+    if (manifest) |m| {
+        // A manifest that names a different package than the one being
+        // installed is a packaging error, not a fetch to silently record
+        // (kaappi#2138). `name:` was documented as the one required field;
+        // this is what finally enforces it.
+        if (m.name) |declared| {
+            if (!std.mem.eql(u8, declared, pkg)) {
+                var msg_buf: [512]u8 = undefined;
+                printErrColor(Color.red, "error: ");
+                const msg = std.fmt.bufPrint(&msg_buf, "manifest declares name '{s}' but installing '{s}'\n", .{ declared, pkg }) catch "manifest name mismatch\n";
+                writeStderr(msg);
+                return error.ManifestNameMismatch;
+            }
+        }
+
+        // Reconcile the declared `source:` with how we actually fetched
+        // (kaappi#2138). A command-line `::url` is authoritative for the
+        // fetch; the manifest only informs provenance.
+        if (!locked_mode) {
+            if (m.source) |declared| {
+                if (parsed.source) |supplied| {
+                    // A fork or mirror sharing history is legitimate, so a
+                    // divergence warns rather than refuses — but it is never
+                    // silent, which is the whole point of the field.
+                    if (!std.mem.eql(u8, supplied, declared)) {
+                        var w: [640]u8 = undefined;
+                        printErrColor(Color.yellow, "  warning: ");
+                        const msg = std.fmt.bufPrint(&w, "{s} declares source '{s}' but was fetched from '{s}'\n", .{ pkg, declared, supplied }) catch "declared source differs from fetch URL\n";
+                        writeStderr(msg);
+                    }
+                } else {
+                    // Installed by bare name: record the declared home as
+                    // provenance so `thottam list` shows it and a later
+                    // --locked install fetches from it. Surfaced, not silent,
+                    // because the manifest now steers where the package comes
+                    // from — the interaction #2138 flags.
+                    record_source = declared;
+                    writeStdout("  note: recording declared source ");
+                    writeStdout(declared);
+                    writeStdout("\n");
+                }
+            }
+        }
+
+        if (m.depends) |deps| {
             var dep_it = std.mem.splitScalar(u8, deps, ' ');
             while (dep_it.next()) |dep| {
                 if (dep.len > 0) {
@@ -810,7 +868,7 @@ fn doInstall(
             }
         }
 
-        if (manifest.build_cmd) |build_cmd| {
+        if (m.build_cmd) |build_cmd| {
             try runBuildCommand(allocator, pkg, build_cmd, pkg_dir);
         }
     }
@@ -821,9 +879,7 @@ fn doInstall(
     }
 
     try addToInstalled(allocator, config.installed, pkg);
-    // A --locked install must not rewrite the lockfile's recorded source: the
-    // provenance it is checking must survive the check (#2137).
-    try updateLockfile(allocator, config.lockfile, pkg, resolved_sha, if (locked_mode) locked_source else parsed.source);
+    try updateLockfile(allocator, config.lockfile, pkg, resolved_sha, record_source);
     writeStdout("  ");
     printColor(Color.green, pkg);
     printBuf(&buf, " installed (locked at {s})\n", .{resolved_sha});

--- a/src/thottam.zig
+++ b/src/thottam.zig
@@ -586,6 +586,22 @@ fn freeVisited(allocator: std.mem.Allocator, visited: *std.StringHashMap(void)) 
     visited.deinit();
 }
 
+/// A source URL with a trailing `/` and a `.git` suffix trimmed — the
+/// cosmetic spellings of one canonical remote. A scheme difference (http vs
+/// https) is deliberately NOT normalized: it is a downgrade, not cosmetic.
+fn canonicalSource(s: []const u8) []const u8 {
+    var t = s;
+    while (t.len > 0 and t[t.len - 1] == '/') t = t[0 .. t.len - 1];
+    if (std.mem.endsWith(u8, t, ".git")) t = t[0 .. t.len - 4];
+    return t;
+}
+
+/// Whether two source URLs name the same repository, ignoring a trailing slash
+/// and a `.git` suffix (kaappi#2138).
+pub fn sourcesEquivalent(a: []const u8, b: []const u8) bool {
+    return std.mem.eql(u8, canonicalSource(a), canonicalSource(b));
+}
+
 fn doInstall(
     allocator: std.mem.Allocator,
     config: Config,
@@ -762,7 +778,11 @@ fn doInstall(
         break :blk std.fmt.bufPrint(&buf, "{s}/{s}.git", .{ config.org, pkg }) catch return error.OutOfMemory;
     };
 
-    if (!dirExists(allocator, pkg_dir)) {
+    // Whether this invocation created the checkout. A later refusal (a manifest
+    // name mismatch) removes it only when we made it, never an already-installed
+    // package's tree (kaappi#2138).
+    const did_clone = !dirExists(allocator, pkg_dir);
+    if (did_clone) {
         writeStdout("  Cloning ");
         writeStdout(clone_url);
         writeStdout("...\n");
@@ -815,13 +835,23 @@ fn doInstall(
     // hosted (kaappi#2138).
     var record_source: ?[]const u8 = if (locked_mode) locked_source else parsed.source;
 
-    if (manifest) |m| {
+    // name: and source: reconciliation both run only outside --locked mode. In
+    // --locked mode the lockfile vouches for the exact SHA and is authoritative
+    // for provenance (#2137), so the manifest at that SHA is not re-litigated —
+    // this is what makes "--locked mode is untouched" true rather than nearly
+    // true (kaappi#2138).
+    if (manifest) |m| if (!locked_mode) {
         // A manifest that names a different package than the one being
         // installed is a packaging error, not a fetch to silently record
         // (kaappi#2138). `name:` was documented as the one required field;
         // this is what finally enforces it.
         if (m.name) |declared| {
             if (!std.mem.eql(u8, declared, pkg)) {
+                // Don't leave an unrecorded checkout behind: `list`/`verify`
+                // would not know about it, and a later fixed install would
+                // silently reuse it (the dirExists guard skips re-cloning).
+                // Only remove what this invocation created.
+                if (did_clone) removeDir(allocator, pkg_dir) catch {};
                 var msg_buf: [512]u8 = undefined;
                 printErrColor(Color.red, "error: ");
                 const msg = std.fmt.bufPrint(&msg_buf, "manifest declares name '{s}' but installing '{s}'\n", .{ declared, pkg }) catch "manifest name mismatch\n";
@@ -830,35 +860,37 @@ fn doInstall(
             }
         }
 
-        // Reconcile the declared `source:` with how we actually fetched
-        // (kaappi#2138). A command-line `::url` is authoritative for the
-        // fetch; the manifest only informs provenance.
-        if (!locked_mode) {
-            if (m.source) |declared| {
-                if (parsed.source) |supplied| {
-                    // A fork or mirror sharing history is legitimate, so a
-                    // divergence warns rather than refuses — but it is never
-                    // silent, which is the whole point of the field.
-                    if (!std.mem.eql(u8, supplied, declared)) {
-                        var w: [640]u8 = undefined;
-                        printErrColor(Color.yellow, "  warning: ");
-                        const msg = std.fmt.bufPrint(&w, "{s} declares source '{s}' but was fetched from '{s}'\n", .{ pkg, declared, supplied }) catch "declared source differs from fetch URL\n";
-                        writeStderr(msg);
-                    }
-                } else {
-                    // Installed by bare name: record the declared home as
-                    // provenance so `thottam list` shows it and a later
-                    // --locked install fetches from it. Surfaced, not silent,
-                    // because the manifest now steers where the package comes
-                    // from — the interaction #2138 flags.
-                    record_source = declared;
-                    writeStdout("  note: recording declared source ");
-                    writeStdout(declared);
-                    writeStdout("\n");
+        // Reconcile the declared `source:` with how we actually fetched. A
+        // command-line `::url` is authoritative for the fetch; the manifest
+        // only informs provenance.
+        if (m.source) |declared| {
+            if (parsed.source) |supplied| {
+                // A fork or mirror sharing history is legitimate, so a
+                // divergence warns rather than refuses — but it is never
+                // silent, which is the whole point of the field. Trailing `/`
+                // and a `.git` suffix are cosmetic and do not warn; a scheme
+                // difference (http vs https) is a real downgrade and still does.
+                if (!sourcesEquivalent(supplied, declared)) {
+                    var w: [640]u8 = undefined;
+                    printErrColor(Color.yellow, "  warning: ");
+                    const msg = std.fmt.bufPrint(&w, "{s} declares source '{s}' but was fetched from '{s}'\n", .{ pkg, declared, supplied }) catch "declared source differs from fetch URL\n";
+                    writeStderr(msg);
                 }
+            } else {
+                // Installed by bare name: record the declared home as
+                // provenance so `thottam list` shows it and a later --locked
+                // install fetches from it. Surfaced on stderr, alongside the
+                // warning above, not silent — the manifest now steers where the
+                // package comes from, the interaction #2138 flags.
+                record_source = declared;
+                writeStderr("  note: recording declared source ");
+                writeStderr(declared);
+                writeStderr("\n");
             }
         }
+    };
 
+    if (manifest) |m| {
         if (m.depends) |deps| {
             var dep_it = std.mem.splitScalar(u8, deps, ' ');
             while (dep_it.next()) |dep| {
@@ -1366,8 +1398,9 @@ pub fn main(init: std.process.Init.Minimal) !void {
             // InvalidPackageName already printed its own message; exiting here
             // keeps Zig's default handler from printing the raw error name as a
             // second line (kaappi#2132). GitNotFound likewise prints its own
-            // message at the clone site (kaappi#2152).
-            if (err == error.GitFailed or err == error.BuildFailed or err == error.CopyFailed or err == error.InvalidPackageName or err == error.GitNotFound) std.process.exit(1);
+            // message at the clone site (kaappi#2152), and ManifestNameMismatch
+            // at the name check (kaappi#2138).
+            if (err == error.GitFailed or err == error.BuildFailed or err == error.CopyFailed or err == error.InvalidPackageName or err == error.GitNotFound or err == error.ManifestNameMismatch) std.process.exit(1);
             return err;
         };
     } else if (std.mem.eql(u8, cmd, "remove")) {

--- a/src/thottam_state.zig
+++ b/src/thottam_state.zig
@@ -9,14 +9,18 @@ pub const PkgSpec = struct {
 };
 
 pub const PkgManifest = struct {
+    name: ?[]const u8 = null,
     depends: ?[]const u8 = null,
     build_cmd: ?[]const u8 = null,
+    source: ?[]const u8 = null,
     owned: bool = false,
 
     pub fn deinit(self: PkgManifest, allocator: std.mem.Allocator) void {
         if (!self.owned) return;
+        if (self.name) |n| allocator.free(n);
         if (self.depends) |d| allocator.free(d);
         if (self.build_cmd) |b| allocator.free(b);
+        if (self.source) |s| allocator.free(s);
     }
 };
 
@@ -59,13 +63,21 @@ pub fn parsePkgManifest(content: []const u8) PkgManifest {
     var result: PkgManifest = .{};
     var it = std.mem.splitScalar(u8, content, '\n');
     while (it.next()) |line| {
-        if (parseField(line, "depends:")) |val| {
+        if (parseField(line, "name:")) |val| {
+            // Consistency-checked against the package being installed
+            // (kaappi#2138); an empty `name:` is an absence, not a claim.
+            if (val.len > 0) result.name = val;
+        } else if (parseField(line, "depends:")) |val| {
             result.depends = val;
         } else if (parseField(line, "build:")) |val| {
             // An empty `build:` is an absence, not a command — running
             // `/bin/sh -c ""` behind a "Building <pkg>..." banner helped
             // nobody (kaappi#2132).
             if (val.len > 0) result.build_cmd = val;
+        } else if (parseField(line, "source:")) |val| {
+            // Recorded as provenance and reconciled with any command-line
+            // `::url` (kaappi#2138); an empty `source:` declares nothing.
+            if (val.len > 0) result.source = val;
         }
     }
     return result;

--- a/tests/scheme/thottam/thottam-lifecycle.sh
+++ b/tests/scheme/thottam/thottam-lifecycle.sh
@@ -688,34 +688,73 @@ check "--locked matching-source restore records the same provenance" \
     "$ORG/kaappi-alpha.git" "$(cat "$KAAPPI_HOME/thottam.lock")"
 
 # ---------------------------------------------------------------------------
-# 10. kaappi.pkg's name:/version:/source: fields are inert (issue #2138)
+# 10. kaappi.pkg's name: and source: fields are wired up (issue #2138)
 # ---------------------------------------------------------------------------
 
-# A manifest that lies about its identity or hosting must not change the
-# install: only depends: and build: are read, and every other key is ignored
-# by construction — the parser no longer recognises them.
-mkdir -p "$WORK/kaappi-srcfield/lib/kaappi"
+# name: is consistency-checked against the package being installed. A manifest
+# that names a different package is a packaging error, and the install refuses
+# BEFORE recording anything, rather than cloning under the wrong identity.
+mkdir -p "$WORK/kaappi-badname/lib/kaappi"
 (
-    cd "$WORK/kaappi-srcfield"
+    cd "$WORK/kaappi-badname"
     git init -q .
     printf 'name: WRONG-NAME-ENTIRELY\nsource: https://evil.example.com/not-this-repo\nversion: 99.99.99\n' > kaappi.pkg
-    printf '(define-library (kaappi srcfield) (export tag) (import (scheme base)) (begin (define tag "srcfield")))\n' \
-        > lib/kaappi/srcfield.sld
+    printf '(define-library (kaappi badname) (export tag) (import (scheme base)) (begin (define tag "bad")))\n' \
+        > lib/kaappi/badname.sld
     git add -A
     git_q commit -q -m base
 )
-git clone -q --bare "$WORK/kaappi-srcfield" "$ORG/kaappi-srcfield.git"
+git clone -q --bare "$WORK/kaappi-badname" "$ORG/kaappi-badname.git"
 fresh_home
-out="$("$THOTTAM" install kaappi-srcfield 2>&1)" && ec=0 || ec=$?
-check_exit "a manifest with an unrelated name and source installs" 0 "$ec"
-check_not "a manifest's source: never reaches the lockfile" \
-    "evil.example.com" "$(cat "$KAAPPI_HOME/thottam.lock")"
-check_not "a manifest's source: never shows in list" \
-    "evil.example.com" "$("$THOTTAM" list)"
-check "the installed package is verified under its real name" "OK: kaappi-srcfield" \
-    "$("$THOTTAM" verify)"
+out="$("$THOTTAM" install kaappi-badname 2>&1)" && ec=0 || ec=$?
+check_exit "a manifest naming a different package is refused" 1 "$ec"
+check "the refusal names both the declared and the requested name" \
+    "declares name 'WRONG-NAME-ENTIRELY' but installing 'kaappi-badname'" "$out"
+check_not "the refused package is not recorded in the lockfile" \
+    "kaappi-badname" "$(cat "$KAAPPI_HOME/thottam.lock" 2>/dev/null || true)"
+# version: is not a field — thottam locks by git SHA — so it neither helps nor
+# harms; the refusal above came from name:, never from the bogus version.
 
-# A manifest with only the two read fields installs cleanly too.
+# source: on a bare-name install is recorded as provenance, so `list` shows
+# where the package is hosted. The record is surfaced with a note, never
+# silent, because the manifest now steers where a later --locked install
+# fetches from.
+mkdir -p "$WORK/kaappi-declared/lib/kaappi"
+(
+    cd "$WORK/kaappi-declared"
+    git init -q .
+    printf 'name: kaappi-declared\nsource: https://forge.example.org/kaappi-declared\n' > kaappi.pkg
+    printf '(define-library (kaappi declared) (export tag) (import (scheme base)) (begin (define tag "d")))\n' \
+        > lib/kaappi/declared.sld
+    git add -A
+    git_q commit -q -m base
+)
+git clone -q --bare "$WORK/kaappi-declared" "$ORG/kaappi-declared.git"
+fresh_home
+out="$("$THOTTAM" install kaappi-declared 2>&1)" && ec=0 || ec=$?
+check_exit "a manifest with a valid name and a source installs" 0 "$ec"
+check "the declared source is surfaced with a note at record time" \
+    "note: recording declared source https://forge.example.org/kaappi-declared" "$out"
+check "the declared source reaches the lockfile as provenance" \
+    "https://forge.example.org/kaappi-declared" "$(cat "$KAAPPI_HOME/thottam.lock")"
+check "the declared source shows in list" \
+    "(from: https://forge.example.org/kaappi-declared)" "$("$THOTTAM" list)"
+
+# A command-line ::url is authoritative for the fetch; a manifest source: that
+# disagrees warns (a fork/mirror is legitimate) and the lockfile records the
+# URL actually fetched, not the manifest's claim.
+fresh_home
+out="$("$THOTTAM" install "kaappi-declared::$ORG/kaappi-declared.git" 2>&1)" && ec=0 || ec=$?
+check_exit "an install with a ::url that disagrees with source: still succeeds" 0 "$ec"
+check "the divergence between ::url and manifest source: is warned, not silent" \
+    "declares source 'https://forge.example.org/kaappi-declared' but was fetched from" "$out"
+check "the lockfile records the fetched ::url, not the manifest's claim" \
+    "$ORG/kaappi-declared.git" "$(cat "$KAAPPI_HOME/thottam.lock")"
+check_not "the manifest's claimed source does not override the fetch URL" \
+    "forge.example.org" "$(cat "$KAAPPI_HOME/thottam.lock")"
+
+# A manifest without a name: still installs — name: is checked when present,
+# not required to exist.
 mkdir -p "$WORK/kaappi-minimal/lib/kaappi"
 (
     cd "$WORK/kaappi-minimal"

--- a/tests/scheme/thottam/thottam-lifecycle.sh
+++ b/tests/scheme/thottam/thottam-lifecycle.sh
@@ -791,6 +791,65 @@ out="$("$THOTTAM" install "kaappi-cosmetic::$ORG/kaappi-cosmetic.git" 2>&1)" && 
 check_exit "a cosmetic ::url-vs-source: difference installs" 0 "$ec"
 check_not "a trailing-.git-only difference does not warn" "declares source" "$out"
 
+# A later --locked install actually consumes the recorded source: it clones
+# from the manifest-declared remote, not the org default. The default's own
+# repo declares an alternate remote (a byte-identical bare clone, so the SHA
+# matches); a bare-name install records the alternate as provenance; then the
+# default is made unavailable and a --locked restore must still succeed —
+# proving it fetched from the recorded alternate.
+mkdir -p "$WORK/kaappi-mirror/lib/kaappi"
+(
+    cd "$WORK/kaappi-mirror"
+    git init -q .
+    printf 'name: kaappi-mirror\nsource: %s/kaappi-mirror-alt.git\n' "$ORG" > kaappi.pkg
+    printf '(define-library (kaappi mirror) (export tag) (import (scheme base)) (begin (define tag "m")))\n' \
+        > lib/kaappi/mirror.sld
+    git add -A
+    git_q commit -q -m base
+)
+git clone -q --bare "$WORK/kaappi-mirror" "$ORG/kaappi-mirror.git"
+# The alternate is a byte-identical bare clone, so its HEAD SHA matches.
+git clone -q --bare "$ORG/kaappi-mirror.git" "$ORG/kaappi-mirror-alt.git"
+fresh_home
+"$THOTTAM" install kaappi-mirror > /dev/null 2>&1
+check "the recorded provenance is the declared alternate remote" \
+    "kaappi-mirror-alt.git" "$(cat "$KAAPPI_HOME/thottam.lock")"
+# Wipe the checkout and make the org default unreachable; only the recorded
+# alternate can satisfy the restore now.
+rm -rf "$KAAPPI_HOME/src/kaappi-mirror" "$KAAPPI_HOME/lib/kaappi/mirror.sld"
+: > "$KAAPPI_HOME/installed.txt"
+mv "$ORG/kaappi-mirror.git" "$ORG/kaappi-mirror.git.unavailable"
+out="$("$THOTTAM" install --locked kaappi-mirror 2>&1)" && ec=0 || ec=$?
+check_exit "--locked restore clones from the recorded source (org default gone)" 0 "$ec"
+check_file "the locked restore actually fetched the library" \
+    "$KAAPPI_HOME/lib/kaappi/mirror.sld"
+mv "$ORG/kaappi-mirror.git.unavailable" "$ORG/kaappi-mirror.git"
+
+# A manifest source that is a git remote-helper transport (ext::<cmd> executes
+# a command) is refused, never recorded, and never executed — the package still
+# installs from where it was actually fetched (kaappi#2138, CWE-78).
+evilmarker="$WORK/evil-ran"
+mkdir -p "$WORK/kaappi-evilsrc/lib/kaappi"
+(
+    cd "$WORK/kaappi-evilsrc"
+    git init -q .
+    printf "name: kaappi-evilsrc\nsource: ext::sh -c 'touch %s'\n" "$evilmarker" > kaappi.pkg
+    printf '(define-library (kaappi evilsrc) (export tag) (import (scheme base)) (begin (define tag "e")))\n' \
+        > lib/kaappi/evilsrc.sld
+    git add -A
+    git_q commit -q -m base
+)
+git clone -q --bare "$WORK/kaappi-evilsrc" "$ORG/kaappi-evilsrc.git"
+fresh_home
+out="$("$THOTTAM" install kaappi-evilsrc 2>&1)" && ec=0 || ec=$?
+check_exit "a manifest with an ext:: source still installs from the fetched remote" 0 "$ec"
+check "the unsupported transport is refused with a warning" \
+    "unsupported source transport" "$out"
+check_not "the ext:: source is not recorded in the lockfile" \
+    "ext::" "$(cat "$KAAPPI_HOME/thottam.lock")"
+[[ -e "$evilmarker" ]] && evilran=yes || evilran=no
+check "the ext:: command is never executed" "no" "$evilran"
+
 # A manifest without a name: still installs — name: is checked when present,
 # not required to exist.
 mkdir -p "$WORK/kaappi-minimal/lib/kaappi"

--- a/tests/scheme/thottam/thottam-lifecycle.sh
+++ b/tests/scheme/thottam/thottam-lifecycle.sh
@@ -712,8 +712,27 @@ check "the refusal names both the declared and the requested name" \
     "declares name 'WRONG-NAME-ENTIRELY' but installing 'kaappi-badname'" "$out"
 check_not "the refused package is not recorded in the lockfile" \
     "kaappi-badname" "$(cat "$KAAPPI_HOME/thottam.lock" 2>/dev/null || true)"
+# The refusal exits cleanly: no raw `error.ManifestNameMismatch` second line
+# from Zig's default handler (the #2132 duplicate-message pattern).
+check_not "the refusal prints no raw Zig error name" "error.ManifestNameMismatch" "$out"
+# And it leaves no unrecorded checkout behind for a later install to reuse.
+[[ -d "$KAAPPI_HOME/src/kaappi-badname" ]] && leftover=present || leftover=absent
+check "the refused install leaves no checkout behind" "absent" "$leftover"
 # version: is not a field — thottam locks by git SHA — so it neither helps nor
 # harms; the refusal above came from name:, never from the bogus version.
+
+# In --locked mode the lockfile vouches for the exact SHA, so the manifest is
+# not re-litigated: a name: that mismatches does NOT refuse a locked restore
+# (the check is scoped to unlocked installs, matching source: being ignored
+# under --locked). Seed a lockfile pointing at the badname repo, then restore.
+fresh_home
+badsha="$(git -C "$ORG/kaappi-badname.git" rev-parse HEAD)"
+printf 'kaappi-badname %s\n' "$badsha" > "$KAAPPI_HOME/thottam.lock"
+mkdir -p "$KAAPPI_HOME"
+out="$("$THOTTAM" install --locked kaappi-badname 2>&1)" && ec=0 || ec=$?
+check_exit "--locked does not enforce name: (lockfile vouches for the SHA)" 0 "$ec"
+check_not "the locked restore does not raise a name mismatch" \
+    "declares name" "$out"
 
 # source: on a bare-name install is recorded as provenance, so `list` shows
 # where the package is hosted. The record is surfaced with a note, never
@@ -752,6 +771,25 @@ check "the lockfile records the fetched ::url, not the manifest's claim" \
     "$ORG/kaappi-declared.git" "$(cat "$KAAPPI_HOME/thottam.lock")"
 check_not "the manifest's claimed source does not override the fetch URL" \
     "forge.example.org" "$(cat "$KAAPPI_HOME/thottam.lock")"
+
+# A ::url that differs from source: only by a trailing slash or a `.git` suffix
+# is the same remote, so it must NOT warn — otherwise the warning trains users
+# to ignore it. Manifest declares the bare path; install via the `.git` spelling.
+mkdir -p "$WORK/kaappi-cosmetic/lib/kaappi"
+(
+    cd "$WORK/kaappi-cosmetic"
+    git init -q .
+    printf 'name: kaappi-cosmetic\nsource: %s/kaappi-cosmetic\n' "$ORG" > kaappi.pkg
+    printf '(define-library (kaappi cosmetic) (export tag) (import (scheme base)) (begin (define tag "c")))\n' \
+        > lib/kaappi/cosmetic.sld
+    git add -A
+    git_q commit -q -m base
+)
+git clone -q --bare "$WORK/kaappi-cosmetic" "$ORG/kaappi-cosmetic.git"
+fresh_home
+out="$("$THOTTAM" install "kaappi-cosmetic::$ORG/kaappi-cosmetic.git" 2>&1)" && ec=0 || ec=$?
+check_exit "a cosmetic ::url-vs-source: difference installs" 0 "$ec"
+check_not "a trailing-.git-only difference does not warn" "declares source" "$out"
 
 # A manifest without a name: still installs — name: is checked when present,
 # not required to exist.


### PR DESCRIPTION
## The gap (#2138)
The `kaappi.pkg` manifest documented four fields, but `thottam` read only `depends:` and `build:`. `name:` and `source:` were **inert** — a manifest could name a different package, or declare a canonical source, and the install neither checked nor recorded either. `version:` was never a field at all.

(Note: the issue described `name:`/`source:` as "parsed but never read"; on current `main` the parser had since been narrowed to two keys, so they weren't even parsed. Same doc-truth gap, addressed the same way.)

## What this does — the "wire up" direction
Per the design call in the issue's **option 1**, respecting the clone-first architecture and the #2137 provenance model:

- **`name:`** — consistency-checked against the package being installed. A manifest naming a different package is a packaging error; the install **refuses before recording anything**. Still optional (a manifest may omit it), but a mismatching `name:` is never accepted.

  ```
  $ thottam install kaappi-badname     # manifest says name: WRONG-NAME-ENTIRELY
  error: manifest declares name 'WRONG-NAME-ENTIRELY' but installing 'kaappi-badname'
  ```

- **`source:`** — declares the canonical host. On a **bare-name install** (no `::url`) it's recorded as the lockfile's provenance, so `thottam list` shows `(from: …)` and a later `--locked` install fetches from it — **surfaced with a one-line note**, never silent, because the manifest is then steering where the package comes from (the interaction the issue flags). When a `::url` is given and disagrees, thottam **warns** (a fork/mirror is legitimate) and records the URL it actually fetched, not the manifest's claim. `--locked` mode is untouched: the lockfile stays authoritative and `source:` is ignored (#2137).

  **Honest limitation, documented:** `source:` **cannot redirect the first clone** — thottam reads the manifest only after cloning the repo, so the initial fetch URL is always the command-line `::url` or the `KAAPPI_ORG` default.

- **`version:`** — dropped from the documented grammar. thottam locks by git SHA, so a manifest version means nothing; it keeps being ignored like any unknown key.

## Regression tests
- `src/tests_thottam.zig`: the parser tests now pin all four read fields plus the empty-value-is-absent rule.
- `tests/scheme/thottam/thottam-lifecycle.sh`: scenario 10 rewritten from "these fields are inert" to cover the name-mismatch refusal (with lockfile untouched), provenance recording + its note, the `::url`-vs-`source:` warning (fetched URL wins), and the no-`name:` install. **152 checks pass** (11 new).

## Verification
- `zig build test` — passes (full suite).
- `bash tests/scheme/thottam/thottam-lifecycle.sh` — 152/0.
- markdownlint (CI `format` gate) on `docs/dev/thottam.md` — 0 issues.
- Manual: verified name-mismatch error, bare-name source recording + `(from:)` in `list`, `::url` mismatch warning, and `--locked` fetching from the lockfile source (authority preserved).

Docs: `docs/dev/thottam.md` rewritten to describe the four read fields, the provenance/first-clone semantics, and the absence of `version:`. (The workspace-root `CLAUDE.md` the issue also quotes is not in this repo — it's a local, untracked orientation file — so it can't be included here; it's the same grammar and should be updated wherever it's maintained.)

Closes #2138

🤖 Generated with [Claude Code](https://claude.com/claude-code)