### PR TITLE
Skip the root-marked map walk for .owned == false env wrappers

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -767,6 +767,14 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
         },
         .scheme_environment => {
             const se = obj.as(types.SchemeEnvironment);
+            // #2377: an .owned == false wrapper's map IS the owning VM's
+            // root-marked globals map (interaction-environment is the only
+            // such constructor) — markVmRoots marks every value in it each
+            // collection regardless, so walking it here was idempotent
+            // redundancy. Mirrors the referencesYoung guard; a child-thread
+            // wrapper's values are foreign to this GC and the owner check
+            // in markValueInner skips them anyway.
+            if (!se.owned) return;
             var vit = se.env.valueIterator();
             while (vit.next()) |val| markValue(gc, val.*);
         },
@@ -1170,6 +1178,11 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
         },
         .scheme_environment => {
             const se = obj.as(types.SchemeEnvironment);
+            // #2377: same rationale as the markObjectContents arm — an
+            // .owned == false wrapper's map is root-marked by markVmRoots
+            // every collection, so queueing its values here was idempotent
+            // redundancy.
+            if (!se.owned) return;
             var vit = se.env.valueIterator();
             while (vit.next()) |val| worklist.append(gc.allocator, val.*) catch @panic("GC mark: worklist OOM");
         },

--- a/src/tests_gc_tracing.zig
+++ b/src/tests_gc_tracing.zig
@@ -518,6 +518,50 @@ test "gc tracing: scheme_environment traces every binding" {
     try expectTraced(&gc, env, &.{ ref(a, 1), ref(b, 2) });
 }
 
+test "gc tracing: .owned == false environment wrapper skips its map (#2377)" {
+    var gc = newGc();
+    defer gc.deinit();
+    // interaction-environment shape: the map plays the owning VM's globals,
+    // whose values are root-marked every collection (markVmRoots) — the
+    // wrapper's own trace must not walk it. The map stays the test's to
+    // free: freeObject leaves an .owned == false wrapper's map alone.
+    const a = try young(&gc, 1);
+    const b = try young(&gc, 2);
+    const map = try gc.allocator.create(std.StringHashMap(Value));
+    map.* = std.StringHashMap(Value).init(gc.allocator);
+    try map.put("a", a);
+    try map.put("b", b);
+    defer {
+        map.deinit();
+        gc.allocator.destroy(map);
+    }
+    const env = try gc.allocEnvironment(map, false, false);
+    try std.testing.expect(!types.toObject(env).as(types.SchemeEnvironment).owned);
+
+    // Root-marked simulation: the wrapper and one separately-rooted map
+    // value survive minor and full collections with both mark arms
+    // skipping the walk.
+    var env_root = env;
+    gc.pushRoot(&env_root);
+    var a_root = a;
+    gc.pushRoot(&a_root);
+    forceMinor(&gc);
+    try expectAlive(&gc, ref(a, 1));
+    forceFull(&gc);
+    try expectAlive(&gc, ref(a, 1));
+    gc.popRoot();
+    gc.popRoot();
+
+    // Discriminating control: with only the wrapper rooted, the un-rooted
+    // map value must be reclaimed — before #2377 the wrapper's redundant
+    // walk re-marked it through every collection.
+    var only_wrapper = env;
+    gc.pushRoot(&only_wrapper);
+    forceFull(&gc);
+    try expectDead(&gc, ref(b, 2));
+    gc.popRoot();
+}
+
 test "gc tracing: transport_cell traces value, holds key weakly (#2006)" {
     var gc = newGc();
     defer gc.deinit();


### PR DESCRIPTION
Closes #2377.

## What

The two mark arms still walked the `.owned == false` environment wrapper's map when the wrapper itself was traced. That wrapper is `interaction-environment` — the only such constructor — and its map *is* the root-marked `vm.globals`, every value of which `markVmRoots` marks each collection regardless. Both walks were idempotent redundancy.

## Change

`markObjectContents`' and `markValueInner`'s `.scheme_environment` arms now return early on `!se.owned`, mirroring the `referencesYoung` guard from #2372's review round (the load-bearing cost fix — enrollment — was already merged there). A child-thread wrapper's map values are foreign to that GC and the owner check skips them anyway.

Cost only, never unsafe: the skipped walk could only re-mark values another root had already marked.

## Regression test

New case in `tests_gc_tracing.zig` pins the new semantics: an `.owned == false` wrapper rooted alone no longer keeps its map's values alive across minor and full collections, while a separately-rooted value (simulating `markVmRoots`) survives with the walk skipped. Verified it fails on `main` and passes with the fix.

## Verification

- `zig build test` — 1779 pass, 7 skip
- `zig build test -Dgc-stress=true` — pass
- `tests/scheme/run-all.sh` — 2115 pass, 0 fail (R7RS suite: 1395 pass, 0 fail)
- `zig fmt --check` on both changed files