### PR TITLE
tests: pin the KP3007 diagnostic in the SRFI 237 arity audit

### DIFF
--- a/tests/scheme/audit/primitives_srfi237-audit.scm
+++ b/tests/scheme/audit/primitives_srfi237-audit.scm
@@ -373,11 +373,26 @@
        (a+b (lambda (inst) (list ((record-accessor A 0) inst) ((record-accessor B 0) inst)))))
   (test-equal "arity control: the correct argument count lays fields out correctly" '(1 2)
               (a+b (ctor 1 2)))
-  ;; #1915: the no-protocol subtype constructor checks its argument count.
+  ;; #1915: the no-protocol subtype constructor checks its argument count, and
+  ;; raises the count-naming KP3007 message rather than any catchable error --
+  ;; so the assertion pins the diagnostic shape, not merely that it raised. The
+  ;; layered constructor fills the parent level first, so the message names the
+  ;; parent rtd's sub-construction (its field count vs. the values routed to
+  ;; it), which is why the counts differ from the subtype's own arity.
   (test-assert "arity: too many subtype constructor arguments raises catchably"
                (raises? (lambda () (ctor 1 2 3))))
+  (test-assert "arity: too many is the count-naming KP3007 message"
+               (let ((m (message-of (lambda () (ctor 1 2 3)))))
+                 (and (string? m)
+                      (string-search m "field(s) but")
+                      (string-search m "value(s) were supplied"))))
   (test-assert "arity: too few subtype constructor arguments raises catchably"
-               (raises? (lambda () (ctor 1)))))
+               (raises? (lambda () (ctor 1))))
+  (test-assert "arity: too few is the count-naming KP3007 message"
+               (let ((m (message-of (lambda () (ctor 1)))))
+                 (and (string? m)
+                      (string-search m "field(s) but")
+                      (string-search m "value(s) were supplied")))))
 
 
 ;;; ===================================================================


### PR DESCRIPTION
Small test-only follow-up to #2374 (already merged).

A CodeRabbit review comment on #2374 landed after that PR merged: the SRFI 237 audit's `#1915` arity tests used `raises?` alone, so a generic catchable error would pass without verifying the count-naming KP3007 message. This asserts the diagnostic shape via `message-of`, matching the strengthening that shipped for the internal-primitives audit in #2374 itself.

Note: the layered subtype constructor fills the parent level first, so the KP3007 message names the **parent** rtd's sub-construction counts, not the subtype's own arity — CodeRabbit's suggested `2/3`/`2/1` pairs don't match the actual path. The tests therefore pin the stable `"field(s) but … value(s) were supplied"` shape (which proves it's the arity diagnostic, not a generic error) rather than coupling to the internal arg-split.

Verification: `primitives_srfi237-audit.scm` → 219 expected passes, 0 failures (up from 217).

🤖 Generated with [Claude Code](https://claude.com/claude-code)