### PR TITLE
Implement SRFI 231 f16-storage-class as software half-floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `(srfi 231)` pure R7RS-small. Verified by an exhaustive 65536-pattern
   round-trip sweep; official-suite divergence ids 98/148/149 pruned (id 150
   re-scoped to the pre-existing c64/c128 representation divergence it was
-  also hiding, #2382).
+  also hiding, #2382). The suite's known-divergence table now records the
+  exact expected divergence count per id, and the verdict epilogue fails on
+  any mismatch in either direction — an undocumented failure under a shared
+  test id (16 storage-class rows re-use one id) can no longer hide behind a
+  documented divergence.
 
 ## [0.25.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **SRFI 231 `f16-storage-class`** (#2379) — software IEEE 754 binary16
+  half-floats over `u16vector`, a faithful transliteration of the reference
+  implementation's own arithmetic codec (round-to-nearest-even, subnormals,
+  signed zeros, ±inf, and the 65520.0 tie rounding up to `+inf.0`), keeping
+  `(srfi 231)` pure R7RS-small. Verified by an exhaustive 65536-pattern
+  round-trip sweep; official-suite divergence ids 98/148/149 pruned (id 150
+  re-scoped to the pre-existing c64/c128 representation divergence it was
+  also hiding, #2382).
+
 ## [0.25.0] - 2026-08-27
 
 ### Added

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -877,8 +877,11 @@ simple/shared/virtual union — confirmed as a genuine hybrid of prior
 conventions on two independent axes: `array?` is disjoint from vector/string
 (matching 25/164, not 63), while `array-set!`'s new-value argument is
 *second*, right after the array (matching 63, not 25/164's value-last). A
-storage class (17 singletons — 14 real, 3 deferred to `#f`: `u1`/`f8`/`f16` —
-plus `make-storage-class` for custom ones) is a 9-field record
+storage class (17 singletons, 16 real, plus `make-storage-class` for custom
+ones; only `f8` is deferred to `#f` — even the reference leaves it `#f`,
+since no standard 8-bit float type exists. `u1` and `f16` are ports of the
+reference's own bit-packing and software half-floats over `u16vector`) is a
+9-field record
 (getter/setter/checker/maker/copier/length/default/data?/data->body) that a
 specialized array's `body`/`indexer` pair delegates to for the actual
 backing-store representation. The single most-reused implementation pattern

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -276,11 +276,15 @@ Conventions specific to this suite:
 
 - **Known divergences are accounted, not failed.** A table of test ids in
   the generated file maps each documented kaappi-vs-reference divergence to
-  its reason and issue reference (the c64/c128 native-vector representation
-  choice, the unsafe-view UB choice, the Gambit string-mutability
-  expectation). The suite exits nonzero only on *unexpected* failures — or
-  when a known divergence stops diverging, which means its entry is stale
-  and hiding real coverage: prune it.
+  its reason, issue reference, and the *exact* number of evaluations
+  expected to diverge under it (shared test forms run once per storage
+  class, so one id can account several rows) — the c64/c128
+  native-vector representation choice, the unsafe-view UB choice, the
+  Gambit string-mutability expectation. The suite exits nonzero only on
+  *unexpected* failures — or when an entry's divergence count doesn't match
+  exactly: zero observed means the entry is stale and hiding real coverage
+  (prune it), and more than recorded means an undocumented failure is
+  absorbing into the entry.
 - **Error-expecting tests pass on any error** — only the Gambit message
   text differs from kaappi's (counted separately as "error-message-only").
 - **It runs ~150 s** (the isolated `KAAPPI_HOME` compiles the SRFI's

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -276,10 +276,11 @@ Conventions specific to this suite:
 
 - **Known divergences are accounted, not failed.** A table of test ids in
   the generated file maps each documented kaappi-vs-reference divergence to
-  its reason and issue reference (f16 deferral, the unsafe-view UB choice,
-  the Gambit string-mutability expectation). The suite exits nonzero only
-  on *unexpected* failures — or when a known divergence stops diverging,
-  which means its entry is stale and hiding real coverage: prune it.
+  its reason and issue reference (the c64/c128 native-vector representation
+  choice, the unsafe-view UB choice, the Gambit string-mutability
+  expectation). The suite exits nonzero only on *unexpected* failures — or
+  when a known divergence stops diverging, which means its entry is stale
+  and hiding real coverage: prune it.
 - **Error-expecting tests pass on any error** — only the Gambit message
   text differs from kaappi's (counted separately as "error-message-only").
 - **It runs ~150 s** (the isolated `KAAPPI_HOME` compiles the SRFI's

--- a/lib/srfi/231/storage-classes.sld
+++ b/lib/srfi/231/storage-classes.sld
@@ -23,10 +23,11 @@
 ;;; spec gives their exact reference definitions verbatim, reused here
 ;;; unchanged. u1 is a direct port of the reference's own bit-packing over
 ;;; u16vector (the representation the spec itself documents for bit
-;;; arrays). f8 is left #f even in the SRFI's OWN reference implementation
-;;; (no standard 8-bit-float Scheme type exists anywhere), and f16 -- which
-;;; the reference implements as software half-floats -- remains #f as a
-;;; documented scope reduction (#2353).
+;;; arrays), and f16 a faithful port of its software half-floats over
+;;; u16vector (#2379) -- the spec's #f escape clause is for implementations
+;;; lacking the substrate, which neither port is. f8 alone is left #f,
+;;; even in the SRFI's OWN reference implementation (no standard 8-bit
+;;; float Scheme type exists anywhere).
 (define-library (srfi 231 storage-classes)
   (import (scheme base)
           (srfi 160 s8) (srfi 160 s16) (srfi 160 s32) (srfi 160 s64)
@@ -34,7 +35,9 @@
           (srfi 160 f32) (srfi 160 f64) (srfi 160 c64) (srfi 160 c128)
           ;; bitwise-and/ior/not for u1's bit-packing (R7RS-small has no
           ;; bitwise primitives of its own)
-          (srfi 60))
+          (srfi 60)
+          ;; finite?/nan? for the f16 codec's special-value classification
+          (scheme inexact))
   (export make-storage-class storage-class?
           storage-class-getter storage-class-setter storage-class-checker
           storage-class-maker storage-class-copier storage-class-length
@@ -199,8 +202,142 @@
              (error "Expecting a u16vector passed to (storage-class-data->body u1-storage-class): " data)
              (vector (* 16 (u16vector-length data)) data)))))
 
+    ;; f8 -- #f even in the SRFI's OWN reference implementation: no
+    ;; standard 8-bit float format exists to conform to.
     (define f8-storage-class #f)
-    ;; f16 stays #f for now: the reference implements software half-floats
-    ;; over u16vectors, which is a deliberate port of its own to make, not
-    ;; a mechanical substrate mapping like u1's (#2353 tracks the call).
-    (define f16-storage-class #f)))
+
+    ;; f16 -- software half-floats over a u16vector: a faithful
+    ;; transliteration of the reference implementation's own codec
+    ;; (generic-arrays.scm's f16->double / double->f16), hand-expanded
+    ;; from its defining macro for the single instantiation (mantissa-width
+    ;; 10, exponent-width 5, bias 15) the class needs (#2379). The codec
+    ;; is pure arithmetic -- no host bit-reinterpretation anywhere -- which
+    ;; is exactly why it ports to R7RS-small. Gambit-ism substitutions,
+    ;; each semantics-preserving:
+    ;;   ##flonum->fixnum (flround x) -> (exact (round x))
+    ;;     (R7RS round IS ties-to-even, the required rounding mode)
+    ;;   flscalbn x n -> (* x (expt 2.0 n))
+    ;;     (every scale factor here is a power of two within f64's exact
+    ;;     range, so the scale-exactly-then-round-ONCE shape -- no double
+    ;;     rounding -- is preserved)
+    ;;   ##flcopysign sign test -> (or (< x 0.0) (eqv? x -0.0))
+    ;;     (comparisons don't distinguish -0.0; eqv? does, per R7RS)
+    ;;   flfinite?/flnan? -> finite?/nan? from (scheme inexact)
+    ;; The two structural properties that make this codec correct, both
+    ;; from the reference and both preserved:
+    ;;   - the subnormal branch scales by 2^24 directly: ONE rounding at
+    ;;     the subnormal ulp (a normalize-then-shift formula would round
+    ;;     twice, at the wrong ulp);
+    ;;   - mantissa carry after rounding: a significand that rounds up to
+    ;;     exactly 2048 bumps the exponent -- exact, no re-round; at the
+    ;;     top binade it overflows to infinity. This is what rounds the
+    ;;     tie 65520.0 UP to +inf.0 while 65519.9 stays 65504.0.
+    ;; -0.0 round-trips both ways (#x8000 <-> -0.0); |x| below 2^-25
+    ;; rounds to signed zero, with the tie 2^-25 exactly going to 0 (even)
+    ;; and the subnormal tie 1.5*2^-24 to mantissa 2. NaN payloads are
+    ;; not preserved -- decode yields +nan.0 and encode canonicalizes
+    ;; every NaN to #x7FFF -- since a NaN's sign and payload are not
+    ;; portable across implementations (decode yields +nan.0 either way).
+    (define (%f16-decode x)   ;; exact integer in [0,65536) -> real
+      (let ((e (bitwise-and 31 (arithmetic-shift x -10)))
+            (m (bitwise-and 1023 x))
+            (s (arithmetic-shift x -15)))
+        (cond ((= e 31)
+               (if (= m 0)
+                   (if (= s 0) +inf.0 -inf.0)
+                   +nan.0))
+              ((> e 0)
+               (let ((n (if (= s 0) (+ 1024 m) (- (+ 1024 m)))))
+                 (* n (expt 2.0 (- e 25)))))
+              ((= m 0)
+               (if (= s 0) +0.0 -0.0))
+              (else
+               (let ((n (if (= s 0) m (- m))))
+                 (* n (expt 2.0 -24)))))))
+
+    ;; floor(log2|x|) for a finite, nonzero real x -- the reference's
+    ;; flilogb, written fresh as a halving/doubling loop (exact at every
+    ;; step: multiplying by 2.0 or 0.5 never rounds). Only the
+    ;; classification against [-14,15] and the exact exponent feeding the
+    ;; scale factor matter to the codec.
+    (define (%ilogb x)
+      (let ((ax (abs x)))
+        (if (>= ax 1.0)
+            (let loop ((e 0) (v ax))
+              (if (< v 2.0) e (loop (+ e 1) (* v 0.5))))
+            (let loop ((e -1) (v (* ax 2.0)))
+              (if (>= v 1.0) e (loop (- e 1) (* v 2.0)))))))
+
+    (define (%f16-encode x)   ;; real -> exact integer in [0,65536)
+      (define (%construct sign-bit biased-exponent mantissa)
+        (bitwise-ior (arithmetic-shift sign-bit 15)
+                     (bitwise-ior (arithmetic-shift biased-exponent 10)
+                                  mantissa)))
+      (let ((sign-bit (if (or (< x 0.0) (eqv? x -0.0)) 1 0)))
+        (cond ((not (finite? x))
+               (if (nan? x)
+                   ;; canonical NaN: the sign bit of a NaN is unobservable
+                   (%construct 0 31 1023)
+                   ;; an infinity
+                   (%construct sign-bit 31 0)))
+              ((zero? x)
+               ;; a zero (sign preserved)
+               (%construct sign-bit 0 0))
+              (else
+               (let ((exponent (%ilogb x)))
+                 (cond ((<= 16 exponent)
+                        ;; infinity: the exponent is too large
+                        (%construct sign-bit 31 0))
+                       ((< -15 exponent)
+                        ;; probably normal, finite in representation,
+                        ;; unless the rounded mantissa carries
+                        (let ((possible-mantissa
+                               (exact (round (* (abs x)
+                                                (expt 2.0 (- 10 exponent)))))))
+                          (if (< possible-mantissa 2048)
+                              ;; no overflow
+                              (%construct sign-bit
+                                          (+ exponent 15)
+                                          (bitwise-and possible-mantissa 1023))
+                              (if (= exponent 15)
+                                  ;; maximum finite exponent: overflow to
+                                  ;; infinity
+                                  (%construct sign-bit 31 0)
+                                  ;; increase exponent by 1, mantissa is
+                                  ;; zero, no double rounding
+                                  (%construct sign-bit (+ exponent 16) 0)))))
+
+                       (else
+                        ;; usually subnormal
+                        (let ((possible-mantissa
+                               (exact (round (* (abs x) (expt 2.0 24))))))
+                          (if (< possible-mantissa 1024)
+                              ;; doesn't overflow to normal
+                              (%construct sign-bit 0 possible-mantissa)
+                              ;; overflow to smallest normal
+                              (%construct sign-bit 1 0))))))))))
+
+    ;; Class wiring mirrors the reference's f16 entry exactly: the same
+    ;; checker acceptance as f32/f64 (flonum? -- the setter ROUNDS, never
+    ;; rejects), the fill encoded once by the maker, and the identity
+    ;; data->body contract of every u16vector-backed class.
+    (define f16-storage-class
+      (make-storage-class
+       ;; getter
+       (lambda (body i) (%f16-decode (u16vector-ref body i)))
+       ;; setter
+       (lambda (body i obj) (u16vector-set! body i (%f16-encode obj)))
+       ;; checker
+       %flonum-checker
+       ;; maker
+       (lambda (n val) (make-u16vector n (%f16-encode val)))
+       ;; copier
+       u16vector-copy!
+       ;; length
+       u16vector-length
+       ;; default
+       0.0
+       ;; data?
+       u16vector?
+       ;; data->body
+       (%checked-data->body u16vector? "f16-storage-class" "u16vector")))))

--- a/lib/srfi/231/storage-classes.sld
+++ b/lib/srfi/231/storage-classes.sld
@@ -255,18 +255,24 @@
                (let ((n (if (= s 0) m (- m))))
                  (* n (expt 2.0 -24)))))))
 
-    ;; floor(log2|x|) for a finite, nonzero real x -- the reference's
-    ;; flilogb, written fresh as a halving/doubling loop (exact at every
-    ;; step: multiplying by 2.0 or 0.5 never rounds). Only the
-    ;; classification against [-14,15] and the exact exponent feeding the
-    ;; scale factor matter to the codec.
+    ;; floor(log2|x|), clamped to [-15, 16], for a finite, nonzero real
+    ;; x -- the reference's flilogb, written fresh as a halving/doubling
+    ;; loop (exact at every step: multiplying by 2.0 or 0.5 never
+    ;; rounds). The clamp loses nothing: %f16-encode only ever consumes
+    ;; the classification ("<= -15", "in [-14,15]", ">= 16") plus the
+    ;; exact exponent inside the normal range, and it bounds the loop to
+    ;; ~31 iterations even for astronomically large or tiny doubles.
     (define (%ilogb x)
       (let ((ax (abs x)))
         (if (>= ax 1.0)
             (let loop ((e 0) (v ax))
-              (if (< v 2.0) e (loop (+ e 1) (* v 0.5))))
+              (cond ((< v 2.0) e)
+                    ((>= e 16) 16)
+                    (else (loop (+ e 1) (* v 0.5)))))
             (let loop ((e -1) (v (* ax 2.0)))
-              (if (>= v 1.0) e (loop (- e 1) (* v 2.0)))))))
+              (cond ((>= v 1.0) e)
+                    ((<= e -15) -15)
+                    (else (loop (- e 1) (* v 2.0))))))))
 
     (define (%f16-encode x)   ;; real -> exact integer in [0,65536)
       (define (%construct sign-bit biased-exponent mantissa)

--- a/tests/scheme/srfi/srfi231-official-transform.py
+++ b/tests/scheme/srfi/srfi231-official-transform.py
@@ -729,11 +729,8 @@ NEW_REPORT = ''';;; --- kaappi vendoring: known-divergence accounting ----------
 (define divergent-tests 0)
 (define diverged-ids (make-vector 10000 #f))
 (define known-divergences
-  (list '(98 . "f16-storage-class is #f (documented deferral, kaappi#2353)")
-        '(148 . "f16-storage-class is #f (documented deferral, kaappi#2353)")
-        '(149 . "f16-storage-class is #f (documented deferral, kaappi#2353)")
-        '(150 . "f16-storage-class is #f (documented deferral, kaappi#2353)")
-        '(147 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")
+  (list '(147 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")
+        '(150 . "c64/c128 are backed by native (srfi 160) c64vector/c128vector, not the reference's even-length f32/f64vector pairs, so those fixtures are rejected (kaappi#2382)")
         '(351 . "unsafe specialized views are unchecked per the spec text; the reference happens to check (see kaappi#2362)")))
 (define (known-divergence id) (assq id known-divergences))
 

--- a/tests/scheme/srfi/srfi231-official-transform.py
+++ b/tests/scheme/srfi/srfi231-official-transform.py
@@ -687,10 +687,13 @@ HEADER = ''';;; srfi231-official.scm -- the OFFICIAL SRFI 231 test suite (test-a
 ;;; are dropped -- the public procedures they underlie are covered directly.
 ;;;
 ;;; Known kaappi divergences are accounted, not failed: a small table of test
-;;; ids whose failure encodes a documented kaappi-vs-reference divergence
-;;; (each with an issue reference). The suite exits nonzero only on
-;;; UNEXPECTED failures -- or when a known divergence stops diverging, which
-;;; means its table entry is stale and hiding real coverage (prune it).
+;;; ids whose failure encodes a documented kaappi-vs-reference divergence,
+;;; each with an issue reference and the exact number of evaluations expected
+;;; to diverge under it (shared test forms run once per storage class). The
+;;; suite exits nonzero only on UNEXPECTED failures -- or when an entry's
+;;; divergence count does not match exactly: zero observed means the entry is
+;;; stale and hiding real coverage (prune it), and more than recorded means
+;;; an undocumented failure is absorbing into the entry.
 ;;; Error-EXPECTING tests count as passes when any error is raised; only the
 ;;; Gambit message text differs.
 ;;;
@@ -723,15 +726,22 @@ assert OLD_REPORT in src
 
 NEW_REPORT = ''';;; --- kaappi vendoring: known-divergence accounting ------------------
 ;;; Test ids whose failure encodes a DOCUMENTED kaappi-vs-reference
-;;; divergence rather than a bug. Each entry: (id . "reason"). A divergence
-;;; that stops diverging is reported at the end and fails the suite -- the
-;;; entry is stale and must be pruned (it hides real coverage).
+;;; divergence rather than a bug. Each entry: (id expected-count
+;;; . "reason") -- expected-count is the EXACT number of evaluations
+;;; under that id expected to diverge (a shared test form runs once per
+;;; storage class, so one id can legitimately account several rows; the
+;;; suite is deterministic, so the count is stable run to run). The
+;;; epilogue fails the suite on any mismatch in either direction: more
+;;; divergences than expected means an undocumented failure is hiding
+;;; under the id (e.g. an f16 regression absorbed by the c64/c128
+;;; entry); fewer means the entry is stale and hiding real coverage --
+;;; prune or re-count it.
 (define divergent-tests 0)
-(define diverged-ids (make-vector 10000 #f))
+(define diverged-counts (make-vector 10000 0))
 (define known-divergences
-  (list '(147 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")
-        '(150 . "c64/c128 are backed by native (srfi 160) c64vector/c128vector, not the reference's even-length f32/f64vector pairs, so those fixtures are rejected (kaappi#2382)")
-        '(351 . "unsafe specialized views are unchecked per the spec text; the reference happens to check (see kaappi#2362)")))
+  (list '(147 1 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")
+        '(150 2 . "c64/c128 are backed by native (srfi 160) c64vector/c128vector, not the reference's even-length f32/f64vector pairs, so those fixtures are rejected (kaappi#2382)")
+        '(351 2 . "unsafe specialized views are unchecked per the spec text; the reference happens to check (see kaappi#2362)")))
 (define (known-divergence id) (assq id known-divergences))
 
 (define (report-failure id line result expected)
@@ -739,9 +749,9 @@ NEW_REPORT = ''';;; --- kaappi vendoring: known-divergence accounting ----------
     (if kd
         (begin
           (set! divergent-tests (+ divergent-tests 1))
-          (vector-set! diverged-ids id #t)
+          (vector-set! diverged-counts id (+ 1 (vector-ref diverged-counts id)))
           (display "DIVERGENT-EXPECTED ") (display id)
-          (display " ") (display (cdr kd)) (newline))
+          (display " ") (display (cddr kd)) (newline))
         (begin
           (set! failed-tests (+ failed-tests 1))
           (display "FAIL ")
@@ -794,27 +804,50 @@ OLD_SUM = '(for-each display (list "Failed " failed-tests " out of " total-tests
 assert OLD_SUM in src
 NEW_SUM = '''
 ;;; --- kaappi vendoring: final verdict ---------------------------------
-;;; Exit nonzero on any UNEXPECTED failure, and on any known divergence
-;;; that no longer diverges (stale entry -- prune it above).
+;;; Exit nonzero on any UNEXPECTED failure, and on any known-divergence
+;;; entry whose observed count does not EXACTLY match its recorded
+;;; expected-count: zero observed means the divergence is gone (stale
+;;; entry -- prune it), more than expected means an undocumented
+;;; failure is hiding under the id, fewer means the entry over-accounts
+;;; (re-count it).
 (define resolved-divergences 0)
+(define divergence-count-mismatches 0)
 (for-each (lambda (entry)
-            (let ((id (car entry)))
-              (when (and (vector-ref executed-tests id)
-                         (not (vector-ref diverged-ids id)))
-                (set! resolved-divergences (+ resolved-divergences 1))
-                (display "DIVERGENCE-RESOLVED ") (display id)
-                (display " -- prune it from known-divergences (")
-                (display (cdr entry)) (display ")") (newline))))
+            (let ((id (car entry))
+                  (expected (cadr entry)))
+              (when (vector-ref executed-tests id)
+                (let ((observed (vector-ref diverged-counts id)))
+                  (cond ((= observed 0)
+                         (set! resolved-divergences (+ resolved-divergences 1))
+                         (display "DIVERGENCE-RESOLVED ") (display id)
+                         (display " -- prune it from known-divergences (")
+                         (display (cddr entry)) (display ")") (newline))
+                        ((not (= observed expected))
+                         (set! divergence-count-mismatches
+                               (+ divergence-count-mismatches 1))
+                         (display "DIVERGENCE-COUNT-MISMATCH ") (display id)
+                         (display ": expected ") (display expected)
+                         (display " diverging evaluations, observed ")
+                         (display observed) (display " -- ")
+                         (display (if (> observed expected)
+                                      "an undocumented failure is hiding under this id"
+                                      "the entry over-accounts (re-count it)"))
+                         (display " (")
+                         (display (cddr entry)) (display ")") (newline)))))))
           known-divergences)
 (display "srfi231-official: ")
 (display (- total-tests failed-tests divergent-tests)) (display " passed, ")
 (display error-string-tests) (display " error-message-only, ")
 (display divergent-tests) (display " known divergences, ")
 (display failed-tests) (display " unexpected failures, ")
-(display resolved-divergences) (display " resolved divergences, out of ")
+(display resolved-divergences) (display " resolved divergences, ")
+(display divergence-count-mismatches) (display " count mismatches, out of ")
 (display total-tests) (display " evaluations")
 (newline)
-(exit (if (and (= failed-tests 0) (= resolved-divergences 0)) 0 1))'''
+(exit (if (and (= failed-tests 0)
+               (= resolved-divergences 0)
+               (= divergence-count-mismatches 0))
+          0 1))'''
 src = src.replace(OLD_SUM, NEW_SUM)
 
 open(OUT, 'w').write(src)

--- a/tests/scheme/srfi/srfi231-official.scm
+++ b/tests/scheme/srfi/srfi231-official.scm
@@ -117,11 +117,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 (define divergent-tests 0)
 (define diverged-ids (make-vector 10000 #f))
 (define known-divergences
-  (list '(98 . "f16-storage-class is #f (documented deferral, kaappi#2353)")
-        '(148 . "f16-storage-class is #f (documented deferral, kaappi#2353)")
-        '(149 . "f16-storage-class is #f (documented deferral, kaappi#2353)")
-        '(150 . "f16-storage-class is #f (documented deferral, kaappi#2353)")
-        '(147 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")
+  (list '(147 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")
+        '(150 . "c64/c128 are backed by native (srfi 160) c64vector/c128vector, not the reference's even-length f32/f64vector pairs, so those fixtures are rejected (kaappi#2382)")
         '(351 . "unsafe specialized views are unchecked per the spec text; the reference happens to check (see kaappi#2362)")))
 (define (known-divergence id) (assq id known-divergences))
 

--- a/tests/scheme/srfi/srfi231-official.scm
+++ b/tests/scheme/srfi/srfi231-official.scm
@@ -14,10 +14,13 @@
 ;;; are dropped -- the public procedures they underlie are covered directly.
 ;;;
 ;;; Known kaappi divergences are accounted, not failed: a small table of test
-;;; ids whose failure encodes a documented kaappi-vs-reference divergence
-;;; (each with an issue reference). The suite exits nonzero only on
-;;; UNEXPECTED failures -- or when a known divergence stops diverging, which
-;;; means its table entry is stale and hiding real coverage (prune it).
+;;; ids whose failure encodes a documented kaappi-vs-reference divergence,
+;;; each with an issue reference and the exact number of evaluations expected
+;;; to diverge under it (shared test forms run once per storage class). The
+;;; suite exits nonzero only on UNEXPECTED failures -- or when an entry's
+;;; divergence count does not match exactly: zero observed means the entry is
+;;; stale and hiding real coverage (prune it), and more than recorded means
+;;; an undocumented failure is absorbing into the entry.
 ;;; Error-EXPECTING tests count as passes when any error is raised; only the
 ;;; Gambit message text differs.
 ;;;
@@ -111,15 +114,22 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ;;; --- kaappi vendoring: known-divergence accounting ------------------
 ;;; Test ids whose failure encodes a DOCUMENTED kaappi-vs-reference
-;;; divergence rather than a bug. Each entry: (id . "reason"). A divergence
-;;; that stops diverging is reported at the end and fails the suite -- the
-;;; entry is stale and must be pruned (it hides real coverage).
+;;; divergence rather than a bug. Each entry: (id expected-count
+;;; . "reason") -- expected-count is the EXACT number of evaluations
+;;; under that id expected to diverge (a shared test form runs once per
+;;; storage class, so one id can legitimately account several rows; the
+;;; suite is deterministic, so the count is stable run to run). The
+;;; epilogue fails the suite on any mismatch in either direction: more
+;;; divergences than expected means an undocumented failure is hiding
+;;; under the id (e.g. an f16 regression absorbed by the c64/c128
+;;; entry); fewer means the entry is stale and hiding real coverage --
+;;; prune or re-count it.
 (define divergent-tests 0)
-(define diverged-ids (make-vector 10000 #f))
+(define diverged-counts (make-vector 10000 0))
 (define known-divergences
-  (list '(147 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")
-        '(150 . "c64/c128 are backed by native (srfi 160) c64vector/c128vector, not the reference's even-length f32/f64vector pairs, so those fixtures are rejected (kaappi#2382)")
-        '(351 . "unsafe specialized views are unchecked per the spec text; the reference happens to check (see kaappi#2362)")))
+  (list '(147 1 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")
+        '(150 2 . "c64/c128 are backed by native (srfi 160) c64vector/c128vector, not the reference's even-length f32/f64vector pairs, so those fixtures are rejected (kaappi#2382)")
+        '(351 2 . "unsafe specialized views are unchecked per the spec text; the reference happens to check (see kaappi#2362)")))
 (define (known-divergence id) (assq id known-divergences))
 
 (define (report-failure id line result expected)
@@ -127,9 +137,9 @@ OTHER DEALINGS IN THE SOFTWARE.
     (if kd
         (begin
           (set! divergent-tests (+ divergent-tests 1))
-          (vector-set! diverged-ids id #t)
+          (vector-set! diverged-counts id (+ 1 (vector-ref diverged-counts id)))
           (display "DIVERGENT-EXPECTED ") (display id)
-          (display " ") (display (cdr kd)) (newline))
+          (display " ") (display (cddr kd)) (newline))
         (begin
           (set! failed-tests (+ failed-tests 1))
           (display "FAIL ")
@@ -6146,24 +6156,47 @@ that computes the componentwise products when we need them, the times are
 
 
 ;;; --- kaappi vendoring: final verdict ---------------------------------
-;;; Exit nonzero on any UNEXPECTED failure, and on any known divergence
-;;; that no longer diverges (stale entry -- prune it above).
+;;; Exit nonzero on any UNEXPECTED failure, and on any known-divergence
+;;; entry whose observed count does not EXACTLY match its recorded
+;;; expected-count: zero observed means the divergence is gone (stale
+;;; entry -- prune it), more than expected means an undocumented
+;;; failure is hiding under the id, fewer means the entry over-accounts
+;;; (re-count it).
 (define resolved-divergences 0)
+(define divergence-count-mismatches 0)
 (for-each (lambda (entry)
-            (let ((id (car entry)))
-              (when (and (vector-ref executed-tests id)
-                         (not (vector-ref diverged-ids id)))
-                (set! resolved-divergences (+ resolved-divergences 1))
-                (display "DIVERGENCE-RESOLVED ") (display id)
-                (display " -- prune it from known-divergences (")
-                (display (cdr entry)) (display ")") (newline))))
+            (let ((id (car entry))
+                  (expected (cadr entry)))
+              (when (vector-ref executed-tests id)
+                (let ((observed (vector-ref diverged-counts id)))
+                  (cond ((= observed 0)
+                         (set! resolved-divergences (+ resolved-divergences 1))
+                         (display "DIVERGENCE-RESOLVED ") (display id)
+                         (display " -- prune it from known-divergences (")
+                         (display (cddr entry)) (display ")") (newline))
+                        ((not (= observed expected))
+                         (set! divergence-count-mismatches
+                               (+ divergence-count-mismatches 1))
+                         (display "DIVERGENCE-COUNT-MISMATCH ") (display id)
+                         (display ": expected ") (display expected)
+                         (display " diverging evaluations, observed ")
+                         (display observed) (display " -- ")
+                         (display (if (> observed expected)
+                                      "an undocumented failure is hiding under this id"
+                                      "the entry over-accounts (re-count it)"))
+                         (display " (")
+                         (display (cddr entry)) (display ")") (newline)))))))
           known-divergences)
 (display "srfi231-official: ")
 (display (- total-tests failed-tests divergent-tests)) (display " passed, ")
 (display error-string-tests) (display " error-message-only, ")
 (display divergent-tests) (display " known divergences, ")
 (display failed-tests) (display " unexpected failures, ")
-(display resolved-divergences) (display " resolved divergences, out of ")
+(display resolved-divergences) (display " resolved divergences, ")
+(display divergence-count-mismatches) (display " count mismatches, out of ")
 (display total-tests) (display " evaluations")
 (newline)
-(exit (if (and (= failed-tests 0) (= resolved-divergences 0)) 0 1))
+(exit (if (and (= failed-tests 0)
+               (= resolved-divergences 0)
+               (= divergence-count-mismatches 0))
+          0 1))

--- a/tests/scheme/srfi/srfi231-storage-classes.scm
+++ b/tests/scheme/srfi/srfi231-storage-classes.scm
@@ -4,7 +4,7 @@
 ;; bare library.
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi231-storage-classes.scm
 
-(import (scheme base) (scheme process-context) (srfi 64)
+(import (scheme base) (scheme inexact) (scheme process-context) (srfi 64)
         (srfi 160 u16) (srfi 231 storage-classes))
 
 (test-begin "srfi-231-storage-classes")
@@ -15,7 +15,8 @@
 (test-equal #f (storage-class? (vector)))
 
 ;;; --- a generic helper exercising the full 9-field contract on a
-;;; storage class, used across every one of the 14 real classes below.
+;;; storage class, used across every one of the 15 real classes below
+;;; that have a copier (u1's is #f, as in the reference).
 ;;; Complex values read back from a c64/c128 body are always genuinely
 ;;; complex-tagged, including a zero imaginary part (an inexact zero imag
 ;;; stays complex, kaappi#2269), so numeric equality (=) is used for the
@@ -65,6 +66,9 @@
 (check-storage-class u64-storage-class 18000000000000000000 -1 0)
 (check-storage-class f32-storage-class 3.5 "not a number" 0.0)
 (check-storage-class f64-storage-class 3.5 "not a number" 0.0)
+;; f16 stores 3.5 exactly (binary16 has plenty of precision there), so
+;; the setter/getter round-trip inside check-storage-class holds as-is
+(check-storage-class f16-storage-class 3.5 "not a number" 0.0)
 (check-storage-class c64-storage-class (make-rectangular 1.0 2.0) "not a number" 0.0)
 (check-storage-class c128-storage-class (make-rectangular 1.0 2.0) "not a number" 0.0)
 
@@ -76,9 +80,10 @@
 ;;; the reference implements it and the spec documents (body = (vector
 ;;; valid-bit-count u16vector), little-endian within each u16) -- #2353.
 ;;; It cannot go through check-storage-class because its copier is #f
-;;; (as in the reference; the spec allows a #f copier). f8/f16 remain
-;;; bound-but-#f (f8 even in the reference; f16 is a documented scope
-;;; reduction). ---
+;;; (as in the reference; the spec allows a #f copier). f16 is likewise
+;;; real (software half-floats over u16vector, #2379 -- see the f16
+;;; section below); f8 alone remains bound-but-#f, as in the SRFI's own
+;;; reference implementation. ---
 (test-equal #t (storage-class? u1-storage-class))
 (test-equal 0 (storage-class-default u1-storage-class))
 (test-equal #t ((storage-class-data? u1-storage-class) (u16vector 0 1)))
@@ -115,7 +120,83 @@
                   ((storage-class-data->body u1-storage-class) 'a)
                   #f))
 (test-equal #f f8-storage-class)
-(test-equal #f f16-storage-class)
+
+;;; --- f16 is a real storage class: software half-floats over u16vector,
+;;; a faithful port of the reference implementation's arithmetic codec
+;;; (#2379; the u16vector substrate makes the spec's #f escape clause --
+;;; written for implementations lacking a homogeneous vector type -- inap-
+;;; plicable). The codec itself is library-internal, so every probe below
+;;; goes through the public getter/setter on a one-element body. ---
+(define %f16-get (storage-class-getter f16-storage-class))
+(define %f16-set! (storage-class-setter f16-storage-class))
+(define %f16-body (make-u16vector 1 0))
+(define (%f16-decode p)            ; bit pattern -> double
+  (u16vector-set! %f16-body 0 p)
+  (%f16-get %f16-body 0))
+(define (%f16-encode x)            ; double -> bit pattern
+  (%f16-set! %f16-body 0 x)
+  (u16vector-ref %f16-body 0))
+
+;; directed edges of the IEEE 754 binary16 conversion
+(test-equal 1.0 (%f16-decode #x3C00))
+(test-equal #x3C00 (%f16-encode 1.0))
+(test-equal -0.0 (%f16-decode #x8000))
+(test-equal #x8000 (%f16-encode -0.0))
+(test-equal +inf.0 (%f16-decode #x7C00))
+(test-equal #x7C00 (%f16-encode +inf.0))
+(test-equal -inf.0 (%f16-decode #xFC00))
+(test-equal #xFC00 (%f16-encode -inf.0))
+;; every NaN pattern decodes to +nan.0 and re-encodes canonically to
+;; #x7FFF: NaN sign/payload is not portable (a sanctioned deviation, the
+;; reference itself documents decode yielding +nan.0)
+(test-equal +nan.0 (%f16-decode #x7C01))
+(test-equal #x7FFF (%f16-encode +nan.0))
+;; max finite 65504, and the overflow tie: 65520.0 (exactly halfway to
+;; the next binade) rounds UP to +inf.0 while 65519.9 stays 65504 -- the
+;; mantissa-carry-at-top-binade branch
+(test-equal 65504.0 (%f16-decode #x7BFF))
+(test-equal #x7BFF (%f16-encode 65504.0))
+(test-equal #x7C00 (%f16-encode 65520.0))
+(test-equal #x7BFF (%f16-encode 65519.9))
+;; below the smallest subnormal rounds to SIGNED zero; the tie 2^-25
+;; goes to 0 (ties-to-even), and the subnormal tie 1.5*2^-24 to
+;; mantissa 2 (even), not 1
+(test-equal #x8000 (%f16-encode (- (expt 2.0 -30))))
+(test-equal #x0000 (%f16-encode (expt 2.0 -25)))
+(test-equal #x0002 (%f16-encode (* 1.5 (expt 2.0 -24))))
+;; smallest subnormal / largest subnormal / smallest normal
+(test-equal #x0001 (%f16-encode (expt 2.0 -24)))
+(test-equal (- (expt 2.0 -14) (expt 2.0 -24)) (%f16-decode #x03FF))
+(test-equal (expt 2.0 -14) (%f16-decode #x0400))
+;; mantissa carry inside the format: 2047.5/1024 rounds up to 2.0
+;; (pattern #x4000); the near tie 2046.5/1024 stays even-down at
+;; 2046/1024 (pattern #x3FFE)
+(test-equal #x4000 (%f16-encode (/ 2047.5 1024.0)))
+(test-equal 2.0 (%f16-decode #x4000))
+(test-equal #x3FFE (%f16-encode (/ 2046.5 1024.0)))
+;; negative values mirror every branch (sign tested via eqv? on -0.0 and
+;; via the sign bit of the pattern)
+(test-equal #xBC00 (%f16-encode -1.0))
+(test-equal -65504.0 (%f16-decode #xFBFF))
+(test-equal #xFC00 (%f16-encode -65520.0))
+
+;; exhaustive: every one of the 65536 bit patterns round-trips
+;; decode+encode unchanged, except the 2046 NaN payloads (e=31, m<>0),
+;; which canonically collapse to #x7FFF. This is the reference
+;; implementation's own validation strategy (its test comment block),
+;; tightened to a full sweep: encode(decode(p)) = p pins the codec's
+;; rounding exactly -- any double rounding or wrong-ulp scaling breaks
+;; some pattern.
+(let ((ok #t)
+      (nan-patterns 0))
+  (do ((p 0 (+ p 1)))
+      ((= p 65536))
+    (let ((x (%f16-decode p)))
+      (if (nan? x)
+          (set! nan-patterns (+ nan-patterns 1))
+          (unless (= p (%f16-encode x)) (set! ok #f)))))
+  (test-equal #t ok)
+  (test-equal 2046 nan-patterns))
 
 ;;; --- fX/cX checkers match the reference exactly: inexact reals only
 ;;; for f32/f64 (flonum?), inexact-real-part + inexact-imag-part for


### PR DESCRIPTION
Closes #2379. Closes #2384 (the divergence-accounting hardening landed here, in d546cb1, rather than as a follow-up).

## What

`f16-storage-class` was bound to `#f` — a scope reduction carried over from #2353 — even though the `u16vector` substrate it needs is shipped and the reference implementation's codec (generic-arrays.scm 1449–1601) is **pure arithmetic** over it: no host bit-reinterpretation anywhere, so it ports to R7RS-small directly. The spec's `#f` escape clause is written for implementations *lacking* the substrate, which this is not.

## The codec

A faithful transliteration of the reference's `f16->double` / `double->f16`, hand-expanded from its defining macro for the single instantiation the class needs (mantissa-width 10, exponent-width 5, bias 15): `%f16-decode` / `%f16-encode` as library-internal defines plus a fresh `%ilogb` loop (halving/doubling, exact at every step). Gambit-ism substitutions, each semantics-preserving:

| Gambit | pure R7RS |
|---|---|
| `##flonum->fixnum (flround x)` | `(exact (round x))` — R7RS round **is** ties-to-even |
| `flscalbn x n` | `(* x (expt 2.0 n))` — every scale factor is a power of two within f64's exact range, so the scale-exactly-then-round-**once** shape survives |
| `##flcopysign` sign test | `(or (< x 0.0) (eqv? x -0.0))` |
| `flfinite?` / `flnan?` | `finite?` / `nan?` from `(scheme inexact)` |

The structure that makes the reference correct is preserved: the subnormal branch scales by 2^24 directly (one rounding at the subnormal ulp), mantissa carry after rounding bumps the exponent exactly — sending the 65520.0 tie **up** to `+inf.0` while 65519.9 stays 65504 — `-0.0` round-trips both ways, and 2^-25 ties to even → 0. NaN payloads canonicalize to `#x7FFF` (sign/payload not portable; decode yields `+nan.0` either way). Class wiring mirrors the f32/u16 entries (`%flonum-checker`, fill encoded once by the maker, `u16vector-copy!`, `%checked-data->body`).

## Tests

- **Exhaustive 65536-pattern round-trip** in `srfi231-storage-classes.scm`, driven through the public getter/setter (the reference's own validation strategy, tightened to a full sweep): every non-NaN pattern re-encodes exactly; 2046 NaN payloads identified.
- Directed edges: `1.0↔#x3C00`, `-0.0↔#x8000`, ±inf, NaN, max finite 65504, the 65520.0 overflow tie, subnormal/carry ties, negatives.
- Old `(test-equal #f f16-storage-class)` replaced with `check-storage-class` coverage (202 passes).

## Official suite

Divergence ids **98/148/149 pruned** and the suite regenerated (never hand-edited). One discovery along the way: **id 150 was overloaded** — its entry was hiding two *pre-existing* c64/c128 row failures (the reference backs complex classes with even-length f32/f64vector pairs; Kaappi uses native `c64vector`/`c128vector`) alongside its f16 row. It stays in the table, re-scoped to that accurate reason — tracked in #2382, filed for it.

Result: `10922 passed, 231 error-message-only, 5 known divergences, 0 unexpected failures, 0 resolved divergences` — evaluation count up from 8879, because f16 paths now complete: the random-builder blocks give `array-copy`/`array-append` real half-float rounding as the external correctness oracle. `arrays.sld` needs no widening table — this port's `array-copy` goes through the generic checker/setter path.

Review hardening (d546cb1, #2384): the known-divergence table now records the exact expected divergence count per id and the verdict epilogue fails on any mismatch in either direction, so an undocumented failure under a shared test id can no longer hide behind a documented divergence; `%ilogb` additionally clamps to the [-15, 16] classification range.

## Docs

`storage-classes.sld` header and `srfi-implementation-notes.md` now say 16 real / 1 deferred (`f8`); `testing.md`'s divergence-reason examples updated; CHANGELOG `### Added` entry.

## Validation

- `tests/scheme/srfi/srfi231-storage-classes.scm`: 202 passes
- Official suite: green as above
- `tests/scheme/run-all.sh`: 720 Scheme files + R7RS 1395/1395 → **2115 pass, 0 fail**