### PR TITLE
Close the last srfi231-official divergence-accounting gaps (#2383 review)

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -283,8 +283,11 @@ Conventions specific to this suite:
   Gambit string-mutability expectation. The suite exits nonzero only on
   *unexpected* failures — or when an entry's divergence count doesn't match
   exactly: zero observed means the entry is stale and hiding real coverage
-  (prune it), and more than recorded means an undocumented failure is
-  absorbing into the entry.
+  (prune it); more than recorded means an undocumented failure is absorbing
+  into the entry; fewer than recorded but nonzero means the entry
+  over-accounts and must be re-counted; and an id that never executes at
+  all fails too, so an entry whose test form a future regeneration drops
+  cannot pass silently.
 - **Error-expecting tests pass on any error** — only the Gambit message
   text differs from kaappi's (counted separately as "error-message-only").
 - **It runs ~150 s** (the isolated `KAAPPI_HOME` compiles the SRFI's

--- a/tests/scheme/srfi/srfi231-official-transform.py
+++ b/tests/scheme/srfi/srfi231-official-transform.py
@@ -857,6 +857,19 @@ NEW_SUM = '''
           0 1))'''
 src = src.replace(OLD_SUM, NEW_SUM)
 
+# --- P6: generation-time guard (complement to the runtime epilogue): every
+# known-divergence id must belong to a test form the scanner actually found
+# and numbered. A dropped/renamed upstream form would otherwise surface only
+# as the committed suite's DIVERGENCE-NEVER-EXECUTED after a ~150 s run;
+# here it fails the regeneration itself, instantly. The runtime check stays
+# authoritative for CI -- it guards the committed artifact, not the step.
+div_ids = [int(m) for m in re.findall(r"'\((\d+) \d+ \. \"", NEW_REPORT)]
+assert div_ids, 'no known-divergence ids parsed from NEW_REPORT (regex drifted?)'
+missing_ids = [i for i in div_ids if i not in {m['id'] for m in test_meta}]
+assert not missing_ids, (
+    'known-divergence ids with no test form in the generated suite '
+    '(dropped or renumbered upstream?): %r' % missing_ids)
+
 open(OUT, 'w').write(src)
 # The id->original-line map is debugging metadata for triaging failures;
 # write it only on request so regeneration leaves no untracked droppings.

--- a/tests/scheme/srfi/srfi231-official-transform.py
+++ b/tests/scheme/srfi/srfi231-official-transform.py
@@ -690,10 +690,11 @@ HEADER = ''';;; srfi231-official.scm -- the OFFICIAL SRFI 231 test suite (test-a
 ;;; ids whose failure encodes a documented kaappi-vs-reference divergence,
 ;;; each with an issue reference and the exact number of evaluations expected
 ;;; to diverge under it (shared test forms run once per storage class). The
-;;; suite exits nonzero only on UNEXPECTED failures -- or when an entry's
-;;; divergence count does not match exactly: zero observed means the entry is
-;;; stale and hiding real coverage (prune it), and more than recorded means
-;;; an undocumented failure is absorbing into the entry.
+;;; suite exits nonzero only on UNEXPECTED failures -- or when an entry does
+;;; not account exactly: an id that never executes, zero observed (stale
+;;; entry hiding real coverage -- prune it), more than recorded (an
+;;; undocumented failure absorbing into the entry), or fewer but nonzero
+;;; (over-accounting -- re-count it).
 ;;; Error-EXPECTING tests count as passes when any error is raised; only the
 ;;; Gambit message text differs.
 ;;;
@@ -731,11 +732,11 @@ NEW_REPORT = ''';;; --- kaappi vendoring: known-divergence accounting ----------
 ;;; under that id expected to diverge (a shared test form runs once per
 ;;; storage class, so one id can legitimately account several rows; the
 ;;; suite is deterministic, so the count is stable run to run). The
-;;; epilogue fails the suite on any mismatch in either direction: more
-;;; divergences than expected means an undocumented failure is hiding
-;;; under the id (e.g. an f16 regression absorbed by the c64/c128
-;;; entry); fewer means the entry is stale and hiding real coverage --
-;;; prune or re-count it.
+;;; epilogue fails the suite unless every entry accounts exactly: an id
+;;; that never executes, zero observed (stale -- prune it), more
+;;; divergences than expected (an undocumented failure is hiding under
+;;; the id, e.g. an f16 regression absorbed by the c64/c128 entry), or
+;;; fewer but nonzero (over-accounting -- re-count it).
 (define divergent-tests 0)
 (define diverged-counts (make-vector 10000 0))
 (define known-divergences
@@ -805,35 +806,41 @@ assert OLD_SUM in src
 NEW_SUM = '''
 ;;; --- kaappi vendoring: final verdict ---------------------------------
 ;;; Exit nonzero on any UNEXPECTED failure, and on any known-divergence
-;;; entry whose observed count does not EXACTLY match its recorded
-;;; expected-count: zero observed means the divergence is gone (stale
-;;; entry -- prune it), more than expected means an undocumented
-;;; failure is hiding under the id, fewer means the entry over-accounts
-;;; (re-count it).
+;;; entry that does not account exactly: an id that never executed (a
+;;; regeneration dropped its test form -- the entry passes silently
+;;; otherwise), zero observed (stale entry -- prune it), more than the
+;;; recorded count (an undocumented failure is hiding under the id), or
+;;; fewer but nonzero (the entry over-accounts -- re-count it).
 (define resolved-divergences 0)
 (define divergence-count-mismatches 0)
 (for-each (lambda (entry)
             (let ((id (car entry))
                   (expected (cadr entry)))
-              (when (vector-ref executed-tests id)
-                (let ((observed (vector-ref diverged-counts id)))
-                  (cond ((= observed 0)
-                         (set! resolved-divergences (+ resolved-divergences 1))
-                         (display "DIVERGENCE-RESOLVED ") (display id)
-                         (display " -- prune it from known-divergences (")
-                         (display (cddr entry)) (display ")") (newline))
-                        ((not (= observed expected))
-                         (set! divergence-count-mismatches
-                               (+ divergence-count-mismatches 1))
-                         (display "DIVERGENCE-COUNT-MISMATCH ") (display id)
-                         (display ": expected ") (display expected)
-                         (display " diverging evaluations, observed ")
-                         (display observed) (display " -- ")
-                         (display (if (> observed expected)
-                                      "an undocumented failure is hiding under this id"
-                                      "the entry over-accounts (re-count it)"))
-                         (display " (")
-                         (display (cddr entry)) (display ")") (newline)))))))
+              (if (not (vector-ref executed-tests id))
+                  (begin
+                    (set! divergence-count-mismatches
+                          (+ divergence-count-mismatches 1))
+                    (display "DIVERGENCE-NEVER-EXECUTED ") (display id)
+                    (display " -- no evaluation ran under this id (its test form is gone from the suite; prune the entry) (")
+                    (display (cddr entry)) (display ")") (newline))
+                  (let ((observed (vector-ref diverged-counts id)))
+                    (cond ((= observed 0)
+                           (set! resolved-divergences (+ resolved-divergences 1))
+                           (display "DIVERGENCE-RESOLVED ") (display id)
+                           (display " -- prune it from known-divergences (")
+                           (display (cddr entry)) (display ")") (newline))
+                          ((not (= observed expected))
+                           (set! divergence-count-mismatches
+                                 (+ divergence-count-mismatches 1))
+                           (display "DIVERGENCE-COUNT-MISMATCH ") (display id)
+                           (display ": expected ") (display expected)
+                           (display " diverging evaluations, observed ")
+                           (display observed) (display " -- ")
+                           (display (if (> observed expected)
+                                        "an undocumented failure is hiding under this id"
+                                        "the entry over-accounts (re-count it)"))
+                           (display " (")
+                           (display (cddr entry)) (display ")") (newline)))))))
           known-divergences)
 (display "srfi231-official: ")
 (display (- total-tests failed-tests divergent-tests)) (display " passed, ")

--- a/tests/scheme/srfi/srfi231-official.scm
+++ b/tests/scheme/srfi/srfi231-official.scm
@@ -17,10 +17,11 @@
 ;;; ids whose failure encodes a documented kaappi-vs-reference divergence,
 ;;; each with an issue reference and the exact number of evaluations expected
 ;;; to diverge under it (shared test forms run once per storage class). The
-;;; suite exits nonzero only on UNEXPECTED failures -- or when an entry's
-;;; divergence count does not match exactly: zero observed means the entry is
-;;; stale and hiding real coverage (prune it), and more than recorded means
-;;; an undocumented failure is absorbing into the entry.
+;;; suite exits nonzero only on UNEXPECTED failures -- or when an entry does
+;;; not account exactly: an id that never executes, zero observed (stale
+;;; entry hiding real coverage -- prune it), more than recorded (an
+;;; undocumented failure absorbing into the entry), or fewer but nonzero
+;;; (over-accounting -- re-count it).
 ;;; Error-EXPECTING tests count as passes when any error is raised; only the
 ;;; Gambit message text differs.
 ;;;
@@ -119,11 +120,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 ;;; under that id expected to diverge (a shared test form runs once per
 ;;; storage class, so one id can legitimately account several rows; the
 ;;; suite is deterministic, so the count is stable run to run). The
-;;; epilogue fails the suite on any mismatch in either direction: more
-;;; divergences than expected means an undocumented failure is hiding
-;;; under the id (e.g. an f16 regression absorbed by the c64/c128
-;;; entry); fewer means the entry is stale and hiding real coverage --
-;;; prune or re-count it.
+;;; epilogue fails the suite unless every entry accounts exactly: an id
+;;; that never executes, zero observed (stale -- prune it), more
+;;; divergences than expected (an undocumented failure is hiding under
+;;; the id, e.g. an f16 regression absorbed by the c64/c128 entry), or
+;;; fewer but nonzero (over-accounting -- re-count it).
 (define divergent-tests 0)
 (define diverged-counts (make-vector 10000 0))
 (define known-divergences
@@ -6157,35 +6158,41 @@ that computes the componentwise products when we need them, the times are
 
 ;;; --- kaappi vendoring: final verdict ---------------------------------
 ;;; Exit nonzero on any UNEXPECTED failure, and on any known-divergence
-;;; entry whose observed count does not EXACTLY match its recorded
-;;; expected-count: zero observed means the divergence is gone (stale
-;;; entry -- prune it), more than expected means an undocumented
-;;; failure is hiding under the id, fewer means the entry over-accounts
-;;; (re-count it).
+;;; entry that does not account exactly: an id that never executed (a
+;;; regeneration dropped its test form -- the entry passes silently
+;;; otherwise), zero observed (stale entry -- prune it), more than the
+;;; recorded count (an undocumented failure is hiding under the id), or
+;;; fewer but nonzero (the entry over-accounts -- re-count it).
 (define resolved-divergences 0)
 (define divergence-count-mismatches 0)
 (for-each (lambda (entry)
             (let ((id (car entry))
                   (expected (cadr entry)))
-              (when (vector-ref executed-tests id)
-                (let ((observed (vector-ref diverged-counts id)))
-                  (cond ((= observed 0)
-                         (set! resolved-divergences (+ resolved-divergences 1))
-                         (display "DIVERGENCE-RESOLVED ") (display id)
-                         (display " -- prune it from known-divergences (")
-                         (display (cddr entry)) (display ")") (newline))
-                        ((not (= observed expected))
-                         (set! divergence-count-mismatches
-                               (+ divergence-count-mismatches 1))
-                         (display "DIVERGENCE-COUNT-MISMATCH ") (display id)
-                         (display ": expected ") (display expected)
-                         (display " diverging evaluations, observed ")
-                         (display observed) (display " -- ")
-                         (display (if (> observed expected)
-                                      "an undocumented failure is hiding under this id"
-                                      "the entry over-accounts (re-count it)"))
-                         (display " (")
-                         (display (cddr entry)) (display ")") (newline)))))))
+              (if (not (vector-ref executed-tests id))
+                  (begin
+                    (set! divergence-count-mismatches
+                          (+ divergence-count-mismatches 1))
+                    (display "DIVERGENCE-NEVER-EXECUTED ") (display id)
+                    (display " -- no evaluation ran under this id (its test form is gone from the suite; prune the entry) (")
+                    (display (cddr entry)) (display ")") (newline))
+                  (let ((observed (vector-ref diverged-counts id)))
+                    (cond ((= observed 0)
+                           (set! resolved-divergences (+ resolved-divergences 1))
+                           (display "DIVERGENCE-RESOLVED ") (display id)
+                           (display " -- prune it from known-divergences (")
+                           (display (cddr entry)) (display ")") (newline))
+                          ((not (= observed expected))
+                           (set! divergence-count-mismatches
+                                 (+ divergence-count-mismatches 1))
+                           (display "DIVERGENCE-COUNT-MISMATCH ") (display id)
+                           (display ": expected ") (display expected)
+                           (display " diverging evaluations, observed ")
+                           (display observed) (display " -- ")
+                           (display (if (> observed expected)
+                                        "an undocumented failure is hiding under this id"
+                                        "the entry over-accounts (re-count it)"))
+                           (display " (")
+                           (display (cddr entry)) (display ")") (newline)))))))
           known-divergences)
 (display "srfi231-official: ")
 (display (- total-tests failed-tests divergent-tests)) (display " passed, ")


### PR DESCRIPTION
Follow-up to #2383 (merged): the two CodeRabbit threads the reviewer's post-merge assessment verdicted **valid** landed after the merge, so they come in here. The third open thread — the signed-zero `eqv?` finding — was declined on the PR with rationale (R7RS §6.1 requires the distinction wherever observable; the degenerate single-zero case is self-consistent on both sides of the codec; it's the reference's own `##flcopysign` semantics on a host with distinguishable signed zeros) and needs no change.

## 1. Document the fewer-than-expected mismatch case (`docs/dev/testing.md`)

The guide described only the zero-observed and greater-than-recorded cases; the epilogue's third case — `0 < observed < expected`, reported as "the entry over-accounts (re-count it)" — is now in the same bullet, together with the never-executed case added here, so the doc matches the verdict logic exactly.

## 2. Fail when a known-divergence id does not execute (`srfi231-official-transform.py`, suite regenerated)

The epilogue's `(when (vector-ref executed-tests id) …)` guard silently skipped an entry whose id never executes — if a future regeneration drops a test form entirely, its table entry passes with observed count zero and neither `DIVERGENCE-RESOLVED` nor a count mismatch fires. That was the last accounting gap. An unexecuted id is now a hard failure with its own wording — `DIVERGENCE-NEVER-EXECUTED … its test form is gone from the suite; prune the entry` — counted into the mismatch total that gates the exit status. The generated file was regenerated from the transform, never hand-edited.

## Validation

- Real suite unchanged-green: `10922 passed, 5 known divergences, 0 unexpected, 0 resolved, 0 count mismatches` (all three real ids execute).
- Negative test (scratch copy, not committed): a correctly-quoted bogus entry `'(9999 2 . …)` prints `DIVERGENCE-NEVER-EXECUTED 9999` and **exits 1**, where the old guard exited 0 silently.
- fmt corpus: 938 files, zero semantic drift, idempotent.