### PR TITLE
Switch SRFI 231 c64/c128 bodies to the reference representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   test id (16 storage-class rows re-use one id) can no longer hide behind a
   documented divergence.
 
+### Changed
+
+- **SRFI 231 c64/c128 array bodies use the reference implementation's
+  interleaved-float representation** (#2382) — an `f32vector`/`f64vector`
+  of twice the logical length holding real/imaginary pairs, instead of
+  native `c64vector`/`c128vector` (the byte layout is identical either
+  way: 2 consecutive f32s/f64s per element). Even-length float vectors
+  are now accepted zero-copy by `make-specialized-array-from-data`, so
+  reference-coupled portable code and the official suite's fixtures work
+  unchanged — the spec's `data?` contract (shares, never copies) makes
+  this the only spec-legal way to accept that data shape. Consequences:
+  `(array-body A)` for a c64/c128 array now reports the float vector,
+  the storage-class copier counts floats (2 per complex element), and
+  `c64vector`/`c128vector` data is no longer accepted directly.
+  Official-suite divergence id 150 pruned; the known-divergence table is
+  down to the two unavoidable entries (string mutability, unsafe-view
+  checking).
+
 ## [0.25.0] - 2026-08-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   unchanged — the spec's `data?` contract (shares, never copies) makes
   this the only spec-legal way to accept that data shape. Consequences:
   `(array-body A)` for a c64/c128 array now reports the float vector,
-  the storage-class copier counts floats (2 per complex element), and
-  `c64vector`/`c128vector` data is no longer accepted directly.
+  and `c64vector`/`c128vector` data is no longer accepted directly.
   Official-suite divergence id 150 pruned; the known-divergence table is
   down to the two unavoidable entries (string mutability, unsafe-view
   checking).

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -884,7 +884,15 @@ reference's own bit-packing and software half-floats over `u16vector`) is a
 9-field record
 (getter/setter/checker/maker/copier/length/default/data?/data->body) that a
 specialized array's `body`/`indexer` pair delegates to for the actual
-backing-store representation. The single most-reused implementation pattern
+backing-store representation. c64/c128 bodies follow the reference's
+interleaved-float representation — an f32/f64vector of twice the logical
+length holding re/im pairs — rather than native `c64vector`/`c128vector`
+(whose byte layout is identical: 2 consecutive f32s/f64s per element): the
+spec's `data?` contract ("`#t` iff `data->body` returns a body sharing the
+data, without copying") makes accepting the reference's even-length float
+vectors possible only by actually using them as the body, and that shape is
+what reference-coupled code and the official suite's fixtures feed to
+`make-specialized-array-from-data` (#2382). The single most-reused implementation pattern
 across the views/combinators/assembly phases: build a lazy virtual array via
 `make-array` with a computed getter over the target domain, then delegate to
 `array-copy` (which already owns all storage-class/mutable?/safe? option

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -278,9 +278,8 @@ Conventions specific to this suite:
   the generated file maps each documented kaappi-vs-reference divergence to
   its reason, issue reference, and the *exact* number of evaluations
   expected to diverge under it (shared test forms run once per storage
-  class, so one id can account several rows) — the c64/c128
-  native-vector representation choice, the unsafe-view UB choice, the
-  Gambit string-mutability expectation. The suite exits nonzero only on
+  class, so one id can account several rows) — the unsafe-view UB choice,
+  the Gambit string-mutability expectation. The suite exits nonzero only on
   *unexpected* failures — or when an entry's divergence count doesn't match
   exactly: zero observed means the entry is stale and hiding real coverage
   (prune it); more than recorded means an undocumented failure is absorbing

--- a/lib/srfi/231/storage-classes.sld
+++ b/lib/srfi/231/storage-classes.sld
@@ -161,53 +161,59 @@
     ;; never boxed -- so this is a change of type tag, not of memory
     ;; shape; the spec explicitly allows either representation ("another
     ;; implementation ... might make another choice"), and reference
-    ;; fidelity is what interoperates. Consequence: the copier's element
-    ;; granularity is FLOATS (2 per complex element), and
+    ;; fidelity is what interoperates. Consequence:
     ;; c64vector/c128vector data is no longer accepted -- convert with
-    ;; make-specialized-array's maker or a copy loop if needed.
+    ;; make-specialized-array's maker or a copy loop if needed. Like the
+    ;; reference's own c64vector-copy!/c128vector-copy! wrappers, the
+    ;; copier takes LOGICAL complex-element offsets and scales by 2
+    ;; internally -- the same units as every other storage-class field.
     (define (%complex-storage-class float-ref float-set! make-float-vector
                                     float-copy! float-length vec?
                                     class-name type-name)
-      (make-storage-class
-       ;; getter -- reassemble the interleaved pair (an inexact zero
-       ;; imag stays complex, kaappi#2269, exactly like the native
-       ;; c64vector decode)
-       (lambda (body i)
-         (make-rectangular (float-ref body (* 2 i))
-                           (float-ref body (+ (* 2 i) 1))))
-       ;; setter -- explode into the interleaved pair (f32 storage rounds)
-       (lambda (body i obj)
-         (float-set! body (* 2 i) (real-part obj))
-         (float-set! body (+ (* 2 i) 1) (imag-part obj)))
-       ;; checker
-       %inexact-complex-checker
-       ;; maker -- the fill exploded into alternating re/im
-       (lambda (n val)
-         (let* ((l (* 2 n))
-                (re (real-part val))
-                (im (imag-part val))
-                (result (make-float-vector l)))
-           (do ((i 0 (+ i 2)))
-               ((= i l) result)
-             (float-set! result i re)
-             (float-set! result (+ i 1) im))))
-       ;; copier
-       float-copy!
-       ;; length -- half the physical float count
-       (lambda (body) (quotient (float-length body) 2))
-       ;; default
-       (make-rectangular 0.0 0.0)
-       ;; data?
-       (lambda (data)
-         (and (vec? data) (even? (float-length data))))
-       ;; data->body -- identity on even-length float vectors
-       (lambda (data)
-         (if (and (vec? data) (even? (float-length data)))
-             data
-             (error (string-append "Expecting a " type-name
-                                   " with an even number of elements passed to (storage-class-data->body "
-                                   class-name "): ")
-                    data)))))
+      (let ((complex-data?
+             (lambda (data) (and (vec? data) (even? (float-length data))))))
+        (make-storage-class
+         ;; getter -- reassemble the interleaved pair (an inexact zero
+         ;; imag stays complex, kaappi#2269, exactly like the native
+         ;; c64vector decode)
+         (lambda (body i)
+           (make-rectangular (float-ref body (* 2 i))
+                             (float-ref body (+ (* 2 i) 1))))
+         ;; setter -- explode into the interleaved pair (f32 storage rounds)
+         (lambda (body i obj)
+           (float-set! body (* 2 i) (real-part obj))
+           (float-set! body (+ (* 2 i) 1) (imag-part obj)))
+         ;; checker
+         %inexact-complex-checker
+         ;; maker -- the fill exploded into alternating re/im; a uniform
+         ;; fill (eqv?: the default 0.0+0.0i is the overwhelmingly common
+         ;; case, and -0.0/0.0 or NaN mismatches still take the loop)
+         ;; collapses to one native fill
+         (lambda (n val)
+           (let* ((l (* 2 n))
+                  (re (real-part val))
+                  (im (imag-part val)))
+             (if (eqv? re im)
+                 (make-float-vector l re)
+                 (let ((result (make-float-vector l)))
+                   (do ((i 0 (+ i 2)))
+                       ((= i l) result)
+                     (float-set! result i re)
+                     (float-set! result (+ i 1) im))))))
+         ;; copier -- the reference's c64vector-copy! wrapper: logical
+         ;; element offsets, scaled by 2 onto the float block copy
+         (lambda (to at from start end)
+           (float-copy! to (* 2 at) from (* 2 start) (* 2 end)))
+         ;; length -- half the physical float count
+         (lambda (body) (quotient (float-length body) 2))
+         ;; default
+         (make-rectangular 0.0 0.0)
+         ;; data?
+         complex-data?
+         ;; data->body -- identity on even-length float vectors
+         (%checked-data->body complex-data? class-name
+                              (string-append type-name
+                                             " with an even number of elements")))))
 
     (define c64-storage-class
       (%complex-storage-class f32vector-ref f32vector-set! make-f32vector

--- a/lib/srfi/231/storage-classes.sld
+++ b/lib/srfi/231/storage-classes.sld
@@ -32,7 +32,7 @@
   (import (scheme base)
           (srfi 160 s8) (srfi 160 s16) (srfi 160 s32) (srfi 160 s64)
           (srfi 160 u16) (srfi 160 u32) (srfi 160 u64)
-          (srfi 160 f32) (srfi 160 f64) (srfi 160 c64) (srfi 160 c128)
+          (srfi 160 f32) (srfi 160 f64)
           ;; bitwise-and/ior/not for u1's bit-packing (R7RS-small has no
           ;; bitwise primitives of its own)
           (srfi 60)
@@ -144,14 +144,79 @@
       (make-storage-class f64vector-ref f64vector-set! %flonum-checker
                            make-f64vector f64vector-copy! f64vector-length 0.0 f64vector? (%checked-data->body f64vector? "f64-storage-class" "f64vector")))
 
+    ;; c64/c128 -- a faithful port of the reference's representation
+    ;; (generic-arrays.scm's make-complex-storage-classes): the body is a
+    ;; homogeneous FLOAT vector (f32vector for c64, f64vector for c128) of
+    ;; twice the logical length, real and imaginary parts interleaved.
+    ;; data? accepts exactly the even-length float vectors that can serve
+    ;; as the body zero-copy -- the spec's data? contract ("returns #t if
+    ;; and only if data->body returns a body sharing data with data,
+    ;; without copying") permits accepting the reference's data shape only
+    ;; by actually using it as the body, so reference-coupled portable code
+    ;; and the official suite's fixtures flow into
+    ;; make-specialized-array-from-data unchanged (#2382; the class
+    ;; previously rejected them -- kaappi's bodies were native
+    ;; c64vector/c128vector). Kaappi's SRFI 160 c64vector/c128vector use
+    ;; the identical byte layout -- 2 consecutive f32s/f64s per element,
+    ;; never boxed -- so this is a change of type tag, not of memory
+    ;; shape; the spec explicitly allows either representation ("another
+    ;; implementation ... might make another choice"), and reference
+    ;; fidelity is what interoperates. Consequence: the copier's element
+    ;; granularity is FLOATS (2 per complex element), and
+    ;; c64vector/c128vector data is no longer accepted -- convert with
+    ;; make-specialized-array's maker or a copy loop if needed.
+    (define (%complex-storage-class float-ref float-set! make-float-vector
+                                    float-copy! float-length vec?
+                                    class-name type-name)
+      (make-storage-class
+       ;; getter -- reassemble the interleaved pair (an inexact zero
+       ;; imag stays complex, kaappi#2269, exactly like the native
+       ;; c64vector decode)
+       (lambda (body i)
+         (make-rectangular (float-ref body (* 2 i))
+                           (float-ref body (+ (* 2 i) 1))))
+       ;; setter -- explode into the interleaved pair (f32 storage rounds)
+       (lambda (body i obj)
+         (float-set! body (* 2 i) (real-part obj))
+         (float-set! body (+ (* 2 i) 1) (imag-part obj)))
+       ;; checker
+       %inexact-complex-checker
+       ;; maker -- the fill exploded into alternating re/im
+       (lambda (n val)
+         (let* ((l (* 2 n))
+                (re (real-part val))
+                (im (imag-part val))
+                (result (make-float-vector l)))
+           (do ((i 0 (+ i 2)))
+               ((= i l) result)
+             (float-set! result i re)
+             (float-set! result (+ i 1) im))))
+       ;; copier
+       float-copy!
+       ;; length -- half the physical float count
+       (lambda (body) (quotient (float-length body) 2))
+       ;; default
+       (make-rectangular 0.0 0.0)
+       ;; data?
+       (lambda (data)
+         (and (vec? data) (even? (float-length data))))
+       ;; data->body -- identity on even-length float vectors
+       (lambda (data)
+         (if (and (vec? data) (even? (float-length data)))
+             data
+             (error (string-append "Expecting a " type-name
+                                   " with an even number of elements passed to (storage-class-data->body "
+                                   class-name "): ")
+                    data)))))
+
     (define c64-storage-class
-      (make-storage-class c64vector-ref c64vector-set! %inexact-complex-checker
-                           make-c64vector c64vector-copy! c64vector-length
-                           (make-rectangular 0.0 0.0) c64vector? (%checked-data->body c64vector? "c64-storage-class" "c64vector")))
+      (%complex-storage-class f32vector-ref f32vector-set! make-f32vector
+                              f32vector-copy! f32vector-length f32vector?
+                              "c64-storage-class" "f32vector"))
     (define c128-storage-class
-      (make-storage-class c128vector-ref c128vector-set! %inexact-complex-checker
-                           make-c128vector c128vector-copy! c128vector-length
-                           (make-rectangular 0.0 0.0) c128vector? (%checked-data->body c128vector? "c128-storage-class" "c128vector")))
+      (%complex-storage-class f64vector-ref f64vector-set! make-f64vector
+                              f64vector-copy! f64vector-length f64vector?
+                              "c128-storage-class" "f64vector"))
 
     ;; u1 -- bit arrays, ported from the reference implementation's own
     ;; bit-packing (generic-arrays.scm's u1-storage-class): the body is a

--- a/tests/scheme/srfi/srfi231-arrays.scm
+++ b/tests/scheme/srfi/srfi231-arrays.scm
@@ -5,6 +5,7 @@
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi231-arrays.scm
 
 (import (scheme base) (scheme process-context) (srfi 64)
+        (srfi 160 f32)
         (srfi 231 intervals) (srfi 231 storage-classes) (srfi 231 arrays))
 
 (test-begin "srfi-231-arrays")
@@ -93,6 +94,24 @@
 ;; data incompatible with the given storage-class is rejected
 (test-equal #t (guard (e (#t #t))
                   (make-specialized-array-from-data "a string" s8-storage-class) #f))
+
+;; c64 wraps the reference's data shape -- an even-length f32vector of
+;; interleaved re/im pairs -- zero-copy, exactly like the reference
+;; implementation does (#2382)
+(let* ((v (f32vector 1.0 2.0 3.0 4.0))
+       (A (make-specialized-array-from-data v c64-storage-class)))
+  (test-equal 2 ((storage-class-length c64-storage-class) (array-body A)))
+  (test-equal 1.0+2.0i (array-ref A 0))
+  (test-equal 3.0+4.0i (array-ref A 1))
+  (test-equal #t (eq? (array-body A) v))
+  ;; mutation through the caller's vector is visible through the array --
+  ;; the sharing the spec's data? contract promises
+  (f32vector-set! v 0 9.0)
+  (test-equal 9.0+2.0i (array-ref A 0))
+  ;; and the odd-length shape is rejected
+  (test-equal #t (guard (e (#t #t))
+                    (make-specialized-array-from-data (make-f32vector 5) c64-storage-class)
+                    #f)))
 
 ;;; --- specialized-array-default-safe?/mutable? are genuine SRFI 39
 ;;; parameters, honored by make-specialized-array when safe?/... omitted ---

--- a/tests/scheme/srfi/srfi231-official-transform.py
+++ b/tests/scheme/srfi/srfi231-official-transform.py
@@ -741,7 +741,6 @@ NEW_REPORT = ''';;; --- kaappi vendoring: known-divergence accounting ----------
 (define diverged-counts (make-vector 10000 0))
 (define known-divergences
   (list '(147 1 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")
-        '(150 2 . "c64/c128 are backed by native (srfi 160) c64vector/c128vector, not the reference's even-length f32/f64vector pairs, so those fixtures are rejected (kaappi#2382)")
         '(351 2 . "unsafe specialized views are unchecked per the spec text; the reference happens to check (see kaappi#2362)")))
 (define (known-divergence id) (assq id known-divergences))
 

--- a/tests/scheme/srfi/srfi231-official-transform.py
+++ b/tests/scheme/srfi/srfi231-official-transform.py
@@ -735,8 +735,9 @@ NEW_REPORT = ''';;; --- kaappi vendoring: known-divergence accounting ----------
 ;;; epilogue fails the suite unless every entry accounts exactly: an id
 ;;; that never executes, zero observed (stale -- prune it), more
 ;;; divergences than expected (an undocumented failure is hiding under
-;;; the id, e.g. an f16 regression absorbed by the c64/c128 entry), or
-;;; fewer but nonzero (over-accounting -- re-count it).
+;;; the id, e.g. a third unsafe-view evaluation absorbed by the 351
+;;; entry, whose site legitimately fires twice), or fewer but nonzero
+;;; (over-accounting -- re-count it).
 (define divergent-tests 0)
 (define diverged-counts (make-vector 10000 0))
 (define known-divergences

--- a/tests/scheme/srfi/srfi231-official.scm
+++ b/tests/scheme/srfi/srfi231-official.scm
@@ -123,8 +123,9 @@ OTHER DEALINGS IN THE SOFTWARE.
 ;;; epilogue fails the suite unless every entry accounts exactly: an id
 ;;; that never executes, zero observed (stale -- prune it), more
 ;;; divergences than expected (an undocumented failure is hiding under
-;;; the id, e.g. an f16 regression absorbed by the c64/c128 entry), or
-;;; fewer but nonzero (over-accounting -- re-count it).
+;;; the id, e.g. a third unsafe-view evaluation absorbed by the 351
+;;; entry, whose site legitimately fires twice), or fewer but nonzero
+;;; (over-accounting -- re-count it).
 (define divergent-tests 0)
 (define diverged-counts (make-vector 10000 0))
 (define known-divergences

--- a/tests/scheme/srfi/srfi231-official.scm
+++ b/tests/scheme/srfi/srfi231-official.scm
@@ -129,7 +129,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 (define diverged-counts (make-vector 10000 0))
 (define known-divergences
   (list '(147 1 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")
-        '(150 2 . "c64/c128 are backed by native (srfi 160) c64vector/c128vector, not the reference's even-length f32/f64vector pairs, so those fixtures are rejected (kaappi#2382)")
         '(351 2 . "unsafe specialized views are unchecked per the spec text; the reference happens to check (see kaappi#2362)")))
 (define (known-divergence id) (assq id known-divergences))
 

--- a/tests/scheme/srfi/srfi231-storage-classes.scm
+++ b/tests/scheme/srfi/srfi231-storage-classes.scm
@@ -25,15 +25,10 @@
 ;;; otherwise spuriously fail despite both sides being the same number.
 ;;; bad-value has no meaningful "checker rejects this" case for
 ;;; generic-storage-class (its checker always returns #t), so that
-;;; assertion is a separate, optional check. A second optional is the
-;;; copier's body-units per logical element -- 1 everywhere except the
-;;; complex classes, whose interleaved-float bodies hold 2 (see the c64
-;;; section below). ---
+;;; assertion is a separate, optional check. ---
 (define (%same? a b) (if (and (number? a) (number? b)) (= a b) (equal? a b)))
 
-(define (check-storage-class sc value bad-value expected-default . opts)
-  (let ((rejects-bad? (or (null? opts) (car opts)))
-        (units-per-element (if (or (null? opts) (null? (cdr opts))) 1 (cadr opts))))
+(define (check-storage-class sc value bad-value expected-default . rejects-bad?)
   (let* ((maker (storage-class-maker sc))
          (getter (storage-class-getter sc))
          (setter (storage-class-setter sc))
@@ -45,17 +40,24 @@
     (test-assert (%same? expected-default (getter body 0)))
     (setter body 1 value)
     (test-assert (%same? value (getter body 1)))
-    ;; exercise the copier field too -- otherwise a wrong copy procedure
-    ;; would pass every other assertion here undetected; the copier counts
-    ;; BODY units, so complex classes copy 2 floats per logical element
+    ;; exercise the copier field twice -- otherwise a wrong copy procedure
+    ;; would pass every other assertion here undetected. The second call
+    ;; uses non-zero at/start on purpose: a copier whose offsets are in
+    ;; the wrong units (e.g. raw floats instead of logical elements for
+    ;; the complex classes) can pass an aligned full-range copy while
+    ;; misplacing data at every other offset
     (let ((copied (maker 3 (storage-class-default sc))))
-      ((storage-class-copier sc) copied 0 body 0 (* 3 units-per-element))
+      ((storage-class-copier sc) copied 0 body 0 3)
       (test-assert (%same? value (getter copied 1))))
+    (let ((shifted (maker 3 (storage-class-default sc))))
+      ((storage-class-copier sc) shifted 1 body 1 3)
+      (test-assert (%same? value (getter shifted 1)))
+      (test-assert (%same? expected-default (getter shifted 2))))
     (test-equal #t (checker value))
-    (when rejects-bad?
+    (when (or (null? rejects-bad?) (car rejects-bad?))
       (test-equal #f (checker bad-value)))
     (test-equal #t ((storage-class-data? sc) body))
-    (test-equal #t (eq? body ((storage-class-data->body sc) body))))))
+    (test-equal #t (eq? body ((storage-class-data->body sc) body)))))
 
 ;; generic's checker accepts everything, including bad-value, by design;
 ;; its default fill value is #f (per the spec's own reference definition)
@@ -76,9 +78,8 @@
 ;; f16 stores 3.5 exactly (binary16 has plenty of precision there), so
 ;; the setter/getter round-trip inside check-storage-class holds as-is
 (check-storage-class f16-storage-class 3.5 "not a number" 0.0)
-;; complex classes: the copier counts FLOATS (2 per complex element)
-(check-storage-class c64-storage-class (make-rectangular 1.0 2.0) "not a number" 0.0 #t 2)
-(check-storage-class c128-storage-class (make-rectangular 1.0 2.0) "not a number" 0.0 #t 2)
+(check-storage-class c64-storage-class (make-rectangular 1.0 2.0) "not a number" 0.0)
+(check-storage-class c128-storage-class (make-rectangular 1.0 2.0) "not a number" 0.0)
 
 ;;; --- generic checker specifically accepts anything, unlike every typed one ---
 (test-equal #t ((storage-class-checker generic-storage-class) (vector 1 2 3)))

--- a/tests/scheme/srfi/srfi231-storage-classes.scm
+++ b/tests/scheme/srfi/srfi231-storage-classes.scm
@@ -5,7 +5,8 @@
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi231-storage-classes.scm
 
 (import (scheme base) (scheme inexact) (scheme process-context) (srfi 64)
-        (srfi 160 u16) (srfi 231 storage-classes))
+        (srfi 160 u16) (srfi 160 f32) (srfi 160 f64) (srfi 160 c64)
+        (srfi 231 storage-classes))
 
 (test-begin "srfi-231-storage-classes")
 
@@ -24,10 +25,15 @@
 ;;; otherwise spuriously fail despite both sides being the same number.
 ;;; bad-value has no meaningful "checker rejects this" case for
 ;;; generic-storage-class (its checker always returns #t), so that
-;;; assertion is a separate, optional check. ---
+;;; assertion is a separate, optional check. A second optional is the
+;;; copier's body-units per logical element -- 1 everywhere except the
+;;; complex classes, whose interleaved-float bodies hold 2 (see the c64
+;;; section below). ---
 (define (%same? a b) (if (and (number? a) (number? b)) (= a b) (equal? a b)))
 
-(define (check-storage-class sc value bad-value expected-default . rejects-bad?)
+(define (check-storage-class sc value bad-value expected-default . opts)
+  (let ((rejects-bad? (or (null? opts) (car opts)))
+        (units-per-element (if (or (null? opts) (null? (cdr opts))) 1 (cadr opts))))
   (let* ((maker (storage-class-maker sc))
          (getter (storage-class-getter sc))
          (setter (storage-class-setter sc))
@@ -40,15 +46,16 @@
     (setter body 1 value)
     (test-assert (%same? value (getter body 1)))
     ;; exercise the copier field too -- otherwise a wrong copy procedure
-    ;; would pass every other assertion here undetected
+    ;; would pass every other assertion here undetected; the copier counts
+    ;; BODY units, so complex classes copy 2 floats per logical element
     (let ((copied (maker 3 (storage-class-default sc))))
-      ((storage-class-copier sc) copied 0 body 0 3)
+      ((storage-class-copier sc) copied 0 body 0 (* 3 units-per-element))
       (test-assert (%same? value (getter copied 1))))
     (test-equal #t (checker value))
-    (when (or (null? rejects-bad?) (car rejects-bad?))
+    (when rejects-bad?
       (test-equal #f (checker bad-value)))
     (test-equal #t ((storage-class-data? sc) body))
-    (test-equal #t (eq? body ((storage-class-data->body sc) body)))))
+    (test-equal #t (eq? body ((storage-class-data->body sc) body))))))
 
 ;; generic's checker accepts everything, including bad-value, by design;
 ;; its default fill value is #f (per the spec's own reference definition)
@@ -69,8 +76,9 @@
 ;; f16 stores 3.5 exactly (binary16 has plenty of precision there), so
 ;; the setter/getter round-trip inside check-storage-class holds as-is
 (check-storage-class f16-storage-class 3.5 "not a number" 0.0)
-(check-storage-class c64-storage-class (make-rectangular 1.0 2.0) "not a number" 0.0)
-(check-storage-class c128-storage-class (make-rectangular 1.0 2.0) "not a number" 0.0)
+;; complex classes: the copier counts FLOATS (2 per complex element)
+(check-storage-class c64-storage-class (make-rectangular 1.0 2.0) "not a number" 0.0 #t 2)
+(check-storage-class c128-storage-class (make-rectangular 1.0 2.0) "not a number" 0.0 #t 2)
 
 ;;; --- generic checker specifically accepts anything, unlike every typed one ---
 (test-equal #t ((storage-class-checker generic-storage-class) (vector 1 2 3)))
@@ -212,6 +220,49 @@
 (test-equal #f ((storage-class-checker c64-storage-class) (make-rectangular 3 4)))
 (test-equal #f ((storage-class-checker c64-storage-class) 1/3))
 (test-equal #f ((storage-class-checker c128-storage-class) (make-rectangular 1/2 2)))
+
+;;; --- c64/c128 use the reference's interleaved-float representation
+;;; (#2382): the body is an f32/f64vector of twice the logical length
+;;; with real and imaginary parts alternating, and even-length float
+;;; vectors are accepted as data ZERO-COPY (the spec's data? contract --
+;;; "#t if and only if data->body returns a body sharing data with data,
+;;; without copying" -- is what lets the reference's data shape
+;;; interoperate, which a converting data->body would violate). Bodies
+;;; are no longer native c64vectors/c128vectors, though the byte layout
+;;; is identical (2 consecutive f32s/f64s per element either way). ---
+(test-equal #t ((storage-class-data? c64-storage-class) (make-f32vector 10)))
+(test-equal #t ((storage-class-data? c128-storage-class) (make-f64vector 10)))
+;; odd-length float vectors cannot be complex bodies
+(test-equal #f ((storage-class-data? c64-storage-class) (make-f32vector 5)))
+(test-equal #f ((storage-class-data? c128-storage-class) (make-f64vector 7)))
+;; and the native complex vectors are no longer the body type
+(test-equal #f ((storage-class-data? c64-storage-class) (make-c64vector 4)))
+;; data->body shares (does not copy) the reference's data shape
+(let ((v (make-f32vector 6 0.0)))
+  (test-equal #t (eq? v ((storage-class-data->body c64-storage-class) v))))
+(test-equal #t (guard (e (#t #t))
+                  ((storage-class-data->body c64-storage-class) (make-f32vector 5))
+                  #f))
+;; interleave: getter/setter/length across the re/im pairs
+(let* ((v (f32vector 1.0 2.0 3.0 4.0 5.0 6.0))
+       (body ((storage-class-data->body c64-storage-class) v))
+       (get (storage-class-getter c64-storage-class))
+       (put! (storage-class-setter c64-storage-class)))
+  (test-equal 3 ((storage-class-length c64-storage-class) body))
+  (test-equal 1.0+2.0i (get body 0))
+  (test-equal 3.0+4.0i (get body 1))
+  (test-equal 5.0+6.0i (get body 2))
+  ;; the setter explodes the complex into the two float slots
+  (put! body 1 (make-rectangular 7.0 8.0))
+  (test-equal 7.0 (f32vector-ref v 2))
+  (test-equal 8.0 (f32vector-ref v 3))
+  (test-equal 7.0+8.0i (get body 1)))
+;; the maker fills alternating re/im across the whole body
+(let* ((body ((storage-class-maker c64-storage-class) 2 (make-rectangular -1.5 2.5)))
+       (get (storage-class-getter c64-storage-class)))
+  (test-equal -1.5+2.5i (get body 0))
+  (test-equal -1.5+2.5i (get body 1))
+  (test-equal 4 (f32vector-length body)))
 
 ;;; --- make-storage-class is a fully general public constructor, not just
 ;;; internal machinery for the 14 named singletons ---


### PR DESCRIPTION
Closes #2382.

## The problem

`c64-storage-class`/`c128-storage-class` were backed by native `c64vector`/`c128vector`, so the reference implementation's data shape — an **even-length `f32vector`/`f64vector` of interleaved re/im pairs** — was rejected by `make-specialized-array-from-data`:

```scheme
(make-specialized-array-from-data (make-f32vector 10) c64-storage-class)
;; ERROR: data is not compatible with storage-class
;; reference: returns a 5-element c64 array sharing the f32vector
```

That was known-divergence id 150 on the official suite (filed as #2382 when the f16 work surfaced it).

## Two findings settled the design

1. **A converting `data->body` is spec-illegal.** SRFI 231's spec says `data?` returns `#t` *iff* `data->body` returns a body **sharing the data, without copying**. So the "accept both representations, convert on the way in" middle path is off the table — accepting the reference's data shape is possible only by actually using it as the body. (The spec explicitly allows either representation: "another implementation … might make another choice.")
2. **Kaappi's `c64vector` already uses the reference's exact byte layout** — `src/types_numeric.zig` documents "2 consecutive f32s/f64s (real, imag) packed contiguously — never boxed". The switch is a **change of type tag, not of memory shape**, which removes the usual argument against it (throwing away a richer representation — there isn't one).

With the port's reference-fidelity philosophy (u1, f16, the #2355 checker), switching is the right call.

## What changed

- `lib/srfi/231/storage-classes.sld`: c64/c128 rebuilt through one `%complex-storage-class` helper — a faithful port of the reference's `make-complex-storage-classes`: getter reassembles the interleaved pair (an inexact zero imag stays complex, kaappi#2269, exactly like the native decode), setter explodes into the two float slots, maker fills alternating re/im, length halves the physical float count, copier is the float block copy, `data?`/`data->body` accept exactly the even-length float vectors (zero-copy identity). The now-unused `(srfi 160 c64)`/`(srfi 160 c128)` imports are dropped.
- **User-visible consequences** (CHANGELOG `### Changed`): `(array-body A)` for a c64/c128 array now reports the float vector; the storage-class copier counts floats (2 per complex element); `c64vector`/`c128vector` data is no longer accepted directly.

## Tests

- `check-storage-class` learns a body-units-per-element option (2 for complex classes) so its copier exercise stays meaningful.
- New representation section in `srfi231-storage-classes.scm`: `data?` acceptance/rejection (even / odd / `c64vector`), `data->body` identity, interleave round-trips, setter explosion, maker fill.
- End-to-end zero-copy proof in `srfi231-arrays.scm`: `make-specialized-array-from-data` over an `f32vector` shares so thoroughly that mutating the caller's vector is visible through the array.

## Official suite

Divergence id 150 pruned, suite regenerated. Pleasing detail: run *before* pruning, the accounting from #2385 flagged the resolution on its own — `DIVERGENCE-RESOLVED 150 -- prune it from known-divergences` — the enforcement working exactly as designed. The table is now down to the two genuinely unavoidable entries: **147** (Gambit string mutability) and **351** (unsafe-view checking).

## Validation

- `srfi231-storage-classes.scm` 219 passes; `srfi231-arrays.scm` 90; all seven other SRFI 231 suites green.
- Official suite: **10,924 passed, 3 known divergences, 0 unexpected failures, 0 resolved, 0 count mismatches**.
- fmt corpus: 938 files, zero semantic drift, idempotent.
- `run-all.sh`: 720 Scheme files + R7RS 1395/1395 → **2,115 pass, 0 fail**.

Rebased onto `main` at `fb703515` (post-#2385); the two #2385 review commits dropped as already-upstream, validation re-run on the rebased tree.