### PR TITLE
Ratify the check/--sandbox compile-time macro execution policy

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -59,6 +59,7 @@ investigation produced analysis worth keeping.
 | [continuation-strategy.md](decisions/continuation-strategy.md) | Native codegen uses direct-style IR; `call/cc` side-exits to the bytecode VM |
 | [self-tail-call-optimization.md](decisions/self-tail-call-optimization.md) | Dedicated `self_tail_call` opcode (Option A shipped; Option B attempted and reverted) |
 | [native-backend-architecture-scope.md](decisions/native-backend-architecture-scope.md) | The native backend stays aarch64/x86_64; interpreter-tier arches (riscv64, s390x, ppc64le) ship without it — what an arch port actually requires and why the unknown-triple path segfaults |
+| [compile-time-macro-execution.md](decisions/compile-time-macro-execution.md) | Macro-defining code is compile-time code, not sandboxed program code (KEP-0006 candidate (a)): procedural transformer bodies run under `check` and `--sandbox`, confined by what the environment lets them reach |
 
 ## Postmortems
 

--- a/docs/dev/check.md
+++ b/docs/dev/check.md
@@ -1,9 +1,11 @@
 # `kaappi check` — compile-only static analysis
 
-`kaappi check <file.scm>` answers "will this fail?" without running anything. It
-reads, macro-expands, and compiles every top-level form — surfacing the same
-read/expand/compile diagnostics a real run would, with their stable `KP` codes —
-but executes no program code, and adds the reserved `KP4xxx` lint findings.
+`kaappi check <file.scm>` answers "will this fail?" without running the
+program. It reads, macro-expands, and compiles every top-level form — surfacing
+the same read/expand/compile diagnostics a real run would, with their stable
+`KP` codes — but executes no *program* code, and adds the reserved `KP4xxx`
+lint findings. Compile-time code is a different matter: procedural macro
+transformers do run during a check (see below).
 
 Part of the machine-legibility epic ([#1503](https://github.com/kaappi/kaappi/issues/1503));
 tracked in [#1511](https://github.com/kaappi/kaappi/issues/1511). See also
@@ -106,7 +108,25 @@ code they compile) so later forms see the bindings and macros they introduce.
 Ordinary `define`s and expressions are compiled and analysed but never executed;
 their bound names are gathered structurally in a pre-pass so a forward reference
 is not warned. `define-syntax` registers its macro at *compile* time, so a
-later use of a same-file macro expands correctly without running anything.
+later use of a same-file macro expands correctly.
+
+For a `syntax-rules` macro that expansion is pure Zig and runs no Scheme at
+all. **Procedural transformers (SRFI 211, since v0.22.0) are different:
+their Scheme code runs during a check.** A statically resolvable
+`(define-syntax name (er-macro-transformer expr))` evaluates `expr` at
+definition time, and every same-file use of the macro calls the resulting
+transformer procedure — `expandProceduralMacro` (`src/expander.zig`) invokes
+the `call_proc_for_macro` VM hook unconditionally; there is deliberately no
+check-mode guard. A spec that *cannot* be resolved without executing program
+code (an alias to a run-time-bound global, or a spec expression referencing
+one) is accepted as a benign placeholder transformer instead of a KP2001
+false positive (kaappi#2007 / kaappi#2329). So `check` executes no *program*
+code, but macro-defining code is compile-time code and does run — meaning a
+bare `check` of untrusted source can have side effects; use
+`kaappi check --sandbox` to check untrusted files inside the restricted
+environment. The policy, the `--sandbox` capability model, and why the
+early-running-macro case is contained are ratified in
+[decisions/compile-time-macro-execution.md](decisions/compile-time-macro-execution.md).
 
 Top-level `begin` and `cond-expand` are *spliced*: their bodies are analysed as
 top-level forms, matching how the interpreter treats them (R7RS 5.1 / 4.2.1). A

--- a/docs/dev/cli-surface.md
+++ b/docs/dev/cli-surface.md
@@ -29,7 +29,7 @@ annotated version — what each flag is *for*, and which document explains it.
 | `--compile`, `-o <file>` | Compile to `.sbc`, or name the output |
 | `--disassemble` | |
 | `--no-ir-opt` | Disables the IR optimization passes, and skips the `.sbc` cache in **both** directions. Useful for miscompilation triage and `--disassemble` comparisons. The cache key folds in the git build id, so a rebuilt binary never serves the old binary's bytecode — the old "delete the cache before testing compiler changes" footgun is fixed (`cache.md`) |
-| `--sandbox` | Restricts filesystem and process access |
+| `--sandbox` | Restricts filesystem and process access by constructing a restricted global environment before any source is read — the capability model, and how it covers compile-time macro execution, is in `decisions/compile-time-macro-execution.md` |
 | `--gc-stats`, `--profile` | |
 | `--timings[=text\|json]` | Per-stage pipeline wall time (read/expand/lower/optimize/emit/execute, plus native `llvm-emit`/`link`) and cache HIT/MISS + path, all on stderr. Disjoint self-timed stages, zero overhead when absent — `timings.md` |
 | `--coverage` | |

--- a/docs/dev/decisions/compile-time-macro-execution.md
+++ b/docs/dev/decisions/compile-time-macro-execution.md
@@ -1,0 +1,135 @@
+# Compile-Time Macro Execution under `check` and `--sandbox`
+
+## Status
+
+**Ratified** (2026-08-27, kaappi#2389). This note writes down the policy
+[KEP-0006](https://github.com/kaappi/keps/blob/main/keps/0006-explicit-renaming-macros.md)
+recommended in its Unresolved question 3 — candidate (a) — and that the
+implementation has followed de facto since `er-macro-transformer` shipped in
+v0.22.0 (kaappi#1811). Nothing in the code changes; the decision changes
+status from "behavior" to "design".
+
+## The decision
+
+**Macro-defining code is compile-time code, not sandboxed program code.**
+Procedural transformer bodies (SRFI 211 `er-macro-transformer` /
+`lisp-transformer`) run wherever macro expansion runs — including under
+`kaappi check`, the LSP, `kaappi expand`/`ir`, `kaappi compile`, and
+`--sandbox`. Confinement comes from what compile-time code can *reach* (the
+environment it expands in), never from pretending expansion runs nothing.
+
+This is Racket's stance: its reference notes a sandbox "cannot fully contain
+compile-time macro execution" and draws the trust boundary at what
+compile-time code can reach, not at which phase it runs in (Racket Reference
+§14.12, Sandboxed Evaluation). KEP-0006 weighed two alternatives and this
+note ratifies their rejection:
+
+- *(b) transformer bodies run under the same sandbox restrictions as the
+  program* — conflates the phases as a special case; in Kaappi it is also
+  redundant, because the sandbox is environmental rather than temporal (see
+  below), so (a) already gives sandboxed expansion exactly the program's
+  capability set.
+- *(c) `check` refuses to fully expand files defining procedural
+  transformers* — would cripple `check` for any file using them and
+  diverges from every other Scheme with procedural macros.
+
+## What runs during `kaappi check`
+
+`check`'s contract is that it executes no *program* code — not that nothing
+executes. Procedural macros add two compile-time execution points to the
+environment-setup category (`import` / `define-library` /
+`define-record-type`) that `check` has always processed for effect:
+
+1. **Definition time.** `(define-syntax name (er-macro-transformer expr))`
+   evaluates `expr` the moment the `define-syntax` is compiled
+   (`resolveTransformerSpec` in `src/compiler_define_syntax.zig` calls the
+   `eval_datum_for_macro` hook), even if the macro is never used.
+2. **Every use.** Expanding a use of the macro calls the transformer
+   procedure (`expandProceduralMacro` in `src/expander.zig` through the
+   `call_proc_for_macro` hook, installed by `setVMInstance` in
+   `src/vm.zig`). There is no check-mode guard, deliberately.
+
+A transformer spec that *cannot* be resolved without executing program code
+— an alias to a global a `define` would bind at run time, or a spec
+expression referencing one — is accepted under analysis as a benign
+placeholder transformer instead of a KP2001 false positive (kaappi#2007,
+fixed by kaappi#2329, first released v0.24.0). The placeholder branch fires
+only when `check_lint.active != null`; a real run still rejects an
+unresolvable spec.
+
+Consequences worth stating plainly:
+
+- **`check` is not a sandbox.** Plain `kaappi check untrusted.scm` runs any
+  transformer bodies in the full, unrestricted environment — a malicious
+  file can write to disk during a "compile-only" check. Checking untrusted
+  source calls for `kaappi check --sandbox` (the flag is global and
+  composes with the subcommand).
+- An error a transformer raises surfaces as a compile diagnostic at the
+  macro use, not a crash. VM limits are phase-blind: `--timeout` and
+  `--max-memory` are applied to the VM/GC before `check` dispatches
+  (`src/main.zig`), so they bound expansion-time execution too — a looping
+  transformer under `--timeout` dies with the usual timeout error at the
+  use site. Without `--timeout`, `check` on a looping transformer hangs,
+  as in every Scheme with procedural macros.
+
+## What `--sandbox` gates, and why the phase ordering doesn't matter
+
+The sharp case KEP-0006 flagged: a sandboxed program that merely *defines*
+(never calls) a macro still runs its transformer body the moment another
+form in the same file uses the macro during compilation — before the
+program's own top level executes. If the sandbox were a runtime switch,
+that would be a pre-sandbox execution window.
+
+It is not a runtime switch. `--sandbox` is enforced by *constructing a
+restricted global environment before any source is read*, so
+expansion-time code and run-time code see the identical capability set —
+there is no pre-sandbox phase. Concretely (`--sandbox` is pre-scanned in
+`src/main.zig` before registration):
+
+- **Primitive registration** — `registerSandboxed` (`src/primitives.zig`)
+  registers only `spec.sandbox` primitives; file, filesystem, process, and
+  FFI primitives are marked `.sandbox = false` and *never exist* in
+  `vm.globals`.
+- **Built-in libraries** — `Lib.sandboxAllowed` (`src/primitives.zig`)
+  excludes `(scheme file)`, `(scheme load)`, `(scheme eval)`,
+  `(scheme repl)`, `(scheme process-context)`, `(scheme r5rs)`,
+  `(kaappi ffi)`, `(srfi 18)`, `(srfi 170)`, `(srfi 192)`; `(kaappi
+  sysinfo)`'s path-revealing members opt out per-spec.
+- **File-backed `.sld` loads are blocked wholesale**
+  (`tryLoadLibraryFromFile` in `src/vm_library.zig`) so sandboxed code
+  cannot probe the host filesystem via crafted import paths; only the
+  comptime-embedded libraries in `embedded_libraries` load. `cond-expand`
+  library probes likewise never touch disk under sandbox.
+- **The bytecode cache is disabled** in both directions (`src/main.zig`,
+  `vm_library_cache.shouldUseCache`) — no filesystem side effects.
+
+Because the transformer body is compiled against, and executes in, that
+same environment, the sharp case is contained: the early-running macro can
+reach exactly what the sandboxed program itself could reach, nothing more.
+Verified end-to-end — a transformer body calling `open-output-file` writes
+its file under plain `kaappi check`, and fails with "undefined variable"
+under `kaappi --sandbox` and `kaappi check --sandbox` alike, because the
+binding was never registered.
+
+Two shape notes, neither a policy gap:
+
+- ER macros are definable under `--sandbox` *without any import*: the
+  `(define-syntax name (er-macro-transformer expr))` spec form is
+  recognized structurally by the compiler (`src/primitives_srfi211.zig`
+  header comment), and `(srfi 211 primitives)` is a registry-backed
+  library that remains importable. The transformer body still runs inside
+  the restricted environment, so this widens nothing.
+- The portable wrapper `(srfi 211 explicit-renaming)` is a `.sld` file and
+  therefore **not importable under `--sandbox`** (it is not in
+  `embedded_libraries`). Sandboxed code that wants the documented library
+  name rather than the primitives sub-library currently cannot have it —
+  a degradation quirk on the same ladder as the other non-embedded
+  libraries, fixable by embedding if it ever matters.
+
+## Residual limits
+
+Same caveat Racket documents: compile-time code execution is arbitrary
+computation. The sandbox bounds *reach* (capabilities), not *cost* — pure
+CPU and memory consumption at expansion time are bounded only if the
+invoker passes `--timeout` / `--max-memory`. That is the accepted trade of
+candidate (a); anything stronger is candidate (c) in disguise.


### PR DESCRIPTION
Resolves the KEP-0006 Divergence 8 follow-up: the stale `check.md` claim, the never-written policy note, and the undocumented `--sandbox` interaction. Docs only — no code changes.

## The correction

`docs/dev/check.md` said a same-file macro use expands "without running anything" (and the intro said `check` answers "will this fail?" *without running anything*). Both corrected against the actual source:

- `expandProceduralMacro` (`src/expander.zig:373`) calls the `call_proc_for_macro` hook (installed in `setVMInstance`, `src/vm.zig:47`) **unconditionally** — there is no check-mode guard — so every use of a resolvable SRFI 211 macro runs its transformer body during `check`.
- `resolveTransformerSpec` (`src/compiler_define_syntax.zig`) additionally evaluates the transformer-spec expression **at definition time**, even for a macro never used.
- Specs unresolvable without executing program code are accepted as benign placeholder transformers (`makeCheckPlaceholderTransformer`, #2007 / #2329, v0.24.0) — that behavior is now documented too.

## The ratified policy

New decision note **`docs/dev/decisions/compile-time-macro-execution.md`** (indexed in `docs/dev/README.md`) ratifies KEP-0006 Unresolved question 3 candidate (a): **macro-defining code is compile-time code, not sandboxed program code** — Racket's stance, trust boundary drawn at what compile-time code can *reach*. The shipped behavior already matched; this changes its status from behavior to design. Candidates (b) and (c) are recorded as rejected with reasons.

## The `--sandbox` model documented

Derived from source and verified empirically with a v0.25.0 binary:

- `--sandbox` is **environmental, not temporal**: `registerSandboxed` / `Lib.sandboxAllowed` build a restricted global environment before any source is read, file-backed `.sld` loads are blocked wholesale, and the bytecode cache is disabled. There is no pre-sandbox phase — so KEP-0006's sharp case (a program that merely *defines* a macro runs its transformer body during compilation, before its own top level) is contained: the early-running transformer reaches exactly what the sandboxed program could reach. Verified: a file-writing transformer writes its file under plain `kaappi check`, and fails with `undefined variable 'open-output-file'` under both `kaappi --sandbox` and `kaappi check --sandbox`.
- `check` is **not** a sandbox: `check.md` now says plainly that a bare check of untrusted source can have side effects and points at `kaappi check --sandbox` (the flag is global and composes with the subcommand — verified).
- `--timeout` / `--max-memory` are VM/GC-level, hence phase-blind: verified a looping transformer under `kaappi --timeout 500 check` dies with the timeout error at the macro use site.
- `cli-surface.md`'s `--sandbox` row now links to the decision note.

## Follow-up flagged (no code fix here, per issue scope)

No code/policy disagreement was found — the environmental sandbox already implements candidate (a)'s reach model. Two shape notes recorded in the decision doc, one of which may warrant a follow-up issue:

- `(srfi 211 explicit-renaming)` is a `.sld` file and **not importable under `--sandbox`** (it is not in `vm_library.zig`'s `embedded_libraries`), while the registry-backed `(srfi 211 primitives)` is, and the ER spec form is recognized structurally without any import. A degradation quirk, not a hole — fixable by embedding the `.sld` if sandboxed code ever needs the documented library name.

Verification: markdownlint-cli2 clean on all four touched files; no `.zig` files changed.

Closes #2389

🤖 Generated with [Claude Code](https://claude.com/claude-code)
