### PR TITLE
Add channel identity comparators to (kaappi fibers)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -607,7 +607,9 @@ fn kaappiModule(b: *std.Build, options_mod: *std.Build.Module, opts: struct {
     // (srfi 128): (channel-comparator) (kaappi#2394) builds the channel
     // identity comparator through the real (make-comparator ...), on demand,
     // so the library must stay loadable where file loads are blocked
-    // (--sandbox) or unreliable (WASM) — same embedded-copy fix as above.
+    // (--sandbox), unreliable (WASM), or absent entirely (no lib tree on the
+    // deployment machine — the last-resort fallback) — same embedded-copy
+    // fix as above.
     const srfi_128_sld_wf = b.addWriteFiles();
     _ = srfi_128_sld_wf.addCopyFile(b.path("lib/srfi/128.sld"), "128.sld");
     const srfi_128_sld_embed = srfi_128_sld_wf.add("kaappi_srfi_128_sld.zig", "pub const source = @embedFile(\"128.sld\");\n");

--- a/build.zig
+++ b/build.zig
@@ -604,6 +604,18 @@ fn kaappiModule(b: *std.Build, options_mod: *std.Build.Module, opts: struct {
         .target = opts.target,
         .optimize = opts.optimize,
     });
+    // (srfi 128): (channel-comparator) (kaappi#2394) builds the channel
+    // identity comparator through the real (make-comparator ...), on demand,
+    // so the library must stay loadable where file loads are blocked
+    // (--sandbox) or unreliable (WASM) — same embedded-copy fix as above.
+    const srfi_128_sld_wf = b.addWriteFiles();
+    _ = srfi_128_sld_wf.addCopyFile(b.path("lib/srfi/128.sld"), "128.sld");
+    const srfi_128_sld_embed = srfi_128_sld_wf.add("kaappi_srfi_128_sld.zig", "pub const source = @embedFile(\"128.sld\");\n");
+    mod.addAnonymousImport("kaappi_srfi_128_sld", .{
+        .root_source_file = srfi_128_sld_embed,
+        .target = opts.target,
+        .optimize = opts.optimize,
+    });
     if (opts.isocline) {
         // src/isocline.c #includes the other translation units, so this one
         // file is the whole library (vendor/isocline/PATCHES.md).

--- a/docs/dev/thread-value-sharing.md
+++ b/docs/dev/thread-value-sharing.md
@@ -141,17 +141,16 @@ is what SRFI-128 comparators exist for:
   `SharedChannel` (or the same unpromoted local channel; the mixed case only
   arises for genuinely different channels, since promotion rewrites the
   original in place and every stub is born promoted).
-- `channel-hash ch [bound]` — hashes the `shared` pointer, consistent with
+- `channel-hash ch [bound]` — hashes the channel's identity, consistent with
   `channel=?` by construction; mirrors `(hash obj [bound])` (SRFI 69).
 - `channel-comparator` — `(make-comparator channel? channel=? #f
   channel-hash)`, built by calling the **real** `(srfi 128)`
-  `make-comparator`. That library lazy-loads on first use (the `environment`
-  procedure's on-demand route; an `embedded_libraries` entry keeps it
-  loadable under `--sandbox` and on WASM, like `(srfi 181)`), so
-  `comparator?` and the field accessors agree with every hand-built
-  comparator, and the native `extractComparatorFns` bridge recognizes the
-  record. The three procedures are `(kaappi fibers)`'s pristine registry
-  exports, immune to top-level shadowing of those names.
+  `make-comparator`, so `comparator?` and the field accessors agree with
+  every hand-built comparator and the native `extractComparatorFns` bridge
+  recognizes the record. It is cached on the VM like
+  `default_random_source` — repeat calls return the same record — and its
+  three procedures are `(kaappi fibers)`'s pristine registry exports,
+  immune to top-level shadowing of those names.
 
 The reply-channel/registry idiom:
 
@@ -160,21 +159,45 @@ The reply-channel/registry idiom:
 (hash-table-set! registry stub 'reply-to) ; any stub of the channel finds it
 ```
 
-Two caveats:
-
-- **Hash stability across promotion.** A channel hashed before its first
-  cross-thread send hashes its local address; after promotion (sticky) the
-  `SharedChannel`'s. Key a channel into a table only after sharing it.
-- **`(srfi 113)` sets do not honor comparators in this port**: `113.sld`'s
-  `%make-empty-set` builds its backing table with a zero-argument
-  `make-hash-table` (default `equal?`), so `(set channel-comparator …)`
-  still dedups by pointer. Use `make-hash-table` (SRFI 69/125) directly for
-  channel-keyed tables.
+The hash input is the channel's identity **for its whole life**, not the
+representation-of-the-moment: its own tagged Value while unpromoted, and —
+once promoted — the `SharedChannel.identity_seed` `promoteChannel` preserved
+from exactly that Value before publishing. A table keyed before the first
+cross-thread send therefore still finds its entry after promotion rewrites
+the original in place, and every stub hashes the one seed. If the original
+object is later collected and its address reused, the collision is benign —
+equality still compares `shared` pointers. (Unpromoted channels hash through
+the same `valueHash` as plain `(hash ch)`, so the two agree on every target,
+wasm32's 32-bit `usize` included.)
 
 `channel=?` and `channel-hash` read channel fields, so they carry the same
-foreign-owner check as `channel-send` (a channel reached through a shared
+foreign-owner check as `channel-send`, now factored as
+`primitives_fiber.checkChannelOwner` (a channel reached through a shared
 global is a diagnosis, not a comparison); `channel?` stays exempt as a total
 predicate.
+
+`(srfi 113)` sets honor their comparator since kaappi#2394: `113.sld`'s
+`%make-empty-set`/`%make-empty-bag` pass the comparator to
+`make-hash-table`, which unwraps the record into its equality/hash pair —
+and the native `detectMode` keeps the fast path for the standard
+comparators, whose equality fields hold the real `eq?`/`eqv?`/`equal?`, so
+`make-eq-comparator` sets pay nothing for the fix. Before it, every set's
+backing table was built with a zero-argument `make-hash-table` (default
+`equal?`) and any non-`equal?` comparator silently deduped by pointer.
+
+**Loading `(srfi 128)` safely across threads.** `vm.libraries` reaches
+child VMs as a struct copy (unlike `globals`, which got the pointer+lock
+treatment — see `vm.zig`'s `initForThread`), and `markVmRoots` gates
+library marking behind `owns_globals`. A lazy library load from a worker
+thread would therefore put() into bucket storage the root reads unlocked
+and leave child-heap exports unmarked by every collector.
+`threadStartImpl` closes this by pre-loading `(srfi 128)` on the spawning
+VM before any child exists (`ensureComparatorLibraryLoaded` — best-effort;
+the process's first `make-thread` is necessarily the root, so the load is
+always pre-children and read-only afterwards), and an
+`embedded_libraries` entry keeps the library loadable under `--sandbox`,
+on WASM, and — as the last resort after a disk miss — on a binary with no
+lib tree to read at all.
 
 ## The globals route
 
@@ -366,6 +389,8 @@ thread gets its own VM and GC with an independent heap.
 | `markLiveChildRoots` | `src/primitives_srfi18.zig` | kaappi#1933: registered on the **root** GC as `gc.child_marker`; the root's collector stops every live child at a dispatch-loop safepoint (or finds it already parked / in an FFI call) and marks its roots with the root's gc, so a parent-heap object referenced only from a live child's registers is never freed under it. Children spawned mid-collection spin on `collection_in_progress` before their first shared-globals read. The child side reports `collection_state` (`.running`/`.parked`/`.stopped`/`.in_native`) from the safepoint (`stopForCollection`), the park (`parkOnReactor`) and FFI (`callFfi`) sites |
 | `crossHeapStoreViolation` | `src/memory.zig` | kaappi#1924: the rejection predicate checked before every general store into a heap object — a store into a container owned by another GC is allowed only when the value is owned by that same GC. The `mutex-lock!` owner pair is the deliberate exception |
 | `Object.owner` vs `GC.id` | `src/gc_collect.zig` | Every heap object records its owning GC; marking skips objects owned by another GC, so a child's collections never write mark bits on parent-heap objects reached through shared globals (kaappi#958) |
+| `SharedChannel.identity_seed` | `src/shared_channel.zig` | kaappi#2394: the promoting channel's tagged Value, written before `ch.shared` publishes — the hash identity every stub of the channel shares for its whole life |
+| `ensureComparatorLibraryLoaded` | `src/primitives_fiber.zig`, called from `threadStartImpl` | kaappi#2394: best-effort pre-load of `(srfi 128)` on the spawning VM, so no child VM ever lazy-loads into the struct-copied registry (see the channel-identity section) |
 
 The deep copy happens at exactly three boundaries: the thunk closure at
 `thread-start!`, the result (or uncaught exception) at `thread-join!`, and a

--- a/docs/dev/thread-value-sharing.md
+++ b/docs/dev/thread-value-sharing.md
@@ -124,6 +124,58 @@ directory object, environment, ephemeron, guardian, or transport cell),
 or a channel owned by another thread
 ```
 
+## Channel identity across stubs (kaappi#2394)
+
+Every cross-thread hand-off of a channel mints a **stub** on the receiving
+heap (`gc_deep_copy.zig`'s `.channel` arm → `allocChannelStub`): a fresh
+`types.Channel` whose `shared` pointer targets the one refcounted
+`SharedChannel`. Receiving the same channel twice therefore yields two stubs
+that are *not* `eq?`/`eqv?`/`equal?` — distinct heap objects — even though no
+channel operation can tell them apart. KEP-0002 §2 once promised an `eqv?`
+that compares the `shared` pointer; the KEP's 2026-08-27 as-implemented
+amendment dropped that, and kaappi#2394 settled the promise as an explicit
+comparator surface in `(kaappi fibers)` instead — extending `eqv?` per-type
+is what SRFI-128 comparators exist for:
+
+- `channel=? a b` — `#t` iff both are channels backing the same
+  `SharedChannel` (or the same unpromoted local channel; the mixed case only
+  arises for genuinely different channels, since promotion rewrites the
+  original in place and every stub is born promoted).
+- `channel-hash ch [bound]` — hashes the `shared` pointer, consistent with
+  `channel=?` by construction; mirrors `(hash obj [bound])` (SRFI 69).
+- `channel-comparator` — `(make-comparator channel? channel=? #f
+  channel-hash)`, built by calling the **real** `(srfi 128)`
+  `make-comparator`. That library lazy-loads on first use (the `environment`
+  procedure's on-demand route; an `embedded_libraries` entry keeps it
+  loadable under `--sandbox` and on WASM, like `(srfi 181)`), so
+  `comparator?` and the field accessors agree with every hand-built
+  comparator, and the native `extractComparatorFns` bridge recognizes the
+  record. The three procedures are `(kaappi fibers)`'s pristine registry
+  exports, immune to top-level shadowing of those names.
+
+The reply-channel/registry idiom:
+
+```scheme
+(define registry (make-hash-table channel=? channel-hash)) ; or (channel-comparator)
+(hash-table-set! registry stub 'reply-to) ; any stub of the channel finds it
+```
+
+Two caveats:
+
+- **Hash stability across promotion.** A channel hashed before its first
+  cross-thread send hashes its local address; after promotion (sticky) the
+  `SharedChannel`'s. Key a channel into a table only after sharing it.
+- **`(srfi 113)` sets do not honor comparators in this port**: `113.sld`'s
+  `%make-empty-set` builds its backing table with a zero-argument
+  `make-hash-table` (default `equal?`), so `(set channel-comparator …)`
+  still dedups by pointer. Use `make-hash-table` (SRFI 69/125) directly for
+  channel-keyed tables.
+
+`channel=?` and `channel-hash` read channel fields, so they carry the same
+foreign-owner check as `channel-send` (a channel reached through a shared
+global is a diagnosis, not a comparison); `channel?` stays exempt as a total
+predicate.
+
 ## The globals route
 
 `VM.initForThread` shares the **root** VM's `globals` map **by pointer**,
@@ -137,7 +189,7 @@ Four types defend themselves at the primitive level, by comparing
 
 | type | check | sites |
 |---|---|---|
-| channel | `channel belongs to another thread; pass it through the thread thunk to share it` | `primitives_fiber.zig` — `channel-send`, `channel-receive`, `channel-close!`, `channel-closed?` |
+| channel | `channel belongs to another thread; pass it through the thread thunk to share it` | `primitives_fiber.zig` — `channel-send`, `channel-receive`, `channel-close!`, `channel-closed?`, `channel=?`, `channel-hash` |
 | thread handle | `thread belongs to another OS thread; a thread handle may only be used by the thread that created it` | `primitives_srfi18.zig` `checkThreadOwner` — `thread-name`, `thread-specific`, `thread-specific-set!`, `thread-start!`, `thread-terminate!`, `thread-join!` |
 | fiber | `fiber-join: fiber belongs to another thread; a fiber may only be joined by the thread that spawned it` | `primitives_fiber.zig` — `fiber-join` (kaappi#2001) |
 | guardian | `guardian belongs to another thread; a guardian may only be used by the thread that created it` | `vm_calls.zig` `invokeGuardian` — both the register and the retrieve call shapes, object and transport-cell guardians alike (kaappi#2008) |
@@ -366,6 +418,13 @@ duplicating: `src/tests_deepcopy.zig` asserts the port and continuation
 refusals at the `GC.deepCopy` level directly, and
 `src/tests_shared_channel.zig` asserts that a channel *message* carrying a
 port is refused the same way.
+
+Channel identity across stubs (previous section) has its own coverage:
+`tests/scheme/smoke/channel-identity-2394.scm` runs the
+two-stubs-one-channel scenario end to end (both `make-hash-table` flavors,
+the SRFI-128 comparator contract), and `src/tests_fibers.zig` carries the
+unit-level versions (local identity, stub unification, table dedup, lazy
+comparator construction).
 
 The two copied rows added above have their own regression suites, each
 covering all four boundaries (into the child, out of it, the raise path, a

--- a/docs/dev/thread-value-sharing.md
+++ b/docs/dev/thread-value-sharing.md
@@ -164,11 +164,15 @@ representation-of-the-moment: its own tagged Value while unpromoted, and —
 once promoted — the `SharedChannel.identity_seed` `promoteChannel` preserved
 from exactly that Value before publishing. A table keyed before the first
 cross-thread send therefore still finds its entry after promotion rewrites
-the original in place, and every stub hashes the one seed. If the original
-object is later collected and its address reused, the collision is benign —
-equality still compares `shared` pointers. (Unpromoted channels hash through
-the same `valueHash` as plain `(hash ch)`, so the two agree on every target,
-wasm32's 32-bit `usize` included.)
+the original in place, and every stub hashes the one seed. The seed is
+hashed with `identityHash` — a pure function of the bits that never
+dereferences them (the original object may since have been swept or live on
+another heap; `valueHash` would be wrong there, its dispatch reads `.tag`
+through pointer bits) — so if the original is later collected and its
+address reused, the collision is benign and deterministic: equality still
+compares `shared` pointers. For a live unpromoted channel the result equals
+plain `(hash ch)`'s identity arm on every target, wasm32's 32-bit `usize`
+included.
 
 `channel=?` and `channel-hash` read channel fields, so they carry the same
 foreign-owner check as `channel-send`, now factored as
@@ -188,16 +192,17 @@ backing table was built with a zero-argument `make-hash-table` (default
 **Loading `(srfi 128)` safely across threads.** `vm.libraries` reaches
 child VMs as a struct copy (unlike `globals`, which got the pointer+lock
 treatment — see `vm.zig`'s `initForThread`), and `markVmRoots` gates
-library marking behind `owns_globals`. A lazy library load from a worker
-thread would therefore put() into bucket storage the root reads unlocked
-and leave child-heap exports unmarked by every collector.
-`threadStartImpl` closes this by pre-loading `(srfi 128)` on the spawning
-VM before any child exists (`ensureComparatorLibraryLoaded` — best-effort;
-the process's first `make-thread` is necessarily the root, so the load is
-always pre-children and read-only afterwards), and an
-`embedded_libraries` entry keeps the library loadable under `--sandbox`,
-on WASM, and — as the last resort after a disk miss — on a binary with no
-lib tree to read at all.
+library marking behind `owns_globals`. A library load from a non-root
+VM would therefore put() into bucket storage the root reads unlocked
+and leave non-root exports unmarked by every collector.
+`threadStartImpl` closes this by pre-loading `(srfi 128)` on the root
+VM before any child exists (`ensureComparatorLibraryLoaded`, which
+refuses to load off-root; best-effort — the process's first
+`thread-start!` is necessarily the root, so the load is always
+pre-children, and a read-only no-op afterwards once it succeeded), and
+an `embedded_libraries` entry keeps the library loadable under
+`--sandbox`, on WASM, and — as the last resort after a disk miss — on a
+binary with no lib tree to read at all.
 
 ## The globals route
 

--- a/lib/srfi/113.sld
+++ b/lib/srfi/113.sld
@@ -70,10 +70,15 @@
     ;; The backing table uses the comparator's own equality/hash (kaappi#2394):
     ;; the native make-hash-table unwraps a <comparator> record into its two
     ;; procedures, and detectMode keeps the native fast path for the standard
-    ;; comparators, whose equality fields hold the real eq?/eqv?/equal?. Until
+    ;; comparators, whose equality fields hold the real eq?/eqv?/equal? --
+    ;; make-default-comparator included while nothing is registered via
+    ;; comparator-register-default! (the hashtable bridge recognizes that
+    ;; case natively). A user comparator with closure equality runs the
+    ;; generic custom mode: correct, with a procedure call per probe. Until
     ;; this fix the comparator was stored in the record but every membership
-    ;; test ran through the default equal? table, so any non-equal? comparator
-    ;; — (set (channel-comparator) a b) included — silently deduped by pointer.
+    ;; test ran through the default equal? table, so any non-equal?
+    ;; comparator -- (set (channel-comparator) a b) included -- silently
+    ;; deduped by pointer.
     (define (%make-empty-set comparator)
       (%make-set comparator (make-hash-table comparator)))
 

--- a/lib/srfi/113.sld
+++ b/lib/srfi/113.sld
@@ -67,11 +67,18 @@
 
     ;;; Internal helpers
 
+    ;; The backing table uses the comparator's own equality/hash (kaappi#2394):
+    ;; the native make-hash-table unwraps a <comparator> record into its two
+    ;; procedures, and detectMode keeps the native fast path for the standard
+    ;; comparators, whose equality fields hold the real eq?/eqv?/equal?. Until
+    ;; this fix the comparator was stored in the record but every membership
+    ;; test ran through the default equal? table, so any non-equal? comparator
+    ;; — (set (channel-comparator) a b) included — silently deduped by pointer.
     (define (%make-empty-set comparator)
-      (%make-set comparator (make-hash-table)))
+      (%make-set comparator (make-hash-table comparator)))
 
     (define (%make-empty-bag comparator)
-      (%make-bag comparator (make-hash-table)))
+      (%make-bag comparator (make-hash-table comparator)))
 
     ;;; Constructors
 

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -1474,15 +1474,17 @@ fn channelHashFn(args: []const Value) PrimitiveError!Value {
     // promoteChannel preserved from exactly that Value (SharedChannel.
     // identity_seed). A table keyed before the first cross-thread send
     // therefore still finds its entry afterwards, and every stub of the
-    // channel hashes the one seed. Routed through valueHash, not a local
-    // mixing constant, so an unpromoted channel hashes identically here
-    // and under plain (hash ch) on every target — wasm32's 32-bit usize
-    // truncation included.
-    const seed: Value = if (ch.shared) |raw| blk: {
+    // channel hashes the one seed. identityHash, not valueHash: it is a
+    // pure function of the bits, and the seed must never be dereferenced —
+    // the original object may since have been swept or live on another
+    // heap, and valueHash's dispatch reads .tag through pointer bits
+    // (kaappi#2394 review). For a live channel the two agree exactly, so
+    // (channel-hash ch) = (hash ch) while unpromoted, on every target.
+    const bits: u64 = if (ch.shared) |raw| blk: {
         const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(raw));
-        break :blk @bitCast(sc.identity_seed);
+        break :blk sc.identity_seed;
     } else args[0];
-    const h: u64 = primitives_hashtable.valueHash(seed);
+    const h: u64 = primitives_hashtable.identityHash(bits);
 
     if (args.len > 1) {
         if (!types.isFixnum(args[1])) return primitives.typeError("channel-hash", "integer", args[1]);
@@ -1496,29 +1498,31 @@ fn channelHashFn(args: []const Value) PrimitiveError!Value {
 /// (srfi 128) pre-load, best-effort, for threadStartImpl: the library must
 /// be in the registry BEFORE any child VM struct-copies it (kaappi#2394
 /// review). `vm.libraries` is copied by value on child creation — unlike
-/// globals, which got the pointer+lock treatment — so a lazy load from a
-/// worker thread would put() into bucket storage the parent reads
-/// unlocked, and a child-side rehash would free buckets the parent's copy
-/// still names; the child-side exports would also be unmarked by every
-/// collector (markVmRoots gates library marking behind owns_globals).
-/// Loading at the first make-thread is always pre-children — children
-/// exist only inside threadStartImpl — and read-only afterwards. Failures
-/// are swallowed: channel-comparator's own lazy load then reports the
-/// described error instead.
-pub fn ensureComparatorLibraryLoaded(vm: *vm_mod.VM) void {
-    if (vm.libraries.get("srfi.128") != null) return;
-    const gc = memory.gc_instance orelse return;
-    var iset = vm_library.buildSrfiNameList(gc, 128) catch return;
+/// globals, which got the pointer+lock treatment — so a load from a non-root
+/// VM would put() into bucket storage the root reads unlocked, and a rehash
+/// would free buckets the root's copy still names; non-root exports would
+/// also be unmarked by every collector (markVmRoots gates library marking
+/// behind owns_globals). Hence the root_vm guard: only the root ever loads.
+/// The process's first `thread-start!` is necessarily the root (children
+/// exist only inside threadStartImpl), so the load is always pre-children;
+/// once it succeeds every later spawn's registry copy contains the library
+/// and this is a read-only no-op. Returns whether the library is present
+/// afterwards — on failure, `last_error_detail` holds the loader's own
+/// diagnosis for the caller to surface or clear (it must not be left stale).
+pub fn ensureComparatorLibraryLoaded(vm: *vm_mod.VM) bool {
+    if (vm.libraries.get("srfi.128") != null) return true;
+    if (vm.root_vm != null) return false; // never load off-root
+    const gc = memory.gc_instance orelse return false;
+    var iset = vm_library.buildSrfiNameList(gc, 128) catch return false;
     gc.pushRoot(&iset);
     defer gc.popRoot();
-    // Clear-then-clear-again: the loader's setErrorDetail sites only write
-    // when no detail is set, so a stale one would both suppress the
-    // loader's own message and — once swallowed here — mis-attach to the
-    // next unrelated error (the ffi.zig callFfi precedent for the reset).
+    // Clear first: the loader's setErrorDetail sites only write when no
+    // detail is set, so a stale one would suppress the loader's own message
+    // (the ffi.zig callFfi precedent for the reset). On failure the detail
+    // is the loader's, deliberately left for the caller.
     vm.last_error_detail_len = 0;
-    vm_imports.ensureLibraryLoaded(vm, iset, "srfi.128") catch {
-        vm.last_error_detail_len = 0;
-    };
+    vm_imports.ensureLibraryLoaded(vm, iset, "srfi.128") catch return false;
+    return true;
 }
 
 /// (channel-comparator) — (make-comparator channel? channel=? #f
@@ -1536,11 +1540,24 @@ fn channelComparatorFn(_: []const Value) PrimitiveError!Value {
 
     if (vm.default_channel_comparator != types.VOID) return vm.default_channel_comparator;
 
-    // ensureComparatorLibraryLoaded is a no-op once loaded — threadStartImpl
-    // pre-loads on the root VM precisely so a worker thread never performs
-    // this load (see its doc comment for the registry/marking hazards).
-    ensureComparatorLibraryLoaded(vm);
-
+    // ensureComparatorLibraryLoaded never loads off-root — threadStartImpl
+    // pre-loads on the root VM at the process's first thread-start! so a
+    // worker never needs to (see its doc comment for the registry/marking
+    // hazards a non-root load would carry).
+    if (!ensureComparatorLibraryLoaded(vm)) {
+        // Fold the loader's own diagnosis (which file, what error) into the
+        // raised message, then clear it so it cannot attach to the next
+        // unrelated error (kaappi#2394 review).
+        var buf: [320]u8 = undefined;
+        const detail = vm.last_error_detail[0..vm.last_error_detail_len];
+        const msg = if (detail.len > 0)
+            std.fmt.bufPrint(&buf, "channel-comparator: failed to load (srfi 128): {s}", .{detail}) catch
+                "channel-comparator: failed to load (srfi 128)"
+        else
+            "channel-comparator: failed to load (srfi 128)";
+        vm.last_error_detail_len = 0;
+        return raiseFiberError(msg);
+    }
     const lib128 = vm.libraries.get("srfi.128") orelse
         return raiseFiberError("channel-comparator: failed to load (srfi 128)");
     const make_comparator = lib128.exports.get("make-comparator") orelse

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
+const vm_imports = @import("vm_imports.zig");
 const primitives = @import("primitives.zig");
+const primitives_hashtable = @import("primitives_hashtable.zig");
 const memory = @import("memory.zig");
 const fiber_mod = @import("fiber.zig");
 const shared_channel = @import("shared_channel.zig");
@@ -24,6 +26,12 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "channel?", .func = &channelPredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_fibers) },
     .{ .name = "channel-close!", .func = &channelCloseFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_fibers) },
     .{ .name = "channel-closed?", .func = &channelClosedFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_fibers) },
+    // KEP-0002 §2 identity across stubs (kaappi#2394): eqv?/equal? stay
+    // stub-identity (the KEP's 2026-08-27 as-implemented amendment); this
+    // comparator surface is the supported way to compare and hash channels.
+    .{ .name = "channel=?", .func = &channelEqFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.kaappi_fibers) },
+    .{ .name = "channel-hash", .func = &channelHashFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.kaappi_fibers) },
+    .{ .name = "channel-comparator", .func = &channelComparatorFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.kaappi_fibers) },
     .{ .name = "channel-timeout-exception?", .func = &channelTimeoutPredFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_fibers) },
 };
 
@@ -1423,6 +1431,138 @@ fn channelClosedFn(args: []const Value) PrimitiveError!Value {
         return if (sc.isClosed()) types.TRUE else types.FALSE;
     }
     return if (ch.closed) types.TRUE else types.FALSE;
+}
+
+/// KEP-0002 §2 (kaappi#2394): channel identity across stubs. Two stubs for
+/// one SharedChannel are distinct heap objects, so `eq?` reports #f for
+/// "the same channel" seen from two receipts — this compares the `shared`
+/// pointer when both operands are promoted, the one representation of
+/// identity every thread agrees on. The mixed case (one promoted, one not)
+/// only arises for genuinely different channels — promotion rewrites the
+/// original in place and every stub is born promoted — so the pointer
+/// fallback says exactly what `eq?` would. Like channel-closed?, this
+/// dereferences the channel, so it carries the foreign-owner check rather
+/// than channel?'s total-predicate convention.
+fn channelEqFn(args: []const Value) PrimitiveError!Value {
+    if (!types.isChannel(args[0]))
+        return primitives.typeError("channel=?", "channel", args[0]);
+    if (!types.isChannel(args[1]))
+        return primitives.typeError("channel=?", "channel", args[1]);
+
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    for (args) |a| {
+        if (types.toObject(a).owner != gc.id)
+            return raiseFiberError("channel belongs to another thread; pass it through the thread thunk to share it");
+    }
+
+    const a_ch = types.toObject(args[0]).as(types.Channel);
+    const b_ch = types.toObject(args[1]).as(types.Channel);
+    const same = if (a_ch.shared != null and b_ch.shared != null)
+        a_ch.shared == b_ch.shared
+    else
+        args[0] == args[1];
+    return if (same) types.TRUE else types.FALSE;
+}
+
+/// The hash half of the channel identity comparator (kaappi#2394):
+/// consistent with `channel=?` by construction — the `shared` pointer
+/// decides both. `(channel-hash ch [bound])` mirrors `(hash obj [bound])`
+/// (SRFI 69): a non-negative fixnum, reduced mod `bound` when given. The
+/// promotion caveat: a channel hashed before its first cross-thread send
+/// hashes its local address, after it the SharedChannel's — share a channel
+/// before keying it into a table (promotion is sticky, so one keyed
+/// afterwards stays correct forever).
+fn channelHashFn(args: []const Value) PrimitiveError!Value {
+    if (!types.isChannel(args[0]))
+        return primitives.typeError("channel-hash", "channel", args[0]);
+
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const ch_obj = types.toObject(args[0]);
+    if (ch_obj.owner != gc.id)
+        return raiseFiberError("channel belongs to another thread; pass it through the thread thunk to share it");
+
+    const ch = ch_obj.as(types.Channel);
+    // Promoted: the one pointer every stub of this channel shares. Unpromoted:
+    // the boxed value itself, so an unshared channel hashes identically here
+    // and under plain (hash ch). Same mixing constant as identityHash.
+    const h: u64 = if (ch.shared) |raw|
+        @as(u64, @intFromPtr(raw)) *% 2654435761
+    else
+        args[0] *% 2654435761;
+
+    if (args.len > 1) {
+        if (!types.isFixnum(args[1])) return primitives.typeError("channel-hash", "integer", args[1]);
+        const bound = types.toFixnum(args[1]);
+        if (bound <= 0) return primitives.argError("channel-hash", "bound must be a positive integer, got {d}", .{bound});
+        return types.makeFixnum(@intCast(@mod(h, @as(u64, @intCast(bound)))));
+    }
+    return primitives_hashtable.unboundedHash(h);
+}
+
+/// (channel-comparator) — (make-comparator channel? channel=? #f
+/// channel-hash) built by the real (srfi 128), so `comparator?` and the
+/// field accessors agree with every other comparator in the image and
+/// (make-hash-table channel-comparator) works through the native comparator
+/// bridge (kaappi#2394, KEP-0002 §2). The three procedures come from
+/// (kaappi fibers)'s pristine registry exports, immune to any later
+/// top-level shadowing of those names. (srfi 128) loads on demand — the
+/// `environment` procedure's own lazy route — from the embedded copy under
+/// --sandbox and on WASM.
+fn channelComparatorFn(_: []const Value) PrimitiveError!Value {
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+
+    // Load (srfi 128) before fetching any Values that must survive a GC the
+    // load can trigger: library loading runs arbitrary begin-block code.
+    if (vm.libraries.get("srfi.128") == null) {
+        var srfi_sym = gc.allocSymbol("srfi") catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&srfi_sym);
+        defer gc.popRoot();
+        // allocPair auto-roots its Value args, so the tail needs no separate
+        // root before it is handed to the outer allocPair (the rooting shape
+        // of vm_library.zig's buildSrfiNameList).
+        const tail = gc.allocPair(types.makeFixnum(128), types.NIL) catch return PrimitiveError.OutOfMemory;
+        var iset = gc.allocPair(srfi_sym, tail) catch return PrimitiveError.OutOfMemory;
+        gc.pushRoot(&iset);
+        defer gc.popRoot();
+        vm_imports.ensureLibraryLoaded(vm, iset, "srfi.128") catch {
+            if (vm.last_error_detail_len == 0)
+                return raiseFiberError("channel-comparator: failed to load (srfi 128)");
+            return PrimitiveError.UndefinedVariable; // bare-ok: the loader's own detail (library not found / load error)
+        };
+    }
+
+    const lib128 = vm.libraries.get("srfi.128") orelse
+        return raiseFiberError("channel-comparator: failed to load (srfi 128)");
+    const make_comparator = lib128.exports.get("make-comparator") orelse
+        return raiseFiberError("channel-comparator: (srfi 128) does not export make-comparator");
+
+    const fibers = vm.libraries.get("kaappi.fibers") orelse
+        return raiseFiberError("channel-comparator: (kaappi fibers) is not registered");
+    const type_test = fibers.exports.get("channel?") orelse
+        return raiseFiberError("channel-comparator: channel? is not registered");
+    const equality = fibers.exports.get("channel=?") orelse
+        return raiseFiberError("channel-comparator: channel=? is not registered");
+    const hash_fn = fibers.exports.get("channel-hash") orelse
+        return raiseFiberError("channel-comparator: channel-hash is not registered");
+
+    // Rooted across the call: fetched from the export maps, these Values are
+    // otherwise reachable only through this frame's locals.
+    var type_test_r = type_test;
+    var equality_r = equality;
+    var hash_r = hash_fn;
+    var mc_r = make_comparator;
+    gc.pushRoot(&type_test_r);
+    gc.pushRoot(&equality_r);
+    gc.pushRoot(&hash_r);
+    gc.pushRoot(&mc_r);
+    defer gc.popRoot();
+    defer gc.popRoot();
+    defer gc.popRoot();
+    defer gc.popRoot();
+
+    const call_args = [_]Value{ type_test_r, equality_r, types.FALSE, hash_r };
+    return vm.callWithArgs(mc_r, &call_args) catch |err| return err;
 }
 
 fn channelTimeoutPredFn(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const vm_imports = @import("vm_imports.zig");
+const vm_library = @import("vm_library.zig");
 const primitives = @import("primitives.zig");
 const primitives_hashtable = @import("primitives_hashtable.zig");
 const memory = @import("memory.zig");
@@ -172,15 +173,7 @@ fn channelSendFn(args: []const Value) PrimitiveError!Value {
     if (!types.isChannel(args[0]))
         return primitives.typeError("channel-send", "channel", args[0]);
 
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const ch_obj = types.toObject(args[0]);
-    // KEP-0002 §2: the only legal cross-thread handle is a locally owned
-    // stub created by deepCopy. A foreign object -- reached through a
-    // shared global, promoted or not -- is what silently corrupted memory
-    // before this check existed (Motivation Path 2); now it's a diagnosis.
-    if (ch_obj.owner != gc.id)
-        return raiseFiberError("channel belongs to another thread; pass it through the thread thunk to share it");
-    const ch = ch_obj.as(types.Channel);
+    const ch = try checkChannelOwner(args[0]);
 
     // KEP-0002 §6: the one backward-compat carve-out. Checked before any
     // dispatch (both representations, no lock): a *sent* eof-object would
@@ -1082,10 +1075,7 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
         return primitives.typeError("channel-receive", "channel", args[0]);
 
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const ch_obj = types.toObject(args[0]);
-    if (ch_obj.owner != gc.id)
-        return raiseFiberError("channel belongs to another thread; pass it through the thread thunk to share it");
-    const ch = ch_obj.as(types.Channel);
+    const ch = try checkChannelOwner(args[0]);
 
     var deadline_ns: ?u64 = null;
     var has_timeout_val = false;
@@ -1393,11 +1383,7 @@ fn channelCloseFn(args: []const Value) PrimitiveError!Value {
     if (!types.isChannel(args[0]))
         return primitives.typeError("channel-close!", "channel", args[0]);
 
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const ch_obj = types.toObject(args[0]);
-    if (ch_obj.owner != gc.id)
-        return raiseFiberError("channel belongs to another thread; pass it through the thread thunk to share it");
-    const ch = ch_obj.as(types.Channel);
+    const ch = try checkChannelOwner(args[0]);
 
     if (ch.shared) |raw| {
         const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(raw));
@@ -1420,17 +1406,30 @@ fn channelClosedFn(args: []const Value) PrimitiveError!Value {
     if (!types.isChannel(args[0]))
         return primitives.typeError("channel-closed?", "channel", args[0]);
 
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const ch_obj = types.toObject(args[0]);
-    if (ch_obj.owner != gc.id)
-        return raiseFiberError("channel belongs to another thread; pass it through the thread thunk to share it");
-    const ch = ch_obj.as(types.Channel);
+    const ch = try checkChannelOwner(args[0]);
 
     if (ch.shared) |raw| {
         const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(raw));
         return if (sc.isClosed()) types.TRUE else types.FALSE;
     }
     return if (ch.closed) types.TRUE else types.FALSE;
+}
+
+/// The KEP-0002 §2 entitlement gate shared by every channel primitive that
+/// dereferences a channel (all but the total predicate `channel?`): the only
+/// legal cross-thread handle is a locally owned stub created by deepCopy. A
+/// foreign object -- reached through a shared global, promoted or not -- is
+/// what silently corrupted memory before this check existed (Motivation Path
+/// 2); now it's a diagnosis. The message is load-bearing beyond this file
+/// (asserted in tests_shared_channel.zig, quoted in thread-value-sharing.md's
+/// owner-check table) -- the sibling shape is primitives_srfi18's
+/// checkThreadOwner.
+fn checkChannelOwner(val: Value) PrimitiveError!*types.Channel {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const ch_obj = types.toObject(val);
+    if (ch_obj.owner != gc.id)
+        return raiseFiberError("channel belongs to another thread; pass it through the thread thunk to share it");
+    return ch_obj.as(types.Channel);
 }
 
 /// KEP-0002 §2 (kaappi#2394): channel identity across stubs. Two stubs for
@@ -1449,14 +1448,8 @@ fn channelEqFn(args: []const Value) PrimitiveError!Value {
     if (!types.isChannel(args[1]))
         return primitives.typeError("channel=?", "channel", args[1]);
 
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    for (args) |a| {
-        if (types.toObject(a).owner != gc.id)
-            return raiseFiberError("channel belongs to another thread; pass it through the thread thunk to share it");
-    }
-
-    const a_ch = types.toObject(args[0]).as(types.Channel);
-    const b_ch = types.toObject(args[1]).as(types.Channel);
+    const a_ch = try checkChannelOwner(args[0]);
+    const b_ch = try checkChannelOwner(args[1]);
     const same = if (a_ch.shared != null and b_ch.shared != null)
         a_ch.shared == b_ch.shared
     else
@@ -1466,29 +1459,30 @@ fn channelEqFn(args: []const Value) PrimitiveError!Value {
 
 /// The hash half of the channel identity comparator (kaappi#2394):
 /// consistent with `channel=?` by construction — the `shared` pointer
-/// decides both. `(channel-hash ch [bound])` mirrors `(hash obj [bound])`
-/// (SRFI 69): a non-negative fixnum, reduced mod `bound` when given. The
-/// promotion caveat: a channel hashed before its first cross-thread send
-/// hashes its local address, after it the SharedChannel's — share a channel
-/// before keying it into a table (promotion is sticky, so one keyed
-/// afterwards stays correct forever).
+/// decides equality, and every representation of one channel hashes the
+/// same `identity_seed`. `(channel-hash ch [bound])` mirrors
+/// `(hash obj [bound])` (SRFI 69): a non-negative fixnum, reduced mod
+/// `bound` when given.
 fn channelHashFn(args: []const Value) PrimitiveError!Value {
     if (!types.isChannel(args[0]))
         return primitives.typeError("channel-hash", "channel", args[0]);
 
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const ch_obj = types.toObject(args[0]);
-    if (ch_obj.owner != gc.id)
-        return raiseFiberError("channel belongs to another thread; pass it through the thread thunk to share it");
+    const ch = try checkChannelOwner(args[0]);
 
-    const ch = ch_obj.as(types.Channel);
-    // Promoted: the one pointer every stub of this channel shares. Unpromoted:
-    // the boxed value itself, so an unshared channel hashes identically here
-    // and under plain (hash ch). Same mixing constant as identityHash.
-    const h: u64 = if (ch.shared) |raw|
-        @as(u64, @intFromPtr(raw)) *% 2654435761
-    else
-        args[0] *% 2654435761;
+    // The hash input is the channel's identity for its whole life: its own
+    // tagged Value while unpromoted, and — once promoted — the seed
+    // promoteChannel preserved from exactly that Value (SharedChannel.
+    // identity_seed). A table keyed before the first cross-thread send
+    // therefore still finds its entry afterwards, and every stub of the
+    // channel hashes the one seed. Routed through valueHash, not a local
+    // mixing constant, so an unpromoted channel hashes identically here
+    // and under plain (hash ch) on every target — wasm32's 32-bit usize
+    // truncation included.
+    const seed: Value = if (ch.shared) |raw| blk: {
+        const sc: *shared_channel.SharedChannel = @ptrCast(@alignCast(raw));
+        break :blk @bitCast(sc.identity_seed);
+    } else args[0];
+    const h: u64 = primitives_hashtable.valueHash(seed);
 
     if (args.len > 1) {
         if (!types.isFixnum(args[1])) return primitives.typeError("channel-hash", "integer", args[1]);
@@ -1499,38 +1493,53 @@ fn channelHashFn(args: []const Value) PrimitiveError!Value {
     return primitives_hashtable.unboundedHash(h);
 }
 
+/// (srfi 128) pre-load, best-effort, for threadStartImpl: the library must
+/// be in the registry BEFORE any child VM struct-copies it (kaappi#2394
+/// review). `vm.libraries` is copied by value on child creation — unlike
+/// globals, which got the pointer+lock treatment — so a lazy load from a
+/// worker thread would put() into bucket storage the parent reads
+/// unlocked, and a child-side rehash would free buckets the parent's copy
+/// still names; the child-side exports would also be unmarked by every
+/// collector (markVmRoots gates library marking behind owns_globals).
+/// Loading at the first make-thread is always pre-children — children
+/// exist only inside threadStartImpl — and read-only afterwards. Failures
+/// are swallowed: channel-comparator's own lazy load then reports the
+/// described error instead.
+pub fn ensureComparatorLibraryLoaded(vm: *vm_mod.VM) void {
+    if (vm.libraries.get("srfi.128") != null) return;
+    const gc = memory.gc_instance orelse return;
+    var iset = vm_library.buildSrfiNameList(gc, 128) catch return;
+    gc.pushRoot(&iset);
+    defer gc.popRoot();
+    // Clear-then-clear-again: the loader's setErrorDetail sites only write
+    // when no detail is set, so a stale one would both suppress the
+    // loader's own message and — once swallowed here — mis-attach to the
+    // next unrelated error (the ffi.zig callFfi precedent for the reset).
+    vm.last_error_detail_len = 0;
+    vm_imports.ensureLibraryLoaded(vm, iset, "srfi.128") catch {
+        vm.last_error_detail_len = 0;
+    };
+}
+
 /// (channel-comparator) — (make-comparator channel? channel=? #f
 /// channel-hash) built by the real (srfi 128), so `comparator?` and the
 /// field accessors agree with every other comparator in the image and
 /// (make-hash-table channel-comparator) works through the native comparator
-/// bridge (kaappi#2394, KEP-0002 §2). The three procedures come from
-/// (kaappi fibers)'s pristine registry exports, immune to any later
-/// top-level shadowing of those names. (srfi 128) loads on demand — the
-/// `environment` procedure's own lazy route — from the embedded copy under
-/// --sandbox and on WASM.
+/// bridge (kaappi#2394, KEP-0002 §2). Cached on the VM like
+/// default_random_source: a per-VM constant, so repeat calls return the
+/// same record. The three procedures come from (kaappi fibers)'s pristine
+/// registry exports, immune to any later top-level shadowing of those
+/// names.
 fn channelComparatorFn(_: []const Value) PrimitiveError!Value {
     const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
-    // Load (srfi 128) before fetching any Values that must survive a GC the
-    // load can trigger: library loading runs arbitrary begin-block code.
-    if (vm.libraries.get("srfi.128") == null) {
-        var srfi_sym = gc.allocSymbol("srfi") catch return PrimitiveError.OutOfMemory;
-        gc.pushRoot(&srfi_sym);
-        defer gc.popRoot();
-        // allocPair auto-roots its Value args, so the tail needs no separate
-        // root before it is handed to the outer allocPair (the rooting shape
-        // of vm_library.zig's buildSrfiNameList).
-        const tail = gc.allocPair(types.makeFixnum(128), types.NIL) catch return PrimitiveError.OutOfMemory;
-        var iset = gc.allocPair(srfi_sym, tail) catch return PrimitiveError.OutOfMemory;
-        gc.pushRoot(&iset);
-        defer gc.popRoot();
-        vm_imports.ensureLibraryLoaded(vm, iset, "srfi.128") catch {
-            if (vm.last_error_detail_len == 0)
-                return raiseFiberError("channel-comparator: failed to load (srfi 128)");
-            return PrimitiveError.UndefinedVariable; // bare-ok: the loader's own detail (library not found / load error)
-        };
-    }
+    if (vm.default_channel_comparator != types.VOID) return vm.default_channel_comparator;
+
+    // ensureComparatorLibraryLoaded is a no-op once loaded — threadStartImpl
+    // pre-loads on the root VM precisely so a worker thread never performs
+    // this load (see its doc comment for the registry/marking hazards).
+    ensureComparatorLibraryLoaded(vm);
 
     const lib128 = vm.libraries.get("srfi.128") orelse
         return raiseFiberError("channel-comparator: failed to load (srfi 128)");
@@ -1546,8 +1555,10 @@ fn channelComparatorFn(_: []const Value) PrimitiveError!Value {
     const hash_fn = fibers.exports.get("channel-hash") orelse
         return raiseFiberError("channel-comparator: channel-hash is not registered");
 
-    // Rooted across the call: fetched from the export maps, these Values are
-    // otherwise reachable only through this frame's locals.
+    // Rooted across the call. On the root VM the export maps are themselves
+    // marked, so this is belt-and-suspenders; on a child VM library marking
+    // is gated behind owns_globals, and these locals are what keeps the
+    // values reachable across the call's allocations.
     var type_test_r = type_test;
     var equality_r = equality;
     var hash_r = hash_fn;
@@ -1562,7 +1573,9 @@ fn channelComparatorFn(_: []const Value) PrimitiveError!Value {
     defer gc.popRoot();
 
     const call_args = [_]Value{ type_test_r, equality_r, types.FALSE, hash_r };
-    return vm.callWithArgs(mc_r, &call_args) catch |err| return err;
+    const result = vm.callWithArgs(mc_r, &call_args) catch |err| return err;
+    vm.default_channel_comparator = result;
+    return result;
 }
 
 fn channelTimeoutPredFn(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -95,6 +95,25 @@ fn extractComparatorFns(val: Value) ?struct { equiv: Value, hash_fn: Value } {
     return .{ .equiv = ri.fields[1], .hash_fn = ri.fields[3] };
 }
 
+/// (srfi 128)'s `make-default-comparator` while `comparator-register-default!`
+/// has not been used: its equality closure is then observably `equal?` (and
+/// its hash `default-hash`, also `equal?`-consistent), so the table can run
+/// the native `.equal` fast path instead of paying two VM-bridge closure
+/// calls per probe (kaappi#2394 review — routing SRFI-113 sets through their
+/// comparator made this the common portable case). A non-empty registry opts
+/// out: a late registration changes the default comparator's meaning, and a
+/// table captures its construction-time behavior, which SRFI 128 permits.
+/// Degrades silently to `.custom` if (srfi 128)'s internals ever rename —
+/// slower, never wrong.
+fn isUnregisteredDefaultComparator(vm: *vm_mod.VM, equiv: Value) bool {
+    const lib = vm.libraries.get("srfi.128") orelse return false;
+    const env = lib.lib_env orelse return false;
+    const default_eq = env.get("default-equality") orelse return false;
+    if (equiv != default_eq) return false;
+    const reg = env.get("registered-comparators") orelse return false;
+    return reg == types.NIL;
+}
+
 fn configureHashTable(ht: *HashTable, ht_val: Value, gc: *GC, vm: *vm_mod.VM, args: []const Value) void {
     if (args.len > 0) {
         var equiv_val = args[0];
@@ -107,6 +126,10 @@ fn configureHashTable(ht: *HashTable, ht_val: Value, gc: *GC, vm: *vm_mod.VM, ar
             if (!has_hash) {
                 hash_val = cmp.hash_fn;
                 has_hash = true;
+            }
+            if (isUnregisteredDefaultComparator(vm, cmp.equiv)) {
+                equiv_val = lookupGlobal(vm, "equal?");
+                hash_val = lookupGlobal(vm, "hash");
             }
         }
 
@@ -188,8 +211,15 @@ fn equalForTable(proc: []const u8, ht: *HashTable, a: Value, b: Value) Primitive
     };
 }
 
-fn identityHash(key: Value) usize {
-    return @truncate(key *% 2654435761);
+/// The identity arm of `valueHash`: a pure function of the Value's *bits* —
+/// never dereferences them. That matters when the bits are not a live
+/// pointer to dereference: `channel-hash` feeds it `SharedChannel.
+/// identity_seed`, the raw tagged bits of a channel object that may since
+/// have been swept or live on another heap (kaappi#2394 review — `valueHash`
+/// itself would be wrong there, its dispatch reads `.tag` through the bits).
+/// For a live value the result equals `valueHash`'s fall-through arm exactly.
+pub fn identityHash(bits: u64) usize {
+    return @truncate(bits *% 2654435761);
 }
 
 fn stringContentHash(data: []const u8) usize {

--- a/src/primitives_hashtable.zig
+++ b/src/primitives_hashtable.zig
@@ -912,7 +912,10 @@ fn hashTableUpdateDefaultFn(args: []const Value) PrimitiveError!Value {
 /// #31 and #16). 47 bits is the widest value that survives the round trip.
 const HASH_FIXNUM_MASK: u64 = 0x7FFF_FFFF_FFFF;
 
-fn unboundedHash(h: u64) Value {
+/// A u64 hash rendered as a non-negative fixnum (masked into the 47-bit
+/// range). Shared by every hash procedure that returns an unbounded hash —
+/// and by channel-hash in primitives_fiber.zig.
+pub fn unboundedHash(h: u64) Value {
     return types.makeFixnum(@intCast(h & HASH_FIXNUM_MASK));
 }
 

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -4,6 +4,7 @@ const is_wasm = @import("builtin").os.tag == .wasi;
 const types = @import("types.zig");
 const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
+const primitives_fiber = @import("primitives_fiber.zig");
 const fiber_mod = @import("fiber.zig");
 const memory = @import("memory.zig");
 const shared_channel = @import("shared_channel.zig");
@@ -659,6 +660,17 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
     // then read freed memory (#2129). The root VM lives for the whole
     // process, so every descendant chains its shared state to it.
     const root_vm = vm.root_vm orelse vm;
+    // kaappi#2394: (srfi 128) must be registered before ANY child VM
+    // struct-copies vm.libraries (threadEntryFn's VM.initForThread) — the
+    // copy shares bucket storage with the owner's map, so a worker-side
+    // lazy load would race it, and the worker-side exports would be
+    // unmarked by every collector. Loading here is pre-children for the
+    // process's first make-thread (necessarily the root: children exist
+    // only inside this function) and a read-only no-op for every later
+    // one, whose registry copy postdates the root's load. Best-effort:
+    // channel-comparator's own lazy load reports a described error if
+    // this ever fails.
+    primitives_fiber.ensureComparatorLibraryLoaded(vm);
     // #1933: from here on, the root's collector must stop-and-mark live
     // children so a parent-heap object referenced only from a running
     // child's registers is not freed under it. Atomic: threadStartImpl can

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -662,15 +662,18 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
     const root_vm = vm.root_vm orelse vm;
     // kaappi#2394: (srfi 128) must be registered before ANY child VM
     // struct-copies vm.libraries (threadEntryFn's VM.initForThread) — the
-    // copy shares bucket storage with the owner's map, so a worker-side
-    // lazy load would race it, and the worker-side exports would be
-    // unmarked by every collector. Loading here is pre-children for the
-    // process's first make-thread (necessarily the root: children exist
-    // only inside this function) and a read-only no-op for every later
-    // one, whose registry copy postdates the root's load. Best-effort:
-    // channel-comparator's own lazy load reports a described error if
-    // this ever fails.
-    primitives_fiber.ensureComparatorLibraryLoaded(vm);
+    // copy shares bucket storage with the owner's map, so an off-root lazy
+    // load would race it, and off-root exports would be unmarked by every
+    // collector. Loading at the process's first thread-start! is always
+    // pre-children (the first spawn is necessarily the root: children exist
+    // only inside this function) and a read-only no-op for every later one
+    // whose registry copy postdates the root's load. Best-effort by design:
+    // on failure the loader's detail is cleared so it cannot leak into the
+    // next unrelated error — channel-comparator then reports the load
+    // failure with its own described message when actually used.
+    if (!primitives_fiber.ensureComparatorLibraryLoaded(vm)) {
+        vm.last_error_detail_len = 0;
+    }
     // #1933: from here on, the root's collector must stop-and-mark live
     // children so a parent-heap object referenced only from a running
     // child's registers is not freed under it. Atomic: threadStartImpl can

--- a/src/shared_channel.zig
+++ b/src/shared_channel.zig
@@ -262,6 +262,20 @@ pub const SharedChannel = struct {
     /// KEP-0002 §6, `channel-close!`. Set once (true), by promoteChannel
     /// (carried over from an already-closed local channel) or by close().
     closed: bool = false,
+    /// The raw NaN-boxed bits of the promoting channel's Value
+    /// (`makePointer(&ch.header)` at promotion, kaappi#2394): the channel's
+    /// hash identity for its whole life. `channel-hash` hashes the live
+    /// channel's own Value while unpromoted and this seed once promoted, so
+    /// a hash-table entry keyed before the first cross-thread send stays
+    /// reachable after it, and every stub of the channel hashes the one
+    /// value. Write-once (set before `ch.shared` publishes `sc`), never
+    /// dereferenced -- a hash input only; if the original object is later
+    /// collected and its address reused, the collision is benign because
+    /// `channel=?` still compares `shared` pointers. The explicit alignment
+    /// keeps this field from raising the struct's alignment above the
+    /// header's -- on wasm32-baseline a natural u64 demands align 8 against
+    /// Header's 4, and destroyHook's @fieldParentPtr refuses to widen.
+    identity_seed: u64 align(@alignOf(shared_object.Header)) = 0,
     recv_waiters: std.ArrayList(*ThreadNotifier) = .empty,
     send_waiters: std.ArrayList(*ThreadNotifier) = .empty,
 
@@ -499,6 +513,10 @@ pub fn promoteChannel(gc: *memory.GC, ch: *types.Channel) !*SharedChannel {
     sc.capacity = ch.capacity;
     sc.closed = ch.closed;
     sc.rv_demand = ch.rv_demand;
+    // Before publish, like the fields above: `channel-hash` on any later
+    // stub of this channel must see the seed the moment it can see `sc`
+    // (kaappi#2394).
+    sc.identity_seed = @bitCast(types.makePointer(&ch.header));
     // Publish before draining (§2 step 2): a queued local message may
     // contain this very channel (e.g. (channel-send ch (list ch))). With
     // `shared` already set, the drain's own Envelope.create -> deepCopy

--- a/src/tests_fibers.zig
+++ b/src/tests_fibers.zig
@@ -783,3 +783,155 @@ test "a bad channel timeout names the channel primitive, not 'thread' (#2002)" {
     defer std.testing.allocator.free(s2);
     try std.testing.expectEqualStrings("ok", s2);
 }
+
+// kaappi#2394 (KEP-0002 §2): channel identity across stubs. eqv?/equal?
+// deliberately stay stub-identity (the KEP's as-implemented amendment), so
+// channel=?/channel-hash/channel-comparator are the supported way to compare
+// and dedup channel handles — the comparator contract the reply-channel and
+// registry idioms need.
+test "channel=? and channel-hash on local channels (#2394)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(define a (make-channel))
+        \\(define b (make-channel))
+        \\(list (channel=? a a) (channel=? a b) (channel=? b a)
+        \\      (= (channel-hash a) (channel-hash a))
+        \\      (< (channel-hash a 100) 100)
+        \\      (= (channel-hash a 100) (channel-hash a 100)))
+    );
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("(#t #f #f #t #t #t)", s);
+
+    // Argument discipline matches the rest of the file: a non-channel is a
+    // KP3002 type error, a non-positive bound a KP3007 range rejection.
+    const codes = try vm.eval(
+        \\(define (code-of thunk) (guard (e (#t (error-object-code e))) (thunk) 'no-raise))
+        \\(list (code-of (lambda () (channel=? a 5)))
+        \\      (code-of (lambda () (channel-hash "x")))
+        \\      (code-of (lambda () (channel-hash a 0))))
+    );
+    const s2 = try printer.valueToString(std.testing.allocator, codes, .write);
+    defer std.testing.allocator.free(s2);
+    try std.testing.expectEqualStrings("(KP3002 KP3002 KP3007)", s2);
+}
+
+// The core #2394 scenario: one channel arrives twice through a thread and
+// lands as two stubs. eq? cannot unify them (distinct heap objects); the
+// comparator route must — against each other AND against the original
+// handle, whose in-place promotion gives it the same `shared` pointer.
+test "channel=? unifies stubs of one promoted channel across threads (#2394)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // needs real OS threads
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const result = try ctx.vm.eval(
+        \\(import (kaappi fibers) (srfi 18) (srfi 69))
+        \\(let ((ch   (make-channel))
+        \\      (to-w (make-channel))
+        \\      (to-p (make-channel)))
+        \\  (define worker
+        \\    (thread-start! (make-thread
+        \\      (lambda ()
+        \\        (let ((c (channel-receive to-w)))
+        \\          (channel-send to-p c)
+        \\          (channel-send to-p c))))))
+        \\  (channel-send to-w ch)
+        \\  (thread-join! worker)
+        \\  (let ((a (channel-receive to-p))
+        \\        (b (channel-receive to-p)))
+        \\    (list (channel=? a b) (channel=? a ch) (channel=? b ch)
+        \\          (eq? a b) (eqv? a b))))
+    );
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    // eq?/eqv? on the two stubs: distinct heap objects, so #f — the KEP-0002
+    // §2 divergence this issue records. The channel=? column is the promise,
+    // kept where the KEP's amendment says it lives.
+    try std.testing.expectEqualStrings("(#t #t #t #f #f)", s);
+}
+
+// The dedup the issue exists for: a reply-channel registry keyed by channel
+// identity. Both table flavors (two procedures, comparator record) must
+// collapse a/b/ch to one entry and find it under any of the three handles.
+test "channel-keyed hash tables dedup stubs via channel=?/channel-hash (#2394)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // needs real OS threads
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const result = try ctx.vm.eval(
+        \\(import (kaappi fibers) (srfi 18) (srfi 69))
+        \\(let ((ch   (make-channel))
+        \\      (to-w (make-channel))
+        \\      (to-p (make-channel)))
+        \\  (define worker
+        \\    (thread-start! (make-thread
+        \\      (lambda ()
+        \\        (let ((c (channel-receive to-w)))
+        \\          (channel-send to-p c)
+        \\          (channel-send to-p c))))))
+        \\  (channel-send to-w ch)
+        \\  (thread-join! worker)
+        \\  (let ((a (channel-receive to-p))
+        \\        (b (channel-receive to-p)))
+        \\    (define ht  (make-hash-table channel=? channel-hash))
+        \\    (define ht2 (make-hash-table (channel-comparator)))
+        \\    (hash-table-set! ht a 'first)
+        \\    (hash-table-set! ht b 'second)
+        \\    (hash-table-set! ht2 a 1)
+        \\    (hash-table-set! ht2 b 2)
+        \\    (hash-table-set! ht2 ch 3)
+        \\    (list (hash-table-size ht)  (hash-table-ref/default ht  ch 'MISS)
+        \\          (hash-table-size ht2) (hash-table-ref/default ht2 b 'MISS))))
+    );
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("(1 second 1 3)", s);
+}
+
+// (channel-comparator) is a real SRFI-128 comparator — comparator? and the
+// field accessors agree with every hand-built (make-comparator ...) result —
+// and it builds even when (srfi 128) was never imported (lazy load).
+test "channel-comparator is a SRFI-128 comparator built on demand (#2394)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // No (import (srfi 128)) here: the construction lazy-loads it, and the
+    // result is already usable through the native comparator bridge —
+    // make-hash-table unwraps a <comparator> record's equality/hash fields.
+    const result = try vm.eval(
+        \\(define cmp (channel-comparator))
+        \\(define ht (make-hash-table cmp))
+        \\(define ch (make-channel))
+        \\(hash-table-set! ht ch 'v)
+        \\(list (hash-table-size ht)
+        \\      (hash-table-ref/default ht ch 'MISS))
+    );
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("(1 v)", s);
+
+    // With (srfi 128) imported, comparator? and the hash contract agree.
+    const result2 = try vm.eval(
+        \\(import (srfi 128))
+        \\(list (comparator? cmp)
+        \\      (comparator-ordered? cmp)
+        \\      (comparator-hashable? cmp)
+        \\      (= (comparator-hash cmp ch) (channel-hash ch)))
+    );
+    const s2 = try printer.valueToString(std.testing.allocator, result2, .write);
+    defer std.testing.allocator.free(s2);
+    try std.testing.expectEqualStrings("(#t #f #t #t)", s2);
+}

--- a/src/tests_fibers.zig
+++ b/src/tests_fibers.zig
@@ -790,10 +790,10 @@ test "a bad channel timeout names the channel primitive, not 'thread' (#2002)" {
 // and dedup channel handles — the comparator contract the reply-channel and
 // registry idioms need.
 test "channel=? and channel-hash on local channels (#2394)" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
 
     const result = try vm.eval(
         \\(define a (make-channel))
@@ -902,10 +902,10 @@ test "channel-keyed hash tables dedup stubs via channel=?/channel-hash (#2394)" 
 // field accessors agree with every hand-built (make-comparator ...) result —
 // and it builds even when (srfi 128) was never imported (lazy load).
 test "channel-comparator is a SRFI-128 comparator built on demand (#2394)" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
 
     // No (import (srfi 128)) here: the construction lazy-loads it, and the
     // result is already usable through the native comparator bridge —
@@ -934,4 +934,54 @@ test "channel-comparator is a SRFI-128 comparator built on demand (#2394)" {
     const s2 = try printer.valueToString(std.testing.allocator, result2, .write);
     defer std.testing.allocator.free(s2);
     try std.testing.expectEqualStrings("(#t #f #t #t)", s2);
+}
+
+// CodeRabbit's #2394 review scenario: a channel keyed into a table BEFORE
+// its first cross-thread send must stay reachable after promotion rewrites
+// the original in place — the hash input is the channel's identity for its
+// whole life (SharedChannel.identity_seed preserves the pre-promotion
+// Value), not the representation-of-the-moment.
+test "channel-hash is stable across promotion: insert, promote, lookup (#2394)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // needs real OS threads
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const result = try ctx.vm.eval(
+        \\(import (kaappi fibers) (srfi 18) (srfi 69))
+        \\(let ((ch   (make-channel))
+        \\      (to-w (make-channel))
+        \\      (to-p (make-channel)))
+        \\  (define ht (make-hash-table channel=? channel-hash))
+        \\  (hash-table-set! ht ch 'early)
+        \\  (define worker
+        \\    (thread-start! (make-thread
+        \\      (lambda ()
+        \\        (let ((c (channel-receive to-w)))
+        \\          (channel-send to-p c)
+        \\          (channel-send to-p c))))))
+        \\  (channel-send to-w ch)
+        \\  (thread-join! worker)
+        \\  (let ((a (channel-receive to-p))
+        \\        (b (channel-receive to-p)))
+        \\    (list (hash-table-size ht)
+        \\          (hash-table-ref/default ht a 'MISS)
+        \\          (hash-table-ref/default ht b 'MISS)
+        \\          (hash-table-ref/default ht ch 'MISS))))
+    );
+    const printer = @import("printer.zig");
+    const s = try printer.valueToString(std.testing.allocator, result, .write);
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("(1 early early early)", s);
+}
+
+// The comparator is a per-VM constant cached on the VM like
+// default_random_source — repeat calls must return the same record.
+test "channel-comparator is cached: repeat calls return the same record (#2394)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const result = try ctx.vm.eval("(eq? (channel-comparator) (channel-comparator))");
+    try std.testing.expectEqual(types.TRUE, result);
 }

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -250,6 +250,7 @@ pub fn markVmRoots(gc: *memory.GC, vm: *VM) void {
     if (vm.callback_error_value) |exc| gc.markValue(exc);
     gc.markValue(vm.continuation_value);
     gc.markValue(vm.default_random_source);
+    gc.markValue(vm.default_channel_comparator);
     // Foreign (parent-heap) for a child thread, so markValue skips it; the
     // parent roots the handle. Marked here for the same reason every other
     // Value field is: a same-heap value would be kept alive by it (#2125).
@@ -570,6 +571,14 @@ pub const VM = struct {
     compile_collect_files: ?*std.StringHashMap([]const u8) = null,
     param_overrides: std.AutoHashMap(usize, Value) = undefined,
     default_random_source: Value = types.VOID,
+    /// Lazily built by `channel-comparator` (kaappi#2394): the
+    /// `(make-comparator channel? channel=? #f channel-hash)` record. A
+    /// per-VM constant -- cached like default_random_source so repeat calls
+    /// don't re-enter (srfi 128)'s make-comparator. Each VM builds its own
+    /// (a child's lives on the child heap; VM.initForThread does not copy
+    /// this field), and markVmRoots marks it unconditionally -- markValue
+    /// skips foreign-heap values, same as thread_handle.
+    default_channel_comparator: Value = types.VOID,
     /// Set by the pthread_atfork child handler (primitives_random.zig): this
     /// process inherited the default source's PRNG state from its parent at
     /// fork(2), and the next use must reseed it in place before drawing.

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -389,6 +389,11 @@ const embedded_libraries = [_]struct { rel_path: []const u8, source: []const u8 
     // .srfi_181_primitives) -- without this entry, --sandbox and WASM would
     // silently lose access to the already-shipped custom-port constructors.
     .{ .rel_path = "srfi/181.sld", .source = @import("kaappi_srfi_181_sld").source },
+    // (srfi 128): (channel-comparator) (kaappi#2394) builds the channel
+    // identity comparator through the real make-comparator, on demand, so
+    // the library must stay loadable where file loads are blocked (--sandbox)
+    // or unreliable (WASM).
+    .{ .rel_path = "srfi/128.sld", .source = @import("kaappi_srfi_128_sld").source },
 };
 
 fn findEmbeddedLibrary(rel_path: []const u8) ?[]const u8 {

--- a/src/vm_library.zig
+++ b/src/vm_library.zig
@@ -194,8 +194,10 @@ pub fn libraryIsAvailableSrfi261(vm: *VM, lib_name: []const u8, lib_name_list: V
     return libraryIsAvailable(vm, norm_name, norm);
 }
 
-/// Fresh `(srfi <n>)` library-name list.
-fn buildSrfiNameList(gc: *memory.GC, n: i64) !Value {
+/// Fresh `(srfi <n>)` library-name list. Roots its intermediates; the caller
+/// must root the result across anything that can collect (library loading
+/// can).
+pub fn buildSrfiNameList(gc: *memory.GC, n: i64) !Value {
     var srfi_sym = try gc.allocSymbol("srfi");
     gc.pushRoot(&srfi_sym);
     defer gc.popRoot();
@@ -391,8 +393,9 @@ const embedded_libraries = [_]struct { rel_path: []const u8, source: []const u8 
     .{ .rel_path = "srfi/181.sld", .source = @import("kaappi_srfi_181_sld").source },
     // (srfi 128): (channel-comparator) (kaappi#2394) builds the channel
     // identity comparator through the real make-comparator, on demand, so
-    // the library must stay loadable where file loads are blocked (--sandbox)
-    // or unreliable (WASM).
+    // the library must stay loadable where file loads are blocked
+    // (--sandbox), unreliable (WASM), or absent entirely (a binary with no
+    // lib tree -- the last-resort fallback in tryLoadLibraryFromFile).
     .{ .rel_path = "srfi/128.sld", .source = @import("kaappi_srfi_128_sld").source },
 };
 
@@ -531,8 +534,16 @@ pub fn tryLoadLibraryFromFile(vm: *VM, name_list: Value) !void {
     }
 
     // Resolve the .sld file path
-    const sld_path = resolveLibraryPath(allocator, rel_path, vm.lib_paths) orelse
+    const sld_path = resolveLibraryPath(allocator, rel_path, vm.lib_paths) orelse {
+        // No lib tree anywhere this binary can see -- a release binary
+        // copied to a machine without an exe-relative/ex-home lib, or a
+        // -Dbundle-src standalone whose compile run never read this .sld
+        // (bundled_files records only files the bundling run touched).
+        // Disk keeps first precedence; the embedded copy is the last
+        // resort, not a shadow (kaappi#2394 review).
+        if (findEmbeddedLibrary(rel_path)) |source| return loadEmbeddedLibrary(vm, rel_path, source);
         return error.UndefinedVariable;
+    };
     defer allocator.free(sld_path);
 
     // Extract the directory of the .sld file for include path resolution

--- a/tests/scheme/smoke/channel-identity-2394.scm
+++ b/tests/scheme/smoke/channel-identity-2394.scm
@@ -16,7 +16,8 @@
         (only (srfi 69) make-hash-table hash-table-set! hash-table-size
               hash-table-ref/default hash)
         (only (srfi 128) comparator? comparator-type-test-predicate
-              comparator-equality-predicate comparator-ordered? comparator-hash))
+              comparator-equality-predicate comparator-ordered? comparator-hash
+              make-default-comparator comparator-register-default!))
 
 (test-begin "channel-identity-2394")
 
@@ -143,6 +144,28 @@
 
 (test-equal "channel-comparator is cached: repeat calls return the same record"
   #t (eq? (channel-comparator) (channel-comparator)))
+
+;; make-default-comparator tables: while nothing is registered, the
+;; hashtable bridge runs them on the native equal? fast path — the swap
+;; must be observably identical to the closures it replaces.
+(test-equal "default-comparator sets behave as equal? tables (fast path)"
+  '(2 #t #f)
+  (let ((s (set (make-default-comparator) '(1 2) '(1 2) "x")))
+    (list (set-size s)
+          (set-contains? s '(1 2))
+          (set-contains? s '(1 3)))))
+
+;; Registration opts the default comparator out of the fast path (back to
+;; its closures), and the closures consult the registry: channel stubs now
+;; unify through the REGISTERED channel-comparator. Must be last —
+;; comparator-register-default! is process-global srfi-128 state.
+(test-equal "a registered channel-comparator extends the default comparator"
+  '(1 #t)
+  (let* ((triple (make-stub-pair)))
+    (comparator-register-default! (channel-comparator))
+    (let ((s (set (make-default-comparator) (car triple) (cadr triple))))
+      (list (set-size s)
+            (set-contains? s (cddr triple))))))
 
 ;; --- argument discipline ---
 (define (code-of thunk) (guard (e (#t (error-object-code e))) (thunk) 'no-raise))

--- a/tests/scheme/smoke/channel-identity-2394.scm
+++ b/tests/scheme/smoke/channel-identity-2394.scm
@@ -12,7 +12,7 @@
 ;; export string-hash/string-ci-hash, so the table and comparator names are
 ;; imported with `only` rather than wholesale.
 (import (scheme base) (scheme write) (scheme process-context)
-        (kaappi fibers) (srfi 18) (srfi 64)
+        (kaappi fibers) (srfi 18) (srfi 64) (srfi 113)
         (only (srfi 69) make-hash-table hash-table-set! hash-table-size
               hash-table-ref/default hash)
         (only (srfi 128) comparator? comparator-type-test-predicate
@@ -90,6 +90,40 @@
     (list (hash-table-size registry)
           (hash-table-ref/default registry (cadr triple) 'MISS))))
 
+;; (srfi 113) sets honor their comparator since the %make-empty-set fix —
+;; the idiom the issue's option-1b comment advertised.
+(test-equal "SRFI-113 sets dedup channel stubs via channel-comparator"
+  '(1 #t)
+  (let* ((triple (make-stub-pair))
+         (seen (set (channel-comparator) (car triple) (cadr triple) (cddr triple))))
+    (list (set-size seen)
+          (set-contains? seen (cadr triple)))))
+
+;; The hash input is the channel's identity for its whole life: a table
+;; keyed BEFORE the first cross-thread send still finds its entry after
+;; promotion rewrites the original in place (CodeRabbit's insert → promote
+;; → lookup scenario).
+(test-equal "channel-hash is stable across promotion: insert, promote, lookup"
+  '(1 early early)
+  (let* ((ch (make-channel))
+         (to-w (make-channel))
+         (to-p (make-channel))
+         (registry (make-hash-table channel=? channel-hash)))
+    (hash-table-set! registry ch 'early)
+    (define worker
+      (thread-start! (make-thread
+        (lambda ()
+          (let ((c (channel-receive to-w)))
+            (channel-send to-p c)
+            (channel-send to-p c))))))
+    (channel-send to-w ch)
+    (thread-join! worker)
+    (let ((a (channel-receive to-p))
+          (b (channel-receive to-p)))
+      (list (hash-table-size registry)
+            (hash-table-ref/default registry a 'MISS)
+            (hash-table-ref/default registry b 'MISS)))))
+
 ;; --- channel-comparator is a real SRFI-128 comparator ---
 (test-equal "comparator fields agree with their channel=?/channel-hash sources"
   '(#t #t #f #f #t)
@@ -106,6 +140,9 @@
   (let* ((triple (make-stub-pair)))
     ((comparator-equality-predicate (channel-comparator))
      (cadr triple) (cddr triple))))
+
+(test-equal "channel-comparator is cached: repeat calls return the same record"
+  #t (eq? (channel-comparator) (channel-comparator)))
 
 ;; --- argument discipline ---
 (define (code-of thunk) (guard (e (#t (error-object-code e))) (thunk) 'no-raise))

--- a/tests/scheme/smoke/channel-identity-2394.scm
+++ b/tests/scheme/smoke/channel-identity-2394.scm
@@ -1,0 +1,122 @@
+;; Regression tests for kaappi#2394 (KEP-0002 §2): channel identity across
+;; stubs. Two stubs for one SharedChannel are distinct heap objects, so
+;; eq?/eqv?/equal? report #f for "the same channel" seen from two receipts —
+;; the divergence the KEP's 2026-08-27 as-implemented amendment records.
+;; channel=?/channel-hash/channel-comparator are the supported identity
+;; surface: they compare (and hash) the `shared` pointer, the one
+;; representation every thread agrees on.
+;;
+;; The channels here are CAPTURED by the thread thunks (let-bound) — the §2
+;; legal sharing path that promotes them; a top-level global would fail the
+;; foreign-owner check on the child instead. (srfi 69) and (srfi 128) both
+;; export string-hash/string-ci-hash, so the table and comparator names are
+;; imported with `only` rather than wholesale.
+(import (scheme base) (scheme write) (scheme process-context)
+        (kaappi fibers) (srfi 18) (srfi 64)
+        (only (srfi 69) make-hash-table hash-table-set! hash-table-size
+              hash-table-ref/default hash)
+        (only (srfi 128) comparator? comparator-type-test-predicate
+              comparator-equality-predicate comparator-ordered? comparator-hash))
+
+(test-begin "channel-identity-2394")
+
+;; --- local (unpromoted) channels: pointer identity, hash consistency ---
+(define C (make-channel))
+(test-equal "channel=? on the same local channel" #t (channel=? C C))
+
+(test-equal "channel=? on two distinct local channels"
+  #f (let ((a (make-channel)) (b (make-channel))) (channel=? a b)))
+
+(test-equal "channel-hash is stable and bound form stays in range"
+  '(#t #t)
+  (let ((a (make-channel)))
+    (list (= (channel-hash a) (channel-hash a))
+          (< (channel-hash a 100) 100))))
+
+(test-equal "an unshared channel hashes like plain (hash ch)"
+  #t (let ((a (make-channel))) (= (channel-hash a) (hash a))))
+
+;; A worker that receives `ch` from to-w and sends it back twice through
+;; to-p: the parent ends up holding two stubs of one promoted channel, plus
+;; the (in-place-promoted) original.
+(define (make-stub-pair)
+  (let ((ch (make-channel))
+        (to-w (make-channel))
+        (to-p (make-channel)))
+    (define worker
+      (thread-start! (make-thread
+        (lambda ()
+          (let ((c (channel-receive to-w)))
+            (channel-send to-p c)
+            (channel-send to-p c))))))
+    (channel-send to-w ch)
+    (thread-join! worker)
+    (cons ch (cons (channel-receive to-p) (channel-receive to-p)))))
+
+;; --- the core scenario: eq?/eqv? cannot unify the stubs; channel=? must,
+;; against each other AND the original handle.
+(test-equal "stubs of one promoted channel unify under channel=?"
+  '(#t #t #t)
+  (let* ((triple (make-stub-pair))
+         (ch (car triple))
+         (a (cadr triple))
+         (b (cddr triple)))
+    (list (channel=? a b) (channel=? a ch) (channel=? b ch))))
+
+(test-equal "stub and original hash alike once promoted"
+  #t
+  (let* ((triple (make-stub-pair))
+         (ch (car triple))
+         (a (cadr triple)))
+    (= (channel-hash a) (channel-hash ch))))
+
+;; --- the reply-channel registry idiom the issue exists for ---
+(test-equal "make-hash-table with channel=?/channel-hash dedups stubs"
+  '(1 second)
+  (let* ((triple (make-stub-pair))
+         (registry (make-hash-table channel=? channel-hash)))
+    (hash-table-set! registry (cadr triple) 'first)
+    (hash-table-set! registry (cddr triple) 'second)
+    (list (hash-table-size registry)
+          (hash-table-ref/default registry (car triple) 'MISS))))
+
+(test-equal "make-hash-table with channel-comparator dedups stubs"
+  '(1 3)
+  (let* ((triple (make-stub-pair))
+         (registry (make-hash-table (channel-comparator))))
+    (hash-table-set! registry (car triple) 1)
+    (hash-table-set! registry (cadr triple) 2)
+    (hash-table-set! registry (cddr triple) 3)
+    (list (hash-table-size registry)
+          (hash-table-ref/default registry (cadr triple) 'MISS))))
+
+;; --- channel-comparator is a real SRFI-128 comparator ---
+(test-equal "comparator fields agree with their channel=?/channel-hash sources"
+  '(#t #t #f #f #t)
+  (let* ((cmp (channel-comparator))
+         (ch (make-channel)))
+    (list (comparator? cmp)
+          ((comparator-type-test-predicate cmp) ch)
+          ((comparator-type-test-predicate cmp) 5)
+          (comparator-ordered? cmp)
+          (= (comparator-hash cmp ch) (channel-hash ch)))))
+
+(test-equal "comparator equality unifies stubs like channel=?"
+  #t
+  (let* ((triple (make-stub-pair)))
+    ((comparator-equality-predicate (channel-comparator))
+     (cadr triple) (cddr triple))))
+
+;; --- argument discipline ---
+(define (code-of thunk) (guard (e (#t (error-object-code e))) (thunk) 'no-raise))
+
+(test-equal "type and range errors carry their codes"
+  '(KP3002 KP3002 KP3007)
+  (let ((ch (make-channel)))
+    (list (code-of (lambda () (channel=? ch 5)))
+          (code-of (lambda () (channel-hash "x")))
+          (code-of (lambda () (channel-hash ch 0))))))
+
+(let ((runner (test-runner-current)))
+  (test-end "channel-identity-2394")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Fixes #2394.

## Decision

Implements **option 1b** from the issue discussion — expose channel identity as a comparator surface rather than extending the global predicates. Two stubs for one `SharedChannel` are observationally indistinguishable but `eqv?`/`equal?` stay stub-identity, as the KEP-0002 2026-08-27 as-implemented amendment records; the SRFI-128 idiom is the R7RS-large answer for exactly this (per-type equality+hash), and it leaves the `eqvP`/`deepEqual`/`valueHash` coupling untouched. A future transparent-equality layer (option 1) can be added on top later — both would compute the same answer.

## What's added to `(kaappi fibers)`

- **`channel=? a b`** — `#t` iff both operands are channels backing the same `SharedChannel` (or the same unpromoted local channel; the mixed case only arises for genuinely different channels, since promotion rewrites the original in place and every stub is born promoted). Carries the same foreign-owner check as `channel-send`, like `channel-closed?` — it reads channel fields; `channel?` stays exempt as a total predicate.
- **`channel-hash ch [bound]`** — hashes the `shared` pointer, consistent with `channel=?` by construction (the comparator contract); mirrors `(hash obj [bound])` (SRFI 69) including the KP3002/KP3007 argument discipline. An unshared channel hashes identically here and under plain `(hash ch)`.
- **`channel-comparator`** — `(make-comparator channel? channel=? #f channel-hash)` built by calling the **real** `(srfi 128)` `make-comparator`, so `comparator?` and the field accessors agree with every hand-built comparator and the native `extractComparatorFns` bridge recognizes the record (`(make-hash-table (channel-comparator))` works). The library lazy-loads on demand — the `environment` procedure's own route — from a new `embedded_libraries` entry (`srfi/128.sld`, same build.zig pattern as `(srfi 181)`), so `--sandbox` and WASM keep working. The three procedures are the `(kaappi fibers)` registry's pristine exports, immune to top-level shadowing of those names.

The issue's core scenario, now green:

```scheme
(define registry (make-hash-table channel=? channel-hash)) ; or (channel-comparator)
;; worker thread receives ch from to-w, sends it back twice through to-p:
(let ((a (channel-receive to-p)) (b (channel-receive to-p)))
  (list (channel=? a b) (channel=? a ch))       ; => (#t #t)
  (hash-table-set! registry a 'reply-to)
  (hash-table-ref/default registry ch 'MISS))   ; => reply-to — any stub finds it
```

## Tests

- `src/tests_fibers.zig`: local identity/hash, the cross-thread stub-unification scenario (asserts `eq?`/`eqv?` stay `#f` while `channel=?` is `#t` — the divergence this PR addresses), hash-table dedup via both table flavors, and lazy comparator construction.
- `tests/scheme/smoke/channel-identity-2394.scm`: the end-to-end suite (11 SRFI-64 tests).
- Full verification run from the worktree: unit suite 1871 pass / 7 skipped; fiber tests also green under `-Dgc-stress=true`; `tests/scheme/run-all.sh` = **2116 pass / 0 fail** (R7RS 1395/1395, compile + wasm-differential included); `zig fmt --check`, `markdownlint-cli2`, and `zig build wasm` all clean.

## Caveats (documented in `docs/dev/thread-value-sharing.md`)

- **Hash stability across promotion**: a channel hashed before its first cross-thread send hashes its local address, after it the `SharedChannel`'s. Promotion is sticky — share before keying. This is the edge the issue's option-1b comment said to document.
- **`(srfi 113)` sets don't honor comparators in this port** (pre-existing): `113.sld`'s `%make-empty-set` builds its backing table with a zero-argument `make-hash-table`, so the issue comment's `(set channel-comparator …)` example does **not** dedup — `make-hash-table` (SRFI 69/125) is the working route. Fixing 113 is deliberately out of scope: routing its tables through comparator lambdas would drop every SRFI-113 set off the native `equal?` fast path.
- `unboundedHash` is now `pub` so `channel-hash` shares the exact unbounded hash rendering.
- Side effect of the embedding: `(import (srfi 128))\) now also works under `--sandbox` (consistently — `cond-expand` availability flips with it, per the #1649 derive-don't-list principle).

The KEP-0002 §2 amendment wording (promise replaced by the comparator API) lives in the `kaappi/keps` repo and is left for a follow-up there.