### PR TITLE
Re-port SRFI 241 and 202 on er-macro-transformer (KEP-0006 step 5)

### DIFF
--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -1456,8 +1456,12 @@ result lists so one cata can bind several variables under `...`). The
 202 re-port additionally gained SRFI 2's bare bound-variable claw and
 vector patterns in quasiquoted claws.
 
-Engine facts the port depends on (each probed before use, all
-regression-covered by `tests/scheme/srfi/srfi241.scm` / `srfi202.scm`):
+Engine facts the port depends on (each probed before use; the macro
+behavior in the first three bullets is regression-covered by
+`tests/scheme/srfi/srfi241.scm` / `srfi202.scm`, and the expansion-time
+diagnostics by `tests/scheme/errors/srfi-241-expansion-errors-2391.sh`;
+the last bullet is a testing-workflow note, not something those suites
+check):
 
 - **A macro expansion can rebind `quasiquote` via `let-syntax` with a
   bare-symbol transformer spec.** `match` wraps each clause body in
@@ -1485,4 +1489,8 @@ regression-covered by `tests/scheme/srfi/srfi241.scm` / `srfi202.scm`):
 - **A worktree's `.sld` edit is invisible until `zig-out/lib` is
   refreshed** — the exe-relative library dir is populated at `zig build`
   time, so rebuild (or re-copy) after editing, on top of the usual
-  `KAAPPI_HOME=$(mktemp -d)` isolation (kaappi#2352).
+  `KAAPPI_HOME=$(mktemp -d)` isolation (kaappi#2352). The
+  `KAAPPI_HOME` isolation and `.sld` staleness invalidation themselves
+  are regression-covered by `tests/scheme/cache/library-cache-1888.sh`;
+  the zig-out/lib refresh step is not covered by any test — it is a
+  local-workflow footgun to remember.

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -1435,3 +1435,54 @@ identifier macros, or output-provenance tracking a symbol-based expander
 cannot honestly provide — implicit renaming specifically cannot
 distinguish injected from macro-generated symbols when both are the same
 interned object.
+
+### SRFI 241 and SRFI 202 — match and pattern and-let*, on explicit renaming
+
+Both libraries were re-ported from pure `syntax-rules` onto
+`er-macro-transformer` (kaappi#2391, KEP-0006 step 5 — the acceptance
+test for SRFI 211). The old ports' template gymnastics — a custom `%%%`
+ellipsis identifier in every helper macro so the literal `...` token
+could be matched as data — are gone; each library is now one procedural
+transformer that compiles the pattern language by ordinary list
+processing. The re-port lifted all four of the old 241 port's documented
+limitations: arbitrary (compound/nested/cata) sub-patterns under an
+ellipsis, mandatory patterns after the ellipsis in lists and vectors
+(`(,x ... ,y . ,r)`, `#(,a ,m ... ,z)`), the SRFI's ellipsis-aware
+quasiquote inside clause bodies, and the spec's cata evaluation order
+(cata operators run only after the guard passes — hidden temporaries are
+bound during the structural match, then applied through the
+`%match-cata` runtime helper, which also transposes per-ellipsis-level
+result lists so one cata can bind several variables under `...`). The
+202 re-port additionally gained SRFI 2's bare bound-variable claw and
+vector patterns in quasiquoted claws.
+
+Engine facts the port depends on (each probed before use, all
+regression-covered by `tests/scheme/srfi/srfi241.scm` / `srfi202.scm`):
+
+- **A macro expansion can rebind `quasiquote` via `let-syntax` with a
+  bare-symbol transformer spec.** `match` wraps each clause body in
+  `(let-syntax ((quasiquote <renamed %match-qq>)) body ...)`, where
+  `%match-qq` is a library-level `(define %match-qq
+  (er-macro-transformer ...))` global holding a Transformer value; the
+  renamed reference resolves at the use site through the whole-def-env
+  import copy, and the binding shadows the built-in quasiquote for
+  exactly the body's scope. The binding NAME is the bare symbol
+  `quasiquote` (deliberately unhygienic — it must capture the body's
+  use-site backticks).
+- **Fresh temporaries are `rename` of counter-distinct symbols.**
+  Renaming the same symbol twice in one expansion yields the same
+  identifier, so every temporary is minted as `%mN.<base>` with a
+  per-expansion counter, then renamed.
+- **Keyword recognition (`...`, `_`, `->`, `guard`, `unquote`,
+  `quasiquote`, `values`) is `compare` against `rename` of the keyword —
+  hygiene-stripped name equality.** That strength suffices for these
+  macros (kaappi#2388 records the evidence); a use inside another
+  er-macro's output whose keywords arrive renamed still compares equal.
+  The known edge: a match form produced by a *syntax-rules* template is
+  subject to that template's own ellipsis processing first, and a
+  template-renamed `quasiquote` in a clause body resolves to the
+  built-in quasiquote, not the match-body one.
+- **A worktree's `.sld` edit is invisible until `zig-out/lib` is
+  refreshed** — the exe-relative library dir is populated at `zig build`
+  time, so rebuild (or re-copy) after editing, on top of the usual
+  `KAAPPI_HOME=$(mktemp -d)` isolation (kaappi#2352).

--- a/lib/srfi/148.sld
+++ b/lib/srfi/148.sld
@@ -8,10 +8,11 @@
 ;; needed by 148.scm's own em-syntax-rules definition, and 148.macros.scm's
 ;; combinators build on 148.scm's CK-machine core. The reference's Chibi
 ;; er-macro-transformer branch (a faster, non-portable identifier-comparison
-;; implementation) is not used here -- Kaappi always takes the reference's
-;; portable "else" branch (148.identifier.scm) since it has no
-;; er-macro-transformer support (that mechanism is SRFI 72's, a much larger,
-;; deferred undertaking -- see docs/dev/srfi-exclusions.md).
+;; implementation) is not used here -- Kaappi has er-macro-transformer since
+;; v0.22.0 (SRFI 211, KEP-0006), but that branch relies on a binding-aware
+;; compare, and Kaappi's compare is hygiene-stripped name equality (see
+;; kaappi#2388), so this port keeps the reference's portable "else" branch
+;; (148.identifier.scm).
 ;;
 ;; em-syntax-rules resolves through SRFI 147 (custom macro transformers):
 ;; its own definition, and several combinators built on top of it (e.g.

--- a/lib/srfi/202.sld
+++ b/lib/srfi/202.sld
@@ -6,118 +6,170 @@
 ;;; (var expr), since a bare identifier is otherwise ambiguous between "bind
 ;;; this variable" and "match this symbol literally". Self-contained (does
 ;;; not import (srfi 241)): and-let* claws only ever need wildcard/variable/
-;;; pair/literal patterns, not 241's ellipsis, cata, or vector patterns.
+;;; pair/vector/literal patterns, not 241's ellipsis or cata patterns.
+;;;
+;;; An er-macro-transformer port (KEP-0006 step 5): the claw list is walked
+;;; by ordinary list processing and each claw compiled directly. Relative to
+;;; the previous pure-syntax-rules port this also adds SRFI 2's bare
+;;; BOUND-VARIABLE claw (a claw that is just an identifier, tested for
+;;; truthiness) and vector patterns inside quasiquoted claws. The claw
+;;; keywords (quasiquote, unquote, _, values) are recognized by
+;;; hygiene-stripped name comparison — see kaappi#2388.
 
 (define-library (srfi 202)
-  (import (scheme base))
+  (import (scheme base)
+          (srfi 211 explicit-renaming))
   (export and-let*)
   (begin
 
-    ;; Structural matcher for a single quasiquoted pattern.
-    (define-syntax %qpat
-      (syntax-rules (unquote _)
-        ((_ val (unquote _) kt kf) kt)
-        ((_ val (unquote var) kt kf) (let ((var val)) kt))
-        ((_ val () kt kf) (if (null? val) kt kf))
-        ((_ val (p1 . p2) kt kf)
-         (if (pair? val)
-             (%qpat (car val) p1 (%qpat (cdr val) p2 kt kf) kf)
-             kf))
-        ((_ val k kt kf) (if (equal? val (quote k)) kt kf))))
-
-    ;; Peels patterns off an already-collected value list one at a time.
-    ;; Running out of vals before the pattern list is exhausted means "too
-    ;; few values" (kf). tailvar = #f means surplus values are discarded;
-    ;; any other identifier means they're collected and bound to it.
-    (define-syntax %match-vals
-      (syntax-rules (quasiquote)
-        ((_ vals () #f kt kf) kt)
-        ((_ vals () tailvar kt kf) (let ((tailvar vals)) kt))
-        ((_ vals ((quasiquote p1) p2 ...) tailvar kt kf)
-         (if (pair? vals)
-             (%qpat (car vals) p1 (%match-vals (cdr vals) (p2 ...) tailvar kt kf) kf)
-             kf))
-        ((_ vals (var p2 ...) tailvar kt kf)
-         (if (pair? vals)
-             (let ((var (car vals))) (%match-vals (cdr vals) (p2 ...) tailvar kt kf))
-             kf))))
-
-    ;; Like %match-vals, but the FIRST pattern additionally requires a
-    ;; truthy value when it's a bare identifier — SRFI 202's rule for the
-    ;; leading pattern of a multi-value (non-"values"-keyword) claw.
-    (define-syntax %match-vals-first
-      (syntax-rules (quasiquote)
-        ((_ vals ((quasiquote p1) p2 ...) kt kf)
-         (if (pair? vals)
-             (%qpat (car vals) p1 (%match-vals (cdr vals) (p2 ...) #f kt kf) kf)
-             kf))
-        ((_ vals (var p2 ...) kt kf)
-         (if (pair? vals)
-             (let ((var (car vals)))
-               (and var (%match-vals (cdr vals) (p2 ...) #f kt kf)))
-             kf))))
-
-    ;; Standard syntax-rules "peel off the last element" idiom: splits a
-    ;; claw's raw (pat1 pat2 ... expr) into ((pat1 pat2 ...) expr), since
-    ;; a general multi-pattern claw has no keyword to anchor the split on
-    ;; (unlike the "values" form below).
-    (define-syntax %split-claw
-      (syntax-rules ()
-        ((_ (last) (pat ...) (k more ...))
-         (k (pat ...) last more ...))
-        ((_ (p1 p2 more ...) (pat ...) k)
-         (%split-claw (p2 more ...) (pat ... p1) k))))
-
-    ;; Dispatches on the shape of the dotted tail captured from
-    ;; (values p1 p2 ... . v*): when the claw is written without an
-    ;; explicit collector (a proper list, e.g. (values a b)), that tail is
-    ;; the literal () rather than a bindable identifier — %match-vals's #f
-    ;; sentinel must be substituted in that case instead.
-    (define-syntax %claw-values
-      (syntax-rules ()
-        ((_ (p ...) () expr cont)
-         (call-with-values
-           (lambda () expr)
-           (lambda vals (%match-vals vals (p ...) #f cont #f))))
-        ((_ (p ...) v* expr cont)
-         (call-with-values
-           (lambda () expr)
-           (lambda vals (%match-vals vals (p ...) v* cont #f))))))
-
-    (define-syntax %claw-multi
-      (syntax-rules ()
-        ((_ (pat ...) expr cont)
-         (call-with-values
-           (lambda () expr)
-           (lambda vals (%match-vals-first vals (pat ...) cont #f))))))
-
-    (define-syntax %and-let*-claws
-      (syntax-rules (values quasiquote)
-        ((_ ()) #t)
-        ((_ () body1 body2 ...) (let () body1 body2 ...))
-
-        ;; guard-only: (expr)
-        ((_ ((gexpr) rest ...) body ...)
-         (and gexpr (%and-let*-claws (rest ...) body ...)))
-
-        ;; values-collecting: ((values p1 p2 ... . v*) expr)
-        ((_ (((values p1 p2 ... . v*) expr) rest ...) body ...)
-         (%claw-values (p1 p2 ...) v* expr (%and-let*-claws (rest ...) body ...)))
-
-        ;; single quasiquoted pattern: (`pat expr)
-        ((_ (((quasiquote pat) expr) rest ...) body ...)
-         (%qpat expr pat (%and-let*-claws (rest ...) body ...) #f))
-
-        ;; single bare-identifier claw: (var expr)  [SRFI 2, truthiness applies]
-        ((_ ((var expr) rest ...) body ...)
-         (let ((var expr)) (and var (%and-let*-claws (rest ...) body ...))))
-
-        ;; general multi-value pattern claw: (pat1 pat2 pat3 ... expr)
-        ((_ ((pat1 pat2 pat3 more ...) rest ...) body ...)
-         (%split-claw (pat1 pat2 pat3 more ...) ()
-                      (%claw-multi (%and-let*-claws (rest ...) body ...))))))
-
     (define-syntax and-let*
-      (syntax-rules ()
-        ((_ (claw ...) body ...)
-         (%and-let*-claws (claw ...) body ...))))))
+      (er-macro-transformer
+       (lambda (form rename compare)
+         (define r-if (rename 'if))
+         (define r-let (rename 'let))
+         (define r-lambda (rename 'lambda))
+         (define r-quote (rename 'quote))
+         (define r-cwv (rename 'call-with-values))
+         (define r-car (rename 'car))
+         (define r-cdr (rename 'cdr))
+         (define r-pair? (rename 'pair?))
+         (define r-null? (rename 'null?))
+         (define r-equal? (rename 'equal?))
+         (define r-vector? (rename 'vector?))
+         (define r-vector->list (rename 'vector->list))
+
+         ;; Keyword recognition is name-based compare (kaappi#2388).
+         (define (kw? x sym) (and (symbol? x) (compare x (rename sym))))
+         (define (qq-form? x)
+           (and (pair? x) (kw? (car x) 'quasiquote)
+                (pair? (cdr x)) (null? (cddr x))))
+         (define (unquote-form? x)
+           (and (pair? x) (kw? (car x) 'unquote)))
+
+         (define counter 0)
+         (define (fresh base)
+           (set! counter (+ counter 1))
+           (rename (string->symbol
+                    (string-append "%al" (number->string counter)
+                                   "." base))))
+
+         (define (verr msg what)
+           (error (string-append "and-let*: " msg) what))
+
+         ;; Structural matcher for one quasiquoted pattern. SK is a thunk
+         ;; returning the success expression; failure yields #f.
+         (define (qpat pat val sk)
+           (cond
+            ((unquote-form? pat)
+             (if (not (and (pair? (cdr pat)) (null? (cddr pat))))
+                 (verr "invalid unquote pattern" pat))
+             (let ((sub (cadr pat)))
+               (cond
+                ((kw? sub '_) (sk))
+                ((symbol? sub) (list r-let (list (list sub val)) (sk)))
+                (else (verr "invalid unquote pattern" pat)))))
+            ((pair? pat)
+             (let ((a (fresh "a")) (d (fresh "d")))
+               (list r-if (list r-pair? val)
+                     (list r-let (list (list a (list r-car val))
+                                       (list d (list r-cdr val)))
+                           (qpat (car pat) a
+                                 (lambda () (qpat (cdr pat) d sk))))
+                     #f)))
+            ((null? pat)
+             (list r-if (list r-null? val) (sk) #f))
+            ((vector? pat)
+             (let ((lst (fresh "v")))
+               (list r-if (list r-vector? val)
+                     (list r-let (list (list lst (list r-vector->list val)))
+                           (qpat (vector->list pat) lst sk))
+                     #f)))
+            (else
+             (list r-if (list r-equal? val (list r-quote pat)) (sk) #f))))
+
+         ;; Match the patterns PS (bare identifiers or quasiquoted
+         ;; patterns) against successive elements of the value list LST.
+         ;; Too few values fails; surplus values are bound to TAILVAR when
+         ;; it is a symbol, discarded when it is #f. FIRST? applies SRFI
+         ;; 202's truthiness rule to a leading bare-identifier pattern.
+         (define (match-vals ps lst tailvar first? sk)
+           (cond
+            ((null? ps)
+             (if tailvar
+                 (list r-let (list (list tailvar lst)) (sk))
+                 (sk)))
+            (else
+             (let ((p (car ps)) (a (fresh "x")) (d (fresh "r")))
+               (list r-if (list r-pair? lst)
+                     (list r-let (list (list a (list r-car lst))
+                                       (list d (list r-cdr lst)))
+                           (cond
+                            ((qq-form? p)
+                             (qpat (cadr p) a
+                                   (lambda ()
+                                     (match-vals (cdr ps) d tailvar #f sk))))
+                            ((symbol? p)
+                             (list r-let (list (list p a))
+                                   (if first?
+                                       (list r-if p
+                                             (match-vals (cdr ps) d tailvar #f sk)
+                                             #f)
+                                       (match-vals (cdr ps) d tailvar #f sk))))
+                            (else (verr "invalid claw pattern" p))))
+                     #f)))))
+
+         ;; Bind EXPR's values to a fresh rest-list and match PS over it.
+         (define (values-claw ps tailvar first? expr cont)
+           (let ((vals (fresh "vals")))
+             (list r-cwv
+                   (list r-lambda '() expr)
+                   (list r-lambda vals
+                         (match-vals ps vals tailvar first? cont)))))
+
+         (define (expand-claws claws body)
+           (cond
+            ((null? claws)
+             (if (null? body) #t (cons r-let (cons '() body))))
+            ((not (pair? claws)) (verr "invalid claw list" claws))
+            (else
+             (let ((claw (car claws))
+                   (cont (lambda () (expand-claws (cdr claws) body))))
+               (cond
+                ;; bare BOUND-VARIABLE claw (SRFI 2)
+                ((symbol? claw) (list r-if claw (cont) #f))
+                ((not (and (pair? claw) (list? claw)))
+                 (verr "invalid claw" claw))
+                ;; guard-only claw: (expr)
+                ((null? (cdr claw))
+                 (list r-if (car claw) (cont) #f))
+                ;; (var expr)  [SRFI 2, truthiness applies]
+                ((and (null? (cddr claw)) (symbol? (car claw)))
+                 (list r-let (list (list (car claw) (cadr claw)))
+                       (list r-if (car claw) (cont) #f)))
+                ;; (`pat expr)  single quasiquoted pattern
+                ((and (null? (cddr claw)) (qq-form? (car claw)))
+                 (let ((v (fresh "t")))
+                   (list r-let (list (list v (cadr claw)))
+                         (qpat (cadr (car claw)) v cont))))
+                ;; ((values p1 p2 ... . v*) expr)  values-collecting
+                ((and (null? (cddr claw)) (pair? (car claw))
+                      (kw? (car (car claw)) 'values))
+                 (let split ((ps (cdr (car claw))) (acc '()))
+                   (if (pair? ps)
+                       (split (cdr ps) (cons (car ps) acc))
+                       (let ((tailvar (cond ((null? ps) #f)
+                                            ((symbol? ps) ps)
+                                            (else (verr "invalid values claw"
+                                                        claw)))))
+                         (values-claw (reverse acc) tailvar #f
+                                      (cadr claw) cont)))))
+                ;; general multi-value pattern claw: (pat1 pat2 ... expr)
+                (else
+                 (let split ((items claw) (acc '()))
+                   (if (null? (cdr items))
+                       (values-claw (reverse acc) #f #t (car items) cont)
+                       (split (cdr items) (cons (car items) acc))))))))))
+
+         (if (not (and (pair? (cdr form)) (list? (cadr form))))
+             (verr "invalid claw list" form))
+         (expand-claws (cadr form) (cddr form)))))))

--- a/lib/srfi/241.sld
+++ b/lib/srfi/241.sld
@@ -1,135 +1,467 @@
 ;;; SRFI 241 — Match
 ;;;
-;;; A syntax-rules-only port of the Wright-Cartwright-Shinn matcher (Kaappi
-;;; has no syntax-case). The "trick" throughout is giving every helper macro
-;;; a custom ellipsis identifier (%%%) so the literal three-dot token can be
-;;; matched as ordinary data instead of triggering syntax-rules' own
-;;; repetition — that is what lets a pattern like (,x ... . ,y) be recognized
-;;; by shape rather than misinterpreted as "repeat the sub-pattern ,x".
+;;; An er-macro-transformer port of the Wright-Cartwright-Shinn matcher
+;;; (KEP-0006 step 5). The previous port was pure syntax-rules and had to
+;;; give every helper macro a custom ellipsis identifier (%%%) so the
+;;; literal three-dot token could be pattern-matched as data; the whole
+;;; pattern language is now compiled by ordinary list processing inside one
+;;; procedural transformer, which lifted the port's four documented
+;;; limitations:
 ;;;
-;;; Scope, relative to the full SRFI:
-;;;  - Ellipsis-repeated sub-patterns are supported only in the two shapes
-;;;    (subpat ...) and (subpat ... . tailpat), and only when subpat is a
-;;;    plain ,var, ,_, or a repeated default-cata ,(var) (which collects
-;;;    (map self ...) — the shape used by the SRFI's own "(+ ,[x*] ...)"
-;;;    example) — not an arbitrary compound pattern. This covers the
-;;;    overwhelmingly common "collect the rest" use.
-;;;  - Vector patterns support fixed length (#(p1 p2 ...)) and whole-vector
-;;;    ellipsis (#(p ...)), not a mixed mandatory-prefix/suffix segment.
-;;;  - Square-bracket clause notation isn't available (Kaappi's reader has no
-;;;    bracket syntax); write clauses and cata patterns with plain parens,
-;;;    e.g. (,(f -> x y) ...) rather than [,[f -> x y] ...].
-;;;  - The ellipsis-aware quasiquote that SRFI 241 binds inside match bodies
-;;;    is not provided; ordinary (scheme base) quasiquote is in scope there,
-;;;    which covers everything but templates that splice an ellipsis-bound
-;;;    variable.
-;;;  - Per the spec, cata operators are evaluated only after a clause's
-;;;    guard passes. This implementation evaluates them as part of the
-;;;    structural match instead (before the guard), which only differs
-;;;    observably if a cata operator has a side effect and the guard then
-;;;    rejects the clause.
+;;;  - Ellipsis-repeated sub-patterns may be arbitrary patterns (including
+;;;    nested ellipses, catas, vectors), not just ,var / ,_ / ,(var).
+;;;  - Ellipses may be followed by further mandatory patterns before the
+;;;    tail, e.g. (,x ... ,y ,z) and (,x ... ,y . ,rest); vector patterns
+;;;    support the full #(p1 ... pk pe ellipsis pm+1 ... pn) grammar with a
+;;;    mandatory prefix and suffix around the ellipsis segment.
+;;;  - The SRFI's ellipsis-aware quasiquote is bound inside match clause
+;;;    bodies (via a let-syntax around each body): a subtemplate followed by
+;;;    ellipses iterates its unquoted expressions the way a syntax-rules
+;;;    template iterates pattern variables, and (... tpl) escapes. Guard
+;;;    expressions keep the ordinary (scheme base) quasiquote.
+;;;  - Cata operators are evaluated only after the clause's guard passes
+;;;    (the spec's order); the structural match binds hidden temporaries and
+;;;    the cata procedures run afterwards, so a rejected guard no longer
+;;;    triggers cata side effects.
+;;;
+;;; Remaining scope notes, relative to the full SRFI:
+;;;  - Square-bracket clause notation isn't available (Kaappi's reader has
+;;;    no bracket syntax); write clauses and cata patterns with plain
+;;;    parens, e.g. (,(f -> x y) ...) rather than [,[f -> x y] ...].
+;;;  - Only match is exported. The auxiliary keywords (unquote, ..., _,
+;;;    guard, ->) are recognized by hygiene-stripped name comparison (the
+;;;    strength of this engine's ER compare — see kaappi#2388), so
+;;;    exporting bindings for them would not change what is matched.
+;;;  - If a match form is produced by another macro's syntax-rules
+;;;    template, that template's own ellipsis processing applies before
+;;;    match sees the form (escape nested ellipses with (... ...)), and
+;;;    quasiquote symbols renamed by such a template resolve to the
+;;;    built-in quasiquote rather than the match-body one.
 
 (define-library (srfi 241)
-  (import (scheme base))
+  (import (scheme base)
+          (srfi 211 explicit-renaming))
   (export match)
   (begin
+
+    ;; ------------------------------------------------------------------
+    ;; Runtime helpers (referenced from expansions via rename).
+    ;; ------------------------------------------------------------------
 
     (define (%match-fail val)
       (error "match: no matching clause" val))
 
-    (define (%scan-tail-to-end val)
-      (if (pair? val) (%scan-tail-to-end (cdr val)) val))
-
-    (define (%split-tail val)
-      (let loop ((v val) (acc '()))
+    ;; Split VAL into (prefix . rest): rest holds VAL's final K pairs plus
+    ;; any improper tail, prefix is a fresh list of the leading elements.
+    ;; #f when VAL has fewer than K pairs.
+    (define (%match-split val k)
+      (let count ((v val) (n 0))
         (if (pair? v)
-            (loop (cdr v) (cons (car v) acc))
-            (values (reverse acc) v))))
+            (count (cdr v) (+ n 1))
+            (and (>= n k)
+                 (let loop ((v val) (m (- n k)) (acc '()))
+                   (if (zero? m)
+                       (cons (reverse acc) v)
+                       (loop (cdr v) (- m 1) (cons (car v) acc))))))))
 
-    ;; (%match-ellipsis-var val self var tailpat kt kf)
-    ;; var/tailpat are unexpanded syntax fragments from the original pattern.
-    (define-syntax %match-ellipsis-var
-      (syntax-rules %%% (unquote _)
-        ((_ val self _ () kt kf)
-         (if (list? val) kt kf))
-        ((_ val self _ (unquote tv) kt kf)
-         (let ((tv (%scan-tail-to-end val))) kt))
-        ((_ val self var () kt kf)
-         (if (list? val) (let ((var val)) kt) kf))
-        ((_ val self var (unquote tv) kt kf)
-         (let-values (((var tv) (%split-tail val))) kt))))
+    ;; Apply cata operator OP to VAL nested DEPTH ellipsis levels deep.
+    ;; Returns the list of NVARS results; at depth > 0 the per-element
+    ;; result lists are transposed so each cata variable receives one
+    ;; (nested) list.
+    (define (%match-cata op val depth nvars)
+      (if (zero? depth)
+          (call-with-values (lambda () (op val)) list)
+          (let ((rows (map (lambda (v) (%match-cata op v (- depth 1) nvars))
+                           val)))
+            (let transpose ((i (- nvars 1)) (acc '()))
+              (if (< i 0)
+                  acc
+                  (transpose (- i 1)
+                             (cons (map (lambda (r) (list-ref r i)) rows)
+                                   acc)))))))
 
-    ;; Dispatches on the shape of the repeated sub-pattern; only ,var / ,_
-    ;; and repeated default-cata ,(var) are supported (see file header).
-    (define-syntax %match-ellipsis-list
-      (syntax-rules %%% (unquote)
-        ;; (,(var) ...)  repeated default-cata: collect (map self ...)
-        ((_ val self (unquote (var)) () kt kf)
-         (if (list? val) (let ((var (map self val))) kt) kf))
-        ((_ val self (unquote var) tailpat kt kf)
-         (%match-ellipsis-var val self var tailpat kt kf))))
+    ;; ------------------------------------------------------------------
+    ;; The ellipsis-aware quasiquote bound inside match clause bodies.
+    ;; A subtemplate followed by K ellipses iterates its unquoted
+    ;; expressions (map at depth 1, flattened once per extra ellipsis);
+    ;; (... tpl) makes ellipses inside tpl literal; nested quasiquote
+    ;; levels behave as in R7RS.
+    ;; ------------------------------------------------------------------
 
-    (define-syntax %match-pat
-      (syntax-rules %%% (unquote _ -> ...)
-        ;; ,_  wildcard
-        ((_ val self (unquote _) kt kf) kt)
+    (define %match-qq
+      (er-macro-transformer
+       (lambda (form rename compare)
+         (define r-quote (rename 'quote))
+         (define r-cons (rename 'cons))
+         (define r-append (rename 'append))
+         (define r-map (rename 'map))
+         (define r-apply (rename 'apply))
+         (define r-lambda (rename 'lambda))
+         (define r-list->vector (rename 'list->vector))
 
-        ;; ,(op -> v ...)  named cata: op is applied to val, results bound to v ...
-        ((_ val self (unquote (op -> v %%%)) kt kf)
-         (let-values (((v %%%) (op val))) kt))
+         (define (kw? x sym) (and (symbol? x) (compare x (rename sym))))
+         (define (ell? x) (kw? x '...))
+         (define (head-kw? x sym)
+           (and (pair? x) (kw? (car x) sym) (list? (cdr x))
+                (pair? (cdr x))))
+         (define (unq? x) (head-kw? x 'unquote))
+         (define (unqs? x) (head-kw? x 'unquote-splicing))
+         (define (qq? x) (head-kw? x 'quasiquote))
+         (define (escape? x eok)        ; (... tpl)
+           (and eok (pair? x) (ell? (car x))
+                (pair? (cdr x)) (null? (cddr x))))
 
-        ;; ,(v ...)  default cata: re-invokes the enclosing match on val
-        ((_ val self (unquote (v %%%)) kt kf)
-         (let-values (((v %%%) (self val))) kt))
+         (define counter 0)
+         (define (fresh)
+           (set! counter (+ counter 1))
+           (rename (string->symbol
+                    (string-append "%qq" (number->string counter)))))
 
-        ;; ,var  variable binding
-        ((_ val self (unquote var) kt kf)
-         (let ((var val)) kt))
+         (define (verr msg what)
+           (error (string-append "match quasiquote: " msg) what))
 
-        ;; ()  empty list
-        ((_ val self () kt kf)
-         (if (null? val) kt kf))
+         ;; No unquote/unquote-splicing/ellipsis marker anywhere: literal.
+         (define (pure? tpl)
+           (cond
+            ((symbol? tpl)
+             (not (or (kw? tpl 'unquote) (kw? tpl 'unquote-splicing)
+                      (ell? tpl))))
+            ((pair? tpl) (and (pure? (car tpl)) (pure? (cdr tpl))))
+            ((vector? tpl)
+             (let loop ((i 0))
+               (or (= i (vector-length tpl))
+                   (and (pure? (vector-ref tpl i)) (loop (+ i 1))))))
+            (else #t)))
 
-        ;; #(sub ...)  whole-vector ellipsis ("..." matched literally)
-        ((_ val self #(sub ...) kt kf)
-         (if (vector? val)
-             (%match-ellipsis-list (vector->list val) self sub () kt kf)
-             kf))
+         ;; exp : template x nesting-level x ellipsis-active? -> expression
+         (define (exp tpl lvl eok)
+           (cond
+            ((pure? tpl) (list r-quote tpl))
+            ((unq? tpl)
+             (if (zero? lvl)
+                 (if (null? (cddr tpl))
+                     (cadr tpl)
+                     (verr "multi-expression unquote outside list context"
+                           tpl))
+                 (list r-cons (list r-quote (car tpl))
+                       (exp (cdr tpl) (- lvl 1) eok))))
+            ((unqs? tpl)
+             (if (zero? lvl)
+                 (verr "unquote-splicing outside list context" tpl)
+                 (list r-cons (list r-quote (car tpl))
+                       (exp (cdr tpl) (- lvl 1) eok))))
+            ((qq? tpl)
+             (list r-cons (list r-quote (car tpl))
+                   (exp (cdr tpl) (+ lvl 1) eok)))
+            ((escape? tpl eok)
+             (exp (cadr tpl) lvl #f))
+            ((pair? tpl) (exp-list tpl lvl eok))
+            ((vector? tpl)
+             (list r-list->vector (exp (vector->list tpl) lvl eok)))
+            (else (list r-quote tpl))))
 
-        ;; #(p1 p2 ...)  fixed-length vector
-        ((_ val self #(p %%%) kt kf)
-         (if (vector? val)
-             (%match-pat (vector->list val) self (p %%%) kt kf)
-             kf))
+         (define (exp-list tpl lvl eok)
+           (let ((head (car tpl)) (tail (cdr tpl)))
+             (cond
+              ;; head followed by one or more ellipses, at level 0
+              ((and eok (zero? lvl) (pair? tail) (ell? (car tail))
+                    (not (escape? tpl eok)))
+               (let count ((tl tail) (k 0))
+                 (if (and (pair? tl) (ell? (car tl)))
+                     (count (cdr tl) (+ k 1))
+                     (let ((seg (exp-ellipsis head k eok)))
+                       (if (null? tl)
+                           seg
+                           (list r-append seg (exp tl lvl eok)))))))
+              ;; splicing element: (unquote-splicing e ...)
+              ((and (zero? lvl) (unqs? head))
+               (append (list r-append) (cdr head)
+                       (list (exp tail lvl eok))))
+              ;; multi-expression unquote element: (unquote e1 e2 ...)
+              ((and (zero? lvl) (unq? head) (not (null? (cddr head))))
+               (let loop ((es (cdr head)))
+                 (if (null? es)
+                     (exp tail lvl eok)
+                     (list r-cons (car es) (loop (cdr es))))))
+              (else
+               (list r-cons (exp head lvl eok) (exp tail lvl eok))))))
 
-        ;; (p1 ... . prest)  ellipsis + tail ("..." matched literally)
-        ((_ val self (p1 ... . prest) kt kf)
-         (%match-ellipsis-list val self p1 prest kt kf))
+         ;; HEAD iterated by K ellipses at level 0: replace each of its
+         ;; level-0 unquoted expressions by a fresh variable, map a lambda
+         ;; of those variables over the expressions, and flatten once per
+         ;; extra ellipsis.
+         (define (exp-ellipsis head k eok)
+           (let ((subs '()))            ; (var . expr), newest first
+             (define (sub! e)
+               (let ((v (fresh)))
+                 (set! subs (cons (cons v e) subs))
+                 v))
+             (define (peel tpl lvl eok)
+               (cond
+                ((and (or (unq? tpl) (unqs? tpl)) (zero? lvl))
+                 (cons (car tpl) (map sub! (cdr tpl))))
+                ((or (unq? tpl) (unqs? tpl))
+                 (cons (car tpl) (peel (cdr tpl) (- lvl 1) eok)))
+                ((qq? tpl)
+                 (cons (car tpl) (peel (cdr tpl) (+ lvl 1) eok)))
+                ((escape? tpl eok)
+                 (list (car tpl) (peel (cadr tpl) lvl #f)))
+                ((pair? tpl)
+                 (cons (peel (car tpl) lvl eok) (peel (cdr tpl) lvl eok)))
+                ((vector? tpl)
+                 (list->vector
+                  (map (lambda (x) (peel x lvl eok)) (vector->list tpl))))
+                (else tpl)))
+             (let ((tpl2 (peel head 0 eok)))
+               (if (null? subs)
+                   (verr "no unquoted expressions under ellipsis" head)
+                   (let* ((pairs (reverse subs))
+                          (body (exp tpl2 0 eok))
+                          (seg0 (append
+                                 (list r-map
+                                       (list r-lambda (map car pairs) body))
+                                 (map cdr pairs))))
+                     (let extra ((k k) (seg seg0))
+                       (if (<= k 1)
+                           seg
+                           (extra (- k 1)
+                                  (list r-apply r-append seg)))))))))
 
-        ;; (p1 . p2)  pair
-        ((_ val self (p1 . p2) kt kf)
-         (if (pair? val)
-             (%match-pat (car val) self p1 (%match-pat (cdr val) self p2 kt kf) kf)
-             kf))
+         (if (and (pair? (cdr form)) (null? (cddr form)))
+             (exp (cadr form) 0 #t)
+             (error "match quasiquote: bad form" form)))))
 
-        ;; symbol or self-evaluating constant, matched via equal?
-        ((_ val self k kt kf)
-         (if (equal? val (quote k)) kt kf))))
-
-    (define-syntax %match-clauses
-      (syntax-rules %%% (guard)
-        ((_ t self () fail-expr) fail-expr)
-        ((_ t self ((pat (guard g %%%) body1 body2 %%%) rest %%%) fail-expr)
-         (let ((kf (lambda () (%match-clauses t self (rest %%%) fail-expr))))
-           (%match-pat t self pat
-                       (if (and g %%%) (begin body1 body2 %%%) (kf))
-                       (kf))))
-        ((_ t self ((pat body1 body2 %%%) rest %%%) fail-expr)
-         (let ((kf (lambda () (%match-clauses t self (rest %%%) fail-expr))))
-           (%match-pat t self pat (begin body1 body2 %%%) (kf))))))
+    ;; ------------------------------------------------------------------
+    ;; match itself: a pattern compiler.
+    ;; ------------------------------------------------------------------
 
     (define-syntax match
-      (syntax-rules ()
-        ((_ expr clause ...)
-         (letrec ((self (lambda (t) (%match-clauses t self (clause ...) (%match-fail t)))))
-           (self expr)))))))
+      (er-macro-transformer
+       (lambda (form rename compare)
+         (define r-if (rename 'if))
+         (define r-let (rename 'let))
+         (define r-letrec (rename 'letrec))
+         (define r-lambda (rename 'lambda))
+         (define r-quote (rename 'quote))
+         (define r-and (rename 'and))
+         (define r-car (rename 'car))
+         (define r-cdr (rename 'cdr))
+         (define r-pair? (rename 'pair?))
+         (define r-null? (rename 'null?))
+         (define r-equal? (rename 'equal?))
+         (define r-vector? (rename 'vector?))
+         (define r-vector->list (rename 'vector->list))
+         (define r-cons (rename 'cons))
+         (define r-reverse (rename 'reverse))
+         (define r-apply (rename 'apply))
+         (define r-let-syntax (rename 'let-syntax))
+         (define r-fail (rename '%match-fail))
+         (define r-split (rename '%match-split))
+         (define r-cata (rename '%match-cata))
+         (define r-qq (rename '%match-qq))
+
+         ;; Keyword recognition is name-based compare (kaappi#2388).
+         (define (kw? x sym) (and (symbol? x) (compare x (rename sym))))
+         (define (ell? x) (kw? x '...))
+         (define (uscore? x) (kw? x '_))
+         (define (arrow? x) (kw? x '->))
+         (define (unquote-form? x)
+           (and (pair? x) (kw? (car x) 'unquote)))
+
+         (define counter 0)
+         (define (fresh base)
+           (set! counter (+ counter 1))
+           (rename (string->symbol
+                    (string-append "%m" (number->string counter)
+                                   "." base))))
+
+         (define (verr msg what)
+           (error (string-append "match: " msg) what))
+
+         ;; Compile one clause against value T; SELF is the whole-match
+         ;; procedure (for default catas), KF the clause-failure thunk.
+         (define (compile-clause clause t self kf)
+           (if (not (and (pair? clause) (list? clause)
+                         (pair? (cdr clause))))
+               (verr "invalid clause" clause))
+           (let* ((pat (car clause))
+                  (rest (cdr clause))
+                  (has-guard (and (pair? (car rest))
+                                  (kw? (car (car rest)) 'guard)
+                                  (pair? (cdr rest))))
+                  (guard-tests (if has-guard (cdr (car rest)) #f))
+                  (body (if has-guard (cdr rest) rest))
+                  (svars '())      ; structurally bound ids, newest first
+                  (catas '()))     ; (tmp op vars depth), op #f = default
+
+             (define (record-var! v) (set! svars (cons v svars)))
+             (define (vars-since mark)   ; oldest-first delta
+               (let loop ((s svars) (acc '()))
+                 (if (eq? s mark) acc (loop (cdr s) (cons (car s) acc)))))
+
+             ;; Record a cata: bind a hidden temporary now, apply the
+             ;; operator only after the guard passes.
+             (define (cata val op cvs depth sk)
+               (if (not (list? cvs)) (verr "invalid cata pattern" cvs))
+               (for-each (lambda (v)
+                           (if (not (symbol? v))
+                               (verr "invalid cata variable" v)))
+                         cvs)
+               (let ((tmp (fresh "c")))
+                 (record-var! tmp)
+                 (set! catas (cons (list tmp op cvs depth) catas))
+                 (list r-let (list (list tmp val)) (sk))))
+
+             ;; cp : pattern x value-id x success-thunk x failure-expr x
+             ;;      ellipsis-depth -> expression
+             ;; SK is invoked exactly once, at the innermost success
+             ;; point, after every variable on the path is recorded.
+             (define (cp pat val sk fk depth)
+               (cond
+                ((unquote-form? pat)
+                 (if (not (and (pair? (cdr pat)) (null? (cddr pat))))
+                     (verr "invalid unquote pattern" pat))
+                 (let ((sub (cadr pat)))
+                   (cond
+                    ((uscore? sub) (sk))
+                    ((symbol? sub)
+                     (record-var! sub)
+                     (list r-let (list (list sub val)) (sk)))
+                    ((pair? sub)
+                     (if (and (pair? (cdr sub)) (arrow? (cadr sub)))
+                         (cata val (car sub) (cddr sub) depth sk)
+                         (cata val #f sub depth sk)))
+                    (else (verr "invalid unquote pattern" pat)))))
+                ((and (pair? pat) (pair? (cdr pat)) (ell? (cadr pat)))
+                 (cp-ellipsis (car pat) (cddr pat) val sk fk depth))
+                ((pair? pat)
+                 (if (ell? (car pat)) (verr "misplaced ellipsis" pat))
+                 (let ((a (fresh "a")) (d (fresh "d")))
+                   (list r-if (list r-pair? val)
+                         (list r-let
+                               (list (list a (list r-car val))
+                                     (list d (list r-cdr val)))
+                               (cp (car pat) a
+                                   (lambda ()
+                                     (cp (cdr pat) d sk fk depth))
+                                   fk depth))
+                         fk)))
+                ((null? pat)
+                 (list r-if (list r-null? val) (sk) fk))
+                ((vector? pat)
+                 (let ((lst (fresh "v")))
+                   (list r-if (list r-vector? val)
+                         (list r-let
+                               (list (list lst (list r-vector->list val)))
+                               (cp (vector->list pat) lst sk fk depth))
+                         fk)))
+                (else
+                 (list r-if (list r-equal? val (list r-quote pat))
+                       (sk) fk))))
+
+             ;; (sub ... . rest) — REST may contain further mandatory
+             ;; patterns before the tail. Split off the final K pairs,
+             ;; loop SUB over the prefix accumulating its variables, then
+             ;; match REST against the remainder.
+             (define (cp-ellipsis sub rest val sk fk depth)
+               (if (ell? sub) (verr "misplaced ellipsis" sub))
+               (let count ((r rest) (k 0))
+                 (cond
+                  ((and (pair? r) (not (unquote-form? r)))
+                   (if (ell? (car r))
+                       (verr "multiple ellipses in one list" rest))
+                   (count (cdr r) (+ k 1)))
+                  (else
+                   (let* ((sp (fresh "sp")) (pre (fresh "pre"))
+                          (tailv (fresh "tl")) (loop (fresh "lp"))
+                          (in (fresh "in")) (e (fresh "e"))
+                          (mark svars)
+                          (accs '())    ; (var . acc-id)
+                          (elem-code
+                           (cp sub e
+                               (lambda ()
+                                 (let ((evars (vars-since mark)))
+                                   (set! accs
+                                         (map (lambda (v)
+                                                (cons v (fresh "ac")))
+                                              evars))
+                                   (cons loop
+                                         (cons (list r-cdr in)
+                                               (map (lambda (p)
+                                                      (list r-cons (car p)
+                                                            (cdr p)))
+                                                    accs)))))
+                               fk (+ depth 1)))
+                          (rest-code (cp rest tailv sk fk depth)))
+                     (list r-let (list (list sp (list r-split val k)))
+                           (list r-if sp
+                                 (list r-let
+                                       (list (list pre (list r-car sp))
+                                             (list tailv (list r-cdr sp)))
+                                       (list r-let loop
+                                             (cons (list in pre)
+                                                   (map (lambda (p)
+                                                          (list (cdr p)
+                                                                (list r-quote '())))
+                                                        accs))
+                                             (list r-if (list r-null? in)
+                                                   (list r-let
+                                                         (map (lambda (p)
+                                                                (list (car p)
+                                                                      (list r-reverse (cdr p))))
+                                                              accs)
+                                                         rest-code)
+                                                   (list r-let
+                                                         (list (list e (list r-car in)))
+                                                         elem-code))))
+                                 fk)))))))
+
+             ;; Success: guard first, then catas, then the body with the
+             ;; ellipsis-aware quasiquote in scope.
+             (define (finish)
+               (let* ((body-code
+                       (cons r-let-syntax
+                             (cons (list (list 'quasiquote r-qq))
+                                   body)))
+                      (cata-code
+                       (let loop ((cs catas) (e body-code))
+                         (if (null? cs)
+                             e
+                             (let* ((c (car cs))
+                                    (tmp (car c)) (op (cadr c))
+                                    (cvs (car (cddr c)))
+                                    (d (cadr (cddr c))))
+                               (loop (cdr cs)
+                                     (list r-apply
+                                           (list r-lambda cvs e)
+                                           (list r-cata
+                                                 (or op self) tmp
+                                                 d (length cvs)))))))))
+                 (if has-guard
+                     (list r-if (cons r-and guard-tests)
+                           cata-code (list kf))
+                     cata-code)))
+
+             (cp pat t finish (list kf) 0)))
+
+         ;; ---- transformer entry ----
+         (if (not (pair? (cdr form)))
+             (verr "missing expression" form))
+         (let ((expr (cadr form))
+               (clauses (cddr form))
+               (self (fresh "self"))
+               (t (fresh "t")))
+           (define (compile-clauses clauses)
+             (if (null? clauses)
+                 (list r-fail t)
+                 (let ((kf (fresh "kf")))
+                   (list r-let
+                         (list (list kf
+                                     (list r-lambda '()
+                                           (compile-clauses (cdr clauses)))))
+                         (compile-clause (car clauses) t self kf)))))
+           (list r-letrec
+                 (list (list self
+                             (list r-lambda (list t)
+                                   (compile-clauses clauses))))
+                 (list self expr))))))))

--- a/tests/scheme/compile/fixtures/srfi-241-202/main.scm
+++ b/tests/scheme/compile/fixtures/srfi-241-202/main.scm
@@ -1,0 +1,30 @@
+;; Fixture for srfi-241-202-bundle-2391.sh: the standalone-binary smoke for
+;; the er-macro-transformer re-port of SRFI 241/202 (kaappi#2391). One line
+;; per lifted capability; the driving script diffs the bundled binary's
+;; whole output against the interpreter's (the oracle).
+;;
+;; Deliberately NOT added to the shared bundle-replay fixture: that fixture's
+;; .sbc bytes must stay independent of the srfi .sld search path, and its
+;; three scripts assert lines of their own.
+(import (scheme base) (scheme write) (srfi 241) (srfi 202))
+
+;; kaappi#2391 lifts 1+2: compound subpattern under an ellipsis, and a
+;; mandatory pattern after it.
+(display "2391-a: ")
+(write (match '((1 2) (3 4) (5 6) end)
+         (((,a ,b) ... ,tail) (list a b tail))))
+(newline)
+
+;; kaappi#2391 lift 3: the ellipsis-aware quasiquote inside a clause body.
+(display "2391-b: ")
+(write (match '(1 2 3) ((,x ... ,y) `(prefix ,x ... suffix ,y))))
+(newline)
+
+;; kaappi#2391: SRFI 202 with a vector pattern claw, a guard claw, and a
+;; values-collecting claw in one and-let*.
+(display "2391-c: ")
+(write (and-let* ((`#(,hi ,lo) (vector 9 4))
+                  ((> hi lo))
+                  ((values q r) (floor/ hi lo)))
+         (list hi lo q r)))
+(newline)

--- a/tests/scheme/compile/srfi-241-202-bundle-2391.sh
+++ b/tests/scheme/compile/srfi-241-202-bundle-2391.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Standalone-binary smoke for the SRFI 241/202 er-macro re-port (kaappi#2391).
+#
+# The re-port's SRFI-64 suites are interpreter-only evidence; per the
+# LLVM-backend notes a compiled-artifact tier needs its own script here.
+# `kaappi compile` refuses programs whose imports resolve from .sld files by
+# design (kaappi#1743), so the compiled route for a library-importing program
+# is the -Dbundle standalone binary: the .sbc pathway compiles the srfi
+# libraries at build time and embeds them, and the resulting binary replays
+# that bytecode with no library search path at all — exercising `match` and
+# `and-let*` expansions through compile-serialize-replay instead of the
+# interpreter's load path.
+#
+# The interpreter is the oracle (see the block in ../shell-common.sh): both
+# tiers run the same fixture and their whole outputs must agree; the golden
+# strings document intent and still catch an answer both tiers get wrong.
+#
+# Build discipline follows bundle_fixture_binary (kaappi#1930/#1926): the
+# .sbc is produced by an interpreter built from the SAME source as the
+# -Dbundle rebuild, into an isolated prefix, so the two share one build id;
+# compiling from inside the fixture directory keeps the recorded paths
+# relative and the .sbc bytes deterministic, making repeat -Dbundle builds
+# content-cache hits. This fixture is separate from the shared bundle-replay
+# one on purpose: srfi imports would make that fixture's .sbc bytes depend
+# on the srfi library search path, and its three scripts share one binary.
+# Every kaappi invocation gets a throwaway KAAPPI_HOME so an installed
+# ~/.kaappi/lib (or its cache) can never shadow the tree's .sld files
+# (kaappi#2352).
+#
+# Usage: bash tests/scheme/compile/srfi-241-202-bundle-2391.sh [path-to-kaappi]
+
+set -euo pipefail
+
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+skip_without_zig "rebuilds the interpreter with -Dbundle on this machine"
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+FIXTURE="$REPO_DIR/tests/scheme/compile/fixtures/srfi-241-202"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+EXPECTED_A='2391-a: ((1 3 5) (2 4 6) end)'
+EXPECTED_B='2391-b: (prefix 1 2 suffix 3)'
+EXPECTED_C='2391-c: (9 4 2 1)'
+
+# --- interpreter run (the oracle) ---------------------------------------
+INTERP_OUTPUT=$(KAAPPI_HOME="$DIR/interp-home" "$KAAPPI" \
+    --lib-path "$REPO_DIR/lib" "$FIXTURE/main.scm" 2>/dev/null)
+for expected in "$EXPECTED_A" "$EXPECTED_B" "$EXPECTED_C"; do
+    if ! grep -Fxq "$expected" <<< "$INTERP_OUTPUT"; then
+        echo "FAIL: interpreter — expected line '$expected' missing" >&2
+        echo "full output: $INTERP_OUTPUT" >&2
+        exit 1
+    fi
+done
+
+# --- standalone binary: interp prefix -> .sbc -> -Dbundle ----------------
+OUT="$REPO_DIR/.zig-cache/kaappi-test-fixtures-2391"
+SBC="$OUT/srfi-241-202.sbc"
+INTERP="$OUT/interp/bin/kaappi"
+BUNDLE_BIN="$DIR/main-standalone"
+LOG=$(mktemp)
+
+build_lock "$REPO_DIR" bundle-2391
+rc=0
+(
+    mkdir -p "$OUT" &&
+        cd "$REPO_DIR" &&
+        zig build -Doptimize=ReleaseSafe --prefix "$OUT/interp" &&
+        [ -x "$INTERP" ] &&
+        cd "$FIXTURE" &&
+        # Relative cwd => relative recorded paths => deterministic .sbc
+        # bytes; srfi resolution comes from the isolated prefix's own
+        # exe-relative lib (installed from this tree by the build above),
+        # and the throwaway KAAPPI_HOME keeps a user install out of it.
+        KAAPPI_HOME="$OUT/home" "$INTERP" --compile -o "$SBC" main.scm &&
+        [ -f "$SBC" ] &&
+        cd "$REPO_DIR" &&
+        zig build -Dbundle="$SBC" -Doptimize=ReleaseSafe \
+            --prefix "$OUT/prefix" &&
+        cp "$OUT/prefix/bin/kaappi" "$BUNDLE_BIN"
+) > "$LOG" 2>&1 || rc=$?
+build_unlock "$REPO_DIR" bundle-2391
+
+if [ "$rc" -ne 0 ]; then
+    echo "FAIL: could not build the bundled srfi-241-202 binary" >&2
+    cat "$LOG" >&2
+    rm -f "$LOG"
+    exit 1
+fi
+rm -f "$LOG"
+
+# --- the two tiers must agree, line for line ----------------------------
+BUNDLE_OUTPUT=$(KAAPPI_HOME="$DIR/bundle-home" "$BUNDLE_BIN" 2>&1)
+if [[ "$BUNDLE_OUTPUT" != "$INTERP_OUTPUT" ]]; then
+    echo "FAIL: standalone output diverges from the interpreter" >&2
+    echo "--- interpreter:" >&2
+    printf '%s\n' "$INTERP_OUTPUT" >&2
+    echo "--- standalone:" >&2
+    printf '%s\n' "$BUNDLE_OUTPUT" >&2
+    exit 1
+fi
+
+echo "PASS: srfi-241-202 bundle smoke (3 lines, both tiers agree)"

--- a/tests/scheme/errors/srfi-241-expansion-errors-2391.sh
+++ b/tests/scheme/errors/srfi-241-expansion-errors-2391.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Expansion-stage diagnostics of the SRFI 241 er-macro port (kaappi#2391).
+#
+# The match transformer and the %match-qq quasiquote transformer validate
+# pattern/template shape while they EXPAND, so every diagnostic here is
+# raised at compile time (syntax-error[KP2002]) — a runtime `guard` in the
+# SRFI-64 suite can never observe them, which is why they get a shell suite:
+# one malformed form per diagnostic, asserting a nonzero exit AND the
+# diagnostic text (a generic "invalid syntax" with the message lost would
+# fail here).
+#
+# The positive behavior of the same code paths lives in
+# tests/scheme/srfi/srfi241.scm.
+#
+# Usage: bash tests/scheme/errors/srfi-241-expansion-errors-2391.sh [path-to-kaappi]
+
+set -euo pipefail
+
+KAAPPI="${1:-${KAAPPI:-zig-out/bin/kaappi}}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+# Hermetic: a throwaway KAAPPI_HOME (an installed ~/.kaappi/lib must not
+# shadow the working tree, kaappi#2352) and the checkout's own lib/ so the
+# .sld under test is the one in the tree, not a stale zig-out/lib copy.
+KAAPPI_HOME="$(mktemp -d)"
+export KAAPPI_HOME
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR" "$KAAPPI_HOME"' EXIT
+
+PASS=0
+FAIL=0
+
+# check_expansion_error <name> <expected-diagnostic-substring> <program>
+check_expansion_error() {
+    local name="$1" expect="$2" src="$3"
+    printf '%s\n' "$src" > "$DIR/$name.scm"
+
+    local status=0 out
+    out=$("$KAAPPI_ABS" --lib-path "$REPO_DIR/lib" "$DIR/$name.scm" 2>&1) \
+        || status=$?
+
+    if [ "$status" -eq 0 ]; then
+        echo "FAIL: $name — expected a nonzero exit, got 0 (output: $out)"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if [[ "$out" != *"$expect"* ]]; then
+        echo "FAIL: $name — diagnostic did not contain '$expect': $out"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    PASS=$((PASS + 1))
+}
+
+IMPORT='(import (scheme base) (srfi 241))'
+
+# An ellipsis with no preceding sub-pattern.
+check_expansion_error "misplaced-ellipsis" \
+    "match: misplaced ellipsis" \
+    "$IMPORT
+(match (list 1) ((... ,x) 1))"
+
+# Two ellipses at the same list level.
+check_expansion_error "multiple-ellipses" \
+    "match: multiple ellipses in one list" \
+    "$IMPORT
+(match (list 1 2) ((,x ... ,y ...) 1))"
+
+# A named cata whose variable position holds a non-identifier.
+check_expansion_error "invalid-cata-variable" \
+    "match: invalid cata variable" \
+    "$IMPORT
+(match (list 1) ((,(f -> \"s\")) 1))"
+
+# A cata whose variable list is improper.
+check_expansion_error "invalid-cata-pattern" \
+    "match: invalid cata pattern" \
+    "$IMPORT
+(match (list 1) ((,(x . y)) 1))"
+
+# ,@ outside any list context in a match-body quasiquote template.
+check_expansion_error "splicing-outside-list" \
+    "match quasiquote: unquote-splicing outside list context" \
+    "$IMPORT
+(display (match (list 1) ((,x) \`,@x)))"
+
+# An ellipsis iterating a subtemplate with nothing unquoted to iterate.
+check_expansion_error "ellipsis-over-constant-template" \
+    "match quasiquote: no unquoted expressions under ellipsis" \
+    "$IMPORT
+(display (match (list 1) ((,x) \`((a) ...))))"
+
+echo ""
+echo "SRFI 241 expansion errors: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/scheme/srfi/srfi202.scm
+++ b/tests/scheme/srfi/srfi202.scm
@@ -92,6 +92,37 @@
              (z (* x y)))
     z))
 
+;;; --- er-port additions (kaappi#2391) ---
+
+;; SRFI 2's bare BOUND-VARIABLE claw, missing from the syntax-rules port.
+(define %srfi202-bound-var 7)
+(define %srfi202-bound-false #f)
+
+(test-equal "srfi 2: bare bound-variable claw, truthy"
+  14
+  (and-let* (%srfi202-bound-var) (* %srfi202-bound-var 2)))
+
+(test-equal "srfi 2: bare bound-variable claw, falsy short-circuits"
+  #f
+  (and-let* (%srfi202-bound-false) 'never))
+
+(test-equal "srfi 2: bare bound-variable claw combines with bindings"
+  21
+  (and-let* ((x 3) %srfi202-bound-var (y (* x %srfi202-bound-var))) y))
+
+;; Vector patterns inside quasiquoted claws.
+(test-equal "pattern binding: vector pattern"
+  '(1 2)
+  (and-let* ((`#(,a ,b) (vector 1 2))) (list a b)))
+
+(test-equal "pattern binding: vector pattern wrong length fails"
+  #f
+  (and-let* ((`#(,a ,b) (vector 1 2 3))) (list a b)))
+
+(test-equal "pattern binding: vector pattern on non-vector fails"
+  #f
+  (and-let* ((`#(,a ,b) (list 1 2))) (list a b)))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-202")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi241.scm
+++ b/tests/scheme/srfi/srfi241.scm
@@ -3,9 +3,10 @@
 ;;
 ;; Kaappi's reader has no [...]  bracket syntax, so clauses and cata patterns
 ;; are written with plain parens throughout (see lib/srfi/241.sld header for
-;; the full list of scope limitations relative to the SRFI text).
+;; the remaining scope notes relative to the SRFI text).
 
-(import (scheme base) (scheme process-context) (srfi 241) (srfi 64))
+(import (scheme base) (scheme process-context) (srfi 241) (srfi 64)
+        (srfi 211 explicit-renaming))
 
 (test-begin "srfi-241")
 
@@ -99,6 +100,188 @@
   (guard (e (#t #t))
     (match 42 ((a) 'no))
     #f))
+
+;;; ==================================================================
+;;; Lifted limitation 1 (kaappi#2391): arbitrary ellipsis sub-patterns
+;;; ==================================================================
+
+(test-equal "compound subpattern under ellipsis"
+  '((1 3) (2 4))
+  (match '((1 2) (3 4)) (((,a ,b) ...) (list a b))))
+
+(test-equal "nested ellipsis"
+  '((1 2 3) (4 5))
+  (match '((1 2 3) (4 5)) (((,x ...) ...) x)))
+
+(test-equal "literal inside ellipsis subpattern"
+  '(1 2)
+  (match '((k 1) (k 2)) (((k ,v) ...) v)))
+
+(test-equal "literal mismatch under ellipsis falls to next clause"
+  'no
+  (match '((k 1) (j 2)) (((k ,v) ...) v) (,_ 'no)))
+
+(test-equal "dotted subpattern under ellipsis"
+  '((a c) (b d))
+  (match '((a . b) (c . d)) (((,x . ,y) ...) (list x y))))
+
+(test-equal "vector subpattern under ellipsis"
+  '((1 3) (2 4))
+  (match '(#(1 2) #(3 4)) ((#(,a ,b) ...) (list a b))))
+
+(test-equal "named cata under ellipsis with multiple values"
+  '((1 2 3) (2 4 6))
+  (let ((dup (lambda (x) (values x (* 2 x)))))
+    (match '(1 2 3) ((,(dup -> a b) ...) (list a b)))))
+
+(test-equal "named cata inside compound subpattern under ellipsis"
+  '((1 3) (20 60))
+  (let ((tenfold (lambda (v) (* v 10))))
+    (match '((1 2) (3 6))
+      (((,a ,(tenfold -> b)) ...) (list a b)))))
+
+(test-equal "named cata at ellipsis depth 2 transposes"
+  '((10 20) (30))
+  (let ((tenfold (lambda (v) (* v 10))))
+    (match '((1 2) (3))
+      (((,(tenfold -> x) ...) ...) x))))
+
+;;; ==================================================================
+;;; Lifted limitation 2 (kaappi#2391): mandatory patterns after the
+;;; ellipsis, in lists and vectors
+;;; ==================================================================
+
+(test-equal "ellipsis followed by one mandatory pattern"
+  '((1 2 3) 4)
+  (match '(1 2 3 4) ((,x ... ,y) (list x y))))
+
+(test-equal "ellipsis followed by two mandatory patterns"
+  '((1 2) 3 4)
+  (match '(1 2 3 4) ((,x ... ,y ,z) (list x y z))))
+
+(test-equal "ellipsis, mandatory pattern, then dotted tail"
+  '((1 2) 3 4)
+  (match '(1 2 3 . 4) ((,x ... ,y . ,r) (list x y r))))
+
+(test-equal "minimum length: too few elements falls to next clause"
+  'no
+  (match '(1) ((,x ... ,y ,z) 'yes) (,_ 'no)))
+
+(test-equal "empty ellipsis prefix before mandatory suffix"
+  '(() 9)
+  (match '(9) ((,x ... ,y) (list x y))))
+
+(test-equal "vector: prefix + ellipsis + suffix"
+  '(1 (2 3) 4)
+  (match #(1 2 3 4) (#(,a ,m ... ,z) (list a m z))))
+
+(test-equal "vector: empty ellipsis segment between prefix and suffix"
+  '(1 () 2)
+  (match #(1 2) (#(,a ,m ... ,z) (list a m z))))
+
+(test-equal "vector: too short for prefix+suffix falls to next clause"
+  'no
+  (match #(1) (#(,a ,m ... ,z) 'yes) (,_ 'no)))
+
+;;; ==================================================================
+;;; Lifted limitation 3 (kaappi#2391): the SRFI's ellipsis-aware
+;;; quasiquote inside match clause bodies
+;;; ==================================================================
+
+(test-equal "qq: splice an ellipsis-bound variable"
+  '(got 1 2 3)
+  (match '(1 2 3) ((,x ...) `(got ,x ...))))
+
+(test-equal "qq: splice with a following literal"
+  '(a 1 2 3 b)
+  (match '(1 2 3) ((,x ...) `(a ,x ... b))))
+
+(test-equal "qq: compound template iterates variables in parallel"
+  '((1 . 2) (3 . 4))
+  (match '((1 2) (3 4)) (((,a ,b) ...) `((,a . ,b) ...))))
+
+(test-equal "qq: nested ellipsis template"
+  '((1 2) (3))
+  (match '((1 2) (3)) (((,x ...) ...) `((,x ...) ...))))
+
+(test-equal "qq: double ellipsis flattens one level"
+  '(1 2 3)
+  (match '((1 2) (3)) (((,x ...) ...) `(,x ... ...))))
+
+(test-equal "qq: arbitrary expression under ellipsis (spec example)"
+  '(a 3 4 5 6 b)
+  (match '() (() `(a ,(+ 1 2) ,(map abs '(4 -5 6)) ... b))))
+
+(test-equal "qq: ordinary template unchanged"
+  '(a 3 (b))
+  (match 3 (,x `(a ,x (b)))))
+
+(test-equal "qq: unquote-splicing still available"
+  '(a 1 2 b)
+  (match '(1 2) ((,x ...) `(a ,@x b))))
+
+(test-equal "qq: (... tpl) escapes the ellipsis"
+  '(a ...)
+  (match '() (() `(... (a ...)))))
+
+(test-equal "qq: nested quasiquote stays literal"
+  '(quasiquote (a (unquote (+ 1 2))))
+  (match '() (() ``(a ,(+ 1 2)))))
+
+(test-equal "qq: vector template with splice"
+  #(1 2 3)
+  (match '(1 2 3) ((,x ...) `#(,x ...))))
+
+(test-equal "qq: quasiquote outside match bodies is untouched"
+  '(plain (1 2 3) ...)
+  `(plain ,(list 1 2 3) ...))
+
+;;; ==================================================================
+;;; Lifted limitation 4 (kaappi#2391): cata operators run only after
+;;; the clause's guard passes (the spec's evaluation order)
+;;; ==================================================================
+
+(define cata-calls 0)
+(define (traced-cata v) (set! cata-calls (+ cata-calls 1)) v)
+
+(test-equal "cata not evaluated when the guard rejects"
+  'fallback
+  (match '(5)
+    ((,(traced-cata -> x)) (guard #f) 'no)
+    (,_ 'fallback)))
+(test-equal "no cata side effect after a rejected guard" 0 cata-calls)
+
+(test-equal "cata evaluated when the guard passes"
+  5
+  (match '(5)
+    ((,(traced-cata -> x)) (guard #t) x)
+    (,_ 'fallback)))
+(test-equal "exactly one cata call after a passing guard" 1 cata-calls)
+
+(test-equal "guard still sees structurally bound variables"
+  'big
+  (match '(10) ((,x) (guard (> x 5)) 'big) (,_ 'small)))
+
+;;; --- multiple values from a clause body ---
+(test-equal "clause body may return multiple values"
+  '(1 2)
+  (call-with-values
+    (lambda () (match '(1 2) ((,a ,b) (values a b))))
+    list))
+
+;;; --- pattern keywords survive an er-macro rename (evidence for #2388:
+;;; compare is hygiene-stripped name equality, so a renamed ... / unquote
+;;; emitted by another macro is still recognized) ---
+(define-syntax collect-all
+  (er-macro-transformer
+   (lambda (form rename compare)
+     (list (rename 'match) (cadr form)
+           (list (list (list (rename 'unquote) (rename 'x)) (rename '...))
+                 (rename 'x))))))
+
+(test-equal "match emitted by an er-macro with renamed keywords"
+  '(1 2 3)
+  (collect-all '(1 2 3)))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-241")


### PR DESCRIPTION
KEP-0006 step 5 — the designated acceptance test for `er-macro-transformer`. Both libraries are re-ported from pure `syntax-rules` onto `(srfi 211 explicit-renaming)`: each is now a single procedural transformer that compiles the pattern language by ordinary list processing, replacing the `%%%` custom-ellipsis template gymnastics wholesale.

## Limitations lifted (all four)

1. **Arbitrary ellipsis sub-patterns** — `(subpat ...)` now accepts any pattern: compound lists, dotted pairs, vectors, literals, nested ellipses, and catas, e.g. `(((,a ,b) ...)`, `((,x ...) ...)`, `((,(f -> b)) ...)`. The old port allowed only `,var`, `,_`, and repeated `,(var)`.
2. **Mandatory patterns after the ellipsis** — `(,x ... ,y)`, `(,x ... ,y . ,rest)`, and the full vector grammar `#(p1 ... pk pe ellipsis pm+1 ... pn)` with mandatory prefix and suffix. The split is deterministic (count the fixed patterns after the ellipsis), no backtracking.
3. **Ellipsis-aware quasiquote in clause bodies** — each clause body is wrapped in `(let-syntax ((quasiquote %match-qq)) ...)`; a subtemplate followed by ellipses iterates its unquoted expressions the way a syntax-rules template iterates pattern variables (`` `((,a . ,b) ...) ``, `` `(,x ... ...) ``, the spec's `` `(a ,(+ 1 2) ,(map abs '(4 -5 6)) ... b) `` example), with `(... tpl)` escape, `,@`, nested levels, and vector templates. Ordinary templates behave exactly as before; quasiquote outside match bodies is untouched.
4. **Spec cata evaluation order** — cata operators now run only after the clause's guard passes (the old port evaluated them during the structural match and documented the deviation). The structural match binds hidden temporaries; `%match-cata` applies operators afterwards and transposes per-ellipsis-level results, so one cata can bind several variables under `...` at any depth.

SRFI 202 came along cleanly on the same pattern and additionally gains SRFI 2's bare **bound-variable claw** (missing from the old port) and **vector patterns** in quasiquoted claws.

## Also in this PR

- `lib/srfi/148.sld` header: the claim that Kaappi "has no er-macro-transformer support" has been false since v0.22.0 — corrected. The code still (correctly) takes the reference's portable branch: the Chibi `er-macro-transformer` branch implements `free-identifier=?`/`bound-identifier=?` on top of a compare it assumes is binding-aware, which Kaappi's name-based compare is not (#2388).
- `docs/dev/srfi-implementation-notes.md`: new SRFI 241/202 section documenting the engine facts the port depends on (let-syntax with a bare-symbol transformer spec across import, counter-distinct renamed temporaries, the deliberate bare-`quasiquote` capture).

## Remaining scope notes (documented in the 241 header)

- Square-bracket clause notation — reader has no `[...]` syntax (pre-existing, unrelated to this port).
- A match form produced by a *syntax-rules* template is subject to that template's own ellipsis processing before match sees it (escape with `(... ...)`) — inherent to syntax-rules, not liftable here. Likewise a template-renamed `quasiquote` in a clause body resolves to the built-in quasiquote rather than the match-body binding.
- Only `match` is exported (as before). With a name-based compare, exporting bindings for the aux keywords (`...`, `->`, `_`, `guard`) would not change what is matched — see below.

## Evidence for #2388

Recorded while porting; **no compare change is made here** — that is #2388's decision.

**Where name-based compare was sufficient (everything these two libraries do):**

- Every literal check — `...`, `_`, `->`, `guard`, `unquote`, `unquote-splicing`, `quasiquote` (241), `values`, `quasiquote`, `unquote`, `_` (202) — is `(compare x (rename 'kw))`. Keywords arrive either as the plain interned symbol (direct use) or hygiene-renamed (`__hyg_N_kw` when the match form is emitted by another er-macro); name-stripping equality answers both correctly. Regression-covered: `srfi241.scm`'s "match emitted by an er-macro with renamed keywords" builds the whole pattern out of `(rename 'unquote)` / `(rename '...)` and passes.
- For the unbound aux keywords (`...`, `_`, `->`, `guard` — no `(scheme base)` binding to compare against), a binding-aware `free-identifier=?` degenerates to name equality on unbound identifiers anyway, so name-based compare is not an approximation there — it is the same answer.

**Where name-based compare is observably weaker (none blocked the port):**

- A use-site local rebinding of a keyword name cannot opt out of keyword-hood. The one literal in these libraries with a real binding is SRFI 202's `values`: a claw `((values a b) e)` written where the user has shadowed `values` is still parsed as the values-claw keyword; a binding-aware compare could distinguish. Same shape for `->` used as a local variable inside a cata position.
- Symmetrically, because compare strips renames, a macro-*generated* identifier that merely spells like a keyword is treated as the keyword (e.g. an er-macro emitting `(rename '_)` as a would-be pattern variable gets the wildcard instead). Harmless in practice — nothing binds `_` — but it is the general shape of the weakness.
- SRFI 148's Chibi fast path stays unusable: with a name-based compare, its derived `free-identifier=?` and `bound-identifier=?` collapse into the same predicate, so the portable branch remains (header now says exactly this).

**Conclusion offered to #2388:** for aux-syntax literals with no binding — the overwhelmingly common case, including R7RS's own `else`/`=>` — name-based compare produces the answers a binding-aware `free-identifier=?` would. The observable divergence requires either a use-site rebinding of a *bound* keyword name or macro-generated same-spelled identifiers; neither arose in re-porting two real macro libraries.

## Testing

- `tests/scheme/srfi/srfi241.scm`: 18 → **54** passes (every lifted limitation has dedicated tests, including the deferred-cata side-effect ordering and depth-2 cata transposition).
- `tests/scheme/srfi/srfi202.scm`: 25 → **31** passes (bare bound-variable claw, vector patterns).
- `tests/scheme/srfi/srfi148.scm`: 142 passes; `srfi211.scm`: 29 passes (unchanged).
- `zig build test`: all unit suites pass (no Zig changes).
- All runs with `KAAPPI_HOME=$(mktemp -d)` and a rebuilt `zig-out/lib` (the exe-relative library dir shadows worktree `.sld` edits until refreshed — now noted in the implementation notes).

Closes #2391

🤖 Generated with [Claude Code](https://claude.com/claude-code)
