### PR TITLE
Make er-macro compare binding-aware free-identifier=? and land the four-quadrant test

### DIFF
--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -1422,12 +1422,19 @@ interned symbols as syntax: a bare-rename product (reserved forms and
 keywords rename to themselves) is the same object as a use-site token of
 that spelling, so compare recognizes the classic
 `(compare <token> (rename 'kw))` shape from the invocation's rename
-record plus whether the spelling occurs in the macro-use input —
-order-independent, reflexive for the invocation's own rename products
-(the hoisted-rename self-compare) and for two plain use-site tokens, and
-non-reflexive only for the quadrant-2 shape: a spelling that occurs in
-the input, bare-renamed this invocation, compared under a use-site local
-shadow of it. A
+record plus whether the spelling occurs in the macro-use input (a walk
+bounded by a node budget and depth cap — datum labels make inputs
+genuinely circular, kaappi#2404 — with exhaustion counting
+conservatively as occurrence) — order-independent, reflexive for two
+plain use-site tokens and for the invocation's own rename products
+whenever the spelling is absent from the input. The unsettled shape,
+stated plainly: a spelling that occurs in the input AND was bare-renamed
+this invocation, compared under a use-site local shadow — the refusal is
+free-identifier=?'s demanded answer when one argument is that input
+token, and known-wrong (broken reflexivity) when both arguments were the
+invocation's own rename products; a distinguishable wrapper for bare
+rename products would break the compiler's bare matching of the reserved
+forms macros emit. A
 bare-symbol
 spec falls back to a globals lookup holding a Transformer value, so
 `(define t (er-macro-transformer p))` + `(define-syntax m t)` works. Two

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -1405,19 +1405,29 @@ reaches the expansion (verified equivalent on both paths). Since kaappi#2388
 free-identifier=? built from the same machinery syntax-rules literal
 matching uses — `UseSiteBindingCheck.resolve` for use-site binding slots,
 `rename`'s per-invocation scope-table identity entries to recognize the
-definition-side bare spelling, def-env-prefixed names as binding identity
-for renamed library references — which makes "an ER macro is exactly as
-hygienic as a syntax-rules one" (KEP-0018 unresolved question 6) a pinned
-guarantee rather than an aspiration: the KEP-0006 four-quadrant test in
-`tests/scheme/srfi/srfi211.scm` asserts every quadrant against BOTH
-systems with the same expected value. One approximation is inherent to
+definition-side bare spelling, def-env-prefixed names agreeing with a
+use-site reference the use site can resolve to the same exported binding
+— which makes "an ER macro is exactly as hygienic as a syntax-rules one"
+(KEP-0018 unresolved question 6) a pinned guarantee for the
+auxiliary-keyword spellings (reserved forms and macro keywords, plus
+gensym-marked renames of any other spelling): the KEP-0006 four-quadrant
+test in `tests/scheme/srfi/srfi211.scm` asserts every quadrant against
+BOTH systems with the same expected value. The guarantee's boundary is
+pinned there too: spellings whose bare rename comes from
+renameForHygiene's other bare-returning branches (the VOID sentinel for a
+name defined later in the use-site body) keep compare's reflexive
+use-token view where a literal refuses — a pre-existing divergence.
+One approximation is inherent to
 interned symbols as syntax: a bare-rename product (reserved forms and
 keywords rename to themselves) is the same object as a use-site token of
 that spelling, so compare recognizes the classic
-`(compare <token> (rename 'kw))` shape by the invocation's rename record
-— order-independent, but not reflexive for that one spelling when a
-use-site local shadows it (two plain use-site tokens of a spelling this
-invocation did not bare-rename stay reflexive). A
+`(compare <token> (rename 'kw))` shape from the invocation's rename
+record plus whether the spelling occurs in the macro-use input —
+order-independent, reflexive for the invocation's own rename products
+(the hoisted-rename self-compare) and for two plain use-site tokens, and
+non-reflexive only for the quadrant-2 shape: a spelling that occurs in
+the input, bare-renamed this invocation, compared under a use-site local
+shadow of it. A
 bare-symbol
 spec falls back to a globals lookup holding a Transformer value, so
 `(define t (er-macro-transformer p))` + `(define-syntax m t)` works. Two

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -1400,7 +1400,24 @@ save/restore discipline as the syntax-rules `active_*` context), and
 `rename` reuses `renameForHygiene` — so ER macros get exactly the hygiene
 strength syntax-rules templates have, including the shared pre-existing
 limitation that a use-site top-level redefinition of a referenced name
-reaches the expansion (verified equivalent on both paths). A bare-symbol
+reaches the expansion (verified equivalent on both paths). Since kaappi#2388
+(KEP-0006's resolved direction), `compare` is binding-aware
+free-identifier=? built from the same machinery syntax-rules literal
+matching uses — `UseSiteBindingCheck.resolve` for use-site binding slots,
+`rename`'s per-invocation scope-table identity entries to recognize the
+definition-side bare spelling, def-env-prefixed names as binding identity
+for renamed library references — which makes "an ER macro is exactly as
+hygienic as a syntax-rules one" (KEP-0018 unresolved question 6) a pinned
+guarantee rather than an aspiration: the KEP-0006 four-quadrant test in
+`tests/scheme/srfi/srfi211.scm` asserts every quadrant against BOTH
+systems with the same expected value. One approximation is inherent to
+interned symbols as syntax: a bare-rename product (reserved forms and
+keywords rename to themselves) is the same object as a use-site token of
+that spelling, so compare recognizes the classic
+`(compare <token> (rename 'kw))` shape by the invocation's rename record
+— order-independent, but not reflexive for that one spelling when a
+use-site local shadows it (two plain use-site tokens stay reflexive). A
+bare-symbol
 spec falls back to a globals lookup holding a Transformer value, so
 `(define t (er-macro-transformer p))` + `(define-syntax m t)` works. Two
 non-obvious integration points: (1) `vm_imports.copyTransformerFreeRefs`
@@ -1479,9 +1496,14 @@ check):
   per-expansion counter, then renamed.
 - **Keyword recognition (`...`, `_`, `->`, `guard`, `unquote`,
   `quasiquote`, `values`) is `compare` against `rename` of the keyword —
-  hygiene-stripped name equality.** That strength suffices for these
-  macros (kaappi#2388 records the evidence); a use inside another
-  er-macro's output whose keywords arrive renamed still compares equal.
+  binding-aware free-identifier=? since kaappi#2388 (name-stripped
+  equality before it; that strength is what the #2398 re-port evidence
+  validated).** A use inside another er-macro's output whose keywords
+  arrive renamed still compares equal (both sides unbound); a use-site
+  local rebinding of a keyword spelling now opts out of keyword-hood
+  exactly as a syntax-rules literal refuses the same shadowing — nothing
+  in either library's own test suite does that, so the port is unaffected
+  (the one bound keyword, 202's `values` claw, gains the refusal).
   The known edge: a match form produced by a *syntax-rules* template is
   subject to that template's own ellipsis processing first, and a
   template-renamed `quasiquote` in a clause body resolves to the

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -1416,7 +1416,8 @@ keywords rename to themselves) is the same object as a use-site token of
 that spelling, so compare recognizes the classic
 `(compare <token> (rename 'kw))` shape by the invocation's rename record
 — order-independent, but not reflexive for that one spelling when a
-use-site local shadows it (two plain use-site tokens stay reflexive). A
+use-site local shadows it (two plain use-site tokens of a spelling this
+invocation did not bare-rename stay reflexive). A
 bare-symbol
 spec falls back to a globals lookup holding a Transformer value, so
 `(define t (er-macro-transformer p))` + `(define-syntax m t)` works. Two

--- a/lib/srfi/202.sld
+++ b/lib/srfi/202.sld
@@ -38,7 +38,7 @@
          (define r-vector? (rename 'vector?))
          (define r-vector->list (rename 'vector->list))
 
-         ;; Keyword recognition is name-based compare (kaappi#2388).
+         ;; Keyword recognition is binding-aware compare (kaappi#2388).
          (define (kw? x sym) (and (symbol? x) (compare x (rename sym))))
          (define (qq-form? x)
            (and (pair? x) (kw? (car x) 'quasiquote)

--- a/lib/srfi/211/explicit-renaming.sld
+++ b/lib/srfi/211/explicit-renaming.sld
@@ -62,8 +62,9 @@
 ;;;     the same object as a use-site token of that spelling; compare
 ;;;     recognizes the classic (compare <token> (rename 'kw)) shape by the
 ;;;     invocation's rename record, which makes the answer independent of
-;;;     argument order, and stays reflexive for two plain use-site tokens
-;;;     (the pairwise input-comparison idiom).
+;;;     argument order. Two plain use-site tokens stay reflexive unless
+;;;     this invocation also renamed that spelling bare and a use-site
+;;;     local shadows it (the pairwise input-comparison idiom).
 ;;;
 ;;;   * `(rename 'x)` used to BIND x when x names a global procedure
 ;;;     returns x unrenamed (reference semantics win); rename fresh names

--- a/lib/srfi/211/explicit-renaming.sld
+++ b/lib/srfi/211/explicit-renaming.sld
@@ -74,14 +74,22 @@
 ;;;     the same object as a use-site token of that spelling; compare
 ;;;     recognizes the classic (compare <token> (rename 'kw)) shape from
 ;;;     the invocation's rename record together with whether the spelling
-;;;     occurs in the macro-use input — which makes the answer independent
-;;;     of argument order, and reflexive both for two of the invocation's
-;;;     own rename products (the hoisted-rename style) and for two plain
-;;;     use-site tokens (the pairwise input-comparison idiom). The one
-;;;     non-reflexive shape: a spelling that occurs in the input, renamed
-;;;     bare this invocation, compared under a use-site local shadow of
-;;;     it — the quadrant-2 case, where the shadowing local is a
-;;;     different binding.
+;;;     occurs in the macro-use input (a bounded walk — datum labels make
+;;;     inputs genuinely circular, and exhaustion conservatively counts as
+;;;     occurrence) — which makes the answer independent of argument
+;;;     order, and reflexive for two plain use-site tokens (the pairwise
+;;;     input-comparison idiom) and for two of the invocation's own
+;;;     rename products whenever the spelling is absent from the input.
+;;;     The shape compare cannot settle, stated plainly: a spelling that
+;;;     occurs in the input AND was bare-renamed this invocation, compared
+;;;     under a use-site local shadow — if one argument is that input
+;;;     token, the refusal is exactly the answer free-identifier=? demands
+;;;     (the shadowing local is a different binding); if both arguments
+;;;     were the invocation's own rename products, the #f is known-wrong
+;;;     (a broken reflexivity), because interned symbols make the two
+;;;     cases representationally identical and a distinguishable wrapper
+;;;     for bare rename products would break the compiler's bare matching
+;;;     of the reserved forms macros emit.
 ;;;
 ;;;   * `(rename 'x)` used to BIND x when x names a global procedure
 ;;;     returns x unrenamed (reference semantics win); rename fresh names

--- a/lib/srfi/211/explicit-renaming.sld
+++ b/lib/srfi/211/explicit-renaming.sld
@@ -11,8 +11,11 @@
 ;;;                      that cannot capture (or be captured by) use-site
 ;;;                      names. Renaming the same symbol twice within one
 ;;;                      expansion yields the same identifier.
-;;;   (compare a b)    — free-identifier=? to the strength this engine can
-;;;                      answer (see limitations below).
+;;;   (compare a b)    — free-identifier=?: the two identifiers denote the
+;;;                      same binding, or both are unbound — the rule a
+;;;                      syntax-rules literal matches by (R7RS 4.3.2), at
+;;;                      the same strength this engine answers it for
+;;;                      literals (see the compare paragraph below).
 ;;;
 ;;; SRFI 211 permits providing only some of its libraries but each provided
 ;;; one whole; this library's full export set is er-macro-transformer plus
@@ -35,22 +38,42 @@
 ;;;     whole environment is the honest static over-approximation).
 ;;;
 ;;;   * Hygiene strength equals this engine's own syntax-rules hygiene
-;;;     exactly — rename routes through the same renameForHygiene the
-;;;     template instantiator uses. The shared, pre-existing limitation:
-;;;     a use-site TOP-LEVEL redefinition of a name the macro's output
-;;;     references (e.g. redefining a library helper's name after import)
-;;;     reaches the expansion, for procedural and syntax-rules macros
-;;;     alike. compare is name-based (hygiene-stripped equality), which
-;;;     answers the classic literal checks (else, =>) correctly but cannot
-;;;     distinguish two same-named bindings.
+;;;     exactly — the documented guarantee (KEP-0018 unresolved question 6,
+;;;     decided with kaappi#2388): rename routes through the same
+;;;     renameForHygiene the template instantiator uses, and compare
+;;;     through the same binding machinery literal matching uses, so the
+;;;     two macro systems answer every keyword-check quadrant identically
+;;;     (regression-pinned, quadrant for quadrant, by the KEP-0006
+;;;     four-quadrant test in tests/scheme/srfi/srfi211.scm). Shared,
+;;;     pre-existing limitations, identical on both paths: a use-site
+;;;     TOP-LEVEL redefinition of a name the macro's output references
+;;;     reaches the expansion; and a reserved-form spelling the hygiene
+;;;     engine keeps bare (else, _, ...) is shadowed by a use-site local of
+;;;     that spelling for a macro-INTRODUCED occurrence just as surely as
+;;;     for a user-typed one, while identifiers the engine CAN mark (any
+;;;     non-reserved spelling, e.g. =>) stay hygienic.
+;;;
+;;;   * compare is binding-aware (kaappi#2388): (compare x (rename 'kw))
+;;;     answers whether the use-site identifier x and the definition-side
+;;;     keyword denote the same binding — an unshadowed use is #t, a
+;;;     use-site local rebinding of the spelling is #f, and a renamed
+;;;     (macro-introduced or global-name) keyword never resolves to a
+;;;     use-site local. Symbols are interned, so a bare-rename product is
+;;;     the same object as a use-site token of that spelling; compare
+;;;     recognizes the classic (compare <token> (rename 'kw)) shape by the
+;;;     invocation's rename record, which makes the answer independent of
+;;;     argument order, and stays reflexive for two plain use-site tokens
+;;;     (the pairwise input-comparison idiom).
 ;;;
 ;;;   * `(rename 'x)` used to BIND x when x names a global procedure
 ;;;     returns x unrenamed (reference semantics win); rename fresh names
 ;;;     for binders — the classic ER idiom — and they gensym correctly.
 ;;;
-;;; Verified: tests/scheme/srfi/srfi211.scm and the "SRFI 211" tests in
-;;; src/tests_macros.zig (swap!/my-or hygiene, compare on else, rename of
-;;; whole trees, library-helper resolution, let-syntax bodies).
+;;; Verified: tests/scheme/srfi/srfi211.scm (including the KEP-0006
+;;; four-quadrant acceptance test and the ER/syntax-rules parity suite)
+;;; and the "SRFI 211" tests in src/tests_macros_procedural.zig
+;;; (swap!/my-or hygiene, compare quadrants, rename of whole trees,
+;;; library-helper resolution, let-syntax bodies).
 (define-library (srfi 211 explicit-renaming)
   (import (scheme base)
           (srfi 211 primitives))

--- a/lib/srfi/211/explicit-renaming.sld
+++ b/lib/srfi/211/explicit-renaming.sld
@@ -38,33 +38,50 @@
 ;;;     whole environment is the honest static over-approximation).
 ;;;
 ;;;   * Hygiene strength equals this engine's own syntax-rules hygiene
-;;;     exactly — the documented guarantee (KEP-0018 unresolved question 6,
-;;;     decided with kaappi#2388): rename routes through the same
-;;;     renameForHygiene the template instantiator uses, and compare
-;;;     through the same binding machinery literal matching uses, so the
-;;;     two macro systems answer every keyword-check quadrant identically
+;;;     exactly for the auxiliary-keyword spellings — the documented
+;;;     guarantee (KEP-0018 unresolved question 6, decided with
+;;;     kaappi#2388): rename routes through the same renameForHygiene the
+;;;     template instantiator uses, and compare through the same binding
+;;;     machinery literal matching uses, so for reserved forms and macro
+;;;     keywords (the spellings rename keeps bare and records) and for
+;;;     gensym-marked renames of any other spelling, the two macro systems
+;;;     answer every keyword-check quadrant identically
 ;;;     (regression-pinned, quadrant for quadrant, by the KEP-0006
-;;;     four-quadrant test in tests/scheme/srfi/srfi211.scm). Shared,
-;;;     pre-existing limitations, identical on both paths: a use-site
-;;;     TOP-LEVEL redefinition of a name the macro's output references
-;;;     reaches the expansion; and a reserved-form spelling the hygiene
-;;;     engine keeps bare (else, _, ...) is shadowed by a use-site local of
-;;;     that spelling for a macro-INTRODUCED occurrence just as surely as
-;;;     for a user-typed one, while identifiers the engine CAN mark (any
-;;;     non-reserved spelling, e.g. =>) stay hygienic.
+;;;     four-quadrant test in tests/scheme/srfi/srfi211.scm). The
+;;;     guarantee does NOT extend to spellings whose bare rename comes
+;;;     from renameForHygiene's other bare-returning branches (e.g. the
+;;;     VOID sentinel for a name defined later in the use-site body):
+;;;     there compare keeps the reflexive use-token view while a
+;;;     syntax-rules literal refuses — a pre-existing divergence, pinned
+;;;     as such by the same suite. Shared, pre-existing limitations,
+;;;     identical on both paths: a use-site TOP-LEVEL redefinition of a
+;;;     name the macro's output references reaches the expansion; and a
+;;;     reserved-form spelling the hygiene engine keeps bare (else, _,
+;;;     ...) is shadowed by a use-site local of that spelling for a
+;;;     macro-INTRODUCED occurrence just as surely as for a user-typed
+;;;     one, while identifiers the engine CAN mark (any non-reserved
+;;;     spelling, e.g. =>) stay hygienic.
 ;;;
 ;;;   * compare is binding-aware (kaappi#2388): (compare x (rename 'kw))
 ;;;     answers whether the use-site identifier x and the definition-side
 ;;;     keyword denote the same binding — an unshadowed use is #t, a
 ;;;     use-site local rebinding of the spelling is #f, and a renamed
 ;;;     (macro-introduced or global-name) keyword never resolves to a
-;;;     use-site local. Symbols are interned, so a bare-rename product is
+;;;     use-site local. A rename of a name bound in the transformer's own
+;;;     library (def-env-marked outside it) compares equal to a use-site
+;;;     reference of the same exported binding, refusing only under a
+;;;     local shadow. Symbols are interned, so a bare-rename product is
 ;;;     the same object as a use-site token of that spelling; compare
-;;;     recognizes the classic (compare <token> (rename 'kw)) shape by the
-;;;     invocation's rename record, which makes the answer independent of
-;;;     argument order. Two plain use-site tokens stay reflexive unless
-;;;     this invocation also renamed that spelling bare and a use-site
-;;;     local shadows it (the pairwise input-comparison idiom).
+;;;     recognizes the classic (compare <token> (rename 'kw)) shape from
+;;;     the invocation's rename record together with whether the spelling
+;;;     occurs in the macro-use input — which makes the answer independent
+;;;     of argument order, and reflexive both for two of the invocation's
+;;;     own rename products (the hoisted-rename style) and for two plain
+;;;     use-site tokens (the pairwise input-comparison idiom). The one
+;;;     non-reflexive shape: a spelling that occurs in the input, renamed
+;;;     bare this invocation, compared under a use-site local shadow of
+;;;     it — the quadrant-2 case, where the shadowing local is a
+;;;     different binding.
 ;;;
 ;;;   * `(rename 'x)` used to BIND x when x names a global procedure
 ;;;     returns x unrenamed (reference semantics win); rename fresh names

--- a/lib/srfi/241.sld
+++ b/lib/srfi/241.sld
@@ -29,9 +29,11 @@
 ;;;    no bracket syntax); write clauses and cata patterns with plain
 ;;;    parens, e.g. (,(f -> x y) ...) rather than [,[f -> x y] ...].
 ;;;  - Only match is exported. The auxiliary keywords (unquote, ..., _,
-;;;    guard, ->) are recognized by hygiene-stripped name comparison (the
-;;;    strength of this engine's ER compare — see kaappi#2388), so
-;;;    exporting bindings for them would not change what is matched.
+;;;    guard, ->) are recognized by binding-aware free-identifier=?
+;;;    compare (kaappi#2388); exporting bindings for them would still not
+;;;    change what is matched, because an exported binding is planted as a
+;;;    global and globals are not use-site local slots — only a LOCAL
+;;;    rebinding of a keyword spelling now opts out of keyword-hood.
 ;;;  - If a match form is produced by another macro's syntax-rules
 ;;;    template, that template's own ellipsis processing applies before
 ;;;    match sees the form (escape nested ellipses with (... ...)), and
@@ -260,7 +262,7 @@
          (define r-cata (rename '%match-cata))
          (define r-qq (rename '%match-qq))
 
-         ;; Keyword recognition is name-based compare (kaappi#2388).
+         ;; Keyword recognition is binding-aware compare (kaappi#2388).
          (define (kw? x sym) (and (symbol? x) (compare x (rename sym))))
          (define (ell? x) (kw? x '...))
          (define (uscore? x) (kw? x '_))

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1104,6 +1104,21 @@ const SetScanBudget = struct {
     truncated: bool = false,
 };
 
+/// Per-list-level cap on cdr-spine steps in collectSetTargets (#2404).
+/// The depth cap bounds only car recursion; a datum-label cycle
+/// (`#0=(zz . #0#)`, R7RS §7.1.2) lives in the spine, where the walk used
+/// to spin forever — reached from a cyclic macro operand re-emitted into a
+/// body position. One million steps per level is far beyond any real form
+/// (the whole repo's suites stay under ~1.7k expansions per top-level
+/// form); exhausting it stops that level's scan, and on a budgeted path
+/// marks `truncated` — the same loses-optimization-never-correctness
+/// degradation the expansion budget already takes, with Part B
+/// (scanSetTargets in expandAndCompileMacroUse) catching anything missed
+/// at real-expansion time. The null-budget callers (define-syntax specs,
+/// the native backend) have no flag to set and just stop: their misses
+/// take the same correct-late path.
+const SET_SCAN_SPINE_CAP: usize = 1_000_000;
+
 /// Recursively collect the symbol names that appear as the target of a
 /// `(set! <name> ...)` anywhere in `expr` into `out`. Used to suppress
 /// constant folding of those names within the enclosing form (see
@@ -1133,7 +1148,16 @@ fn collectSetTargets(self: ?*Compiler, expr: Value, out: *std.StringHashMap(void
         return;
     }
     var cur = expr;
+    var spine_steps: usize = 0;
     while (types.isPair(cur)) {
+        // #2404: a datum-label cycle makes this spine infinite; the step
+        // cap turns it into the scan's ordinary loses-optimization
+        // truncation (see SET_SCAN_SPINE_CAP).
+        spine_steps += 1;
+        if (spine_steps > SET_SCAN_SPINE_CAP) {
+            if (budget) |b| b.truncated = true;
+            return;
+        }
         const head = types.car(cur);
         if (types.isSymbol(head)) {
             const hname = types.stripHygienicPrefix(types.symbolName(head));
@@ -1235,7 +1259,13 @@ fn collectSetTargets(self: ?*Compiler, expr: Value, out: *std.StringHashMap(void
                     const rest = types.cdr(cur);
                     if (!types.isPair(rest)) return;
                     var bindings_cur = types.car(rest);
+                    var binding_steps: usize = 0;
                     while (types.isPair(bindings_cur)) {
+                        binding_steps += 1;
+                        if (binding_steps > SET_SCAN_SPINE_CAP) {
+                            budget.?.truncated = true;
+                            return;
+                        }
                         const binding = types.car(bindings_cur);
                         if (types.isPair(binding)) {
                             try collectSetTargets(self, types.cdr(binding), out, depth, null);

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -505,7 +505,15 @@ pub const Compiler = struct {
     /// pattern matchers) quadratic — every level re-expanded its whole subtree.
     pub fn scanSetTargets(self: *Compiler, expr: Value) CompileError!void {
         if (self.set_targets) |st| {
-            try collectSetTargets(self, expr, st, 0, null);
+            // Structure-only (no speculative expansion — the top-level
+            // pre-scan already did that), but budgeted so the depth and
+            // spine caps report truncation: a silently-partial target set
+            // could leave a `set!`-ed local unboxed and foldable, so a
+            // truncated Part B scan falls back to the same
+            // every-name-is-a-target conservatism the pre-scan uses.
+            var b = SetScanBudget{ .expansions_left = 0, .expand = false };
+            try collectSetTargets(self, expr, st, 0, &b);
+            if (b.truncated) self.set_targets_all = true;
         }
     }
 
@@ -1099,7 +1107,16 @@ pub threadlocal var prescan_truncations: u64 = 0;
 
 const SetScanBudget = struct {
     expansions_left: u32,
-    /// Set when the scan stopped early (budget exhausted or depth cap hit),
+    /// False for structure-only scans (Part B, the native backend): walk
+    /// and report truncation like any budgeted scan, but never speculatively
+    /// expand macros — expansion is the top-level pre-scan's job. With this
+    /// flag, a non-null budget no longer implies "expanding scan", so the
+    /// old null-vs-non-null distinction collapses to expand-vs-not and the
+    /// depth/spine caps report truncation on every caller (#2401 review:
+    /// a partial target set from a silently-truncated scan could leave a
+    /// `set!`-ed local unboxed and foldable).
+    expand: bool = true,
+    /// Set when the scan stopped early (budget exhausted or a cap hit),
     /// meaning `out` is an under-approximation of the real target set.
     truncated: bool = false,
 };
@@ -1110,13 +1127,14 @@ const SetScanBudget = struct {
 /// to spin forever — reached from a cyclic macro operand re-emitted into a
 /// body position. One million steps per level is far beyond any real form
 /// (the whole repo's suites stay under ~1.7k expansions per top-level
-/// form); exhausting it stops that level's scan, and on a budgeted path
-/// marks `truncated` — the same loses-optimization-never-correctness
-/// degradation the expansion budget already takes, with Part B
-/// (scanSetTargets in expandAndCompileMacroUse) catching anything missed
-/// at real-expansion time. The null-budget callers (define-syntax specs,
-/// the native backend) have no flag to set and just stop: their misses
-/// take the same correct-late path.
+/// form); exhausting it marks the scan truncated — the same
+/// loses-optimization-never-correctness degradation the expansion budget
+/// takes. Every caller propagates that now: the pre-scan via
+/// set_targets_all, Part B via scanSetTargets, the native backend by
+/// eval-falling-back the form. The define-syntax/let-syntax spec walks
+/// still pass a structure-only budget with no propagation: a `set!` that
+/// only materializes when the spec's own macros run is caught at the
+/// macro's real use site, the same correct-late path as before.
 const SET_SCAN_SPINE_CAP: usize = 1_000_000;
 
 /// Recursively collect the symbol names that appear as the target of a
@@ -1171,10 +1189,16 @@ fn collectSetTargets(self: ?*Compiler, expr: Value, out: *std.StringHashMap(void
                     }
                 }
             } else if (budget) |b| {
-                // Only a budgeted scan expands, and only a budgeted scan is
-                // ever handed a Compiler — so `self.?` below is reached only
-                // when `maybe_macro` was non-null, which requires one.
-                const maybe_macro = if (self) |c| c.lookupMacro(types.symbolName(head)) else null;
+                // Only an expanding scan looks macros up, and only an
+                // expanding scan is ever handed a Compiler — so `self.?`
+                // below is reached only when `maybe_macro` was non-null,
+                // which requires one. Structure-only scans (b.expand ==
+                // false) never take this branch and keep walking the form
+                // literally.
+                const maybe_macro = if (b.expand) blk: {
+                    const c = self orelse break :blk null;
+                    break :blk c.lookupMacro(types.symbolName(head));
+                } else null;
                 if (maybe_macro) |transformer| {
                     if (b.expansions_left == 0) {
                         b.truncated = true;
@@ -1300,8 +1324,15 @@ fn collectSetTargets(self: ?*Compiler, expr: Value, out: *std.StringHashMap(void
 /// unrelated reason (it has already *executed* form N, so the globals check in
 /// isRedefined sees the rebound value), which is why only the compiled tier
 /// diverges.
-pub fn scanSetTargetsWithoutMacros(expr: Value, out: *std.StringHashMap(void)) CompileError!void {
-    return collectSetTargets(null, expr, out, 0, null);
+/// Returns true when the scan truncated (depth cap, spine cap, or — never,
+/// for this structure-only caller — expansion budget): `out` is then a
+/// partial answer, and the caller must not trust it to gate folding or
+/// boxing (the LLVM backend's conservative action is to eval-fallback the
+/// whole form; see native_compiler).
+pub fn scanSetTargetsWithoutMacros(expr: Value, out: *std.StringHashMap(void)) CompileError!bool {
+    var b = SetScanBudget{ .expansions_left = 0, .expand = false };
+    try collectSetTargets(null, expr, out, 0, &b);
+    return b.truncated;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -517,21 +517,112 @@ fn erRenameDatum(gc: *GC, v: Value) anyerror!Value {
 /// among well_known_forms are renamed like any other template identifier
 /// (kaappi#2074), matching syntax-rules.
 fn erRenameSymbol(gc: *GC, name: []const u8) anyerror!Value {
-    if (isTemplateReserved(name)) return gc.allocSymbol(name);
-    if (er_macros) |m| {
-        if (m.contains(name)) return gc.allocSymbol(name);
+    const keeps_name = isTemplateReserved(name) or blk: {
+        const m = er_macros orelse break :blk false;
+        break :blk m.contains(name);
+    };
+    if (!keeps_name) return renameForHygiene(gc, name, er_scope, er_globals);
+    // Reserved forms and keywords rename to themselves, and symbols are
+    // interned — the product is the very same object a use-site token of
+    // that spelling. Record an identity entry under this invocation's
+    // scope so erCompareFn can tell "the transformer holds the
+    // definition-side spelling of this name" apart from a pairwise
+    // comparison of two plain use-site tokens (kaappi#2388). The branch is
+    // deterministic per name (isTemplateReserved is pure, er_macros is
+    // fixed for the invocation), so any (name, er_scope) entry here is an
+    // identity one; the dedup scan keeps repeated renames agreeing.
+    for (scope_table[0..scope_table_count]) |entry| {
+        if (entry.scope == er_scope and std.mem.eql(u8, entry.original_name, name))
+            return gc.allocSymbol(entry.renamed_to);
     }
-    return renameForHygiene(gc, name, er_scope, er_globals);
+    if (scope_table_count >= MAX_SCOPE_ENTRIES) return ExpandError.ScopeTableFull;
+    scope_table[scope_table_count] = .{ .original_name = name, .scope = er_scope, .renamed_to = name };
+    scope_table_count += 1;
+    return gc.allocSymbol(name);
+}
+
+/// The binding one `compare` argument denotes, to the strength this
+/// symbol-based expander can answer — the same classification
+/// matchPattern's literal branch derives from `literal_bound`
+/// (definition-site) and `use_check.resolve` (use-site): a use-site local
+/// binding slot, one specific definition-library binding (a
+/// def-env-marked reference's full spelling is its identity), or no
+/// binding this engine can see — aux syntax, gensym'd rename/template
+/// products, unshadowed global references.
+const ErIdentifierBinding = union(enum) {
+    free,
+    local: u32,
+    def_env: []const u8,
+};
+
+fn erIdentifierBinding(full: []const u8) ErIdentifierBinding {
+    if (std.mem.startsWith(u8, full, types.def_env_binding_prefix))
+        return .{ .def_env = full };
+    // Bare and renamed spellings alike: a use-site local of exactly this
+    // name (captured-local slot aliases carry the full renamed name) is
+    // the binding; otherwise nothing resolves to a slot.
+    const slot = active_use_check.resolve(full);
+    if (slot != LITERAL_UNBOUND) return .{ .local = slot };
+    return .free;
+}
+
+fn erBindingsAgree(a: ErIdentifierBinding, b: ErIdentifierBinding) bool {
+    return switch (a) {
+        .free => b == .free,
+        .local => |slot| b == .local and b.local == slot,
+        .def_env => |name| b == .def_env and std.mem.eql(u8, name, b.def_env),
+    };
+}
+
+/// Did this invocation's `rename` return the bare spelling of `name`
+/// (reserved form or keyword)? The scope-table identity entries
+/// erRenameSymbol records answer exactly that.
+fn erRenamedBareThisInvocation(name: []const u8) bool {
+    for (scope_table[0..scope_table_count]) |entry| {
+        if (entry.scope == er_scope and std.mem.eql(u8, entry.original_name, name) and
+            std.mem.eql(u8, entry.renamed_to, name)) return true;
+    }
+    return false;
 }
 
 /// The `compare` procedure handed to explicit-renaming transformers:
-/// free-identifier=? to the strength this symbol-based expander can answer
-/// — equal effective (hygiene-stripped) names. Non-symbols compare #f.
+/// free-identifier=? — "the two identifiers denote the same binding, or
+/// both are unbound" (SRFI 211) — reusing the binding machinery
+/// syntax-rules literal matching already runs on, so an ER macro is
+/// exactly as hygienic as a syntax-rules one (KEP-0018 UQ6, kaappi#2388).
+/// Non-symbols compare #f. Two approximations are inherent to symbols as
+/// syntax: different effective names never denote the same binding (the
+/// one global table shared by use site and definition site), and a
+/// bare-rename product is the same interned object as a use-site token of
+/// that spelling, so the classic (compare <token> (rename 'kw)) shape is
+/// recognized by the invocation's rename record rather than by the
+/// argument position — which also makes it order-independent.
 fn erCompareFn(args: []const Value) anyerror!Value {
     if (!types.isSymbol(args[0]) or !types.isSymbol(args[1])) return types.FALSE;
-    const a = types.stripHygienicPrefix(types.symbolName(args[0]));
-    const b = types.stripHygienicPrefix(types.symbolName(args[1]));
-    return if (std.mem.eql(u8, a, b)) types.TRUE else types.FALSE;
+    const full_a = types.symbolName(args[0]);
+    const full_b = types.symbolName(args[1]);
+    const eff_a = types.stripHygienicPrefix(full_a);
+    const eff_b = types.stripHygienicPrefix(full_b);
+    if (!std.mem.eql(u8, eff_a, eff_b)) return types.FALSE;
+    if (std.mem.eql(u8, full_a, eff_a) and std.mem.eql(u8, full_b, eff_b)) {
+        // Both bare: interned symbols make same-spelling identifiers one
+        // object, so "which side is the rename product" is unanswerable
+        // from the values. When this invocation renamed the spelling bare,
+        // assume the classic shape — one side the definition-site keyword,
+        // the other a use-site token — and answer whether the two sites'
+        // views agree: a use-site local rebinding of the spelling is a
+        // different binding, exactly as a syntax-rules literal refuses the
+        // same shadowing. Otherwise the arguments are two use-site tokens
+        // — the same identifier — and compare is reflexive (the pairwise
+        // input-token idiom, e.g. duplicate-key checks, keeps working).
+        if (erRenamedBareThisInvocation(eff_a))
+            return if (active_use_check.resolve(eff_a) == LITERAL_UNBOUND) types.TRUE else types.FALSE;
+        return types.TRUE;
+    }
+    return if (erBindingsAgree(erIdentifierBinding(full_a), erIdentifierBinding(full_b)))
+        types.TRUE
+    else
+        types.FALSE;
 }
 
 /// SRFI 213: the `lookup` procedure a capture-lookup re-entry receives.

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -219,6 +219,16 @@ pub threadlocal var active_use_check: UseSiteBindingCheck = .{};
 pub threadlocal var active_def_env: ?*std.StringHashMap(Value) = null;
 pub threadlocal var active_def_lib_name: ?[]const u8 = null;
 
+// Per-invocation context for erCompareFn (#2388): the rooted slot holding
+// the macro-use input (a pointer to expandProceduralMacro's rooted local,
+// so a moving GC updates it through the root). compare consults it to
+// tell "both arguments are this invocation's own rename products" (the
+// spelling nowhere occurs in the input — a hoisted-rename self-compare,
+// which free-identifier=? must answer reflexively) from the classic
+// (compare <input-token> (rename 'kw)) shape, where the spelling does
+// occur in the input and the use-site view is the one that must agree.
+pub threadlocal var er_input_slot: ?*Value = null;
+
 pub fn expandMacro(gc: *GC, expr: Value, transformer_val: Value, globals: ?*std.StringHashMap(Value), macros: ?*const std.StringHashMap(Value), use_check: UseSiteBindingCheck) !Value {
     // The rule-matching bindings buffer is ~1MB and only entries below
     // bind_count are ever read, so it must not be filled per call: Zig 0.16
@@ -390,6 +400,7 @@ fn expandProceduralMacro(gc: *GC, expr: Value, transformer: *types.Transformer, 
     const saved_refs = active_def_local_refs;
     const saved_def_env = active_def_env;
     const saved_def_lib_name = active_def_lib_name;
+    const saved_input_slot = er_input_slot;
     er_scope = freshScope();
     er_globals = globals;
     er_macros = macros;
@@ -405,6 +416,7 @@ fn expandProceduralMacro(gc: *GC, expr: Value, transformer: *types.Transformer, 
         active_def_local_refs = saved_refs;
         active_def_env = saved_def_env;
         active_def_lib_name = saved_def_lib_name;
+        er_input_slot = saved_input_slot;
     }
     // The rename dedup cache entries belong to this invocation only (the
     // scope id is globally fresh); release them on return like expandMacro.
@@ -419,6 +431,8 @@ fn expandProceduralMacro(gc: *GC, expr: Value, transformer: *types.Transformer, 
     var input_root = input;
     gc.pushRoot(&input_root);
     pushed += 1;
+    // compare reads the input through the rooted slot (see er_input_slot).
+    er_input_slot = &input_root;
 
     var result: Value = undefined;
     if (transformer.kind == .er_macro) {
@@ -566,6 +580,22 @@ fn erIdentifierBinding(full: []const u8) ErIdentifierBinding {
     return .free;
 }
 
+/// A def-env-marked rename (#1812) and a bare use-site reference of the
+/// same effective spelling denote the same binding when the use site can
+/// actually resolve the spelling — the library was imported, planting the
+/// binding in the use-site globals — and no local shadows it (#2401
+/// review: an exported library binding must still compare equal to a
+/// use-site reference of that spelling; a shadowing local, or a spelling
+/// the use site never imported, is a different binding or none).
+fn erDefEnvAgreesWithBare(bare_full: []const u8) bool {
+    if (active_use_check.resolve(bare_full) != LITERAL_UNBOUND) return false;
+    const g = er_globals orelse return false;
+    const gmod = @import("globals.zig");
+    const glk = gmod.acquireGlobalsRead(g);
+    defer gmod.releaseGlobalsRead(glk);
+    return g.contains(bare_full);
+}
+
 fn erBindingsAgree(a: ErIdentifierBinding, b: ErIdentifierBinding) bool {
     return switch (a) {
         .free => b == .free,
@@ -585,18 +615,45 @@ fn erRenamedBareThisInvocation(name: []const u8) bool {
     return false;
 }
 
+/// Does the interned symbol `sym` occur anywhere in the macro-use input
+/// (pairs, dotted tails, vectors)? Read-only and allocation-free, so it is
+/// safe from compare at any point of the transformer call. Used only for
+/// bare spellings this invocation also renamed: occurrence in the input
+/// is what separates a use-site token from the invocation's own rename
+/// products when the two are representationally identical (interned).
+fn erFormMentionsSymbol(form: Value, sym: Value) bool {
+    if (types.isSymbol(form)) return form == sym;
+    if (types.isPair(form)) {
+        var cur = form;
+        while (types.isPair(cur)) : (cur = types.cdr(cur)) {
+            if (erFormMentionsSymbol(types.car(cur), sym)) return true;
+        }
+        return erFormMentionsSymbol(cur, sym);
+    }
+    if (types.isVector(form)) {
+        for (types.toObject(form).as(types.Vector).data) |el| {
+            if (erFormMentionsSymbol(el, sym)) return true;
+        }
+    }
+    return false;
+}
+
 /// The `compare` procedure handed to explicit-renaming transformers:
 /// free-identifier=? — "the two identifiers denote the same binding, or
-/// both are unbound" (SRFI 211) — reusing the binding machinery
-/// syntax-rules literal matching already runs on, so an ER macro is
-/// exactly as hygienic as a syntax-rules one (KEP-0018 UQ6, kaappi#2388).
-/// Non-symbols compare #f. Two approximations are inherent to symbols as
-/// syntax: different effective names never denote the same binding (the
-/// one global table shared by use site and definition site), and a
-/// bare-rename product is the same interned object as a use-site token of
-/// that spelling, so the classic (compare <token> (rename 'kw)) shape is
-/// recognized by the invocation's rename record rather than by the
-/// argument position — which also makes it order-independent.
+/// both are unbound" (SRFI 211, an equivalence relation) — reusing the
+/// binding machinery syntax-rules literal matching already runs on, so an
+/// ER macro is exactly as hygienic as a syntax-rules one for the
+/// auxiliary-keyword spellings (KEP-0018 UQ6, kaappi#2388). Non-symbols
+/// compare #f. One approximation is inherent to symbols as syntax:
+/// different effective names never denote the same binding (the one
+/// global table shared by use site and definition site). A bare-rename
+/// product is the same interned object as a use-site token of that
+/// spelling, so the classic (compare <token> (rename 'kw)) shape is
+/// recognized from the invocation's rename record plus whether the
+/// spelling occurs in the macro-use input — never from the argument
+/// position, which keeps the answer order-independent AND reflexive for
+/// two of the invocation's own rename products (a hoisted-rename
+/// self-compare; #2401 review).
 fn erCompareFn(args: []const Value) anyerror!Value {
     if (!types.isSymbol(args[0]) or !types.isSymbol(args[1])) return types.FALSE;
     const full_a = types.symbolName(args[0]);
@@ -604,21 +661,38 @@ fn erCompareFn(args: []const Value) anyerror!Value {
     const eff_a = types.stripHygienicPrefix(full_a);
     const eff_b = types.stripHygienicPrefix(full_b);
     if (!std.mem.eql(u8, eff_a, eff_b)) return types.FALSE;
-    if (std.mem.eql(u8, full_a, eff_a) and std.mem.eql(u8, full_b, eff_b)) {
+    const a_bare = std.mem.eql(u8, full_a, eff_a);
+    const b_bare = std.mem.eql(u8, full_b, eff_b);
+    if (a_bare and b_bare) {
         // Both bare: interned symbols make same-spelling identifiers one
         // object, so "which side is the rename product" is unanswerable
-        // from the values. When this invocation renamed the spelling bare,
-        // assume the classic shape — one side the definition-site keyword,
-        // the other a use-site token — and answer whether the two sites'
-        // views agree: a use-site local rebinding of the spelling is a
-        // different binding, exactly as a syntax-rules literal refuses the
-        // same shadowing. Otherwise the arguments are two use-site tokens
-        // — the same identifier — and compare is reflexive (the pairwise
-        // input-token idiom, e.g. duplicate-key checks, keeps working).
-        if (erRenamedBareThisInvocation(eff_a))
-            return if (active_use_check.resolve(eff_a) == LITERAL_UNBOUND) types.TRUE else types.FALSE;
+        // from the values alone. When this invocation renamed the spelling
+        // bare AND it occurs in the macro-use input, assume the classic
+        // shape — one side the definition-site keyword, the other a
+        // use-site token — and answer whether the two sites' views agree:
+        // a use-site local rebinding of the spelling is a different
+        // binding, exactly as a syntax-rules literal refuses the same
+        // shadowing. When the spelling does NOT occur in the input, both
+        // arguments are the invocation's own rename products — the same
+        // identifier — and compare is reflexive. With no bare rename of
+        // the spelling at all, the arguments are two plain use-site
+        // tokens, likewise reflexive (the pairwise input-token idiom,
+        // e.g. duplicate-key checks, keeps working).
+        if (erRenamedBareThisInvocation(eff_a)) {
+            const in_input = if (er_input_slot) |slot| erFormMentionsSymbol(slot.*, args[0]) else false;
+            if (in_input)
+                return if (active_use_check.resolve(eff_a) == LITERAL_UNBOUND) types.TRUE else types.FALSE;
+        }
         return types.TRUE;
     }
+    // A def-env-marked rename agrees with a bare reference the use site
+    // can resolve to the same (imported) binding; handled here because
+    // the globals lookup needs the bare spelling, which the classified
+    // pair below no longer carries.
+    if (a_bare and std.mem.startsWith(u8, full_b, types.def_env_binding_prefix))
+        return if (erDefEnvAgreesWithBare(full_a)) types.TRUE else types.FALSE;
+    if (b_bare and std.mem.startsWith(u8, full_a, types.def_env_binding_prefix))
+        return if (erDefEnvAgreesWithBare(full_b)) types.TRUE else types.FALSE;
     return if (erBindingsAgree(erIdentifierBinding(full_a), erIdentifierBinding(full_b)))
         types.TRUE
     else

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -581,12 +581,14 @@ fn erIdentifierBinding(full: []const u8) ErIdentifierBinding {
 }
 
 /// A def-env-marked rename (#1812) and a bare use-site reference of the
-/// same effective spelling denote the same binding when the use site can
-/// actually resolve the spelling — the library was imported, planting the
-/// binding in the use-site globals — and no local shadows it (#2401
-/// review: an exported library binding must still compare equal to a
-/// use-site reference of that spelling; a shadowing local, or a spelling
-/// the use site never imported, is a different binding or none).
+/// same effective spelling compare equal when no local shadows the
+/// spelling and the use-site globals hold SOME binding of it. That is the
+/// same class of over-approximation the whole-def-env import copy makes
+/// for rename (an unrelated use-site global of the same spelling answers
+/// #t too — #2401 review): from inside a symbol expander, "the use site
+/// resolves this name to a global" is the strongest resolvability fact
+/// available, and a shadowing local — the case that must refuse — is
+/// excluded exactly.
 fn erDefEnvAgreesWithBare(bare_full: []const u8) bool {
     if (active_use_check.resolve(bare_full) != LITERAL_UNBOUND) return false;
     const g = er_globals orelse return false;
@@ -617,22 +619,38 @@ fn erRenamedBareThisInvocation(name: []const u8) bool {
 
 /// Does the interned symbol `sym` occur anywhere in the macro-use input
 /// (pairs, dotted tails, vectors)? Read-only and allocation-free, so it is
-/// safe from compare at any point of the transformer call. Used only for
-/// bare spellings this invocation also renamed: occurrence in the input
-/// is what separates a use-site token from the invocation's own rename
-/// products when the two are representationally identical (interned).
-fn erFormMentionsSymbol(form: Value, sym: Value) bool {
+/// safe from compare at any point of the transformer call. R7RS datum
+/// labels produce genuinely circular inputs (#2404) and generated forms
+/// can be arbitrarily large, so the walk is bounded by a node budget and
+/// a depth cap; exhausting either conservatively answers "occurs" — the
+/// quadrant rule then applies, refusing under shadowing and never
+/// wrongly accepting. Used only for bare spellings this invocation also
+/// renamed: occurrence in the input is what separates a use-site token
+/// from the invocation's own rename products when the two are
+/// representationally identical (interned).
+const ER_WALK_NODE_BUDGET: u32 = 1_000_000;
+const ER_WALK_DEPTH_CAP: u32 = 10_000;
+
+fn erFormMentionsSymbol(form: Value, sym: Value, depth: u32, budget: *u32) bool {
+    if (budget.* == 0 or depth == 0) return true;
+    budget.* -= 1;
     if (types.isSymbol(form)) return form == sym;
     if (types.isPair(form)) {
+        // The spine is iterated (long flat lists must not pay recursion
+        // depth); car recursion pays one depth unit per level, and both
+        // loops pay the node budget, which is what terminates cdr- and
+        // car-cycles from datum labels.
         var cur = form;
         while (types.isPair(cur)) : (cur = types.cdr(cur)) {
-            if (erFormMentionsSymbol(types.car(cur), sym)) return true;
+            if (budget.* == 0) return true;
+            budget.* -= 1;
+            if (erFormMentionsSymbol(types.car(cur), sym, depth - 1, budget)) return true;
         }
-        return erFormMentionsSymbol(cur, sym);
+        return erFormMentionsSymbol(cur, sym, depth - 1, budget);
     }
     if (types.isVector(form)) {
         for (types.toObject(form).as(types.Vector).data) |el| {
-            if (erFormMentionsSymbol(el, sym)) return true;
+            if (erFormMentionsSymbol(el, sym, depth - 1, budget)) return true;
         }
     }
     return false;
@@ -650,10 +668,18 @@ fn erFormMentionsSymbol(form: Value, sym: Value) bool {
 /// product is the same interned object as a use-site token of that
 /// spelling, so the classic (compare <token> (rename 'kw)) shape is
 /// recognized from the invocation's rename record plus whether the
-/// spelling occurs in the macro-use input — never from the argument
-/// position, which keeps the answer order-independent AND reflexive for
-/// two of the invocation's own rename products (a hoisted-rename
-/// self-compare; #2401 review).
+/// spelling occurs in the macro-use input (bounded walk; exhaustion is
+/// conservative) — never from the argument position, which keeps the
+/// answer order-independent and reflexive whenever the spelling is
+/// absent from the input. The shape compare cannot settle — stated
+/// plainly (#2401 review): a spelling that occurs in the input AND was
+/// bare-renamed this invocation, compared under a use-site local shadow.
+/// If one argument is that input token, the refusal is the answer
+/// free-identifier=? demands; if both arguments were the invocation's
+/// own rename products, the #f is known-wrong (a broken reflexivity) —
+/// the two are representationally identical under interning, and a
+/// distinguishable wrapper for bare rename products would break the
+/// compiler's bare matching of the reserved forms macros emit.
 fn erCompareFn(args: []const Value) anyerror!Value {
     if (!types.isSymbol(args[0]) or !types.isSymbol(args[1])) return types.FALSE;
     const full_a = types.symbolName(args[0]);
@@ -679,7 +705,10 @@ fn erCompareFn(args: []const Value) anyerror!Value {
         // tokens, likewise reflexive (the pairwise input-token idiom,
         // e.g. duplicate-key checks, keeps working).
         if (erRenamedBareThisInvocation(eff_a)) {
-            const in_input = if (er_input_slot) |slot| erFormMentionsSymbol(slot.*, args[0]) else false;
+            const in_input = if (er_input_slot) |slot| blk: {
+                var budget: u32 = ER_WALK_NODE_BUDGET;
+                break :blk erFormMentionsSymbol(slot.*, args[0], ER_WALK_DEPTH_CAP, &budget);
+            } else false;
             if (in_input)
                 return if (active_use_check.resolve(eff_a) == LITERAL_UNBOUND) types.TRUE else types.FALSE;
         }

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -191,6 +191,11 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
     // interpreter gets the second half from Compiler.compile's own per-form
     // pre-scan; this is the same scan, minus macro expansion.
     var redefined_names = std.StringHashMap(void).init(allocator);
+    // Set when a form's structure-only set! scan truncated (depth/spine
+    // cap): from that form to the end of the file, every top-level form is
+    // eval-fallbacked — see the scan site below for why one form's
+    // truncation poisons the whole rest of the program.
+    var native_scan_truncated = false;
     defer redefined_names.deinit();
     ir_instance.set_targets = &redefined_names;
 
@@ -246,11 +251,21 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
         // map, and continuing with a partial set would silently fold a call
         // the scan had not finished proving unsafe. A truncated scan (depth
         // or spine cap — e.g. a datum-label cycle in the form) means the
-        // partial map cannot gate folding or inline dispatch either, and
-        // this tier has no set_targets_all switch: eval-fallback the whole
-        // form (same action as #2119's continuation forms), where the full
-        // compiler's own conservative machinery applies (#2401 review).
-        if (try compiler.scanSetTargetsWithoutMacros(expr, &redefined_names)) {
+        // partial map cannot gate folding or inline dispatch — and not just
+        // for this form: the form may rebind a primitive at run time (it is
+        // about to be VM-evaluated), and collectRedefinedNamesMacroAware
+        // below can no more see through the truncation than the scan could,
+        // so later forms' folds would go stale (#2212's divergence class).
+        // This tier has no set_targets_all switch, so the conservative
+        // action is to eval-fallback this form AND every remaining
+        // top-level form of the file (same action as #2119's continuation
+        // forms; execution order is preserved, so forms lowered before the
+        // truncation stay temporally correct). Only pathological inputs
+        // reach the caps, so ordinary files keep their native lowering.
+        if (!native_scan_truncated) {
+            native_scan_truncated = try compiler.scanSetTargetsWithoutMacros(expr, &redefined_names);
+        }
+        if (native_scan_truncated) {
             const passthrough_node = ir_instance.makePassthrough(expr) catch continue;
             ir_nodes.append(allocator, passthrough_node) catch continue;
             continue;

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -244,8 +244,17 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
 
         // `try`, not a swallowed error: the only failure is OOM growing the
         // map, and continuing with a partial set would silently fold a call
-        // the scan had not finished proving unsafe.
-        try compiler.scanSetTargetsWithoutMacros(expr, &redefined_names);
+        // the scan had not finished proving unsafe. A truncated scan (depth
+        // or spine cap — e.g. a datum-label cycle in the form) means the
+        // partial map cannot gate folding or inline dispatch either, and
+        // this tier has no set_targets_all switch: eval-fallback the whole
+        // form (same action as #2119's continuation forms), where the full
+        // compiler's own conservative machinery applies (#2401 review).
+        if (try compiler.scanSetTargetsWithoutMacros(expr, &redefined_names)) {
+            const passthrough_node = ir_instance.makePassthrough(expr) catch continue;
+            ir_nodes.append(allocator, passthrough_node) catch continue;
+            continue;
+        }
 
         const root = ir_mod.lowerAndOptimize(&ir_instance, expr, &vm.macros, false) catch |err| {
             const code = diagnostics.compileErrorCode(err);

--- a/src/tests_macros_procedural.zig
+++ b/src/tests_macros_procedural.zig
@@ -60,6 +60,84 @@ test "SRFI 211: compare answers free-identifier equality for else" {
     );
 }
 
+// kaappi#2388: compare is binding-aware free-identifier=? — the same
+// machinery syntax-rules literal matching runs on (literal_bound +
+// use_check.resolve), so the KEP-0006 four-quadrant answers hold: a
+// use-site local rebinding of a keyword spelling is refused for both the
+// reserved (bare-rename) and renamed (global-name) keyword shapes, while
+// an unshadowed use still compares equal. End-to-end parity against a
+// syntax-rules cond-style transformer is pinned in
+// tests/scheme/srfi/srfi211.scm (KEP-0018 UQ6). The macro names carry a
+// q2388- prefix because a vm.eval'd define-syntax re-using a keyword
+// already defined by an earlier test in this process trips a pre-existing
+// quirk unrelated to compare (kaappi#2400).
+test "SRFI 211: compare refuses a locally rebound keyword spelling (#2388)" {
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax q2388-else?
+        \\    (er-macro-transformer
+        \\     (lambda (form rename compare)
+        \\       (list (rename 'quote) (compare (car (cdr form)) (rename 'else))))))
+        \\  (define-syntax q2388-arrow?
+        \\    (er-macro-transformer
+        \\     (lambda (form rename compare)
+        \\       (list (rename 'quote) (compare (car (cdr form)) (rename '=>))))))
+        \\  (and (q2388-else? else)
+        \\       (q2388-arrow? =>)
+        \\       (not (let ((else 1)) (q2388-else? else)))
+        \\       (not (let ((=> 1)) (q2388-arrow? =>)))))
+    );
+}
+
+test "SRFI 211: compare refuses a locally rebound rename of a global name (#2388)" {
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax q2388-values?
+        \\    (er-macro-transformer
+        \\     (lambda (form rename compare)
+        \\       (list (rename 'quote) (compare (car (cdr form)) (rename 'values))))))
+        \\  (and (q2388-values? values)
+        \\       (not (let ((values 1)) (q2388-values? values)))))
+    );
+}
+
+// Pairwise comparison of two USE-SITE tokens (the duplicate-key idiom)
+// must stay reflexive even when the spelling is locally bound at the use
+// site: with no bare rename of that spelling in the invocation, compare
+// sees the same identifier on both sides.
+test "SRFI 211: compare stays reflexive on plain use-site tokens (#2388)" {
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax q2388-tok=?
+        \\    (er-macro-transformer
+        \\     (lambda (form rename compare)
+        \\       (list (rename 'quote)
+        \\             (compare (car (cdr form)) (car (cddr form)))))))
+        \\  (and (q2388-tok=? vv vv)
+        \\       (let ((vv 1)) (q2388-tok=? vv vv))))
+    );
+}
+
+// A macro-INTRODUCED keyword (rename product, gensym-marked) compares
+// equal to the definition-side keyword even where a use-site local
+// shadows the bare spelling — the hygiene quadrant reserved-form
+// spellings cannot express (they stay bare, so both systems refuse under
+// shadowing; see the srfi211.scm parity suite).
+test "SRFI 211: a macro-introduced keyword stays hygienic under shadowing (#2388)" {
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax q2388-arrow2?
+        \\    (er-macro-transformer
+        \\     (lambda (form rename compare)
+        \\       (list (rename 'quote) (compare (car (cdr form)) (rename '=>))))))
+        \\  (define-syntax q2388-probe
+        \\    (er-macro-transformer
+        \\     (lambda (form rename compare)
+        \\       (list 'q2388-arrow2? (rename '=>)))))
+        \\  (and (q2388-probe) (let ((=> 1)) (q2388-probe))))
+    );
+}
+
 test "SRFI 211: lisp-transformer receives the whole use datum, unhygienically" {
     try th.expectEval(
         \\(begin

--- a/src/tests_prescan.zig
+++ b/src/tests_prescan.zig
@@ -220,3 +220,62 @@ test "#1775: ordinary code does not trigger the pre-scan fallback" {
     try std.testing.expectEqual(@as(i64, 12), types.toFixnum(result));
     try std.testing.expectEqual(@as(u64, 0), compiler.prescan_truncations - before);
 }
+
+// #2404/#2401 review: the scan's caps must REPORT, never silently return a
+// partial target set — a missed `set!` target leaves a local unboxed
+// (continuation-unsafe, #1168) and foldable (IR.isRedefined). The spine cap
+// exists because datum-label cycles make a form's cdr spine infinite; this
+// pins the reporting half on the structure-only callers (Part B propagates
+// to set_targets_all; the native backend's return value is what makes it
+// eval-fallback the form).
+test "#2404: scanSetTargetsWithoutMacros reports truncation on a cyclic form" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    const cyclic = try ctx.vm.eval("'#0=(zz . #0#)");
+    var targets = std.StringHashMap(void).init(std.testing.allocator);
+    defer targets.deinit();
+    try std.testing.expect(try compiler.scanSetTargetsWithoutMacros(cyclic, &targets));
+
+    // The reporting is not hair-trigger: an ordinary small form scans to
+    // completion and reports false.
+    var targets2 = std.StringHashMap(void).init(std.testing.allocator);
+    defer targets2.deinit();
+    try std.testing.expect(!try compiler.scanSetTargetsWithoutMacros(
+        try ctx.vm.eval("'(begin (set! a 1) (if x (set! b 2)))"),
+        &targets2,
+    ));
+    try std.testing.expect(targets2.contains("a"));
+    try std.testing.expect(targets2.contains("b"));
+}
+
+// End-to-end: a macro use whose operand is a datum-label cycle (the
+// #2404 shape) still compiles with correct set!/continuation semantics —
+// the expansion's Part B scan truncates on the cycle and falls back to
+// every-name boxing rather than trusting the partial set.
+test "#2404: a cyclic macro operand keeps set! boxing correct" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // The wrapper shape is the discriminator (verified against origin/main,
+    // which hangs on it): a macro use whose operand is another macro use
+    // carrying the cyclic datum — the re-emitted body position is what
+    // reaches the set! pre-scan's spine walk. A plain top-level use of
+    // `probe` expands and discards the operand before any scan sees it.
+    const result = try ctx.vm.eval(
+        \\(begin
+        \\  (define-syntax probe
+        \\    (syntax-rules () ((probe n x) n)))
+        \\  (define-syntax wrap
+        \\    (syntax-rules () ((wrap e) (let ((tmp-w 0)) e tmp-w))))
+        \\  (let ((n 0) (k* #f))
+        \\    (call/cc (lambda (k) (set! k* k)))
+        \\    (set! n (+ n 1))
+        \\    (wrap (probe n #0=(zz . #0#)))
+        \\    (if (< n 3) (k* #f))
+        \\    n))
+    );
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
+}

--- a/tests/scheme/audit/primitives_smallbatch-audit.scm
+++ b/tests/scheme/audit/primitives_smallbatch-audit.scm
@@ -758,11 +758,15 @@
   (er-macro-transformer (lambda (form rename compare) (list (rename 'quote) (compare (cadr form) (rename '=>))))))
 (test-assert "SRFI 211 compare matches the => literal" (er-is-arrow =>))
 (test-assert "SRFI 211 compare distinguishes => from else" (not (er-is-arrow else)))
-;; compare is name-based (hygiene-stripped equality), so a use-site LOCAL
-;; rebinding of the literal still compares equal. That is the engine's
-;; documented strength limit, pinned here so a stronger compare shows up.
-(test-assert "SRFI 211 compare is name-based: a locally rebound else still matches"
-             (let ((else 1)) (er-is-else else)))
+;; compare is binding-aware free-identifier=? (kaappi#2388): a use-site
+;; LOCAL rebinding of the literal is a different binding and no longer
+;; compares equal, exactly as a syntax-rules literal refuses the same
+;; shadowing. The old name-based compare answered #t here; this pin is the
+;; one test the stronger semantics was designed to flip.
+(test-assert "SRFI 211 compare is binding-aware: a locally rebound else no longer matches"
+             (not (let ((else 1)) (er-is-else else))))
+(test-assert "SRFI 211 compare is binding-aware: a locally rebound => no longer matches"
+             (not (let ((=> 1)) (er-is-arrow =>))))
 
 ;;; --- lisp-transformer is deliberately UNhygienic; that is the feature ---
 

--- a/tests/scheme/compile/native-truncated-scan-fallback-2404.sh
+++ b/tests/scheme/compile/native-truncated-scan-fallback-2404.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Regression test for the #2404/#2401-review conservative fallback: when a
+# top-level form's structure-only set! scan truncates (depth cap, or the
+# spine cap on a datum-label cycle), the native tier must not keep folding
+# later forms against a possibly-stale primitive table.
+#
+# The hole this pins (second CodeRabbit review of #2401): the truncated
+# form is eval-fallbacked (VM-executed), so a macro-produced `(set! + *)`
+# inside it rebinds at run time — but the whole-program redefined_names
+# map can no more see through the truncation than the scan could, and
+# `kaappi compile` never executes forms to find out. A later natively
+# lowered `(+ 5 2)` then folded to 7 while the interpreter printed 10.
+# The fix eval-fallbacks every remaining top-level form after a truncated
+# scan, so the later form runs in the VM and consults the live globals.
+#
+# The cyclic wrapper shape (macro use whose operand is another macro use
+# carrying a datum-label cycle) is the minimal form whose scan truncates —
+# verified against the scan's caps; a plain top-level cyclic use expands
+# and discards the operand before any scan reaches it.
+#
+# Each case must produce the same output from the native binary as from the
+# interpreter (the interpreter is the oracle — see shell-common.sh).
+#
+# Usage: bash tests/scheme/compile/native-truncated-scan-fallback-2404.sh [path-to-kaappi]
+
+set -euo pipefail
+
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+ensure_runtime_lib "$REPO_DIR"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+fail=0
+
+check() {
+    local name="$1" src="$2" expect_out="$3" expect_status="$4"
+
+    printf '%s' "$src" > "$DIR/$name.scm"
+
+    local interp_out interp_status=0
+    interp_out=$(interp_stdout "$KAAPPI_ABS" "$DIR" "$name.scm") || interp_status=$?
+    if [[ "$interp_out" != "$expect_out" ]]; then
+        echo "FAIL: $name — interpreter stdout '$interp_out' != expected '$expect_out'" >&2
+        fail=1
+        return
+    fi
+    if [[ "$interp_status" -ne "$expect_status" ]]; then
+        echo "FAIL: $name — interpreter exit $interp_status != expected $expect_status" >&2
+        fail=1
+        return
+    fi
+
+    if ! (cd "$DIR" && "$KAAPPI_ABS" compile "$name.scm" -o "$name" > /dev/null 2>&1); then
+        echo "FAIL: $name — native compilation failed" >&2
+        fail=1
+        return
+    fi
+
+    set +e
+    local out status
+    out=$("$DIR/$name" 2>/dev/null)
+    status=$?
+    set -e
+
+    assert_tiers_agree "$name" "$interp_out" "$interp_status" "$out" "$status" || fail=1
+}
+
+# 1. The hole: truncated scan (cyclic wrapper operand), then a macro use
+#    rebinding `+` to `*`, then a fold-sensitive `(+ 5 2)`. The rebind runs
+#    in the VM either way; the later form must see the LIVE `+` (10), not a
+#    stale fold (7).
+check truncated-then-rebind \
+'(define-syntax m (syntax-rules () ((m x) (quote ok))))
+(define-syntax w (syntax-rules () ((w e) (begin e (if #f #f)))))
+(w (m #0=(zz . #0#)))
+(define-syntax rebind (syntax-rules () ((_) (set! + *))))
+(rebind)
+(display (+ 5 2))
+(newline)' \
+'10' 0
+
+# 2. Discriminating control: the SAME program without the cyclic form keeps
+#    its native lowering (the fallback must be engagement-gated, not
+#    unconditional) — output identical, still both tiers.
+check no-truncation-plain-rebind \
+'(define-syntax rebind (syntax-rules () ((_) (set! + *))))
+(rebind)
+(display (+ 5 2))
+(newline)' \
+'10' 0
+
+# 3. A truncated scan with NO rebinding anywhere: later plain forms still
+#    evaluate correctly through the eval-fallback path.
+check truncated-plain-arithmetic \
+'(define-syntax m (syntax-rules () ((m x) (quote ok))))
+(define-syntax w (syntax-rules () ((w e) (begin e (if #f #f)))))
+(w (m #0=(zz . #0#)))
+(display (+ 5 2))
+(newline)' \
+'7' 0
+
+if [[ "$fail" -ne 0 ]]; then
+    exit 1
+fi
+echo "native-truncated-scan-fallback-2404: all cases passed"

--- a/tests/scheme/hygiene/cyclic-macro-input-2404.scm
+++ b/tests/scheme/hygiene/cyclic-macro-input-2404.scm
@@ -8,14 +8,18 @@
 ;;   * compiler.collectSetTargets, whose cdr-spine loops had no bound (the
 ;;     scan's depth cap counts only car recursion). Pre-existing on
 ;;     origin/main: a cyclic macro operand re-emitted into a body position
-;;     — e.g. as a test-assert operand — reached it and hung. Now bounded
-;;     by SET_SCAN_SPINE_CAP; exhaustion degrades to the scan's ordinary
-;;     loses-optimization truncation (set_targets_all boxing), and the
-;;     ellipsis case shows matchEllipsis's own MAX_ELLIPSIS_VALUES cap
-;;     already terminating on an infinite spine.
+;;     reached it and hung. The shape that reaches the scan is a macro use
+;;     whose OPERAND is another macro use carrying the cycle (a plain
+;;     top-level use expands and discards the operand before any scan sees
+;;     it) — the wrapper form below is the minimal discriminator, verified
+;;     to hang on origin/main. Exhaustion degrades to the scan's ordinary
+;;     loses-optimization truncation (set_targets_all boxing).
 ;;   * expander.erFormMentionsSymbol (compare's input walk), which the
 ;;     #2401 review introduced and fixed with a node budget + depth cap in
 ;;     the same class.
+;;
+;; The ellipsis case shows matchEllipsis's own MAX_ELLIPSIS_VALUES cap
+;; already terminating on an infinite spine.
 ;;
 ;; erRenameDatum on the same cyclic input aborts on the root stack
 ;; instead (#2403) — a different failure mode needing its own semantic
@@ -27,9 +31,16 @@
   (syntax-rules () ((cyc-m x) 'ok-fixed)))
 (define-syntax cyc-mell
   (syntax-rules () ((_ x ...) 'ok-ell)))
+(define-syntax cyc-wrap
+  (syntax-rules () ((cyc-wrap e) (let ((cyc-r 0)) e cyc-r))))
 
-;; Fixed-arity pattern: the scanner walks the operand's spine; the
-;; matcher stops at the pattern's end.
+;; The scanner discriminator: the inner use's cyclic operand is re-emitted
+;; into a body position, which is what the set! pre-scan walks. The
+;; wrapper's own cyc-r (0) is the result.
+(if (not (= (cyc-wrap (cyc-m #0=(zz . #0#))) 0))
+    (begin (display "FAIL: wrapped cyclic macro input") (newline) (exit 1)))
+
+;; Fixed-arity pattern at top level: matcher stops at the pattern's end.
 (if (not (eq? (cyc-m #0=(zz . #0#)) 'ok-fixed))
     (begin (display "FAIL: fixed-arity macro on cyclic input") (newline) (exit 1)))
 

--- a/tests/scheme/hygiene/cyclic-macro-input-2404.scm
+++ b/tests/scheme/hygiene/cyclic-macro-input-2404.scm
@@ -1,0 +1,52 @@
+;; Regression test for kaappi#2404: walkers that touch a macro-use input
+;; as if it were acyclic spin forever on the genuine cycles R7RS datum
+;; labels (§7.1.2) produce — `(eq? x (cdr x))` is #t for
+;; '#0=(zz . #0#), so this is a real cycle, not a reader artifact.
+;;
+;; Two walkers are exercised:
+;;
+;;   * compiler.collectSetTargets, whose cdr-spine loops had no bound (the
+;;     scan's depth cap counts only car recursion). Pre-existing on
+;;     origin/main: a cyclic macro operand re-emitted into a body position
+;;     — e.g. as a test-assert operand — reached it and hung. Now bounded
+;;     by SET_SCAN_SPINE_CAP; exhaustion degrades to the scan's ordinary
+;;     loses-optimization truncation (set_targets_all boxing), and the
+;;     ellipsis case shows matchEllipsis's own MAX_ELLIPSIS_VALUES cap
+;;     already terminating on an infinite spine.
+;;   * expander.erFormMentionsSymbol (compare's input walk), which the
+;;     #2401 review introduced and fixed with a node budget + depth cap in
+;;     the same class.
+;;
+;; erRenameDatum on the same cyclic input aborts on the root stack
+;; instead (#2403) — a different failure mode needing its own semantic
+;; decision, not covered here.
+;;
+;; A hang here fails by timeout, which run-all.sh reports.
+
+(define-syntax cyc-m
+  (syntax-rules () ((cyc-m x) 'ok-fixed)))
+(define-syntax cyc-mell
+  (syntax-rules () ((_ x ...) 'ok-ell)))
+
+;; Fixed-arity pattern: the scanner walks the operand's spine; the
+;; matcher stops at the pattern's end.
+(if (not (eq? (cyc-m #0=(zz . #0#)) 'ok-fixed))
+    (begin (display "FAIL: fixed-arity macro on cyclic input") (newline) (exit 1)))
+
+;; Ellipsis pattern against the infinite spine: bounded by the matcher's
+;; ellipsis-values cap.
+(if (not (eq? (cyc-mell #0=(zz . #0#)) 'ok-ell))
+    (begin (display "FAIL: ellipsis macro on cyclic input") (newline) (exit 1)))
+
+;; The compare walk: the searched spelling is absent from the input, so
+;; the walk cannot short-circuit before reaching the cycle (the exact
+;; shape the #2404 report used).
+(define-syntax cyc-self-else?
+  (er-macro-transformer
+   (lambda (form rename compare)
+     (list (rename 'quote) (compare (rename 'else) (rename 'else))))))
+(define cyc-compare-result (cyc-self-else? #0=(zz . #0#)))
+(if (not (eq? cyc-compare-result #t))
+    (begin (display "FAIL: compare on cyclic input") (newline) (exit 1)))
+
+(display "cyclic-macro-input-2404: ok") (newline)

--- a/tests/scheme/srfi/srfi211.scm
+++ b/tests/scheme/srfi/srfi211.scm
@@ -106,6 +106,128 @@
      (list (rename 'quote) (compare 1 1)))))
 (test-equal #f (compare-nums))
 
+;;; --- KEP-0006 four-quadrant acceptance test (kaappi#2388): compare is
+;;; binding-aware free-identifier=? ---
+;;; Against an ER cond-style transformer, the else/=> keyword checks must
+;;; answer exactly what a syntax-rules literal with the same keywords
+;;; answers -- the same binding, or both unbound (R7RS 4.3.2). Every
+;;; quadrant below runs BOTH systems against the SAME expected value; that
+;;; equivalence is the KEP-0018 unresolved-question-6 guarantee (an ER
+;;; macro is exactly as hygienic as a syntax-rules one), pinned here as a
+;;; contract.
+
+(define-syntax erq-cond
+  (er-macro-transformer
+   (lambda (form rename compare)
+     (let loop ((cs (cdr form)))
+       (cond
+         ((null? cs) (list (rename 'quote) 'no-clause))
+         ((and (pair? (car cs)) (compare (caar cs) (rename 'else)))
+          (cadr (car cs)))
+         ((and (pair? (car cs)) (pair? (cdr (car cs)))
+               (compare (cadr (car cs)) (rename '=>)))
+          (list (rename 'let)
+                (list (list (rename 't) (caar cs)))
+                (list (rename 'if) (rename 't)
+                      (list (caddr (car cs)) (rename 't))
+                      (loop (cdr cs)))))
+         (else (list (rename 'if) (caar cs) (cadr (car cs))
+                     (loop (cdr cs)))))))))
+
+(define-syntax srq-cond
+  (syntax-rules (else =>)
+    ((_ (else expr) rest ...) expr)
+    ((_ (test => proc) rest ...)
+     (let ((t test)) (if t (proc t) (srq-cond rest ...))))
+    ((_ (test expr) rest ...) (if test expr (srq-cond rest ...)))
+    ((_) 'no-clause)))
+
+;; Quadrant 1: the else clause fires in both systems.
+(test-equal 'q1 (erq-cond (#f 'a) (else 'q1)))
+(test-equal 'q1 (srq-cond (#f 'a) (else 'q1)))
+
+;; Quadrant 2: a use-site local rebinding of the keyword is a different
+;; binding, so the clause is NOT an else clause in either system. With
+;; else bound to #f the refused clause falls through to (#t 'q2); the
+;; name-based compare this replaces answered 'wrong here.
+(test-equal 'q2 (let ((else #f)) (erq-cond (#f 'a) (else 'wrong) (#t 'q2))))
+(test-equal 'q2 (let ((else #f)) (srq-cond (#f 'a) (else 'wrong) (#t 'q2))))
+
+;; Quadrant 3: an outer macro that introduces else into the cond it emits.
+;; Unshadowed, it fires in both systems...
+(define-syntax q3-er-wrap (syntax-rules () ((_) (erq-cond (#f 'x) (else 'q3)))))
+(define-syntax q3-sr-wrap (syntax-rules () ((_) (srq-cond (#f 'x) (else 'q3)))))
+(test-equal 'q3 (q3-er-wrap))
+(test-equal 'q3 (q3-sr-wrap))
+;; ...and under a same-spelling use-site local, both systems agree the
+;; clause falls through: `else` is a reserved form the hygiene engine
+;; keeps bare, so a user local of that spelling shadows a macro-introduced
+;; one in syntax-rules literals and ER compare alike -- the one shared,
+;; documented reserved-form deviation (identifiers the engine CAN mark,
+;; like => in quadrant 4, stay hygienic).
+(define-syntax q3b-er-wrap
+  (syntax-rules () ((_) (erq-cond (#f 'x) (else 'wrong) (#t 'q3b)))))
+(define-syntax q3b-sr-wrap
+  (syntax-rules () ((_) (srq-cond (#f 'x) (else 'wrong) (#t 'q3b)))))
+(test-equal 'q3b (let ((else #f)) (q3b-er-wrap)))
+(test-equal 'q3b (let ((else #f)) (q3b-sr-wrap)))
+
+;; Quadrant 4: the => variants. Unshadowed, the arrow fires in both...
+(test-equal 1 (erq-cond ((- 1) => abs) (else 'no)))
+(test-equal 1 (srq-cond ((- 1) => abs) (else 'no)))
+;; ...a use-site local rebinding of => is refused by compare exactly as
+;; the literal is refused, so the clause compiles as (test expr) whose
+;; expr is the local's value in both systems...
+(test-equal 7 (let ((=> 7)) (erq-cond (#t =>) (#t 'q4c))))
+(test-equal 7 (let ((=> 7)) (srq-cond (#t =>) (#t 'q4c))))
+;; ...and a macro-INTRODUCED => stays hygienic in both: the introducing
+;; rename/template marks the identifier, and the shadowing local cannot
+;; reach it.
+(define-syntax q4d-er-wrap
+  (er-macro-transformer
+   (lambda (form rename compare)
+     (list 'erq-cond
+           (list 42 (rename '=>) (list 'lambda (list 'x)
+                                       (list 'list ''arrow-er 'x)))
+           (list #t ''fallback)))))
+(define-syntax q4d-sr-wrap
+  (syntax-rules ()
+    ((_) (srq-cond (42 => (lambda (x) (list 'arrow-sr x)))
+                   (#t 'fallback)))))
+(test-equal '(arrow-er 42) (let ((=> #f)) (q4d-er-wrap)))
+(test-equal '(arrow-sr 42) (let ((=> #f)) (q4d-sr-wrap)))
+
+;; compare stays reflexive on plain use-site tokens (the pairwise
+;; input-token comparison idiom, e.g. duplicate-key checks)...
+(define-syntax er-token=?
+  (er-macro-transformer
+   (lambda (form rename compare)
+     (list (rename 'quote) (compare (cadr form) (caddr form))))))
+(test-assert "two identical use-site tokens compare equal" (er-token=? zz zz))
+(test-assert "... even when the spelling is locally rebound at the use site"
+             (let ((zz 1)) (er-token=? zz zz)))
+;; ...but a token against the definition-side keyword of the same spelling
+;; is refused under that rebinding regardless of argument order.
+(define-syntax er-is-arrow-rev
+  (er-macro-transformer
+   (lambda (form rename compare)
+     (list (rename 'quote) (compare (rename '=>) (cadr form))))))
+(test-assert "reversed-argument compare under rebinding is also refused"
+             (not (let ((=> 1)) (er-is-arrow-rev =>))))
+
+;; The bound-keyword case from the #2398 evidence (SRFI 202's values
+;; claw): renaming a GLOBAL-bound name yields a marked identifier, so an
+;; unshadowed use still compares equal while a use-site local rebinding
+;; of the spelling is refused.
+(define-syntax er-is-values
+  (er-macro-transformer
+   (lambda (form rename compare)
+     (list (rename 'quote) (compare (cadr form) (rename 'values))))))
+(test-assert "unshadowed values compares equal to its rename"
+             (er-is-values values))
+(test-assert "a locally rebound values is refused"
+             (not (let ((values 1)) (er-is-values values))))
+
 ;;; --- identifier?: symbols (renamed or not) are identifiers ---
 (test-assert "plain symbol" (identifier? 'x))
 (test-assert "not a number" (not (identifier? 3)))

--- a/tests/scheme/srfi/srfi211.scm
+++ b/tests/scheme/srfi/srfi211.scm
@@ -355,7 +355,7 @@
 ;;; own non-exported helper at the use site ---
 (define-library (t211 helperlib)
   (import (scheme base) (srfi 211 explicit-renaming))
-  (export lib-twice combo is-lib-bound?)
+  (export lib-twice combo is-lib-bound? lib-bound-var)
   (begin
     (define (t211-helper x) (* x 2))
     (define lib-bound-var 'marker)
@@ -382,6 +382,18 @@
              (is-lib-bound? lib-bound-var))
 (test-assert "... but not under a use-site local rebinding of the spelling"
              (not (let ((lib-bound-var 1)) (is-lib-bound? lib-bound-var))))
+;; compare's input walk terminates on circular data: R7RS datum labels
+;; make the macro-use input genuinely cyclic, and the spelling being
+;; absent means the walk cannot short-circuit before reaching the cycle
+;; (#2404). Exhausting the walk's budget counts conservatively as
+;; occurrence, so the answer here is the quadrant rule's unshadowed #t.
+;; The use is a define initializer, NOT a test-assert operand: wrapping a
+;; cyclic datum in a body-position macro triggers the pre-existing
+;; collectSetTargets hang (reproduced on origin/main; noted on #2404),
+;; which would mask what this test pins.
+(define er-cyclic-result (er-self-else? #0=(zz . #0#)))
+(test-assert "compare terminates on a circular macro-use input (datum labels)"
+             er-cyclic-result)
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-211")

--- a/tests/scheme/srfi/srfi211.scm
+++ b/tests/scheme/srfi/srfi211.scm
@@ -113,8 +113,10 @@
 ;;; answers -- the same binding, or both unbound (R7RS 4.3.2). Every
 ;;; quadrant below runs BOTH systems against the SAME expected value; that
 ;;; equivalence is the KEP-0018 unresolved-question-6 guarantee (an ER
-;;; macro is exactly as hygienic as a syntax-rules one), pinned here as a
-;;; contract.
+;;; macro is exactly as hygienic as a syntax-rules one) for the
+;;; auxiliary-keyword spellings, pinned here as a contract. The guarantee's
+;;; boundary — spellings whose bare rename comes from renameForHygiene's
+;;; other bare-returning branches — is pinned separately below.
 
 (define-syntax erq-cond
   (er-macro-transformer
@@ -228,6 +230,46 @@
 (test-assert "a locally rebound values is refused"
              (not (let ((values 1)) (er-is-values values))))
 
+;; Reflexivity of a rename against itself (the hoisted `r-*` rename style
+;; the 241/202 ports use): free-identifier=? is an equivalence relation,
+;; so a transformer comparing two of its OWN rename products must get #t
+;; even where a use-site local shadows the bare spelling (#2401 review).
+;; The spelling nowhere occurs in the macro-use input, which is what
+;; separates this from the quadrant-2 shape above.
+(define-syntax er-self-else?
+  (er-macro-transformer
+   (lambda (form rename compare)
+     (list (rename 'quote) (compare (rename 'else) (rename 'else))))))
+(test-assert "a rename compares equal to itself" (er-self-else?))
+(test-assert "... even under a use-site shadow of the bare spelling"
+             (let ((else 1)) (er-self-else?)))
+(define-syntax er-self-arrow?
+  (er-macro-transformer
+   (lambda (form rename compare)
+     (list (rename 'quote) (compare (rename '=>) (rename '=>))))))
+(test-assert "a renamed (gensym-marked) keyword compares equal to itself"
+             (let ((=> 1)) (er-self-arrow?)))
+
+;; Boundary of the ER/syntax-rules parity guarantee, pinned as-is: a
+;; spelling whose bare rename comes from renameForHygiene's OTHER
+;; bare-returning branches (here: the VOID sentinel for a later internal
+;; define in the use-site body) records no identity entry, so compare
+;; answers the (reflexive) use-token view while a syntax-rules literal
+;; refuses. Pre-existing divergence, not covered by the parity contract --
+;; see the .sld header's qualified guarantee statement (#2401 review).
+(define-syntax er-is-laterdef?
+  (er-macro-transformer
+   (lambda (form rename compare)
+     (list (rename 'quote) (compare (cadr form) (rename 'laterdef))))))
+(define-syntax sr-is-laterdef?
+  (syntax-rules (laterdef) ((_ laterdef) #t) ((_ x) #f)))
+(define (er-laterdef-probe)
+  (define result
+    (list (er-is-laterdef? laterdef) (let ((laterdef 1)) (er-is-laterdef? laterdef))))
+  (define laterdef 9)
+  result)
+(test-equal '(#t #t) (er-laterdef-probe))
+
 ;;; --- identifier?: symbols (renamed or not) are identifiers ---
 (test-assert "plain symbol" (identifier? 'x))
 (test-assert "not a number" (not (identifier? 3)))
@@ -313,19 +355,33 @@
 ;;; own non-exported helper at the use site ---
 (define-library (t211 helperlib)
   (import (scheme base) (srfi 211 explicit-renaming))
-  (export lib-twice combo)
+  (export lib-twice combo is-lib-bound?)
   (begin
     (define (t211-helper x) (* x 2))
+    (define lib-bound-var 'marker)
     (define-syntax lib-twice
       (er-macro-transformer
        (lambda (form rename compare)
          (list (rename 't211-helper) (cadr form)))))
+    ;; compare against a rename of a name bound in the transformer's OWN
+    ;; definition environment: outside that library, renameForHygiene's
+    ;; #1812 branch marks it def-env-prefixed, and the marked identifier
+    ;; must still compare equal to a use-site reference of the exported
+    ;; binding (#2401 review -- this was the def_env/free regression).
+    (define-syntax is-lib-bound?
+      (er-macro-transformer
+       (lambda (form rename compare)
+         (list (rename 'quote) (compare (cadr form) (rename 'lib-bound-var))))))
     (define-syntax combo
       (syntax-rules ()
         ((_ e) (list (lib-twice e) e))))))
 (import (t211 helperlib))
 (test-equal 42 (lib-twice 21))
 (test-equal '(20 10) (combo 10))
+(test-assert "a def-env-marked rename compares equal to the use-site reference of the same exported binding"
+             (is-lib-bound? lib-bound-var))
+(test-assert "... but not under a use-site local rebinding of the spelling"
+             (not (let ((lib-bound-var 1)) (is-lib-bound? lib-bound-var))))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-211")

--- a/tests/scheme/srfi/srfi211.scm
+++ b/tests/scheme/srfi/srfi211.scm
@@ -387,10 +387,9 @@
 ;; absent means the walk cannot short-circuit before reaching the cycle
 ;; (#2404). Exhausting the walk's budget counts conservatively as
 ;; occurrence, so the answer here is the quadrant rule's unshadowed #t.
-;; The use is a define initializer, NOT a test-assert operand: wrapping a
-;; cyclic datum in a body-position macro triggers the pre-existing
-;; collectSetTargets hang (reproduced on origin/main; noted on #2404),
-;; which would mask what this test pins.
+;; Kept as a define initializer so this test pins compare's walk alone;
+;; the cyclic input through wrapper macros (collectSetTargets, ellipsis
+;; matching) is pinned by tests/scheme/hygiene/cyclic-macro-input-2404.scm.
 (define er-cyclic-result (er-self-else? #0=(zz . #0#)))
 (test-assert "compare terminates on a circular macro-use input (datum labels)"
              er-cyclic-result)


### PR DESCRIPTION
Closes #2388

## The decision: option (a) — implement binding-aware `compare`

KEP-0006 (amended 2026-08-27) already resolved Unresolved question 2 against SRFI 211's contract — "`compare` is `free-identifier=?`" — with a falsifiable four-quadrant test; ratifying the name-based deviation (option b) would have contradicted the amended KEP. The #2398 evidence step (SRFI 241/202 re-port, #2398) completed in the meantime: name-based compare held up in real library code, but recorded concrete observable weaknesses — SRFI 202's `values` claw parsing as the keyword even where the user shadowed `values`, and macro-generated same-spelled identifiers counting as keywords. Nothing blocked the stronger semantics, and the reuse the KEP's design section sketched ("the same machinery, exposed a second way") turned out to be genuinely small.

## What changed

**`src/expander.zig` — `erCompareFn` is now free-identifier=?**, mirroring `matchPattern`'s symbol-literal branch outcome-for-outcome, reusing the machinery it already runs on:

- Each argument is classified as a **use-site local slot** (`UseSiteBindingCheck.resolve` — the same callback literal matching uses), a **def-env binding** (`def_env_binding_prefix`-marked spelling as identity), or **free** (aux syntax, gensym'd rename/template products, unshadowed globals). Same classification ⇒ same binding; free/free ⇒ both unbound ⇒ equal.
- The one wrinkle symbols-as-syntax impose: **symbols are interned**, so `(rename 'else)` (reserved forms rename to themselves) is *the same object* as a user-typed `else` — no per-side classification is possible for a bare/bare pair. `erRenameSymbol` therefore records identity entries in the per-invocation scope table, and a bare/bare pair where that spelling was bare-renamed this invocation answers "do the def-site and use-site views agree" (a local rebinding ⇒ `#f`); any other bare/bare pair is two use-site tokens — the same identifier — and stays reflexive, so the pairwise input-token comparison idiom (duplicate-key checks) keeps working. The rule is keyed on the pair, not the argument position, so it is order-independent.

**The KEP-0006 four-quadrant acceptance test, finally written** — as an ER/syntax-rules *parity* suite in `tests/scheme/srfi/srfi211.scm`: a cond-style `erq-cond` transformer and a `srq-cond` `syntax-rules` twin with `else`/`=>` literals, every quadrant asserted against the **same expected value** for both systems. That pins KEP-0018 UQ6 — "an ER macro is exactly as hygienic as a syntax-rules one" — as a documented guarantee (the issue's References asked for exactly that fold-in). Also covers reflexivity, reversed-argument compare, and the `values` claw improvement.

**The audit pin flipped** — `primitives_smallbatch-audit.scm` asserted name-based compare *precisely so a stronger compare shows up as a test change*; it now asserts the refusal for both `else` and `=>`, plus the quadrant coverage moved into the parity suite.

**Docs**: the SRFI 211 `.sld` header's "compare is name-based" deviation paragraph is replaced by the binding-aware contract, the shared-limitation statement (reserved-form spellings kept bare are shadowed for macro-introduced occurrences in *both* systems; spellings the engine can mark, like `=>`, stay hygienic), and the verified-by pointers. `docs/dev/srfi-implementation-notes.md`'s SRFI 211 mechanism section and the 241/202 "keyword recognition" bullet updated likewise.

## Behavior change, precisely

`(compare x (rename 'kw))` where a use-site **local** shadows `kw`'s spelling now answers `#f` (was `#t`) — for reserved-form keywords (`else`), renamed global-name keywords (`values`), and non-reserved ones (`=>`) alike; everything else answers as before. SRFI 211/213/241/202/148 suites pass unchanged (29→48, 17, 54, 31, 142).

## Also in this PR

**Closes #2404 fully** — the `compare` input-walk hang (fixed in 5160768c) *and* the pre-existing `compiler.collectSetTargets` instance of the same class found while verifying it: the scan's depth cap counts only car recursion, so a cyclic macro operand re-emitted into a body position (e.g. a `test-assert` operand) hung the compiler on `origin/main`. Both spine loops now carry a 1M-step cap; exhaustion takes the scanner's ordinary loses-optimization-never-correctness truncation path (`set_targets_all` boxing, Part B correct-late). Regression suite: `tests/scheme/hygiene/cyclic-macro-input-2404.scm`. (#2403, `erRenameDatum` on circular input, stays out: no finite rename exists for an unfoldable cycle, so it needs a semantic decision.)

- **kaappi#2400** (filed, not fixed here): a *pre-existing* quirk found while writing the Zig tests — a `vm.eval`'d `define-syntax` re-using a macro keyword name from an earlier eval in the same process can fail with a bare `CompileError`. Reproduces on `origin/main` with the old compare (verified by stashing this change). The new Zig tests use `q2388-`-prefixed unique names with a comment pointing at the issue.
- KEP-0006's "As implemented" section (Divergence 1) and the four-quadrant record live in the keps repo — they'll need a small as-built amendment there once this lands; happy to open the keps PR as a follow-up.

## Testing

- `zig build test` — all unit suites pass, including four new engine-seam tests in `tests_macros_procedural.zig`.
- `zig build test -Dgc-stress=true` — passes (compare allocates nothing; the identity entries follow the existing scope-table slice lifetime pattern).
- `bash tests/scheme/run-all.sh` — **2118 pass, 0 fail** (723 Scheme files + the 1395-test R7RS suite).
- `bash tests/scheme/compile/srfi-241-202-bundle-2391.sh` — native tier agrees with the interpreter on the re-ported er-macro libraries.
- `npx markdownlint-cli2` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
