### PR TITLE
Add the kaappi-shared-channels cond-expand feature identifier (KEP-0004 Phase 2)

### DIFF
--- a/docs/dev/features.md
+++ b/docs/dev/features.md
@@ -41,7 +41,8 @@ native-only; WASM's entry point just runs a file.
   "sandbox_available": true,
   "features": ["r7rs", "kaappi", "ieee-float", "posix", "exact-closed",
                "exact-complex", "kaappi-fibers", "kaappi-reactor",
-               "kaappi-diagnostics", "kaappi-threads"],
+               "kaappi-diagnostics", "kaappi-threads",
+               "kaappi-shared-channels"],
   "srfis": { "builtin": [1, 9, 13, …], "portable": [0, 2, 4, …] },
   "limits": {
     "initial_frame_capacity": 480,

--- a/docs/dev/freebsd.md
+++ b/docs/dev/freebsd.md
@@ -33,7 +33,8 @@ FreeBSD is a POSIX platform — there is no `freebsd` identifier, just as
 macOS builds expose no `darwin`. The triple in `kaappi features` and the
 crash banner (`aarch64-freebsd-none`) distinguishes the OS when it
 matters. All capability identifiers (`kaappi-threads`, `kaappi-fibers`,
-`kaappi-reactor`, `kaappi-diagnostics`) are present — nothing is gated.
+`kaappi-reactor`, `kaappi-diagnostics`, `kaappi-shared-channels`) are
+present — nothing is gated.
 
 ## Native backend (`kaappi compile`)
 

--- a/docs/dev/netbsd.md
+++ b/docs/dev/netbsd.md
@@ -156,7 +156,8 @@ OS-class identifier per build, and NetBSD is a POSIX platform (there is no
 `kaappi features` and the crash banner (`aarch64-netbsd-none`)
 distinguishes the OS when it matters. All capability identifiers
 (`kaappi-threads`, `kaappi-fibers`, `kaappi-reactor`,
-`kaappi-diagnostics`) are present — nothing is gated.
+`kaappi-diagnostics`, `kaappi-shared-channels`) are present — nothing is
+gated.
 
 ## Testing on a NetBSD machine
 

--- a/docs/dev/openbsd.md
+++ b/docs/dev/openbsd.md
@@ -124,7 +124,8 @@ identifier per build, and OpenBSD is a POSIX platform (there is no `openbsd`
 identifier, just as macOS exposes no `darwin`). The triple in `kaappi features`
 and the crash banner (`aarch64-openbsd-none`) distinguishes the OS when it
 matters. All capability identifiers (`kaappi-threads`, `kaappi-fibers`,
-`kaappi-reactor`, `kaappi-diagnostics`) are present — nothing is gated.
+`kaappi-reactor`, `kaappi-diagnostics`, `kaappi-shared-channels`) are
+present — nothing is gated.
 
 ## Testing on an OpenBSD machine
 

--- a/src/tests_advanced.zig
+++ b/src/tests_advanced.zig
@@ -626,6 +626,25 @@ test "cond-expand kaappi-threads feature" {
     try std.testing.expectEqualStrings(want, types.symbolName(result));
 }
 
+// KEP-0004 Phase 2: kaappi-shared-channels advertises KEP-0002 cross-thread
+// channel promotion. Same platform gate as kaappi-threads — promotion needs
+// OS threads, which wasm32-wasi doesn't have (KEP-0002 §5: notify is a no-op
+// there and nothing ever calls it).
+test "cond-expand kaappi-shared-channels feature" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(cond-expand
+        \\  (kaappi-shared-channels 'yes)
+        \\  (else 'no))
+    );
+    const want: []const u8 = if (comptime platform.is_wasm) "no" else "yes";
+    try std.testing.expectEqualStrings(want, types.symbolName(result));
+}
+
 // Regression: libraryIsAvailable must not let cond-expand report a
 // disk-only library as available under --sandbox, since
 // tryLoadLibraryFromFile rejects every file-backed load there — the

--- a/src/tests_libraries.zig
+++ b/src/tests_libraries.zig
@@ -1010,6 +1010,7 @@ test "srfi-N feature: number parser requires the srfi- prefix (#1649)" {
     try std.testing.expectEqual(@as(?i64, null), f("vectors-133"));
     // Non-srfi platform features never look like one.
     try std.testing.expectEqual(@as(?i64, null), f("kaappi-threads"));
+    try std.testing.expectEqual(@as(?i64, null), f("kaappi-shared-channels"));
     try std.testing.expectEqual(@as(?i64, null), f("r7rs"));
     // Malformed / noncanonical srfi- forms.
     try std.testing.expectEqual(@as(?i64, null), f("srfi-")); // no digits

--- a/src/types.zig
+++ b/src/types.zig
@@ -1532,7 +1532,10 @@ const is_wasm_target = builtin.os.tag == .wasi;
 /// accessor, KEP-0005 §4) is likewise always compiled in — no platform
 /// carve-out. `kaappi-threads` is omitted on wasm, matching
 /// Lib.wasmAvailable()'s `srfi_18 => false` gate (primitives.zig) — no OS
-/// threads there. (KEP-0004)
+/// threads there. `kaappi-shared-channels` (KEP-0002 cross-thread channel
+/// promotion; gate cleared when kaappi#1487/#1489 closed) rides the same
+/// non-wasm branch: promotion needs OS threads, and on wasi `notify` is a
+/// no-op that nothing ever calls (KEP-0002 §5). (KEP-0004)
 const is_windows_target = builtin.os.tag == .windows;
 const base_platform_features = [_][]const u8{ "r7rs", "kaappi", "ieee-float", "exact-closed", "exact-complex", "kaappi-fibers", "kaappi-reactor", "kaappi-diagnostics" };
 // R7RS appendix B feature identifiers: exactly one OS-class identifier —
@@ -1542,7 +1545,7 @@ const os_feature = [_][]const u8{if (is_windows_target) "windows" else "posix"};
 pub const platform_features = if (is_wasm_target)
     base_platform_features ++ os_feature
 else
-    base_platform_features ++ os_feature ++ [_][]const u8{"kaappi-threads"};
+    base_platform_features ++ os_feature ++ [_][]const u8{ "kaappi-threads", "kaappi-shared-channels" };
 
 test "nil is not a pointer" {
     try std.testing.expect(!isPointer(NIL));

--- a/tests/scheme/smoke/features-consistency.scm
+++ b/tests/scheme/smoke/features-consistency.scm
@@ -21,6 +21,10 @@
 (test-assert "kaappi-fibers in features" (and (memq 'kaappi-fibers (features)) #t))
 (test-assert "kaappi-reactor in features" (and (memq 'kaappi-reactor (features)) #t))
 (test-assert "kaappi-threads in features" (and (memq 'kaappi-threads (features)) #t))
+;; KEP-0004 Phase 2: cross-thread channel promotion (KEP-0002). Same
+;; non-wasm gate as kaappi-threads — promotion needs OS threads.
+(test-assert "kaappi-shared-channels in features"
+  (and (memq 'kaappi-shared-channels (features)) #t))
 
 ;; Expression-level cond-expand must agree
 (test-equal "expr cond-expand exact-closed" 'yes
@@ -33,6 +37,8 @@
   (cond-expand (kaappi-reactor 'yes) (else 'no)))
 (test-equal "expr cond-expand kaappi-threads" 'yes
   (cond-expand (kaappi-threads 'yes) (else 'no)))
+(test-equal "expr cond-expand kaappi-shared-channels" 'yes
+  (cond-expand (kaappi-shared-channels 'yes) (else 'no)))
 
 (let ((runner (test-runner-current)))
   (test-end "features-consistency")


### PR DESCRIPTION
KEP-0004 Phase 2 was blocked on KEP-0002's cross-thread wakeup landing on `main` **with its review findings resolved**. Both halves have been true for six weeks — [#1487](https://github.com/kaappi/kaappi/issues/1487) and [#1489](https://github.com/kaappi/kaappi/issues/1489) closed 2026-07-13/14 and were fixed in v0.15.0, and KEP-0002 as a whole shipped in v0.15.0/v0.16.0 — but the identifier itself never landed. This adds it.

## Why the non-wasm branch

`kaappi-shared-channels` joins `kaappi-threads` in the non-wasm suffix of `platform_features`, not the always-on base array next to `kaappi-fibers`/`kaappi-reactor`/`kaappi-diagnostics`.

Cross-thread channel promotion requires OS threads, which wasm32-wasi does not have. KEP-0002 §5 spells out the consequence: on WASI the reactor's `notify` is a no-op and nothing ever calls it, and its cross-platform section states no promotion ever happens there — channels stay fiber-local. Advertising the identifier on a target where the capability cannot occur is exactly the failure mode KEP-0004 exists to prevent.

## Changes

- `src/types.zig` — the identifier, plus a doc comment recording the gate and the KEP-0002 §5 rationale for the platform split.
- `src/tests_advanced.zig` — a `cond-expand` test asserting `yes` natively and `no` on wasm, mirroring the existing `kaappi-threads` test (the unit suite builds for wasm since #2153, so both answers are assertable).
- `src/tests_libraries.zig` — the `srfiFeatureNumber` parser test confirms the new identifier never parses as an SRFI id.
- `tests/scheme/smoke/features-consistency.scm` — Scheme-level parity per #1177: `(features)` membership and expression-level `cond-expand`.
- `docs/dev/features.md` — the example JSON matches real output again.

## Verification

- `zig build test` — 13/13 steps, 1877/1884 passed (7 skipped, 0 failed).
- `zig build wasm` — cross-compiles clean, so the comptime branch holds on the target that omits the identifier.
- `tests/scheme/errors/features.sh` — 45/45, including a derived-from-the-binary `cond-expand recognizes 'kaappi-shared-channels'`. This suite is what keeps `kaappi features`, `(features)`, and `cond-expand` from drifting, so it is the load-bearing check here.
- `features-consistency.scm` — 16 passes, exit 0.

Companion PRs: [kaappi/keps#53](https://github.com/kaappi/keps/pull/53) records Phase 2 as shipped; [kaappi/kaappi.github.io](https://github.com/kaappi/kaappi.github.io) updates the conformance table's "Cross-thread channels" row, which until now told readers the fixes had shipped but the identifier had not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)