### PR TITLE
Make er rename reject a circular datum instead of aborting (#2403)

### DIFF
--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -1436,6 +1436,23 @@ invocation's own rename products; a distinguishable wrapper for bare
 rename products would break the compiler's bare matching of the reserved
 forms macros emit. A
 bare-symbol
+reaches the expansion (verified equivalent on both paths). Since #2403,
+`rename` rejects a circular datum with a catchable, diagnosed condition
+instead of the old uncatchable GC root-stack abort: R7RS datum labels put
+genuine cycles in macro-use inputs, and `erRenameDatum` now walks with a
+visited-on-active-path set keyed on Object address (stable — this GC
+never moves objects; shared-but-acyclic `#1=` data still renames, only a
+back-edge is refused), reporting through `globals.set_error_detail_for_macro`
+— the write-side sibling of `error_detail_for_macro` — so the message
+survives `mapNativeError`. Two `compiler.collectSetTargets` guards were
+needed for that diagnosis to reach the user at all: the `set!` pre-scan
+expands macros best-effort, swallows the rejection, and then kept walking
+the same cycle — its spine walk now runs Floyd's tortoise-and-hare
+(exact, because every loop path advances exactly one cdr; the old
+let-syntax two-cdr jump became a sub-walk for exactly this reason) and
+its self-recursions charge the depth cap like every other descent, with
+the `SET_SCAN_SPINE_CAP` from kaappi#2404 keeping the let-syntax
+bindings loop (the one inner spine the tortoise does not cover) bounded. A bare-symbol
 spec falls back to a globals lookup holding a Transformer value, so
 `(define t (er-macro-transformer p))` + `(define-syntax m t)` works. Two
 non-obvious integration points: (1) `vm_imports.copyTransformerFreeRefs`

--- a/lib/srfi/211/explicit-renaming.sld
+++ b/lib/srfi/211/explicit-renaming.sld
@@ -95,6 +95,15 @@
 ;;;     returns x unrenamed (reference semantics win); rename fresh names
 ;;;     for binders — the classic ER idiom — and they gensym correctly.
 ;;;
+;;;   * rename rejects a CIRCULAR datum (kaappi#2403): rebuilding pairs
+;;;     and vectors around renamed leaves is only well-defined for acyclic
+;;;     data, and a cycle arrives easily — R7RS datum labels in the macro
+;;;     use. The rejection is an ordinary catchable condition ("cannot
+;;;     rename a circular datum") the transformer's own guard can field;
+;;;     before #2403 it was an uncatchable GC root-stack abort. Shared but
+;;;     acyclic structure (#1= reuse) renames normally — only a back-edge
+;;;     on the walk's active path is refused.
+;;;
 ;;; Verified: tests/scheme/srfi/srfi211.scm (including the KEP-0006
 ;;; four-quadrant acceptance test and the ER/syntax-rules parity suite)
 ;;; and the "SRFI 211" tests in src/tests_macros_procedural.zig

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1121,20 +1121,20 @@ const SetScanBudget = struct {
     truncated: bool = false,
 };
 
-/// Per-list-level cap on cdr-spine steps in collectSetTargets (#2404).
-/// The depth cap bounds only car recursion; a datum-label cycle
-/// (`#0=(zz . #0#)`, R7RS §7.1.2) lives in the spine, where the walk used
-/// to spin forever — reached from a cyclic macro operand re-emitted into a
-/// body position. One million steps per level is far beyond any real form
-/// (the whole repo's suites stay under ~1.7k expansions per top-level
-/// form); exhausting it marks the scan truncated — the same
+/// Step cap on the let-syntax/letrec-syntax BINDINGS loop inside
+/// collectSetTargets (#2404) — the one cdr-spine the main walk's
+/// tortoise-and-hare guard below does not cover. A datum-label cycle
+/// (`#0=(let-syntax #1=(#1#) body)`, R7RS §7.1.2) makes that inner spine
+/// infinite; exhausting the cap marks the scan truncated — the same
 /// loses-optimization-never-correctness degradation the expansion budget
-/// takes. Every caller propagates that now: the pre-scan via
-/// set_targets_all, Part B via scanSetTargets, the native backend by
-/// eval-falling-back the form. The define-syntax/let-syntax spec walks
-/// still pass a structure-only budget with no propagation: a `set!` that
-/// only materializes when the spec's own macros run is caught at the
-/// macro's real use site, the same correct-late path as before.
+/// takes. One million steps is far beyond any real form (the whole repo's
+/// suites stay under ~1.7k expansions per top-level form). Every caller
+/// propagates truncation: the pre-scan via set_targets_all, Part B via
+/// scanSetTargets, the native backend by eval-falling-back the form. The
+/// define-syntax/let-syntax spec walks still pass a structure-only budget
+/// with no propagation: a `set!` that only materializes when the spec's
+/// own macros run is caught at the macro's real use site, the same
+/// correct-late path as before.
 const SET_SCAN_SPINE_CAP: usize = 1_000_000;
 
 /// Recursively collect the symbol names that appear as the target of a
@@ -1165,14 +1165,23 @@ fn collectSetTargets(self: ?*Compiler, expr: Value, out: *std.StringHashMap(void
         if (budget) |b| b.truncated = true;
         return;
     }
+    // #2403: the spine walk must terminate on circular data — R7RS datum
+    // labels can put a genuine cycle in code position. Every body path
+    // that resumes iteration does so via the continue expression, which
+    // advances exactly one cdr, so Floyd's tortoise-and-hare is exact: a
+    // tortoise advancing every other step can only re-meet `cur` on a
+    // real cycle, and an acyclic spine costs just one extra cdr per
+    // element. On detection the scan stops early exactly as the depth cap
+    // does — an under-approximation the truncated flag already models.
     var cur = expr;
-    var spine_steps: usize = 0;
-    while (types.isPair(cur)) {
-        // #2404: a datum-label cycle makes this spine infinite; the step
-        // cap turns it into the scan's ordinary loses-optimization
-        // truncation (see SET_SCAN_SPINE_CAP).
-        spine_steps += 1;
-        if (spine_steps > SET_SCAN_SPINE_CAP) {
+    var tortoise = expr;
+    var step: usize = 0;
+    while (types.isPair(cur)) : ({
+        cur = types.cdr(cur);
+        step += 1;
+        if (step % 2 == 0) tortoise = types.cdr(tortoise);
+    }) {
+        if (step > 0 and cur == tortoise) {
             if (budget) |b| b.truncated = true;
             return;
         }
@@ -1221,7 +1230,6 @@ fn collectSetTargets(self: ?*Compiler, expr: Value, out: *std.StringHashMap(void
                         .{},
                     ) catch {
                         c.gc.no_collect -= 1;
-                        cur = types.cdr(cur);
                         continue;
                     };
                     var expanded_root = expanded;
@@ -1237,7 +1245,6 @@ fn collectSetTargets(self: ?*Compiler, expr: Value, out: *std.StringHashMap(void
                     // Fall through to the sub-form walk below, which is what
                     // compiling the built-in form will visit anyway.
                     if (macro.valuesStructurallyEqual(expanded_root, cur, 128)) {
-                        cur = types.cdr(cur);
                         continue;
                     }
                     try collectSetTargets(self, expanded_root, out, depth + 1, budget);
@@ -1260,7 +1267,7 @@ fn collectSetTargets(self: ?*Compiler, expr: Value, out: *std.StringHashMap(void
                     const rest = types.cdr(cur);
                     if (types.isPair(rest)) {
                         // Skip the macro name; walk the spec without a budget.
-                        try collectSetTargets(self, types.cdr(rest), out, depth, null);
+                        try collectSetTargets(self, types.cdr(rest), out, depth + 1, null);
                     }
                     return;
                 } else if (std.mem.eql(u8, hname, "let-syntax") or
@@ -1292,17 +1299,28 @@ fn collectSetTargets(self: ?*Compiler, expr: Value, out: *std.StringHashMap(void
                         }
                         const binding = types.car(bindings_cur);
                         if (types.isPair(binding)) {
-                            try collectSetTargets(self, types.cdr(binding), out, depth, null);
+                            try collectSetTargets(self, types.cdr(binding), out, depth + 1, null);
                         }
                         bindings_cur = types.cdr(bindings_cur);
                     }
-                    cur = types.cdr(rest);
-                    continue;
+                    // The body keeps the budgeted scan. A sub-walk, not the
+                    // old two-cdr jump (`cur = cdr(rest); continue`): the
+                    // tortoise-and-hare spine guard above is exact only when
+                    // every iteration advances exactly one cdr, and a cycle
+                    // through the body (`#0=(let-syntax () . #0#)`) must hit
+                    // the depth cap as recursion, not loop forever (#2403).
+                    try collectSetTargets(self, types.cdr(rest), out, depth + 1, budget);
+                    return;
                 }
             }
         }
-        try collectSetTargets(self, head, out, depth, budget);
-        cur = types.cdr(cur);
+        // depth+1, not depth: a sub-form is nesting like any other, and the
+        // same-depth recursion this used to make was unbounded — reader-cap
+        // fine for acyclic data, infinite on a car-side cycle
+        // (`(display #1=(p #1# q))`), which the spine guard above cannot
+        // see (#2403). The scan's depth cap now bounds it, at the same
+        // conservative-truncation cost the cap already charges elsewhere.
+        try collectSetTargets(self, head, out, depth + 1, budget);
     }
 }
 

--- a/src/expander.zig
+++ b/src/expander.zig
@@ -485,15 +485,34 @@ fn mapProcCallError(err: anyerror) ExpandError {
 /// leaves, everything else passes through.
 fn erRenameFn(args: []const Value) anyerror!Value {
     const gc = memory.gc_instance orelse return error.InvalidBytecode; // no GC: internal invariant
-    return erRenameDatum(gc, args[0]);
+    // #2403: the argument may be genuinely circular -- R7RS datum labels in
+    // the macro use (`#0=(zz . #0#)`), or a cycle the transformer built at
+    // expansion time. Track the pairs/vectors on the active path so a
+    // back-edge is rejected below instead of recursing until the GC root
+    // stack panics (uncatchable). Keyed on Object address, which the
+    // non-moving GC keeps stable across collections.
+    var path: std.AutoHashMapUnmanaged(usize, void) = .empty;
+    defer path.deinit(gc.allocator);
+    return erRenameDatum(gc, args[0], &path);
 }
 
-fn erRenameDatum(gc: *GC, v: Value) anyerror!Value {
+fn erRenameDatum(gc: *GC, v: Value, path: *std.AutoHashMapUnmanaged(usize, void)) anyerror!Value {
     if (types.isSymbol(v)) return erRenameSymbol(gc, types.symbolName(v));
     if (types.isPair(v)) {
-        var car_new = try erRenameDatum(gc, types.car(v));
+        // #2403: path membership (not mere prior visitation) is what counts
+        // -- shared-but-acyclic structure, the same `#1=` sub-datum used
+        // twice, renews legitimately and must not read as a cycle. The
+        // path push/remove must stay INSIDE this branch's scope: a defer
+        // in an outer guard block would fire before the recursion below,
+        // emptying the path. Keyed on Object address, stable across
+        // collections in this non-moving GC.
+        const key = @intFromPtr(types.toObject(v));
+        if (path.contains(key)) return erRenameCycle();
+        try path.put(gc.allocator, key, {});
+        defer _ = path.remove(key);
+        var car_new = try erRenameDatum(gc, types.car(v), path);
         gc.pushRoot(&car_new);
-        const cdr_new = erRenameDatum(gc, types.cdr(v)) catch |err| {
+        const cdr_new = erRenameDatum(gc, types.cdr(v), path) catch |err| {
             gc.popRoot();
             return err;
         };
@@ -506,9 +525,16 @@ fn erRenameDatum(gc: *GC, v: Value) anyerror!Value {
     }
     if (types.isVector(v)) {
         const vec = types.toObject(v).as(types.Vector);
+        // Same cycle guard as the pair branch, on the vector itself: a
+        // vector reachable from its own element (or from a pair within one)
+        // must trip here, before the fresh list spine below is walked.
+        const key = @intFromPtr(types.toObject(v));
+        if (path.contains(key)) return erRenameCycle();
+        try path.put(gc.allocator, key, {});
+        defer _ = path.remove(key);
         var as_list = try vectorToList(gc, vec.data);
         gc.pushRoot(&as_list);
-        const renamed = erRenameDatum(gc, as_list) catch |err| {
+        const renamed = erRenameDatum(gc, as_list, path) catch |err| {
             gc.popRoot();
             return err;
         };
@@ -520,6 +546,18 @@ fn erRenameDatum(gc: *GC, v: Value) anyerror!Value {
         return out;
     }
     return v;
+}
+
+/// #2403: `rename` rebuilds pairs and vectors around their renamed leaves,
+/// which is only well-defined for acyclic data -- a cycle has no leaves to
+/// bottom out at. Reject it the way a primitive rejects a well-typed but
+/// unacceptable argument: a catchable InvalidArgument whose detail survives
+/// mapNativeError (the transformer's own `guard` sees the condition; an
+/// uncaught one reports as syntax-error[KP2002] instead of aborting).
+fn erRenameCycle() anyerror!Value {
+    if (@import("globals.zig").set_error_detail_for_macro) |set|
+        set("rename: cannot rename a circular datum");
+    return error.InvalidArgument; // bare-ok: the message is set through set_error_detail_for_macro just above, not primitives.argError (the expander cannot import primitives.zig -> vm.zig)
 }
 
 /// Mirror of instantiateTemplate's template-introduced-symbol path (minus

--- a/src/globals.zig
+++ b/src/globals.zig
@@ -172,6 +172,15 @@ pub var call_proc_for_macro: ?CallProcFn = null;
 pub const ErrorDetailFn = *const fn () []const u8;
 pub var error_detail_for_macro: ?ErrorDetailFn = null;
 
+/// #2403: the write side of error_detail_for_macro. The expander's own
+/// native procedures (`rename`) reject inputs the way a primitive would --
+/// with a precise message in the VM's error detail -- but cannot call
+/// vm.setErrorDetail directly, so they go through this registration exactly
+/// as its read-side sibling. When no VM is registered the call is a no-op
+/// and mapNativeError's fallback text reports the failure instead.
+pub const SetErrorDetailFn = *const fn (msg: []const u8) void;
+pub var set_error_detail_for_macro: ?SetErrorDetailFn = null;
+
 /// SRFI 213 (identifier properties): set/get on the VM-owned property
 /// table, keyed by the effective (hygiene-stripped) names of the property's
 /// identifier and key. Registered by vm.setVMInstance; the table's Values

--- a/src/tests_macros_procedural.zig
+++ b/src/tests_macros_procedural.zig
@@ -417,3 +417,78 @@ test "SRFI 213 gc-stress: allocation across the lookup re-entry hop keeps form a
     const result = try ctx.vm.eval("(hop hop-var hop-key)");
     try std.testing.expectEqual(churn_n + churn_n + 17, types.toFixnum(result));
 }
+
+// ---------------------------------------------------------------------------
+// #2403: rename on a circular datum. R7RS datum labels put genuine cycles
+// in macro-use inputs; erRenameDatum used to walk them with unbounded
+// recursion, pushing two roots per level until the GC root stack panicked
+// — uncatchable, process gone. The regression contract pinned here:
+// rejection as a normal (guard-able, diagnosed) syntax error, exact cycle
+// detection (shared-but-acyclic data still renames), and the pre-scan
+// guards that let the diagnosis reach the user instead of a hang.
+// ---------------------------------------------------------------------------
+
+test "#2403: rename on a circular macro-use datum is a diagnosed error, not an abort" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    // The five-line repro from the issue.
+    const result = ctx.vm.eval(
+        \\(begin
+        \\  (define-syntax m
+        \\    (er-macro-transformer
+        \\     (lambda (form rename compare) (rename (car (cdr form))))))
+        \\  (m #0=(zz . #0#)))
+    );
+    try std.testing.expectError(error.CompileError, result);
+    try std.testing.expect(std.mem.indexOf(u8, ctx.vm.getErrorDetail(), "circular") != null);
+}
+
+test "#2403: rename cycle rejection covers car-edge and vector cycles" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    _ = try ctx.vm.eval(
+        \\(define-syntax d
+        \\  (er-macro-transformer
+        \\   (lambda (form rename compare) (rename (car (cdr form))))))
+    );
+    // A cycle through the car of the renamed datum (spine guard alone
+    // cannot see this shape) and a self-referential vector.
+    try std.testing.expectError(error.CompileError, ctx.vm.eval("(d #1=(p #1# q))"));
+    try std.testing.expect(std.mem.indexOf(u8, ctx.vm.getErrorDetail(), "circular") != null);
+    try std.testing.expectError(error.CompileError, ctx.vm.eval("(d #0=#(1 #0#))"));
+    try std.testing.expect(std.mem.indexOf(u8, ctx.vm.getErrorDetail(), "circular") != null);
+}
+
+test "#2403: a transformer's guard catches the circular-datum rejection" {
+    // The whole point of rejecting through the normal error channel: the
+    // transformer can intercept it and recover, which no uncatchable
+    // root-stack panic ever allowed.
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax g
+        \\    (er-macro-transformer
+        \\     (lambda (form rename compare)
+        \\       (guard (e (#t (list (rename 'quote) 'caught)))
+        \\         (rename (car (cdr form)))))))
+        \\  (eq? 'caught (g #0=(zz . #0#))))
+    );
+}
+
+test "#2403: shared-but-acyclic datum still renames (no false cycle)" {
+    // `#1=` reuse is sharing, not a cycle: the same sub-datum appears twice
+    // but the walk never revisits a node on its own path. Renaming it must
+    // succeed — only a back-edge may be rejected.
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define-syntax s
+        \\    (er-macro-transformer
+        \\     (lambda (form rename compare)
+        \\       (list (rename 'quote) (rename (car (cdr form)))))))
+        \\  ((lambda (x) (and (= 2 (length x))
+        \\                     (pair? (car x))
+        \\                     (pair? (car (cdr x)))))
+        \\   (s (#1=(b c) #1#))))
+    );
+}

--- a/src/tests_prescan.zig
+++ b/src/tests_prescan.zig
@@ -279,3 +279,48 @@ test "#2404: a cyclic macro operand keeps set! boxing correct" {
     );
     try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
 }
+
+test "#2403: the pre-scan terminates on a circular spine" {
+    // R7RS datum labels can put a genuine cycle in code position. The
+    // spine walk used to iterate forever (#2403's repro reached it after
+    // rename's own rejection was swallowed by the best-effort expansion
+    // below); the tortoise-and-hare guard must stop the walk so
+    // compilation fails on its own terms instead of hanging.
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try std.testing.expectError(error.CompileError, ctx.vm.eval("#0=(display 1 . #0#)"));
+}
+
+test "#2403: the pre-scan terminates when an ER macro use carries a cycle" {
+    // The issue's five-line repro end to end: rename rejects the circular
+    // argument, the pre-scan swallows that best-effort failure and keeps
+    // walking — which used to spin on the same cycle. With both guards it
+    // terminates, and the real expansion then surfaces the diagnosis.
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const result = ctx.vm.eval(
+        \\(begin
+        \\  (define-syntax m
+        \\    (er-macro-transformer
+        \\     (lambda (form rename compare) (rename (car (cdr form))))))
+        \\  (m #0=(zz . #0#)))
+    );
+    try std.testing.expectError(error.CompileError, result);
+    try std.testing.expect(std.mem.indexOf(u8, ctx.vm.getErrorDetail(), "circular") != null);
+}
+
+test "#2403: let-syntax walking still scans ordinary nesting after the depth-charge change" {
+    // #2403 made the walk's self-recursions charge the depth cap so a
+    // cyclic let-syntax body stops at the cap in the PRE-SCAN (a cycle
+    // through the real let-syntax compiler — compileSyntaxBody on its own
+    // body — is the separate circular-code-in-code-position issue, not
+    // this one). What must not regress: ordinary let-syntax forms still
+    // compile and run.
+    try th.expectEval(
+        \\(begin
+        \\  (let-syntax ((ls-x (syntax-rules () ((_) 7))))
+        \\    (ls-x)))
+    , 7);
+}

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -46,6 +46,7 @@ pub fn setVMInstance(vm: *VM) void {
     globals_mod.eval_datum_for_macro = &evalDatumForMacro;
     globals_mod.call_proc_for_macro = &callProcForMacro;
     globals_mod.error_detail_for_macro = &errorDetailForMacro;
+    globals_mod.set_error_detail_for_macro = &setErrorDetailForMacro;
     globals_mod.syntax_property_set = &syntaxPropertySet;
     globals_mod.syntax_property_get = &syntaxPropertyGet;
     globals_mod.env_map_rooted_lookup = &envMapIsGcRooted;
@@ -107,6 +108,14 @@ fn callProcForMacro(proc: Value, args: []const Value) anyerror!Value {
 fn errorDetailForMacro() []const u8 {
     const vm = vm_instance orelse return "";
     return vm.getErrorDetail();
+}
+
+/// #2403: let the expander's native procedures record a precise rejection
+/// message in the VM's error detail (see globals.set_error_detail_for_macro).
+/// No-ops without a VM: mapNativeError then supplies its generic fallback.
+fn setErrorDetailForMacro(msg: []const u8) void {
+    const vm = vm_instance orelse return;
+    vm.setErrorDetail("{s}", .{msg});
 }
 
 /// SRFI 213: store a property value under the composite key

--- a/tests/scheme/errors/er-rename-circular-2403.sh
+++ b/tests/scheme/errors/er-rename-circular-2403.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# #2403: `rename` on a circular macro-use datum. The five-line repro used to
+# recurse until the GC root stack panicked — an uncatchable process abort.
+# It must instead surface as an ordinary syntax error carrying the diagnosis
+# (a transformer's own `guard` can intercept it; the uncaught case is pinned
+# here), and the process must exit non-zero rather than abort or hang.
+
+set -euo pipefail
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+PASS=0
+FAIL=0
+TMPDIR_TESTS="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TESTS"' EXIT
+
+REPRO="$TMPDIR_TESTS/circ-er.scm"
+cat > "$REPRO" <<'EOF'
+(import (scheme base) (srfi 211 explicit-renaming))
+(define-syntax m
+  (er-macro-transformer
+   (lambda (form rename compare) (rename (cadr form)))))
+(m #0=(zz . #0#))
+EOF
+
+output=$("$KAAPPI" "$REPRO" 2>&1 || true)
+
+if grep -qF "rename: cannot rename a circular datum" <<< "$output"; then
+    echo "PASS: uncaught circular rename reports the diagnosis"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: expected 'rename: cannot rename a circular datum' in output:"
+    echo "$output"
+    FAIL=$((FAIL + 1))
+fi
+
+if grep -qF "KP2002" <<< "$output"; then
+    echo "PASS: uncaught circular rename is a syntax error (KP2002)"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: expected KP2002 in output:"
+    echo "$output"
+    FAIL=$((FAIL + 1))
+fi
+
+status=0
+"$KAAPPI" "$REPRO" > /dev/null 2>&1 || status=$?
+if [[ "$status" -ne 0 && "$status" -ne 1 ]]; then
+    echo "FAIL: expected exit 0 (success) or 1 (error), got $status — abort or signal?"
+    FAIL=$((FAIL + 1))
+else
+    echo "PASS: exits with an ordinary error status (got $status)"
+    PASS=$((PASS + 1))
+fi
+
+echo
+echo "=== Results ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo "CIRCULAR RENAME REGRESSION DETECTED"
+    exit 1
+fi
+
+echo "All circular rename tests pass."
+exit 0

--- a/tests/scheme/errors/er-rename-circular-2403.sh
+++ b/tests/scheme/errors/er-rename-circular-2403.sh
@@ -44,11 +44,11 @@ fi
 
 status=0
 "$KAAPPI" "$REPRO" > /dev/null 2>&1 || status=$?
-if [[ "$status" -ne 0 && "$status" -ne 1 ]]; then
-    echo "FAIL: expected exit 0 (success) or 1 (error), got $status — abort or signal?"
+if [[ "$status" -ne 1 ]]; then
+    echo "FAIL: expected exit 1 (uncaught syntax error), got $status — silent success, abort or signal?"
     FAIL=$((FAIL + 1))
 else
-    echo "PASS: exits with an ordinary error status (got $status)"
+    echo "PASS: exits with the ordinary uncaught-error status 1"
     PASS=$((PASS + 1))
 fi
 

--- a/tests/scheme/srfi/srfi211.scm
+++ b/tests/scheme/srfi/srfi211.scm
@@ -85,6 +85,30 @@
      (rename '(let ((fresh-leaf 7)) (* fresh-leaf 2))))))
 (test-equal 14 (tree-rename))
 
+;;; --- #2403: rename on a circular datum is a catchable error, not an abort
+;;; R7RS datum labels put a genuine cycle in the macro-use input; rename
+;;; used to walk it with unbounded recursion until the GC root stack
+;;; panicked (uncatchable). It must now reject through the normal error
+;;; channel — a transformer's own guard sees the condition and recovers.
+(define-syntax circ-guard
+  (er-macro-transformer
+   (lambda (form rename compare)
+     (guard (e (#t (list (rename 'quote) 'caught)))
+       (rename (cadr form))))))
+(test-equal 'caught (circ-guard #0=(zz . #0#)))
+(test-equal 'caught (circ-guard #1=(p #1# q))) ; cycle via the car edge
+(test-equal 'caught (circ-guard #2=#(1 #2#))) ; cycle through a vector
+
+;;; --- #2403: shared-but-acyclic data renews — only a back-edge is a cycle
+(define-syntax shared-rename
+  (er-macro-transformer
+   (lambda (form rename compare)
+     (list (rename 'quote) (rename (cadr form))))))
+(let ((renamed (shared-rename (#3=(b c) #3#))))
+  (test-equal 2 (length renamed))
+  (test-assert (pair? (car renamed)))
+  (test-assert (pair? (cadr renamed))))
+
 ;;; --- compare: the classic else-clause detection ---
 (define-syntax cond1
   (er-macro-transformer


### PR DESCRIPTION
Fixes #2403.

## The bug

`rename` on a circular macro-use input recursed forever, pushing two GC roots per level, until the root stack panicked — uncatchable, process gone, from five ordinary lines:

```scheme
(import (scheme base) (srfi 211 explicit-renaming))
(define-syntax m
  (er-macro-transformer
   (lambda (form rename compare) (rename (cadr form)))))
(m #0=(zz . #0#))
```

```
thread panic: GC root stack overflow
  src/memory.zig:626  growRootBuffer
  src/expander.zig:481  erRenameDatum   <- gc.pushRoot(&car_new)
  src/expander.zig:482  erRenameDatum   <- recursion on types.cdr(v)
  ... (repeats to MAX_ROOT_CAPACITY)
```

## The fix (three pieces)

**1. Cycle guard in `erRenameDatum`** (`src/expander.zig`) — the walk now carries a visited-on-**active-path** set keyed on `*Object` address (stable: this GC never moves objects). Path membership, not prior visitation, is what counts: shared-but-acyclic `#1=` data renews legitimately and must not read as a cycle — only a back-edge is refused. The guard covers pairs and vectors, including car-edge cycles (`#1=(p #1# q)`) and self-referential vectors (`#0=#(1 #0#)`).

**2. A diagnosable, catchable rejection.** Rebuilding pairs/vectors around renamed leaves is only well-defined for acyclic data, so a cycle raises `error.InvalidArgument` with the message `"rename: cannot rename a circular datum"`. Getting that message out required one new hook: the expander cannot import `vm.zig`, so `globals.set_error_detail_for_macro` is the write-side sibling of the existing `error_detail_for_macro` (`#1846`), registered by `setVMInstance`. Outcome:

- uncaught ⟹ `/file.scm:5:1: syntax-error[KP2002]: rename: cannot rename a circular datum`, exit 1 (was: abort);
- caught ⟹ the transformer's own `guard` sees the condition and recovers (pinned by tests) — exactly the "catchable, diagnosable" behavior the issue asked for.

**3. Two `collectSetTargets` guards** (`src/compiler.zig`) — needed for the diagnosis to reach the user *at all*. The `set!` pre-scan expands macros best-effort and **swallows** the rename rejection (by design), then kept walking the same cycle forever: the issue's repro still hung after piece 1. Now:

- the spine walk runs **Floyd's tortoise-and-hare** — exact, because every body path that resumes iteration now advances exactly one `cdr` (the old let-syntax two-cdr jump became a sub-walk for precisely this reason), and an acyclic spine costs one extra `cdr` per element;
- the walk's self-recursions charge the depth cap instead of recursing at un-incremented depth, so a car-side cycle stops at the cap (conservative truncation, the same fallback the cap already models) rather than overflowing the native stack.

## Behavior matrix (all verified)

| input | before | after |
|---|---|---|
| issue repro `(m #0=(zz . #0#))` | root-stack panic (uncatchable abort) | `KP2002 rename: cannot rename a circular datum`, exit 1 |
| `(rename …)` on `#1=(p #1# q)` (car edge) | abort | same clean `KP2002` |
| `(rename …)` on `#0=#(1 #0#)` (vector) | abort | same clean `KP2002` |
| transformer `guard`s the rename | impossible | `'caught` |
| shared-but-acyclic `(#1=(b c) #1#)` under rename | ok | still ok — no false cycle |
| quoted circular datum / `write` | ok | unchanged |
| `syntax-rules` use with circular arg | ok (`done`) | unchanged |
| `(eq? x (cdr x))` on `'#0=(zz . #0#)` in transformer | ok (`#t`) | unchanged |

## Not in scope (filed separately)

- **#2405** — the macro-free circular-*code*-position family reachable without any ER macro (IR-fold stack overflow on `(display #1=(p #1# q))`, `compileSyntaxBody` hang on `#0=(let-syntax () . #0#)`, `KP9001` for spine cycles). Reproduces on `main` untouched by this PR.
- **#2404** — the `compare`-side walk in #2401's branch (not on `main`) should adopt the same path-set pattern when it lands; per the comment on #2403, one shared traversal discipline closes both.

## Tests

- `src/tests_macros_procedural.zig` — rejection + message for spine/car/vector cycles, `guard` catchability, shared-datum no-false-positive.
- `src/tests_prescan.zig` — pre-scan termination on a circular spine, the issue repro end-to-end through the pre-scan, and a let-syntax still-compiles positive control.
- `tests/scheme/srfi/srfi211.scm` — guard-catch cases (3 cycle shapes) and shared-datum rename.
- `tests/scheme/errors/er-rename-circular-2403.sh` — pins the uncaught message, the `KP2002` class, and an ordinary exit status.
- Docs: `lib/srfi/211/explicit-renaming.sld` engine notes + the SRFI 211 section of `docs/dev/srfi-implementation-notes.md`.

Full suites: unit **1883/1890** (+7 skip), `-Dgc-stress=true` clean, `run-all.sh` **2119/2119**, R7RS **1395/1395**.