### PR TITLE
Implement SRFI 273: extensions to data (type-)checking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Kaappi — R7RS Scheme in Zig
 
 Complete R7RS-small Scheme implementation. Zig 0.16, ~100k lines, 695 built-in
-procedures, 178 SRFIs.
+procedures, 179 SRFIs.
 
 This file is the orientation map. Detail lives in `docs/dev/` — every section
 below names the document that owns it. `docs/dev/README.md` is the full index.
@@ -186,14 +186,14 @@ Exceptions: auto-generated data files (`unicode_tables.zig`) are exempt.
 
 ## Libraries and SRFIs
 
-178 SRFIs supported: 12 built-in as Zig primitives (1, 9, 13, 18, 39, 69, 133,
-170, 192, 254, 258, 260), 162 portable `.sld` files under `lib/srfi/` loaded on
+179 SRFIs supported: 12 built-in as Zig primitives (1, 9, 13, 18, 39, 69, 133,
+170, 192, 254, 258, 260), 163 portable `.sld` files under `lib/srfi/` loaded on
 demand, plus SRFI 261 (an import-resolver convention with no library file) and
 the sub-library-only 160, 211 and 226. Every supported SRFI is also a
 `cond-expand` feature identifier `srfi-<n>`, derived rather than listed.
 
 Re-derive the counts after each release with `kaappi features --json` — it
-reports only the 12 + 162, since it scans just the top-level `lib/srfi/N.sld`
+reports only the 12 + 163, since it scans just the top-level `lib/srfi/N.sld`
 files; add the other four by hand.
 
 The library loader in `vm_library.zig` supports `cond-expand`, `include` (paths

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -16,7 +16,7 @@ must stay clean. See README.md "Known limitations → Script output".
 
 ## SRFI conformance
 
-178 SRFIs supported. 12 built-in (native Zig), 162 portable (.sld files), plus SRFI 261 (Portable SRFI Library Reference) as an import-resolver convention with no library file, and SRFI 226, SRFI 160, and SRFI 211 as sub-libraries only with no bare `(srfi 226)`/`(srfi 160)`/`(srfi 211)` file (so none appears as a bare number in `kaappi features`' scan, unlike every other portable SRFI). `(srfi srfi-<n>)` and `(srfi <mnemonic>-<n>)` — e.g. `(srfi srfi-1)`, `(srfi lists-1)`, `(srfi vectors-133)` — resolve to `(srfi <n>)`, with literal names winning when they exist. Coverage details for the built-in SRFIs follow.
+179 SRFIs supported. 12 built-in (native Zig), 163 portable (.sld files), plus SRFI 261 (Portable SRFI Library Reference) as an import-resolver convention with no library file, and SRFI 226, SRFI 160, and SRFI 211 as sub-libraries only with no bare `(srfi 226)`/`(srfi 160)`/`(srfi 211)` file (so none appears as a bare number in `kaappi features`' scan, unlike every other portable SRFI). `(srfi srfi-<n>)` and `(srfi <mnemonic>-<n>)` — e.g. `(srfi srfi-1)`, `(srfi lists-1)`, `(srfi vectors-133)` — resolve to `(srfi <n>)`, with literal names winning when they exist. Coverage details for the built-in SRFIs follow.
 
 ### SRFI 1 — List Library
 
@@ -168,7 +168,7 @@ Each call returns a fresh symbol whose name is unique "for all practical purpose
 
 String ports track their own position directly (the read cursor and the SRFI 192 write cursor), with the read cursor corrected for a pushed-back peek byte — `read-line`'s CR handling pushes one back on string ports too, and a seek discards it, exactly as on fd ports (#1941). Fd-backed ports get a real `lseek`-equivalent (POSIX `lseek`, Windows `_lseeki64`, WASI `fd_seek`), with the OS's raw offset corrected for whatever software buffering this port has read ahead of (peek/read-ahead buffers) or not yet flushed behind (the write buffer) — otherwise the reported position would drift from what a subsequent read or seek expects. `set-port-position!` on an output port flushes pending writes first, per spec, even when the position won't change.
 
-### Portable SRFIs (165 SRFIs: 162 importable as bare `(srfi N)`, plus SRFI 160, 211, and 226 as sub-libraries only)
+### Portable SRFIs (166 SRFIs: 163 importable as bare `(srfi N)`, plus SRFI 160, 211, and 226 as sub-libraries only)
 
 Loaded on demand from `.sld` files via `(import (srfi N))`. Sub-libraries: (srfi 146 hash), (srfi 166 pretty), (srfi 166 columnar), (srfi 166 unicode), (srfi 166 color), (srfi 171 meta), (srfi 211 explicit-renaming), (srfi 211 define-macro), (srfi 211 syntax-parameter), (srfi 226 control prompts), (srfi 226 control continuations), (srfi 226 control times), (srfi 248 primitives), (srfi 254 ephemerons), (srfi 254 guardians), (srfi 254 transport-cell-guardians), (srfi 254 ephemerons-and-guardians), (srfi 257 misc), (srfi 257 box), (srfi 257 rx), (srfi 263 syntax), (srfi 271 randomized), (srfi 271 determinized).
 
@@ -339,6 +339,7 @@ Loaded on demand from `.sld` files via `(import (srfi N))`. Sub-libraries: (srfi
 | 267 | Raw string syntax † |
 | 270 | Hexadecimal Floating-Point Constants |
 | 271 | Random port libraries |
+| 273 | Extensions to data (type) checking |
 
 § SRFI 115 is matched by a backtracking interpreter, not by the reference
 implementation's NFA, so it shares the cost profile of every backtracking

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 Kaappi implements every identifier from [R7RS Appendix A](https://small.r7rs.org/)
 — 696 built-in procedures, 32 syntax forms, and all 16 standard libraries — plus
-178 SRFIs, a C FFI, OS threads and fibers, an LLVM native-code backend, a package
+179 SRFIs, a C FFI, OS threads and fibers, an LLVM native-code backend, a package
 manager, and a stepping debugger. The runtime is a register-based bytecode VM
 with generational garbage collection and stack-copying first-class continuations.
 
@@ -207,7 +207,7 @@ symbols, and **multi-line input** with automatic paren balancing.
 
 ### Beyond the standard
 
-- **178 SRFIs** — 12 built-in, 162 as portable `.sld` libraries, plus SRFI 261 portable library references (`(srfi srfi-1)`, `(srfi lists-1)`) resolved in the importer and SRFI 226/160/211 as sub-libraries only (full list in [CONFORMANCE.md](CONFORMANCE.md))
+- **179 SRFIs** — 12 built-in, 163 as portable `.sld` libraries, plus SRFI 261 portable library references (`(srfi srfi-1)`, `(srfi lists-1)`) resolved in the importer and SRFI 226/160/211 as sub-libraries only (full list in [CONFORMANCE.md](CONFORMANCE.md))
 - **Native binaries** — `kaappi compile program.scm -o program` compiles Scheme to a native executable via LLVM, with self-tail-calls compiled as loops ([details](docs/dev/llvm-backend.md))
 - **Standalone bundles** — `zig build -Dbundle-src=program.scm` embeds bytecode + libraries in a single executable
 - **C FFI** — call shared libraries from Scheme via `(kaappi ffi)`; 18 marshalled types, callbacks for passing Scheme procedures to C
@@ -547,7 +547,7 @@ R7RS-small and is not implemented.
 
 ### SRFI coverage
 
-178 SRFIs are supported. Some built-in SRFIs have minor coverage gaps (e.g.,
+179 SRFIs are supported. Some built-in SRFIs have minor coverage gaps (e.g.,
 linear-update variants in SRFI-1, `string-xcopy!` in SRFI-13). See
 [CONFORMANCE.md](CONFORMANCE.md) for per-SRFI details.
 

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -13,8 +13,8 @@ Companions:
 
 ## What ships
 
-178 SRFIs supported. 12 built-in (Zig primitives): 1, 9, 13, 18, 39, 69, 133,
-170, 192, 254, 258, 260. 162 portable R7RS .sld files loaded on demand via
+179 SRFIs supported. 12 built-in (Zig primitives): 1, 9, 13, 18, 39, 69, 133,
+170, 192, 254, 258, 260. 163 portable R7RS .sld files loaded on demand via
 `(import (srfi N))`, plus SRFI 261 (Portable SRFI Library References) as an
 import-resolver convention with no library file, and SRFI 226, SRFI 160, and
 SRFI 211 (see below) as sub-libraries only with no bare `(srfi 226)`/`(srfi
@@ -29,7 +29,7 @@ features`' scan): 0, 2, 4, 5, 6, 7, 8, 11, 14, 16, 17, 19, 23, 25, 26, 27, 28,
 201, 202, 203, 207, 209, 210, 213, 214, 215, 216, 217, 219, 221, 222, 223,
 224, 225, 227, 228, 229, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240,
 241, 242, 244, 247, 248, 250, 251, 252, 253, 255, 257, 259, 263, 264, 267,
-270, 271. Sub-libraries: (srfi 146 hash), (srfi 171 meta), (srfi 166 pretty),
+270, 271, 273. Sub-libraries: (srfi 146 hash), (srfi 171 meta), (srfi 166 pretty),
 (srfi 166 columnar), (srfi 166 unicode), (srfi 166 color), (srfi 211
 explicit-renaming), (srfi 211 define-macro), (srfi 211 syntax-parameter),
 (srfi 226 control prompts), (srfi 226 control continuations), (srfi 226
@@ -1494,3 +1494,62 @@ check):
   are regression-covered by `tests/scheme/cache/library-cache-1888.sh`;
   the zig-out/lib refresh step is not covered by any test — it is a
   local-workflow footgun to remember.
+
+### SRFI 273 — extensions to data (type-)checking
+
+Pure `syntax-rules` port layered on `(srfi 253)`; no engine changes. Ships as
+`lib/srfi/273.sld` exporting the new forms (`define-check`,
+`declare-checked`, `define-values-checked`, and the `check-impl?` auxiliary
+syntax) plus a re-export of the whole `(srfi 253)` vocabulary, so importing
+`(srfi 273)` alone is enough.
+
+- **Where the `=>` return-value checks live.** The issue asked for a recorded
+  decision: fold them into `253.sld` or serve them from a re-exporting
+  `(srfi 273)`. They were already folded into `253.sld` — the SRFI 253 sample
+  implementation carries them, and Kaappi's port inherited that — so `(srfi
+  253)` remains the owner of the extended forms and `(srfi 273)` only
+  re-exports them. What this port added to `253.sld`: the two missing
+  `lambda-checked` `=>` shapes (empty formals, rest formals) and correct
+  multi-value checking (below).
+- **Multi-value `=>` checks (the `values-checked` trap).** The naive
+  expansion — `(values-checked (pred ...) (begin body ...))` — pairs N
+  predicate *expressions* with 1 value expression, an ellipsis-count mismatch
+  that compiled to garbage. `values-checked` checks N expressions pairwise;
+  it cannot check the N values of one expression. The fix is `%check-results`
+  in `253.sld`: syntax-rules cannot mint N distinct identifiers for a
+  fixed-arity receiver, so each predicate wraps one `(lambda (v . more))`
+  layer (hygiene gives every recursive level a fresh `v`/`more`) that checks
+  its layer's first value and rotates it to the tail on the way out, with the
+  predicate list reversed first (`%cr-rev`) so the innermost layer carries
+  the first predicate. Rotation is a full cycle — identity — only when value
+  and predicate counts match, so `%cr-finish` rejects any other count, as
+  `values-checked`'s "number of values and predicates should match" already
+  does. A first cut of this layering without the reversal checked *every*
+  predicate against the *first* value and left the rest unchecked — the
+  srfi273 test suite pins the pairing (`(=> (integer? string?) (values 7
+  "x"))` passes while the swapped predicate list errors) so that cannot
+  return.
+- **`declare-checked` is advisory** and expands to `(when #f #f)`, as in the
+  SRFI's reference implementation: there is no static checker to inform, and
+  re-wrapping an already-defined (possibly imported) procedure cannot be done
+  from `syntax-rules`. All three declaration shapes evaluate without error,
+  including declarations for imported identifiers, which the spec "highly
+  recommends" accepting.
+- **`define-values-checked` checks for real**, unlike the minimal reference
+  implementation: it routes the form through `call-with-values` so the values
+  are received exactly once (a `values-checked` splice would evaluate the
+  form once per value) and applies `check-arg` to each in order.
+- **`check-impl?` strips to its datum**: `(define-syntax check-impl?
+  (syntax-rules () ((_ datum) datum)))`. Kaappi defines no
+  implementation-specific check datatypes, so the datum is used unaltered as
+  the check expression — a bound name behaves as itself and an unknown one
+  (`uint`, `pointer`) is an unbound variable, which is why the spec's
+  `(values-checked ((check-impl? uint)) -1)` is an error here too. Because
+  Kaappi's `check-arg` is a macro, the form also works in its operand
+  position, which the spec explicitly does not guarantee.
+- **`check-case` arrow clauses are deliberately absent** — the SRFI waives
+  them ("portable code must not rely on it working in check-case").
+- The optimizable patterns (`disjoin`/`conjoin`/`complement`/`cut ...`
+  recognitions, SRFIs 235/26/43/1) are not statically recognized; they work
+  as ordinary predicates, which is all compliance requires. The tests import
+  `(srfi 235)` and `(srfi 26)` to pin that composition.

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -1516,19 +1516,28 @@ syntax) plus a re-export of the whole `(srfi 253)` vocabulary, so importing
   predicate *expressions* with 1 value expression, an ellipsis-count mismatch
   that compiled to garbage. `values-checked` checks N expressions pairwise;
   it cannot check the N values of one expression. The fix is `%check-results`
-  in `253.sld`: syntax-rules cannot mint N distinct identifiers for a
-  fixed-arity receiver, so each predicate wraps one `(lambda (v . more))`
-  layer (hygiene gives every recursive level a fresh `v`/`more`) that checks
-  its layer's first value and rotates it to the tail on the way out, with the
-  predicate list reversed first (`%cr-rev`) so the innermost layer carries
-  the first predicate. Rotation is a full cycle — identity — only when value
-  and predicate counts match, so `%cr-finish` rejects any other count, as
-  `values-checked`'s "number of values and predicates should match" already
-  does. A first cut of this layering without the reversal checked *every*
-  predicate against the *first* value and left the rest unchecked — the
-  srfi273 test suite pins the pairing (`(=> (integer? string?) (values 7
-  "x"))` passes while the swapped predicate list errors) so that cannot
-  return.
+  in `253.sld`: a single predicate — the common shape — takes the same cheap
+  `let` shape `values-checked` uses (no per-call closures; and like
+  `values-checked` it does not count values itself — a body returning zero or
+  several still fails the predicate, because Kaappi propagates multiple
+  values through a single-variable `let` binding and no predicate matches
+  the resulting values object); several
+  predicates go through `%cr-gate` and a layer tower. syntax-rules cannot
+  mint N distinct identifiers for a fixed-arity receiver, so each predicate
+  wraps one `(lambda (v . more))` layer (hygiene gives every recursive level
+  a fresh `v`/`more`) that checks its layer's first value and rotates it to
+  the tail on the way out, with the predicate list reversed first (`%cr-rev`)
+  so the innermost layer carries the first predicate. Rotation is a full
+  cycle — identity — only when value and predicate counts match, and a short
+  value list would otherwise pair predicate k with value k-M and fail inside
+  a predicate check with a misleading message, so `%cr-gate` compares the
+  count *before* the tower runs and rejects a mismatch, as `values-checked`'s
+  "number of values and predicates should match" already does. A first cut
+  of the layering without the reversal checked *every* predicate against the
+  *first* value and left the rest unchecked — the srfi273 test suite pins
+  the pairing (`(=> (integer? string?) (values 7 "x"))` passes while the
+  swapped predicate list errors, and the count-mismatch tests assert on the
+  error message) so that cannot return.
 - **`declare-checked` is advisory** and expands to `(when #f #f)`, as in the
   SRFI's reference implementation: there is no static checker to inform, and
   re-wrapping an already-defined (possibly imported) procedure cannot be done

--- a/lib/srfi/253.sld
+++ b/lib/srfi/253.sld
@@ -9,6 +9,10 @@
 ;;; Reference: https://srfi.schemers.org/srfi-253/srfi-253.html
 ;;; License: MIT
 ;;; Author: Artyom Bologov (reference impl); ported to Kaappi
+;;;
+;;; The `=>` return-value checking that SRFI 273 adds to these forms lives
+;;; here too (the SRFI 253 sample implementation carries it); (srfi 273)
+;;; re-exports this library and layers its own forms on top.
 
 (define-library (srfi 253)
   (import (scheme base)
@@ -46,6 +50,53 @@
         ((_ (predicate ...) value ...)
          (values (values-checked (predicate) value) ...))))
 
+    ;; %check-results — check each value returned by a body against the
+    ;; corresponding predicate, preserving count and order (SRFI 273's =>
+    ;; clauses). values-checked cannot be reused here: it pairs N predicate
+    ;; *expressions* with N value expressions, while a body is one
+    ;; expression returning N values. syntax-rules cannot mint N distinct
+    ;; identifiers for a fixed-arity receiver, so instead each predicate
+    ;; wraps one value-passing layer ((v . more) — hygiene gives every
+    ;; recursive expansion's v/more a distinct binding) that checks its
+    ;; layer's first value and rotates it to the tail on the way out. The
+    ;; rotation lines value k up with predicate k and restores the original
+    ;; order at the outermost layer — which is why %cr-rev first reverses
+    ;; the predicates: the innermost layer must carry the first predicate.
+    ;; Rotation is a full cycle (identity) only when the counts match, so
+    ;; %cr-finish rejects any other count, as values-checked's "number of
+    ;; values and predicates should match" already does.
+    (define-syntax %check-results
+      (syntax-rules ()
+        ((_ caller (predicate ...) body ...)
+         (call-with-values
+             (lambda () (%cr-rev caller () (predicate ...) body ...))
+           (%cr-finish caller (predicate ...))))))
+    (define-syntax %cr-rev
+      (syntax-rules ()
+        ((_ caller (rev ...) () body ...)
+         (%cr-check caller (rev ...) body ...))
+        ((_ caller (rev ...) (predicate . remaining) body ...)
+         (%cr-rev caller (predicate rev ...) remaining body ...))))
+    (define-syntax %cr-check
+      (syntax-rules ()
+        ((_ caller () body ...)
+         (begin body ...))
+        ((_ caller (predicate . remaining) body ...)
+         (call-with-values
+             (lambda () (%cr-check caller remaining body ...))
+           (lambda (v . more)
+             (check-arg predicate v caller)
+             (apply values (append more (list v))))))))
+    (define-syntax %cr-finish
+      (syntax-rules ()
+        ((_ caller (predicate ...))
+         (let ((expected (length '(predicate ...))))
+           (lambda received
+             (if (= (length received) expected)
+                 (apply values received)
+                 (error "number of values and predicates should match"
+                        caller)))))))
+
     ;; check-case — predicate dispatch.
     (define-syntax %check-case
       (syntax-rules (else)
@@ -80,9 +131,7 @@
         ((_ name (=> (returns ...) body ...) args (checks ...))
          (lambda args
            checks ...
-           (values-checked
-            (returns ...)
-            (begin body ...))))
+           (%check-results 'name (returns ...) body ...)))
         ;; Terminal: without return check
         ((_ name (body ...) args (checks ...))
          (lambda args
@@ -106,11 +155,17 @@
 
     ;; lambda-checked — lambda with type-checked arguments.
     (define-syntax lambda-checked
-      (syntax-rules ()
+      (syntax-rules (=>)
+        ;; Empty formals with a return-value check (SRFI 273)
+        ((_ () => (returns ...) body ...)
+         (lambda () (%check-results 'lambda-checked (returns ...) body ...)))
         ((_ () body ...)
          (lambda () body ...))
         ((_ (arg . args) body ...)
          (%lambda-checked lambda-checked (body ...) () () arg . args))
+        ;; Rest-arg lambda with a return-value check (SRFI 273)
+        ((_ arg => (returns ...) body ...)
+         (lambda arg (%check-results 'lambda-checked (returns ...) body ...)))
         ;; Rest-arg lambda (no-op, can't check)
         ((_ arg body ...)
          (lambda arg body ...))))
@@ -146,7 +201,7 @@
           (done ...
            (formals
             checks ...
-            (values-checked (returns ...) (begin body ...))))
+            (%check-results 'case-lambda-checked (returns ...) body ...)))
           remaining ...))
         ;; All args consumed — plain body
         ((_ (done ...) (remaining ...)
@@ -199,7 +254,7 @@
             remaining ...)
          (%clc-clauses
           (done ...
-           (() (values-checked (returns ...) (begin body ...))))
+           (() (%check-results 'case-lambda-checked (returns ...) body ...)))
           remaining ...))
         ;; Clause with empty formals, plain body
         ((_ (done ...)

--- a/lib/srfi/253.sld
+++ b/lib/srfi/253.sld
@@ -54,23 +54,51 @@
     ;; corresponding predicate, preserving count and order (SRFI 273's =>
     ;; clauses). values-checked cannot be reused here: it pairs N predicate
     ;; *expressions* with N value expressions, while a body is one
-    ;; expression returning N values. syntax-rules cannot mint N distinct
-    ;; identifiers for a fixed-arity receiver, so instead each predicate
-    ;; wraps one value-passing layer ((v . more) — hygiene gives every
-    ;; recursive expansion's v/more a distinct binding) that checks its
-    ;; layer's first value and rotates it to the tail on the way out. The
-    ;; rotation lines value k up with predicate k and restores the original
-    ;; order at the outermost layer — which is why %cr-rev first reverses
-    ;; the predicates: the innermost layer must carry the first predicate.
-    ;; Rotation is a full cycle (identity) only when the counts match, so
-    ;; %cr-finish rejects any other count, as values-checked's "number of
-    ;; values and predicates should match" already does.
+    ;; expression returning N values.
+    ;;
+    ;; A single predicate — by far the common shape — takes the same cheap
+    ;; let shape values-checked uses: no call-with-values, no closures per
+    ;; call. Like values-checked, it does not itself count values; a body
+    ;; returning zero or several still fails the predicate, because Kaappi
+    ;; propagates multiple values through a single-variable let binding and
+    ;; no predicate matches the resulting values object.
+    ;;
+    ;; Several predicates go through %cr-gate and a layer tower.
+    ;; syntax-rules cannot mint N distinct identifiers for a fixed-arity
+    ;; receiver, so each predicate wraps one value-passing layer
+    ;; ((v . more) — hygiene gives every recursive expansion's v/more a
+    ;; distinct binding) that checks its layer's first value and rotates it
+    ;; to the tail on the way out. The rotation lines value k up with
+    ;; predicate k and restores the original order at the outermost layer —
+    ;; which is why %cr-rev first reverses the predicates: the innermost
+    ;; layer must carry the first predicate. Rotation is a full cycle
+    ;; (identity) only when the counts match, and a short value list would
+    ;; otherwise pair predicate k with value k-M and fail with a misleading
+    ;; predicate message, so %cr-gate checks the count up front and rejects
+    ;; a mismatch, as values-checked's "number of values and predicates
+    ;; should match" already does.
     (define-syntax %check-results
       (syntax-rules ()
+        ((_ caller (predicate) body ...)
+         (let ((v (begin body ...)))
+           (check-arg predicate v caller)
+           v))
         ((_ caller (predicate ...) body ...)
          (call-with-values
-             (lambda () (%cr-rev caller () (predicate ...) body ...))
-           (%cr-finish caller (predicate ...))))))
+             (lambda () body ...)
+           (%cr-gate caller (predicate ...))))))
+    (define-syntax %cr-gate
+      (syntax-rules ()
+        ((_ caller (predicate ...))
+         (let ((expected (length '(predicate ...))))
+           (lambda received
+             (if (= (length received) expected)
+                 ;; The tower rides in the gate's body — as a receiver
+                 ;; operand it would be evaluated eagerly, running the
+                 ;; checks before any values exist.
+                 (%cr-rev caller () (predicate ...) (apply values received))
+                 (error "number of values and predicates should match"
+                        caller)))))))
     (define-syntax %cr-rev
       (syntax-rules ()
         ((_ caller (rev ...) () body ...)
@@ -87,15 +115,6 @@
            (lambda (v . more)
              (check-arg predicate v caller)
              (apply values (append more (list v))))))))
-    (define-syntax %cr-finish
-      (syntax-rules ()
-        ((_ caller (predicate ...))
-         (let ((expected (length '(predicate ...))))
-           (lambda received
-             (if (= (length received) expected)
-                 (apply values received)
-                 (error "number of values and predicates should match"
-                        caller)))))))
 
     ;; check-case — predicate dispatch.
     (define-syntax %check-case

--- a/lib/srfi/273.sld
+++ b/lib/srfi/273.sld
@@ -70,9 +70,12 @@
     ;; inform, and re-wrapping an already-defined procedure — possibly an
     ;; imported one, e.g. (declare-checked (negative? (x real?)) =>
     ;; (boolean?)) — cannot be done portably from syntax-rules. Later
-    ;; modifications of a declared value are likewise left unchecked.
+    ;; modifications of a declared value are likewise left unchecked. `=>`
+    ;; is declared as a literal (as in every other =>-aware macro of this
+    ;; port) so the third clause cannot silently capture an unrelated
+    ;; form in that position.
     (define-syntax declare-checked
-      (syntax-rules ()
+      (syntax-rules (=>)
         ((_ name predicate)
          (when #f #f))
         ((_ (name . args))

--- a/lib/srfi/273.sld
+++ b/lib/srfi/273.sld
@@ -1,0 +1,81 @@
+;;; SRFI 273: Extensions to Data (Type-)Checking
+;;;
+;;; Quality-of-life extensions layered on SRFI 253: define-check for
+;;; aliasing checking predicates under new names, declare-checked for
+;;; advisory pre-/post-declarations, define-values-checked for checked
+;;; multi-value binding, and the check-impl? auxiliary syntax for
+;;; implementation-specific checks.
+;;;
+;;; The return-value (`=>`) checking this SRFI adds to the SRFI 253 forms
+;;; lives in (srfi 253) itself — the SRFI 253 sample implementation carries
+;;; it — so this library re-exports those forms rather than redefining them;
+;;; importing (srfi 273) alone gives the complete vocabulary.
+;;;
+;;; Reference: https://srfi.schemers.org/srfi-273/srfi-273.html
+;;; License: MIT
+;;; Author: Artyom Bologov (reference impl); ported to Kaappi
+
+(define-library (srfi 273)
+  (import (scheme base)
+          (scheme case-lambda)
+          (srfi 253))
+  (export
+   ;; Re-exported from (srfi 253), with the => return-value checking.
+   check-arg values-checked check-case
+   lambda-checked define-checked
+   case-lambda-checked define-record-type-checked
+   ;; New in this SRFI.
+   define-check declare-checked define-values-checked
+   check-impl?)
+  (begin
+
+    ;; check-impl? — auxiliary syntax. (check-impl? datum) hands the datum
+    ;; to the implementation in place of a predicate: the wrapper itself is
+    ;; discarded as a non-predicate. Kaappi has no implementation-specific
+    ;; check datatypes, so the datum is used unaltered as the check
+    ;; expression — an unrecognized name (uint, pointer, ...) is an unbound
+    ;; variable, which is why the spec's (values-checked ((check-impl? uint))
+    ;; -1) is an error here too. Because check-arg is a macro in this
+    ;; implementation, (check-arg (check-impl? name) x) also works.
+    (define-syntax check-impl?
+      (syntax-rules ()
+        ((_ datum) datum)))
+
+    ;; define-check — alias a checking predicate under a new name (a
+    ;; compiled implementation could instead mint a derived type here).
+    (define-syntax define-check
+      (syntax-rules ()
+        ((_ name predicate)
+         (define name predicate))))
+
+    ;; define-values-checked — like R7RS define-values, but the values
+    ;; returned by form must satisfy the corresponding predicates.
+    ;; call-with-values receives the values exactly once: splicing form
+    ;; through values-checked would evaluate it once per value, which is
+    ;; wrong for forms with effects or cost.
+    (define-syntax define-values-checked
+      (syntax-rules ()
+        ((_ (var ...) (predicate ...) form)
+         (define-values (var ...)
+           (call-with-values
+               (lambda () form)
+             (lambda (var ...)
+               (check-arg predicate var 'define-values-checked)
+               ...
+               (values var ...)))))))
+
+    ;; declare-checked — advisory declaration of the checks for a value or
+    ;; for a separately defined procedure. Expands to nothing, as in the
+    ;; SRFI's reference implementation: Kaappi has no static checker to
+    ;; inform, and re-wrapping an already-defined procedure — possibly an
+    ;; imported one, e.g. (declare-checked (negative? (x real?)) =>
+    ;; (boolean?)) — cannot be done portably from syntax-rules. Later
+    ;; modifications of a declared value are likewise left unchecked.
+    (define-syntax declare-checked
+      (syntax-rules ()
+        ((_ name predicate)
+         (when #f #f))
+        ((_ (name . args))
+         (when #f #f))
+        ((_ (name . args) => return)
+         (when #f #f))))))

--- a/tests/scheme/srfi/srfi253.scm
+++ b/tests/scheme/srfi/srfi253.scm
@@ -212,6 +212,13 @@
 (set! c "whatever")
 (test-assert c)
 
+;; Return value checks
+(define-checked (c-return (a integer?)) => (integer?) (* a 2))
+(test-equal 6 (c-return 3))
+(test-error (c-return "hello"))
+(define-checked (c-return-bad (a integer?)) => (string?) (* a 2))
+(test-error (c-return-bad 3))
+
 (test-end "define-checked")
 
 

--- a/tests/scheme/srfi/srfi273.scm
+++ b/tests/scheme/srfi/srfi273.scm
@@ -38,7 +38,7 @@
 (test-assert (begin (check-arg integer? 3) #t))
 (test-error (check-arg integer? "hello"))
 (test-equal 3 (values-checked (integer?) 3))
-(test-assert (check-case 3 (integer? 'int) (else 'other)))
+(test-equal 'int (check-case 3 (integer? 'int) (else 'other)))
 (test-assert ((lambda-checked ((a integer?)) #t) 3))
 (test-assert (case-lambda-checked
               (((a integer?)) #t)
@@ -209,8 +209,8 @@
 (test-equal #\k (str-ref "kaappi" 0))
 
 ;; In check-case clauses.
-(test-assert (check-case 3 ((check-impl? integer?) 'int) (else 'other)))
-(test-assert (check-case "x" ((check-impl? integer?) 'int) (else 'other)))
+(test-equal 'int (check-case 3 ((check-impl? integer?) 'int) (else 'other)))
+(test-equal 'other (check-case "x" ((check-impl? integer?) 'int) (else 'other)))
 (test-error (check-case "x" ((check-impl? no-such-check) 'int)))
 
 ;; A defined check from define-check composes through check-impl? too.
@@ -253,10 +253,34 @@
 (test-error
  ((lambda-checked ((n string?)) => (integer? string?) (values n "x")) "n"))
 ;; The number of values must match the number of predicates — in either
-;; direction, as with values-checked.
+;; direction, as with values-checked. The count is rejected up front, so the
+;; error is the documented arity one whatever the predicates are: a short
+;; value list must not pair predicate k with value k-M and fail inside a
+;; predicate check instead.
+(define (count-mismatch-error? thunk)
+  (guard (ex ((and (error-object? ex)
+                   (string=? (error-object-message ex)
+                             "number of values and predicates should match"))
+             #t))
+    (thunk)
+    #f))
+(test-assert
+ (count-mismatch-error?
+  (lambda () ((lambda-checked () => (integer? string? symbol?) (values 1 'two))))))
+(test-assert
+ (count-mismatch-error?
+  (lambda () ((lambda-checked () => (integer? string?) (values 1))))))
+(test-assert
+ (count-mismatch-error?
+  (lambda () ((lambda-checked () => (integer? string?) (values))))))
+(test-assert
+ (count-mismatch-error?
+  (lambda () ((lambda-checked () => (integer? string? symbol?)
+                (values 1 'two "three" 'four))))))
+;; A single predicate goes through its own fast path — any count other than
+;; one is still an error.
 (test-error
  ((lambda-checked () => (integer?) (values 1 'two "three"))))
-(test-error ((lambda-checked () => (integer? integer?) (values 1))))
 
 ;; define-checked
 (define-checked (re-checked (n integer?)) => (integer?) (* n 2))
@@ -319,8 +343,8 @@
 (test-error (check-arg (conjoin integer? positive?) -1))
 (test-assert (begin (check-arg (cut every integer? <>) '(1 2)) #t))
 (test-error (begin (check-arg (cut every integer? <>) '(1 #\a)) #t))
-(test-assert (check-case 3 ((cut memv <> '(1 2 3)) 'small) (else 'other)))
-(test-assert (check-case 9 ((cut memv <> '(1 2 3)) 'small) (else 'other)))
+(test-equal 'small (check-case 3 ((cut memv <> '(1 2 3)) 'small) (else 'other)))
+(test-equal 'other (check-case 9 ((cut memv <> '(1 2 3)) 'small) (else 'other)))
 
 (test-end "optimizable-patterns")
 

--- a/tests/scheme/srfi/srfi273.scm
+++ b/tests/scheme/srfi/srfi273.scm
@@ -1,0 +1,332 @@
+;;; SRFI 273 test suite — Extensions to Data (Type-)Checking
+;;;
+;;; Covers what this SRFI adds over SRFI 253: define-check, declare-checked,
+;;; define-values-checked, the check-impl? auxiliary syntax, and the =>
+;;; return-value checking contributed to the (srfi 253) forms (which
+;;; (srfi 273) re-exports). Follows the spec's own examples where it has
+;;; them; the optimizable-pattern section checks that the suggested patterns
+;;; compose as ordinary predicates (Kaappi does not statically recognize
+;;; them — recognition is optional per the SRFI).
+
+(import (scheme base)
+        (scheme case-lambda)
+        (scheme char)
+        (srfi 1)
+        (srfi 26)
+        (srfi 235)
+        (srfi 253)
+        (srfi 273)
+        (srfi 64))
+
+(test-begin "srfi-273")
+
+;;; ====================================================================
+;;; Availability. The library loads standalone and answers its feature
+;;; identifier.
+;;; ====================================================================
+
+(test-assert (cond-expand (srfi-273 #t) (else #f)))
+(test-assert (cond-expand ((library (srfi 273)) #t) (else #f)))
+
+;;; ====================================================================
+;;; Re-exports. Importing (srfi 273) alone gives the full (srfi 253)
+;;; vocabulary (extended with => return-value checking).
+;;; ====================================================================
+
+(test-begin "re-exports")
+
+(test-assert (begin (check-arg integer? 3) #t))
+(test-error (check-arg integer? "hello"))
+(test-equal 3 (values-checked (integer?) 3))
+(test-assert (check-case 3 (integer? 'int) (else 'other)))
+(test-assert ((lambda-checked ((a integer?)) #t) 3))
+(test-assert (case-lambda-checked
+              (((a integer?)) #t)
+              (args #t)))
+(define-record-type-checked <boxed>
+  (make-boxed n)
+  boxed?
+  (n integer? boxed-n))
+(test-assert (boxed-n (make-boxed 3)))
+(test-error (boxed-n (make-boxed "hello")))
+
+(test-end "re-exports")
+
+;;; ====================================================================
+;;; define-check
+;;; ====================================================================
+
+(test-begin "define-check")
+
+;; The spec's examples.
+(define-check any? (constantly #t))
+(test-assert (any? 123))
+(test-assert (any? "anything at all"))
+(define-check email? string?)
+(test-assert (email? "srfi-273@example.com"))
+(test-assert (not (email? 42)))
+(define-check positive-integer? (conjoin integer? positive?))
+(test-assert (positive-integer? 3))
+(test-assert (not (positive-integer? -3)))
+
+;; The aliased checks compose with the SRFI 253 forms.
+(test-assert (begin (check-arg email? "srfi-273@example.com") #t))
+(test-error (check-arg positive-integer? -3))
+(test-equal 4 (values-checked (positive-integer?) 4))
+(test-error (values-checked (positive-integer?) -4))
+(define-checked (twice (n positive-integer?)) => (positive-integer?) (* n 2))
+(test-equal 8 (twice 4))
+(test-error (twice -4))
+
+;; A lambda works as the predicate too.
+(define-check palindromic-string?
+  (lambda (s)
+    (and (string? s)
+         (string=? s (list->string (reverse (string->list s)))))))
+(test-assert (palindromic-string? "racecar"))
+(test-assert (not (palindromic-string? "kaappi")))
+
+(test-end "define-check")
+
+;;; ====================================================================
+;;; declare-checked
+;;;
+;;; Declarations are advisory: they expand to nothing (the reference
+;;; implementation's choice), so what we test is that every shape expands
+;;; and evaluates without error — including declarations for imported
+;;; identifiers, which the spec "highly recommends" supporting — and that
+;;; the separately defined procedure keeps its normal behavior.
+;;; ====================================================================
+
+(test-begin "declare-checked")
+
+;; Value declaration, then the definition it anticipates.
+(declare-checked numbered-answer integer?)
+(define numbered-answer 42)
+(test-equal 42 numbered-answer)
+
+;; Procedure declaration with argument checks only.
+(declare-checked (numbered-string (str string?) (idx integer?)))
+(define (numbered-string str idx)
+  (string-append str (number->string idx)))
+(test-equal "x3" (numbered-string "x" 3))
+(test-equal "x-3" (numbered-string "x" -3))
+
+;; Procedure declaration with argument and return checks — the spec's
+;; post-factum-hardening example.
+(declare-checked (negative? (x real?)) => (boolean?))
+(test-assert (negative? -1))
+(test-assert (not (negative? 1)))
+
+;; Declaring an imported variadic procedure.
+(declare-checked (string-append (a string?) (b string?)) => (string?))
+(test-equal "ab" (string-append "a" "b"))
+
+;; Declarations also work in bodies, not just at the top level.
+(test-assert
+ (let ()
+   (declare-checked local-decl integer?)
+   #t))
+
+;; The declaration's value is unspecified: it must evaluate without error
+;; (the expression above did exactly that), which is all a portable program
+;; may rely on.
+
+(test-end "declare-checked")
+
+;;; ====================================================================
+;;; define-values-checked
+;;; ====================================================================
+
+(test-begin "define-values-checked")
+
+(define-values-checked (q r) (integer? integer?) (values 3 1))
+(test-equal 3 q)
+(test-equal 1 r)
+
+(define-values-checked (n) (integer?) 42)
+(test-equal 42 n)
+
+(define-values-checked (name rank) (string? symbol?) (values "kaappi" 'srfi))
+(test-equal "kaappi" name)
+(test-equal 'srfi rank)
+
+;; The form is evaluated exactly once: its effects must not be duplicated.
+(define effect-count 0)
+(define-values-checked (a b) (integer? integer?)
+  (begin
+    (set! effect-count (+ effect-count 1))
+    (values 1 2)))
+(test-equal 1 effect-count)
+(test-equal 1 a)
+(test-equal 2 b)
+
+;; Failing checks are errors at binding time.
+(test-error
+ (let ()
+   (define-values-checked (n) (integer?) "hello")
+   'ok))
+(test-error
+ (let ()
+   (define-values-checked (a b) (integer? string?) (values 1 2))
+   'ok))
+;; Fewer values than variables is an error, as with define-values.
+(test-error
+ (let ()
+   (define-values-checked (a b) (integer? integer?) (values 1))
+   'ok))
+
+(test-end "define-values-checked")
+
+;;; ====================================================================
+;;; check-impl?
+;;;
+;;; The (check-impl? datum) wrapper is discarded as a non-predicate and the
+;;; datum is passed to the implementation unaltered. Kaappi has no
+;;; implementation-specific check datatypes, so a bound datum behaves as
+;;; itself and an unknown datum (uint, pointer, ...) is an unbound
+;;; variable — the spec's (values-checked ((check-impl? uint)) -1) is an
+;;; error here.
+;;; ====================================================================
+
+(test-begin "check-impl?")
+
+(test-assert (values-checked ((check-impl? integer?)) 3))
+(test-error (values-checked ((check-impl? integer?)) "hello"))
+(test-error (values-checked ((check-impl? uint)) -1))
+
+;; In check-arg (a macro here, so the auxiliary syntax is usable).
+(test-assert (begin (check-arg (check-impl? string?) "ok") #t))
+(test-error (check-arg (check-impl? string?) 3))
+
+;; In checked argument position — the spec's FFI example shape. The
+;; argument check runs before the body, so the unknown datum errors at
+;; call time.
+(define-checked (ffi-ref (data (check-impl? pointer)) (idx integer?)) idx)
+(test-error (ffi-ref 'anything 0))
+(define-checked (str-ref (s (check-impl? string?)) (idx integer?))
+  (string-ref s idx))
+(test-equal #\k (str-ref "kaappi" 0))
+
+;; In check-case clauses.
+(test-assert (check-case 3 ((check-impl? integer?) 'int) (else 'other)))
+(test-assert (check-case "x" ((check-impl? integer?) 'int) (else 'other)))
+(test-error (check-case "x" ((check-impl? no-such-check) 'int)))
+
+;; A defined check from define-check composes through check-impl? too.
+(test-assert (values-checked ((check-impl? email?)) "ab@example.org"))
+
+(test-end "check-impl?")
+
+;;; ====================================================================
+;;; Return-value checks (=>). These extend the (srfi 253) forms; they are
+;;; re-tested here because SRFI 273 is what specifies them.
+;;; ====================================================================
+
+(test-begin "return-value-checks")
+
+;; lambda-checked
+(test-equal 2 ((lambda-checked ((n integer?)) => (integer?) (+ n 1)) 1))
+(test-error ((lambda-checked ((n integer?)) => (integer?) #t) 1))
+;; Empty formals.
+(test-equal 1 ((lambda-checked () => (integer?) 1)))
+(test-error ((lambda-checked () => (integer?) #t)))
+;; Rest formals.
+(test-equal 3 ((lambda-checked all => (integer?) (length all)) 'a 'b 'c))
+(test-error ((lambda-checked all => (integer?) #t) '()))
+;; Multiple return values.
+(define-values (m1 m2)
+  ((lambda-checked ((n integer?)) => (integer? integer?) (values n n)) 7))
+(test-equal 7 m1)
+(test-equal 7 m2)
+;; Each value is checked against its own predicate, in order, and the
+;; returned order is preserved.
+(define-values (s1 s2 s3)
+  ((lambda-checked () => (integer? string? symbol?) (values 7 "x" 'sym))))
+(test-equal 7 s1)
+(test-equal "x" s2)
+(test-equal 'sym s3)
+(test-assert
+ ((lambda-checked ((n integer?)) => (integer? string?) (values n "x")) 7))
+(test-error
+ ((lambda-checked ((n integer?)) => (string? integer?) (values n "x")) 7))
+(test-error
+ ((lambda-checked ((n string?)) => (integer? string?) (values n "x")) "n"))
+;; The number of values must match the number of predicates — in either
+;; direction, as with values-checked.
+(test-error
+ ((lambda-checked () => (integer?) (values 1 'two "three"))))
+(test-error ((lambda-checked () => (integer? integer?) (values 1))))
+
+;; define-checked
+(define-checked (re-checked (n integer?)) => (integer?) (* n 2))
+(test-equal 8 (re-checked 4))
+(test-error (re-checked "four"))
+(define-checked (re-checked-bad (n integer?)) => (string?) (* n 2))
+(test-error (re-checked-bad 4))
+(define-checked (re-multi (n integer?) (d integer?)) => (integer? integer?)
+  (values (quotient n d) (remainder n d)))
+(define-values (qq rr) (re-multi 7 2))
+(test-equal 3 qq)
+(test-equal 1 rr)
+(test-error ((lambda-checked ((n integer?)) => (string?) (if (> n 0) n #t)) 5))
+
+;; case-lambda-checked
+(define clc-return
+  (case-lambda-checked
+   (() => (integer?) 1)
+   (((n integer?)) => (integer?) (+ n 1))
+   (args => (integer?) (length args))))
+(test-equal 1 (clc-return))
+(test-equal 3 (clc-return 2))
+(test-equal 4 (clc-return 'a 'b 'c 'd))
+(define clc-return-bad
+  (case-lambda-checked
+   (() => (integer?) #t)))
+(test-error (clc-return-bad))
+
+;; Unchecked argument lists with return checks still check the returns.
+(test-equal 5 ((lambda-checked (a b) => (integer?) (+ a b)) 2 3))
+(test-error ((lambda-checked (a b) => (integer?) #t) 2 3))
+
+(test-end "return-value-checks")
+
+;;; ====================================================================
+;;; Optimizable patterns. Recognition is optional per the SRFI; here the
+;;; patterns only need to work as ordinary checking predicates.
+;;; ====================================================================
+
+(test-begin "optimizable-patterns")
+
+(test-assert ((disjoin integer? string?) 3))
+(test-assert ((disjoin integer? string?) "x"))
+(test-assert (not ((disjoin integer? string?) 'sym)))
+(test-assert ((conjoin integer? positive?) 3))
+(test-assert (not ((conjoin integer? positive?) -3)))
+(test-assert ((complement integer?) "x"))
+(test-assert (not ((complement integer?) 3)))
+(test-assert ((cut memv <> '(1 2 3)) 2))
+(test-assert (not ((cut memv <> '(1 2 3)) 4)))
+(test-assert ((cut eqv? <> 'sym) 'sym))
+(test-assert ((cut every integer? <>) '(1 2 3)))
+(test-assert (not ((cut every integer? <>) '(1 "x" 3))))
+(test-assert ((cut every char? <>) (string->list "kaappi")))
+(test-assert ((constantly #t) 'anything))
+(test-assert (not ((constantly #f) 'anything)))
+
+;; Through the checking forms.
+(test-assert (begin (check-arg (disjoin integer? string?) "ok") #t))
+(test-error (check-arg (conjoin integer? positive?) -1))
+(test-assert (begin (check-arg (cut every integer? <>) '(1 2)) #t))
+(test-error (begin (check-arg (cut every integer? <>) '(1 #\a)) #t))
+(test-assert (check-case 3 ((cut memv <> '(1 2 3)) 'small) (else 'other)))
+(test-assert (check-case 9 ((cut memv <> '(1 2 3)) 'small) (else 'other)))
+
+(test-end "optimizable-patterns")
+
+;;; ---- summary ----
+
+(let ((runner (test-runner-current)))
+  (test-end "srfi-273")
+  (when (> (test-runner-fail-count runner) 0)
+    (exit 1)))


### PR DESCRIPTION
Closes #2408

Supersedes #2410 (closed only because its branch was replaced to add the DCO sign-off; identical change plus `Signed-off-by`).

## What

Ships [SRFI 273](https://srfi.schemers.org/srfi-273/srfi-273.html) as a portable `lib/srfi/273.sld` layered on `(srfi 253)`, plus the fixes the `=>` return-value checking needed in `253.sld` — the SRFI 273-specified extension to the 253 forms was already folded into `253.sld` by the original port, but two shapes and all multi-value cases were broken.

## `(srfi 273)` contents

- **`define-check`** — alias a checking predicate under a new name.
- **`declare-checked`** — advisory declaration (all three shapes); expands to `(when #f #f)` exactly as the reference implementation does. Declarations for imported identifiers are accepted, as the spec highly recommends.
- **`define-values-checked`** — like `define-values`, but each returned value is checked against its predicate. Routes the form through `call-with-values` so the values are received exactly once (a `values-checked` splice would evaluate the form once per value). Unlike the minimal reference implementation, the checks are real.
- **`check-impl?`** — auxiliary syntax that strips to its datum. Kaappi defines no implementation-specific check datatypes, so a bound datum behaves as itself and an unknown one (`uint`, `pointer`) is an unbound variable — the spec's `(values-checked ((check-impl? uint)) -1)` is an error here too. Since Kaappi's `check-arg` is a macro, it also works in operand position.
- Re-exports the whole `(srfi 253)` vocabulary, so importing `(srfi 273)` alone suffices.
- `check-case` arrow clauses are deliberately absent — the SRFI waives them.
- The optimizable patterns (SRFI 235/26/43/1) are not statically recognized; they work as ordinary predicates, which is all compliance requires.

## `253.sld` fixes (pre-existing bugs the port surfaced)

- `(lambda-checked () => (pred) body…)` and the rest-formals equivalent silently dropped the clause and compiled to a body with a bare `=>` variable reference. Both shapes now check their returns.
- **Multi-value `=>` checks never worked**: the terminal expansions spliced N predicates into `values-checked` against a single value expression — an ellipsis-count mismatch that compiled to garbage (KP2001) or silently mis-checked. `values-checked` checks N value *expressions* pairwise; it cannot check the N values of one expression.
- New `%check-results` helper: each predicate wraps one `(lambda (v . more))` layer (hygiene gives each recursive level fresh `v`/`more`), checks its layer's first value, and rotates it to the tail on the way out, with the predicate list reversed first so the innermost layer carries the first predicate. The rotation lines value *k* up with predicate *k* and restores the original order at the outermost layer; a count mismatch errors, matching `values-checked`'s documented "number of values and predicates should match".
  - A first cut of this layering without the reversal checked *every* predicate against the *first* value and left the rest unchecked — the new suite pins the pairing (`(=> (integer? string?) (values 7 "x"))` passes, the swapped predicate list errors) so that cannot return.
- Return-check failure errors now name the caller as a quoted symbol (`'f`), consistent with the argument checks.

## Tests

- New `tests/scheme/srfi/srfi273.scm` — 102 assertions: availability (`srfi-273` feature id and `(library (srfi 273))`), re-exports, `define-check`, `declare-checked` (incl. foreign declarations), `define-values-checked` (incl. evaluated-exactly-once and error paths), `check-impl?` (bound datum, unknown datum, argument position, `check-case`), `=>` return checks across `lambda-checked`/`define-checked`/`case-lambda-checked` (empty/rest formals, multi-value pairing, count mismatches), and the optimizable patterns through the checking forms.
- `tests/scheme/srfi/srfi253.scm` — adds the previously untested `define-checked` `=>` path.
- Full `tests/scheme/run-all.sh`: 724 scheme files pass, R7RS suite 1395/1395. `zig build test` green. `tools/check-srfi-status.sh`: OK (SRFI 273 is final).

## Docs

- `docs/dev/srfi-implementation-notes.md` — new SRFI 273 section recording the fold-vs-re-export decision (re-export; `253.sld` stays the owner of the extended forms) and the `values-checked` trap.
- Counts updated: 179 SRFIs / 163 portable in `CLAUDE.md` (AGENTS.md symlink), `README.md`, `CONFORMANCE.md` (+ table row), and the notes' shipped list.
- `srfi-273` registers as a `cond-expand` feature identifier automatically (derived from the `.sld`).