### PR TITLE
Diagnose circular datums in code position instead of aborting or hanging (#2405)

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1135,6 +1135,18 @@ pub const SpineWalk = struct {
     }
 };
 
+/// Detection-only variant, for fixed-arity forms that consume positions
+/// without walking the rest (`if` takes its alternate from a possibly
+/// improper tail and historically ignores what follows): true when the
+/// spine starting at `start` contains a datum-label cycle (#2405).
+pub fn spineCyclic(start: Value) bool {
+    var walk = SpineWalk.init(start);
+    while (types.isPair(walk.cur)) : (walk.next()) {
+        if (walk.cyclic()) return true;
+    }
+    return false;
+}
+
 /// Diagnose a datum-label cycle met in code position: a catchable
 /// InvalidSyntax whose recorded detail the reporter renders as
 /// `syntax-error[KP2002]` with a named cause. Finite improper lists never

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -127,6 +127,27 @@ pub const Compiler = struct {
     // constant folders (IR and legacy) to avoid folding calls to a name that
     // may be reassigned before the call executes.
     set_targets: ?*std.StringHashMap(void) = null,
+    // Pairs (and quasiquote vectors) on the active code-compilation path
+    // (#2405, review of PR #2413), keyed on Object address — stable in this
+    // non-moving GC, holding no Values so the GC never traces it. Two maps,
+    // because the two halves of the guard must not see each other's entries:
+    //
+    //   - `code_roots` spans the lower+emit phases of one compile unit (the
+    //     entry points in this file push around both). A datum-label cycle
+    //     crosses that boundary — `#0=(let ((x #0#)) x)` lowers the let,
+    //     then compiles its own init through compileExprViaIR, forever, each
+    //     round a fresh IR whose own state is empty — so re-entering a
+    //     compilation unit whose root is still live IS the cycle, checked at
+    //     the entry itself.
+    //   - `code_path` spans one lowering/qq-walk tree (ir.lowerWithMacros,
+    //     compileQQ); it catches back-edges that stay within a single
+    //     lowering, which never reach an entry point.
+    //
+    // Membership in either means "this exact form object is an ancestor of
+    // itself" — a real cycle for any legitimate program: shared-but-acyclic
+    // structure renews as a sibling, sequentially, never nested.
+    code_roots: std.AutoHashMapUnmanaged(usize, void) = .empty,
+    code_path: std.AutoHashMapUnmanaged(usize, void) = .empty,
     // True when the pre-scan that built `set_targets` had to stop early (see
     // SetScanBudget), making that map an under-approximation. Both consumers
     // then behave as if *every* name were a `set!` target: box every local and
@@ -170,6 +191,66 @@ pub const Compiler = struct {
         self.upvalues.deinit(self.gc.allocator);
         self.macros.deinit();
         self.body_macros.deinit(self.gc.allocator);
+        self.code_roots.deinit(self.gc.allocator);
+        self.code_path.deinit(self.gc.allocator);
+    }
+
+    /// #2405: the root of this compiler's parent chain. The cycle-guard maps
+    /// live on it and are consulted through the chain: a lambda body compiles
+    /// in a CHILD compiler (initChild), and it is a descendant of every
+    /// enclosing unit, so the child must see the ancestors' spans and add
+    /// its own to the same maps.
+    fn cycleRoot(self: *Compiler) *Compiler {
+        var c = self;
+        while (c.parent) |p| c = p;
+        return c;
+    }
+
+    fn codeRootsContains(self: *Compiler, key: usize) bool {
+        var c: ?*Compiler = self;
+        while (c) |cc| : (c = cc.parent) {
+            if (cc.code_roots.contains(key)) return true;
+        }
+        return false;
+    }
+
+    /// #2405 lowering-path primitives, shared with ir.zig and compileQQ
+    /// through the parent chain (see cycleRoot).
+    pub fn codePathContains(self: *Compiler, key: usize) bool {
+        var c: ?*Compiler = self;
+        while (c) |cc| : (c = cc.parent) {
+            if (cc.code_path.contains(key)) return true;
+        }
+        return false;
+    }
+
+    pub fn codePathPush(self: *Compiler, key: usize) void {
+        // OOM: guard silently off for this span — better a missed diagnosis
+        // than a wrong error.
+        self.cycleRoot().code_path.put(self.gc.allocator, key, {}) catch {};
+    }
+
+    pub fn codePathPop(self: *Compiler, key: usize) void {
+        _ = self.cycleRoot().code_path.remove(key);
+    }
+
+    /// #2405: enter a compile unit — the root stays on `code_roots` for the
+    /// span of one lower+emit (the caller pops with leaveCodeRoot). Meeting
+    /// a root that is already live — anywhere up the compiler chain, since a
+    /// lambda body is a descendant of every enclosing unit — is the
+    /// cross-boundary back-edge itself and is diagnosed here. Non-pairs are
+    /// a no-op.
+    pub fn enterCodeRoot(self: *Compiler, expr: Value) CompileError!void {
+        if (!types.isPair(expr)) return;
+        const key = @intFromPtr(types.toObject(expr));
+        if (self.codeRootsContains(key)) return circularFormError();
+        self.cycleRoot().code_roots.put(self.gc.allocator, key, {}) catch return;
+    }
+
+    /// #2405: leave a compile unit entered by enterCodeRoot.
+    pub fn leaveCodeRoot(self: *Compiler, expr: Value) void {
+        if (!types.isPair(expr)) return;
+        _ = self.cycleRoot().code_roots.remove(@intFromPtr(types.toObject(expr)));
     }
 
     pub fn unrootFunction(gc: *memory.GC, func: *types.Function) void {
@@ -609,6 +690,11 @@ pub const Compiler = struct {
         }
 
         // Lower AST to IR, run analysis and optimizations, then emit bytecode.
+        // #2405: the root stays on code_roots across BOTH phases — a datum
+        // label cycle crosses the lower/emit boundary (a fresh IR per
+        // sub-form), and re-entering a live root is the back-edge.
+        try self.enterCodeRoot(expr_root);
+        defer self.leaveCodeRoot(expr_root);
         var ir = ir_mod.IR.init(self.gc.allocator);
         ir.globals = self.globals;
         ir.restricted_env = self.restricted_env;
@@ -651,6 +737,9 @@ pub const Compiler = struct {
         var dst: u16 = 0;
         for (exprs, 0..) |expr, i| {
             // Lower each expression through the IR pipeline.
+            // #2405: Compiler-scoped root span, same as compile().
+            try self.enterCodeRoot(expr);
+            defer self.leaveCodeRoot(expr);
             var ir = ir_mod.IR.init(self.gc.allocator);
             ir.globals = self.globals;
             ir.restricted_env = self.restricted_env;
@@ -683,6 +772,9 @@ pub const Compiler = struct {
     }
 
     pub fn compileExprViaIR(self: *Compiler, expr: Value, dst: u16, is_tail: bool) CompileError!void {
+        // #2405: same Compiler-scoped root span as compile() — see there.
+        try self.enterCodeRoot(expr);
+        defer self.leaveCodeRoot(expr);
         var ir = ir_mod.IR.init(self.gc.allocator);
         ir.globals = self.globals;
         ir.restricted_env = self.restricted_env;

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1069,6 +1069,84 @@ fn formatSyntaxError(args: Value) void {
     syntax_error_detail_len = w.buffered().len;
 }
 
+// -- Circular-form guards (#2405) ---------------------------------------------
+//
+// A datum label (R7RS 7.1.2 `#n=`/`#n#`) can put a genuine cycle in *code*
+// position — `(display #1=(p #1# q))`, `#0=(display 1 . #0#)` — and several
+// compile-side walks assumed forms are acyclic: the IR lowerer recursed until
+// the native stack aborted, arg/body spine walks spun forever, and the one
+// walk with a cap reported KP9001 "internal error". Quoted circular data is
+// and stays fine everywhere (the printer detects cycles, #1954); only the
+// code-position walks need guards. Two shapes, mirroring what #2403 did in
+// the expander and the `set!` pre-scan:
+//
+//   - a spine walk (advance exactly one cdr per iteration) takes a `SpineWalk`
+//     below — Floyd tortoise-and-hare, exact and allocation-free;
+//   - a walk that recurses through arbitrary sub-form positions cannot use the
+//     tortoise (the recursion is not a single cdr iteration) and instead keeps
+//     an active-path set keyed on the pair's Object address, which the
+//     non-moving GC keeps stable across collections (#2403's erRenameDatum
+//     discipline). Only path membership counts: shared-but-acyclic structure
+//     — the same `#1=` sub-datum used twice — renews legitimately.
+//
+// Both report through `circularFormError`, which records the detail string the
+// compile-error reporter prefers over the registry template, so the user sees
+// `syntax-error[KP2002]: circular form in code position ...` instead of an
+// abort, a hang, or KP9001.
+
+/// One tortoise-and-hare step state for a cdr-spine walk. Exact: a tortoise
+/// advancing every other step can only re-meet the walk head on a real cycle,
+/// and an acyclic spine costs one extra `cdr` per two elements.
+///
+/// ```zig
+/// var walk = SpineWalk.init(args);
+/// while (types.isPair(walk.cur)) : (walk.next()) {
+///     if (walk.cyclic()) return circularFormError();
+///     ... use walk.cur ...
+/// }
+/// ```
+///
+/// `next` must be the ONLY way `cur` advances — the guard is sound exactly
+/// when every iteration advances one cdr (same contract as the pre-scan's
+/// spine guard from #2403, which this generalizes). The tortoise is only ever
+/// advanced to a position the walk head already occupied and survived, so its
+/// own `cdr` never dereferences a non-pair.
+pub const SpineWalk = struct {
+    cur: Value,
+    tortoise: Value,
+    step: usize = 0,
+
+    pub fn init(start: Value) SpineWalk {
+        return .{ .cur = start, .tortoise = start };
+    }
+
+    /// True when the head has come back around to a previously visited spine
+    /// position — a datum-label cycle. Only consulted at the top of an
+    /// iteration whose `cur` passed the caller's own isPair test.
+    pub fn cyclic(self: *const SpineWalk) bool {
+        return self.step > 0 and self.cur == self.tortoise;
+    }
+
+    /// Advance the head one cdr and, every second step, the tortoise one cdr.
+    pub fn next(self: *SpineWalk) void {
+        self.cur = types.cdr(self.cur);
+        self.step += 1;
+        if (self.step % 2 == 0) self.tortoise = types.cdr(self.tortoise);
+    }
+};
+
+/// Diagnose a datum-label cycle met in code position: a catchable
+/// InvalidSyntax whose recorded detail the reporter renders as
+/// `syntax-error[KP2002]` with a named cause. Finite improper lists never
+/// reach this — the spine guards detect cycles only, and existing
+/// `!isPair` checks already reject non-cyclic improper tails.
+pub fn circularFormError() CompileError {
+    const msg = "circular form in code position: the form contains itself (datum-label cycle)";
+    @memcpy(syntax_error_detail[0..msg.len], msg);
+    syntax_error_detail_len = msg.len;
+    return CompileError.InvalidSyntax;
+}
+
 /// Work limit for one top-level `set!` pre-scan (kaappi#1775).
 ///
 /// The pre-scan expands macros so it can see a `set!` a template introduces

--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -153,13 +153,13 @@ pub fn compileCase(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
 
     var end_jumps: std.ArrayList(usize) = .empty;
     defer end_jumps.deinit(self.gc.allocator);
-    var current = clauses;
+    var current = compiler_mod.SpineWalk.init(clauses);
     var had_else = false;
 
-    while (current != types.NIL) {
-        if (!types.isPair(current)) return CompileError.InvalidSyntax;
-        const clause = types.car(current);
-        current = types.cdr(current);
+    while (current.cur != types.NIL) : (current.next()) {
+        if (!types.isPair(current.cur)) return CompileError.InvalidSyntax;
+        if (current.cyclic()) return compiler_mod.circularFormError();
+        const clause = types.car(current.cur);
         if (!types.isPair(clause)) return CompileError.InvalidSyntax;
 
         const datums = types.car(clause);

--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -315,12 +315,13 @@ pub fn compileQuasiquote(self: *Compiler, args: Value, dst: u16) CompileError!vo
     const template = types.car(args);
     // #2405: a datum-label cycle in the template recursed through compileQQ's
     // car/cdr (and vector re-wrapping) forever — the template is rebuilt with
-    // runtime conses, which a cycle has no finite form of. Active-path set
-    // keyed on Object address (stable in this non-moving GC, holds no Values),
-    // the erRenameDatum discipline from #2403.
-    var path: std.AutoHashMapUnmanaged(usize, void) = .empty;
-    defer path.deinit(self.gc.allocator);
-    try compileQQ(self, template, dst, 0, &path);
+    // runtime conses, which a cycle has no finite form of. The path is the
+    // Compiler's SHARED set (see Compiler.code_path): the splicing desugar
+    // re-wraps a template element as a fresh `(quasiquote elem)` pair and
+    // compiles it through compileExprViaIR, which re-enters compileQuasiquote
+    // with a new wrapper each round — only an address set that survives the
+    // re-wrap catches the element coming back around (review of PR #2413).
+    try compileQQ(self, template, dst, 0);
 }
 
 /// True when `head` is the quasiquote keyword `kw` — recognized through the
@@ -332,15 +333,15 @@ fn isQQKeyword(head: Value, comptime kw: []const u8) bool {
     return std.mem.eql(u8, types.stripHygienicPrefix(types.symbolName(head)), kw);
 }
 
-fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8, path: *std.AutoHashMapUnmanaged(usize, void)) CompileError!void {
+fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!void {
     if (types.isVector(tmpl)) {
         // #2405: key the path on the VECTOR too — its fresh list wrapper gets
         // a new address each visit, so only the vector's own address catches
         // the vector↔pair cycle (`#0=#((x . #0#))`).
         const vec_key = @intFromPtr(types.toObject(tmpl));
-        if (path.contains(vec_key)) return compiler_mod.circularFormError();
-        try path.put(self.gc.allocator, vec_key, {});
-        defer _ = path.remove(vec_key);
+        if (self.codePathContains(vec_key)) return compiler_mod.circularFormError();
+        self.codePathPush(vec_key);
+        defer self.codePathPop(vec_key);
         // Vector quasiquote: compile elements as a list at the current depth,
         // then call list->vector. This preserves the nesting level so that
         // inner unquotes at depth > 0 remain literal (#850).
@@ -365,7 +366,7 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8, path: *std.AutoH
         // Compile the list at the current quasiquote depth
         const fn_reg = try self.allocReg();
         const arg_reg = try self.allocReg();
-        try compileQQ(self, list, arg_reg, depth, path);
+        try compileQQ(self, list, arg_reg, depth);
         // Call list->vector on the result
         const l2v_sym = gc.allocSymbol("list->vector") catch return CompileError.OutOfMemory;
         const l2v_idx = try self.addConstant(l2v_sym);
@@ -398,9 +399,9 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8, path: *std.AutoH
     // #2405: the active-path membership test for the pair branches below —
     // see compileQuasiquote.
     const tmpl_key = @intFromPtr(types.toObject(tmpl));
-    if (path.contains(tmpl_key)) return compiler_mod.circularFormError();
-    try path.put(self.gc.allocator, tmpl_key, {});
-    defer _ = path.remove(tmpl_key);
+    if (self.codePathContains(tmpl_key)) return compiler_mod.circularFormError();
+    self.codePathPush(tmpl_key);
+    defer self.codePathPop(tmpl_key);
 
     const head = types.car(tmpl);
 
@@ -427,7 +428,7 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8, path: *std.AutoH
             try self.emitU16(unquote_sym_idx);
 
             const inner_reg = try self.allocReg();
-            try compileQQ(self, types.car(rest), inner_reg, depth - 1, path);
+            try compileQQ(self, types.car(rest), inner_reg, depth - 1);
 
             // Build (inner . ())
             const nil_reg = try self.allocReg();
@@ -470,7 +471,7 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8, path: *std.AutoH
         try self.emitU16(us_sym_idx);
 
         const inner_reg = try self.allocReg();
-        try compileQQ(self, types.car(rest), inner_reg, depth - 1, path);
+        try compileQQ(self, types.car(rest), inner_reg, depth - 1);
 
         // Build (inner . ())
         const nil_reg = try self.allocReg();
@@ -511,7 +512,7 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8, path: *std.AutoH
         try self.emitU16(qq_sym_idx);
 
         const inner_reg = try self.allocReg();
-        try compileQQ(self, types.car(rest), inner_reg, depth + 1, path);
+        try compileQQ(self, types.car(rest), inner_reg, depth + 1);
 
         const nil_reg = try self.allocReg();
         try self.emitOp(.load_nil);
@@ -542,10 +543,10 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8, path: *std.AutoH
 
     // Regular pair: cons car and cdr
     const car_reg = try self.allocReg();
-    try compileQQ(self, types.car(tmpl), car_reg, depth, path);
+    try compileQQ(self, types.car(tmpl), car_reg, depth);
 
     const cdr_reg = try self.allocReg();
-    try compileQQ(self, types.cdr(tmpl), cdr_reg, depth, path);
+    try compileQQ(self, types.cdr(tmpl), cdr_reg, depth);
 
     try self.emitOp(.cons);
     try self.emitU16(dst);

--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -313,7 +313,14 @@ pub fn compileCase(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
 pub fn compileQuasiquote(self: *Compiler, args: Value, dst: u16) CompileError!void {
     if (args == types.NIL) return CompileError.InvalidSyntax;
     const template = types.car(args);
-    try compileQQ(self, template, dst, 0);
+    // #2405: a datum-label cycle in the template recursed through compileQQ's
+    // car/cdr (and vector re-wrapping) forever — the template is rebuilt with
+    // runtime conses, which a cycle has no finite form of. Active-path set
+    // keyed on Object address (stable in this non-moving GC, holds no Values),
+    // the erRenameDatum discipline from #2403.
+    var path: std.AutoHashMapUnmanaged(usize, void) = .empty;
+    defer path.deinit(self.gc.allocator);
+    try compileQQ(self, template, dst, 0, &path);
 }
 
 /// True when `head` is the quasiquote keyword `kw` — recognized through the
@@ -325,8 +332,15 @@ fn isQQKeyword(head: Value, comptime kw: []const u8) bool {
     return std.mem.eql(u8, types.stripHygienicPrefix(types.symbolName(head)), kw);
 }
 
-fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!void {
+fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8, path: *std.AutoHashMapUnmanaged(usize, void)) CompileError!void {
     if (types.isVector(tmpl)) {
+        // #2405: key the path on the VECTOR too — its fresh list wrapper gets
+        // a new address each visit, so only the vector's own address catches
+        // the vector↔pair cycle (`#0=#((x . #0#))`).
+        const vec_key = @intFromPtr(types.toObject(tmpl));
+        if (path.contains(vec_key)) return compiler_mod.circularFormError();
+        try path.put(self.gc.allocator, vec_key, {});
+        defer _ = path.remove(vec_key);
         // Vector quasiquote: compile elements as a list at the current depth,
         // then call list->vector. This preserves the nesting level so that
         // inner unquotes at depth > 0 remain literal (#850).
@@ -351,7 +365,7 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!voi
         // Compile the list at the current quasiquote depth
         const fn_reg = try self.allocReg();
         const arg_reg = try self.allocReg();
-        try compileQQ(self, list, arg_reg, depth);
+        try compileQQ(self, list, arg_reg, depth, path);
         // Call list->vector on the result
         const l2v_sym = gc.allocSymbol("list->vector") catch return CompileError.OutOfMemory;
         const l2v_idx = try self.addConstant(l2v_sym);
@@ -381,6 +395,13 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!voi
         return;
     }
 
+    // #2405: the active-path membership test for the pair branches below —
+    // see compileQuasiquote.
+    const tmpl_key = @intFromPtr(types.toObject(tmpl));
+    if (path.contains(tmpl_key)) return compiler_mod.circularFormError();
+    try path.put(self.gc.allocator, tmpl_key, {});
+    defer _ = path.remove(tmpl_key);
+
     const head = types.car(tmpl);
 
     // Check for (unquote expr)
@@ -406,7 +427,7 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!voi
             try self.emitU16(unquote_sym_idx);
 
             const inner_reg = try self.allocReg();
-            try compileQQ(self, types.car(rest), inner_reg, depth - 1);
+            try compileQQ(self, types.car(rest), inner_reg, depth - 1, path);
 
             // Build (inner . ())
             const nil_reg = try self.allocReg();
@@ -449,7 +470,7 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!voi
         try self.emitU16(us_sym_idx);
 
         const inner_reg = try self.allocReg();
-        try compileQQ(self, types.car(rest), inner_reg, depth - 1);
+        try compileQQ(self, types.car(rest), inner_reg, depth - 1, path);
 
         // Build (inner . ())
         const nil_reg = try self.allocReg();
@@ -490,7 +511,7 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!voi
         try self.emitU16(qq_sym_idx);
 
         const inner_reg = try self.allocReg();
-        try compileQQ(self, types.car(rest), inner_reg, depth + 1);
+        try compileQQ(self, types.car(rest), inner_reg, depth + 1, path);
 
         const nil_reg = try self.allocReg();
         try self.emitOp(.load_nil);
@@ -514,17 +535,17 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!voi
     }
 
     // Check if any element uses unquote-splicing
-    if (hasUnquoteSplicing(tmpl, depth)) {
+    if (try hasUnquoteSplicing(tmpl, depth)) {
         try compileQQSplicing(self, tmpl, dst, depth);
         return;
     }
 
     // Regular pair: cons car and cdr
     const car_reg = try self.allocReg();
-    try compileQQ(self, types.car(tmpl), car_reg, depth);
+    try compileQQ(self, types.car(tmpl), car_reg, depth, path);
 
     const cdr_reg = try self.allocReg();
-    try compileQQ(self, types.cdr(tmpl), cdr_reg, depth);
+    try compileQQ(self, types.cdr(tmpl), cdr_reg, depth, path);
 
     try self.emitOp(.cons);
     try self.emitU16(dst);
@@ -536,10 +557,12 @@ fn compileQQ(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileError!voi
 }
 
 /// Check if a list template contains any (unquote-splicing ...) at the current depth.
-fn hasUnquoteSplicing(tmpl: Value, depth: u8) bool {
-    var current = tmpl;
-    while (types.isPair(current)) {
-        const elem = types.car(current);
+/// #2405: spine-guarded — a cyclic template spine spun this scan forever.
+fn hasUnquoteSplicing(tmpl: Value, depth: u8) CompileError!bool {
+    var walk = compiler_mod.SpineWalk.init(tmpl);
+    while (types.isPair(walk.cur)) : (walk.next()) {
+        if (walk.cyclic()) return compiler_mod.circularFormError();
+        const elem = types.car(walk.cur);
         if (types.isPair(elem)) {
             const elem_head = types.car(elem);
             if (types.isSymbol(elem_head) and
@@ -549,7 +572,6 @@ fn hasUnquoteSplicing(tmpl: Value, depth: u8) bool {
                 return true;
             }
         }
-        current = types.cdr(current);
     }
     return false;
 }
@@ -579,20 +601,23 @@ fn compileQQSplicing(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileE
     var segments_buf: [64]Value = undefined;
     var seg_count: usize = 0;
 
-    var current = tmpl;
+    var current = compiler_mod.SpineWalk.init(tmpl);
     var group_buf: [64]Value = undefined;
     var group_count: usize = 0;
 
-    while (types.isPair(current)) {
+    while (types.isPair(current.cur)) : (current.next()) {
+        // #2405: a cyclic template spine overflowed the 64-segment buffers
+        // as a KP9001; name the cycle instead.
+        if (current.cyclic()) return compiler_mod.circularFormError();
         // Detect dotted unquote tail (#852): when the current pair looks
         // like (unquote <expr>) — car is the unquote symbol and cdr is a
         // one-element list — this is `. ,<expr>` in the template. Flush
         // the pending group and add the evaluated expression as the final
         // segment so that `append` uses it as the tail.
-        if (depth == 0 and types.isSymbol(types.car(current))) {
-            const maybe_uq_name = types.symbolName(types.car(current));
+        if (depth == 0 and types.isSymbol(types.car(current.cur))) {
+            const maybe_uq_name = types.symbolName(types.car(current.cur));
             if (std.mem.eql(u8, types.stripHygienicPrefix(maybe_uq_name), "unquote")) {
-                const uq_args = types.cdr(current);
+                const uq_args = types.cdr(current.cur);
                 if (types.isPair(uq_args) and types.cdr(uq_args) == types.NIL) {
                     // Flush pending group
                     if (group_count > 0) {
@@ -604,14 +629,13 @@ fn compileQQSplicing(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileE
                     if (seg_count >= 64) return CompileError.TooManyLocals;
                     segments_buf[seg_count] = types.car(uq_args);
                     seg_count += 1;
-                    current = types.NIL;
+                    current.cur = types.NIL;
                     break;
                 }
             }
         }
 
-        const elem = types.car(current);
-        current = types.cdr(current);
+        const elem = types.car(current.cur);
 
         // Check if this element is (unquote-splicing expr)
         if (types.isPair(elem) and depth == 0) {
@@ -665,11 +689,11 @@ fn compileQQSplicing(self: *Compiler, tmpl: Value, dst: u16, depth: u8) CompileE
     }
 
     // Handle dotted tail
-    if (current != types.NIL and !types.isPair(current)) {
+    if (current.cur != types.NIL and !types.isPair(current.cur)) {
         // This shouldn't normally happen with splicing, but handle it
         if (seg_count >= 64) return CompileError.TooManyLocals;
         // Wrap as (quote tail)
-        const quoted_tail = gc.allocPair(quote_sym, gc.allocPair(current, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
+        const quoted_tail = gc.allocPair(quote_sym, gc.allocPair(current.cur, types.NIL) catch return CompileError.OutOfMemory) catch return CompileError.OutOfMemory;
         segments_buf[seg_count] = quoted_tail;
         seg_count += 1;
     }

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -648,6 +648,13 @@ pub fn compileLetValues(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
         defer gc.popRoot();
         const slot = try self.allocReg();
         temp_slots[i] = slot;
+        // #2405 note: no embed span is needed for the producer. The wrapper
+        // embeds it in a lambda body, which compiles it through
+        // compileExprViaIR — the producer becomes a live entry root, and a
+        // cycle re-entering it (producer == the enclosing let-values form)
+        // is caught by enterCodeRoot on the second descent, through the
+        // child-compiler chain. An explicit producer span would false-
+        // positive on the producer's own legitimate first descent.
         try self.compileExprViaIR(cwv_expr, slot, false);
     }
 

--- a/src/compiler_bindings.zig
+++ b/src/compiler_bindings.zig
@@ -19,44 +19,60 @@ fn makeUniqueLoopName(gc: *memory.GC, original: []const u8) CompileError!Value {
     return gc.allocSymbol(name) catch return CompileError.OutOfMemory;
 }
 
-fn renameInBody(gc: *memory.GC, expr: Value, old_name: []const u8, new_sym: Value) CompileError!Value {
+// #2405: renameInBody/renameInQuasiquote rebuild every pair they walk, so a
+// datum-label cycle in a named-let body has no leaves to bottom out at — the
+// active-path set keyed on Object address (stable in this non-moving GC, holds
+// no Values) turns the back-edge into the shared circular-form diagnosis
+// instead of unbounded recursion. Path membership, not prior visitation:
+// shared-but-acyclic body structure renews legitimately.
+const RenamePath = std.AutoHashMapUnmanaged(usize, void);
+
+fn renameInBody(gc: *memory.GC, expr: Value, old_name: []const u8, new_sym: Value, path: *RenamePath) CompileError!Value {
     if (types.isSymbol(expr)) {
         if (std.mem.eql(u8, types.symbolName(expr), old_name)) return new_sym;
         return expr;
     }
     if (types.isPair(expr)) {
+        const path_key = @intFromPtr(types.toObject(expr));
+        if (path.contains(path_key)) return compiler_mod.circularFormError();
+        try path.put(gc.allocator, path_key, {});
+        defer _ = path.remove(path_key);
         const head = types.car(expr);
         if (types.isSymbol(head)) {
             const hname = types.symbolName(head);
             if (std.mem.eql(u8, hname, "quote"))
                 return expr;
             if (std.mem.eql(u8, hname, "quasiquote")) {
-                const new_tmpl = try renameInQuasiquote(gc, types.cdr(expr), old_name, new_sym);
+                const new_tmpl = try renameInQuasiquote(gc, types.cdr(expr), old_name, new_sym, path);
                 if (new_tmpl == types.cdr(expr)) return expr;
                 return gc.allocPair(head, new_tmpl) catch return CompileError.OutOfMemory;
             }
         }
-        const new_car = try renameInBody(gc, types.car(expr), old_name, new_sym);
-        const new_cdr = try renameInBody(gc, types.cdr(expr), old_name, new_sym);
+        const new_car = try renameInBody(gc, types.car(expr), old_name, new_sym, path);
+        const new_cdr = try renameInBody(gc, types.cdr(expr), old_name, new_sym, path);
         if (new_car == types.car(expr) and new_cdr == types.cdr(expr)) return expr;
         return gc.allocPair(new_car, new_cdr) catch return CompileError.OutOfMemory;
     }
     return expr;
 }
 
-fn renameInQuasiquote(gc: *memory.GC, template: Value, old_name: []const u8, new_sym: Value) CompileError!Value {
+fn renameInQuasiquote(gc: *memory.GC, template: Value, old_name: []const u8, new_sym: Value, path: *RenamePath) CompileError!Value {
     if (!types.isPair(template)) return template;
+    const path_key = @intFromPtr(types.toObject(template));
+    if (path.contains(path_key)) return compiler_mod.circularFormError();
+    try path.put(gc.allocator, path_key, {});
+    defer _ = path.remove(path_key);
     const head = types.car(template);
     if (types.isSymbol(head)) {
         const hname = types.symbolName(head);
         if (std.mem.eql(u8, hname, "unquote") or std.mem.eql(u8, hname, "unquote-splicing")) {
-            const new_cdr = try renameInBody(gc, types.cdr(template), old_name, new_sym);
+            const new_cdr = try renameInBody(gc, types.cdr(template), old_name, new_sym, path);
             if (new_cdr == types.cdr(template)) return template;
             return gc.allocPair(head, new_cdr) catch return CompileError.OutOfMemory;
         }
     }
-    const new_car = try renameInQuasiquote(gc, head, old_name, new_sym);
-    const new_cdr = try renameInQuasiquote(gc, types.cdr(template), old_name, new_sym);
+    const new_car = try renameInQuasiquote(gc, head, old_name, new_sym, path);
+    const new_cdr = try renameInQuasiquote(gc, types.cdr(template), old_name, new_sym, path);
     if (new_car == head and new_cdr == types.cdr(template)) return template;
     return gc.allocPair(new_car, new_cdr) catch return CompileError.OutOfMemory;
 }
@@ -101,10 +117,11 @@ pub fn compileLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compile
     var names: [MAX_LET_BINDINGS][]const u8 = undefined;
     var count: usize = 0;
 
-    var binding_list = bindings;
-    while (binding_list != types.NIL) {
-        if (!types.isPair(binding_list)) return CompileError.InvalidSyntax;
-        const binding = types.car(binding_list);
+    var binding_list = compiler_mod.SpineWalk.init(bindings);
+    while (binding_list.cur != types.NIL) : (binding_list.next()) {
+        if (!types.isPair(binding_list.cur)) return CompileError.InvalidSyntax;
+        if (binding_list.cyclic()) return compiler_mod.circularFormError();
+        const binding = types.car(binding_list.cur);
         if (!types.isPair(binding)) return CompileError.InvalidSyntax;
 
         const var_name = types.car(binding);
@@ -118,8 +135,6 @@ pub fn compileLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compile
         slots[count] = slot;
         names[count] = types.symbolName(var_name);
         count += 1;
-
-        binding_list = types.cdr(binding_list);
     }
 
     // Phase 2: add all locals at once
@@ -143,10 +158,11 @@ pub fn compileLetStar(self: *Compiler, args: Value, dst: u16, is_tail: bool) Com
 
     self.beginScope();
 
-    var binding_list = bindings;
-    while (binding_list != types.NIL) {
-        if (!types.isPair(binding_list)) return CompileError.InvalidSyntax;
-        const binding = types.car(binding_list);
+    var binding_list = compiler_mod.SpineWalk.init(bindings);
+    while (binding_list.cur != types.NIL) : (binding_list.next()) {
+        if (!types.isPair(binding_list.cur)) return CompileError.InvalidSyntax;
+        if (binding_list.cyclic()) return compiler_mod.circularFormError();
+        const binding = types.car(binding_list.cur);
         if (!types.isPair(binding)) return CompileError.InvalidSyntax;
 
         const var_name = types.car(binding);
@@ -159,8 +175,6 @@ pub fn compileLetStar(self: *Compiler, args: Value, dst: u16, is_tail: bool) Com
         const vname = types.symbolName(var_name);
         try self.addLocal(vname, slot);
         try self.boxIfSetTarget(vname, slot);
-
-        binding_list = types.cdr(binding_list);
     }
 
     try compileLetBody(self, body, dst, is_tail);
@@ -183,10 +197,11 @@ fn compileLetrecImpl(self: *Compiler, args: Value, dst: u16, is_tail: bool) Comp
     var count: usize = 0;
 
     // Parse bindings
-    var binding_list = bindings;
-    while (binding_list != types.NIL) {
-        if (!types.isPair(binding_list)) return CompileError.InvalidSyntax;
-        const binding = types.car(binding_list);
+    var binding_list = compiler_mod.SpineWalk.init(bindings);
+    while (binding_list.cur != types.NIL) : (binding_list.next()) {
+        if (!types.isPair(binding_list.cur)) return CompileError.InvalidSyntax;
+        if (binding_list.cyclic()) return compiler_mod.circularFormError();
+        const binding = types.car(binding_list.cur);
         if (!types.isPair(binding)) return CompileError.InvalidSyntax;
         const var_name = types.car(binding);
         if (!types.isSymbol(var_name)) return CompileError.InvalidSyntax;
@@ -196,7 +211,6 @@ fn compileLetrecImpl(self: *Compiler, args: Value, dst: u16, is_tail: bool) Comp
         names[count] = types.symbolName(var_name);
         inits[count] = types.car(types.cdr(binding));
         count += 1;
-        binding_list = types.cdr(binding_list);
     }
 
     self.beginScope();
@@ -241,10 +255,11 @@ pub fn compileNamedLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Co
     var init_exprs: [MAX_LET_BINDINGS]Value = undefined;
     var param_count: usize = 0;
 
-    var binding_list = bindings;
-    while (binding_list != types.NIL) {
-        if (!types.isPair(binding_list)) return CompileError.InvalidSyntax;
-        const binding = types.car(binding_list);
+    var binding_list = compiler_mod.SpineWalk.init(bindings);
+    while (binding_list.cur != types.NIL) : (binding_list.next()) {
+        if (!types.isPair(binding_list.cur)) return CompileError.InvalidSyntax;
+        if (binding_list.cyclic()) return compiler_mod.circularFormError();
+        const binding = types.car(binding_list.cur);
         if (!types.isPair(binding)) return CompileError.InvalidSyntax;
         if (!types.isPair(types.cdr(binding))) return CompileError.InvalidSyntax;
 
@@ -252,7 +267,6 @@ pub fn compileNamedLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Co
         var_names[param_count] = types.car(binding);
         init_exprs[param_count] = types.car(types.cdr(binding));
         param_count += 1;
-        binding_list = types.cdr(binding_list);
     }
 
     // Bind the loop procedure to a boxed local (single-binding letrec) so the
@@ -279,7 +293,9 @@ pub fn compileNamedLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Co
             i -= 1;
             formals = self.gc.allocPair(var_names[i], formals) catch return CompileError.OutOfMemory;
         }
-        const renamed_body = try renameInBody(self.gc, body, types.symbolName(loop_name), unique_sym);
+        var rename_path: RenamePath = .empty;
+        defer rename_path.deinit(self.gc.allocator);
+        const renamed_body = try renameInBody(self.gc, body, types.symbolName(loop_name), unique_sym, &rename_path);
         renamed_lambda_args = self.gc.allocPair(formals, renamed_body) catch return CompileError.OutOfMemory;
     }
     self.gc.pushRoot(&renamed_lambda_args);
@@ -345,6 +361,11 @@ pub fn compileNamedLet(self: *Compiler, args: Value, dst: u16, is_tail: bool) Co
 const CaptureScan = struct {
     names: *std.ArrayList([]const u8),
     alloc: std.mem.Allocator,
+    // #2405: pairs on the active recursion path, keyed on Object address
+    // (stable in this non-moving GC, holds no Values). A car-side datum-label
+    // cycle recursed forever; path membership — not prior visitation — is
+    // what a cycle is, and shared-but-acyclic sub-datum renews legitimately.
+    path: std.AutoHashMapUnmanaged(usize, void) = .empty,
 
     fn addName(self: *@This(), name: []const u8) error{OutOfMemory}!void {
         for (self.names.items) |n| {
@@ -353,7 +374,7 @@ const CaptureScan = struct {
         try self.names.append(self.alloc, name);
     }
 
-    fn walk(self: *@This(), expr: Value) error{OutOfMemory}!void {
+    fn walk(self: *@This(), expr: Value) CompileError!void {
         if (types.isSymbol(expr)) {
             try self.addName(types.symbolName(expr));
             return;
@@ -366,12 +387,19 @@ const CaptureScan = struct {
             if (std.mem.eql(u8, types.symbolName(head), "quote")) return;
         }
 
-        var p = expr;
-        while (types.isPair(p)) : (p = types.cdr(p)) {
-            try self.walk(types.car(p));
+        const path_key = @intFromPtr(types.toObject(expr));
+        if (self.path.contains(path_key)) return compiler_mod.circularFormError();
+        try self.path.put(self.alloc, path_key, {});
+        defer _ = self.path.remove(path_key);
+
+        // #2405: spine guard — a cyclic command list spun this loop forever.
+        var p = compiler_mod.SpineWalk.init(expr);
+        while (types.isPair(p.cur)) : (p.next()) {
+            if (p.cyclic()) return compiler_mod.circularFormError();
+            try self.walk(types.car(p.cur));
         }
         // Improper (dotted) tail: a bare symbol is still a reference.
-        if (types.isSymbol(p)) try self.addName(types.symbolName(p));
+        if (types.isSymbol(p.cur)) try self.addName(types.symbolName(p.cur));
     }
 };
 
@@ -396,10 +424,11 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
     var has_step: [MAX_LET_BINDINGS]bool = undefined;
     var var_count: usize = 0;
 
-    var spec_list = var_specs;
-    while (spec_list != types.NIL) {
-        if (!types.isPair(spec_list)) return CompileError.InvalidSyntax;
-        const spec = types.car(spec_list);
+    var spec_list = compiler_mod.SpineWalk.init(var_specs);
+    while (spec_list.cur != types.NIL) : (spec_list.next()) {
+        if (!types.isPair(spec_list.cur)) return CompileError.InvalidSyntax;
+        if (spec_list.cyclic()) return compiler_mod.circularFormError();
+        const spec = types.car(spec_list.cur);
         if (!types.isPair(spec)) return CompileError.InvalidSyntax;
 
         const var_name = types.car(spec);
@@ -423,7 +452,6 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
         }
 
         var_count += 1;
-        spec_list = types.cdr(spec_list);
     }
 
     // Phase 2: add all locals at once (let semantics, not let*)
@@ -452,6 +480,7 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
         var referenced: std.ArrayList([]const u8) = .empty;
         defer referenced.deinit(self.gc.allocator);
         var scan = CaptureScan{ .names = &referenced, .alloc = self.gc.allocator };
+        defer scan.path.deinit(self.gc.allocator);
         try scan.walk(test_expr);
         try scan.walk(commands);
         for (0..var_count) |j| {
@@ -488,11 +517,11 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
     try self.emitI16(0);
 
     // Commands
-    var cmd = commands;
-    while (cmd != types.NIL) {
-        if (!types.isPair(cmd)) return CompileError.InvalidSyntax;
-        try self.compileExprViaIR(types.car(cmd), dst, false);
-        cmd = types.cdr(cmd);
+    var cmd = compiler_mod.SpineWalk.init(commands);
+    while (cmd.cur != types.NIL) : (cmd.next()) {
+        if (!types.isPair(cmd.cur)) return CompileError.InvalidSyntax;
+        if (cmd.cyclic()) return compiler_mod.circularFormError();
+        try self.compileExprViaIR(types.car(cmd.cur), dst, false);
     }
 
     // Step: evaluate all steps to temp registers, then assign back
@@ -540,12 +569,12 @@ pub fn compileDo(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileE
         try self.emitOp(.load_void);
         try self.emitU16(dst);
     } else {
-        var result = result_exprs;
-        while (result != types.NIL) {
-            if (!types.isPair(result)) return CompileError.InvalidSyntax;
-            const expr = types.car(result);
-            result = types.cdr(result);
-            const tail = is_tail and result == types.NIL;
+        var result = compiler_mod.SpineWalk.init(result_exprs);
+        while (result.cur != types.NIL) : (result.next()) {
+            if (!types.isPair(result.cur)) return CompileError.InvalidSyntax;
+            if (result.cyclic()) return compiler_mod.circularFormError();
+            const expr = types.car(result.cur);
+            const tail = is_tail and types.cdr(result.cur) == types.NIL;
             try self.compileExprViaIR(expr, dst, tail);
         }
     }

--- a/src/compiler_conditionals.zig
+++ b/src/compiler_conditionals.zig
@@ -138,13 +138,13 @@ pub fn compileCond(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
 
     var end_jumps: std.ArrayList(usize) = .empty;
     defer end_jumps.deinit(self.gc.allocator);
-    var current = args;
+    var current = compiler_mod.SpineWalk.init(args);
     var had_else = false;
 
-    while (current != types.NIL) {
-        if (!types.isPair(current)) return CompileError.InvalidSyntax;
-        const clause = types.car(current);
-        current = types.cdr(current);
+    while (current.cur != types.NIL) : (current.next()) {
+        if (!types.isPair(current.cur)) return CompileError.InvalidSyntax;
+        if (current.cyclic()) return compiler_mod.circularFormError();
+        const clause = types.car(current.cur);
         if (!types.isPair(clause)) return CompileError.InvalidSyntax;
 
         const test_expr = types.car(clause);
@@ -225,12 +225,14 @@ pub fn compileCond(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
 }
 
 pub fn compileCondBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) CompileError!void {
-    var current = body;
-    while (current != types.NIL) {
-        if (!types.isPair(current)) return CompileError.InvalidSyntax;
-        const expr = types.car(current);
-        current = types.cdr(current);
-        const tail = is_tail and current == types.NIL;
+    // #2405: a cond/else clause body is a raw spine — cyclic tails spun
+    // this loop forever.
+    var current = compiler_mod.SpineWalk.init(body);
+    while (current.cur != types.NIL) : (current.next()) {
+        if (!types.isPair(current.cur)) return CompileError.InvalidSyntax;
+        if (current.cyclic()) return compiler_mod.circularFormError();
+        const expr = types.car(current.cur);
+        const tail = is_tail and types.cdr(current.cur) == types.NIL;
         try self.compileExprViaIR(expr, dst, tail);
     }
 }
@@ -241,11 +243,14 @@ pub fn compileCondBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Co
 /// of the first matching clause. Features are checked against a hardcoded
 /// list and the library registry.
 pub fn compileCondExpand(self: *Compiler, args: Value, dst: u16, is_tail: bool) CompileError!void {
-    var current = args;
-    while (current != types.NIL) {
-        if (!types.isPair(current)) return CompileError.InvalidSyntax;
-        const clause = types.car(current);
-        current = types.cdr(current);
+    // #2405: guarded — a cyclic clause list with no matching clause spun
+    // this loop forever (a match returns early, which is why the common
+    // case only terminates by luck).
+    var current = compiler_mod.SpineWalk.init(args);
+    while (current.cur != types.NIL) : (current.next()) {
+        if (!types.isPair(current.cur)) return CompileError.InvalidSyntax;
+        if (current.cyclic()) return compiler_mod.circularFormError();
+        const clause = types.car(current.cur);
 
         if (!types.isPair(clause)) return CompileError.InvalidSyntax;
         const feature_req = types.car(clause);

--- a/src/compiler_define_syntax.zig
+++ b/src/compiler_define_syntax.zig
@@ -160,11 +160,11 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
     // so pushRoot pointers into its backing buffer stay valid across
     // subsequent appends (GC safety: no reallocation after rooting).
     var bind_count: usize = 0;
-    var count_list = bindings;
-    while (count_list != types.NIL) {
-        if (!types.isPair(count_list)) return CompileError.InvalidSyntax;
+    var count_walk = compiler_mod.SpineWalk.init(bindings);
+    while (count_walk.cur != types.NIL) : (count_walk.next()) {
+        if (!types.isPair(count_walk.cur)) return CompileError.InvalidSyntax;
+        if (count_walk.cyclic()) return compiler_mod.circularFormError();
         bind_count += 1;
-        count_list = types.cdr(count_list);
     }
 
     var kw_names: std.ArrayList([]const u8) = .empty;
@@ -181,10 +181,11 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
     // exactly one pop here, and nothing after the loop pushes.
     defer for (0..roots_pushed) |_| self.gc.popRoot();
 
-    var binding_list = bindings;
-    while (binding_list != types.NIL) {
-        if (!types.isPair(binding_list)) return CompileError.InvalidSyntax;
-        const binding = types.car(binding_list);
+    var binding_list = compiler_mod.SpineWalk.init(bindings);
+    while (binding_list.cur != types.NIL) : (binding_list.next()) {
+        if (!types.isPair(binding_list.cur)) return CompileError.InvalidSyntax;
+        if (binding_list.cyclic()) return compiler_mod.circularFormError();
+        const binding = types.car(binding_list.cur);
         if (!types.isPair(binding)) return CompileError.InvalidSyntax;
         const keyword = types.car(binding);
         if (!types.isSymbol(keyword)) return CompileError.InvalidSyntax;
@@ -201,7 +202,6 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
         self.gc.pushRoot(&tx_vals.items[tx_vals.items.len - 1]);
         roots_pushed += 1;
         kw_names.appendAssumeCapacity(types.symbolName(keyword));
-        binding_list = types.cdr(binding_list);
     }
 
     // Build peer snapshot: each keyword's outer macro value (NIL = unbound).
@@ -307,10 +307,11 @@ pub fn compileLetrecSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool
     var saved_values: std.ArrayList(?Value) = .empty;
     defer saved_values.deinit(self.gc.allocator);
 
-    var binding_list = bindings;
-    while (binding_list != types.NIL) {
-        if (!types.isPair(binding_list)) return CompileError.InvalidSyntax;
-        const binding = types.car(binding_list);
+    var binding_list = compiler_mod.SpineWalk.init(bindings);
+    while (binding_list.cur != types.NIL) : (binding_list.next()) {
+        if (!types.isPair(binding_list.cur)) return CompileError.InvalidSyntax;
+        if (binding_list.cyclic()) return compiler_mod.circularFormError();
+        const binding = types.car(binding_list.cur);
         if (!types.isPair(binding)) return CompileError.InvalidSyntax;
         const keyword = types.car(binding);
         if (!types.isSymbol(keyword)) return CompileError.InvalidSyntax;
@@ -331,7 +332,6 @@ pub fn compileLetrecSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool
         saved_values.append(self.gc.allocator, self.macros.get(name)) catch return CompileError.OutOfMemory;
         try finalizeTransformer(self, transformer);
         self.macros.put(name, transformer) catch return CompileError.OutOfMemory;
-        binding_list = types.cdr(binding_list);
     }
 
     try compileSyntaxBody(self, body, dst, is_tail);
@@ -370,12 +370,17 @@ fn compileSyntaxBody(self: *Compiler, body: Value, dst: u16, is_tail: bool) Comp
     self.in_body_scope = true;
     const macro_mark = self.beginBodyMacroScope();
     errdefer self.endBodyMacroScope(macro_mark) catch {};
-    var current = body;
-    while (current != types.NIL) {
-        if (!types.isPair(current)) return CompileError.InvalidSyntax;
-        const expr = types.car(current);
-        current = types.cdr(current);
-        const tail = is_tail and current == types.NIL;
+    // #2405: a let-syntax/letrec-syntax body is a raw spine, and a datum-label
+    // cycle through it (`#0=(let-syntax () . #0#)`, whose body IS the whole
+    // form) used to spin this loop forever, emitting an unbounded instruction
+    // stream. The tortoise-and-hare guard names the cycle instead; `tail`
+    // peeks one cdr ahead rather than consuming, which the guarded walk needs.
+    var current = compiler_mod.SpineWalk.init(body);
+    while (current.cur != types.NIL) : (current.next()) {
+        if (!types.isPair(current.cur)) return CompileError.InvalidSyntax;
+        if (current.cyclic()) return compiler_mod.circularFormError();
+        const expr = types.car(current.cur);
+        const tail = is_tail and types.cdr(current.cur) == types.NIL;
         try self.compileExprViaIR(expr, dst, tail);
     }
     try self.endBodyMacroScope(macro_mark);

--- a/src/compiler_define_syntax.zig
+++ b/src/compiler_define_syntax.zig
@@ -923,13 +923,28 @@ pub fn parseSyntaxRules(self: *Compiler, spec: Value, extra_bound: []const []con
 /// is the (possibly custom) ellipsis identifier; a symbol of that name listed
 /// in `literals` is a literal, not an ellipsis (R7RS: a literal has priority
 /// over the ellipsis).
+///
+/// #2405 (CodeRabbit on PR #2413): a datum-label cycle in the pattern
+/// (`(_ #0=(a . #0#))`) spun the spine loop or overflowed the recursion.
+/// Both are bounded here — the spine with the shared tortoise-and-hare
+/// guard, the recursion with a depth cap far beyond any real pattern — and
+/// a pattern that hits either bound is simply not valid grammar, which is
+/// the truthful answer for a pattern with no finite form.
+const PATTERN_GRAMMAR_DEPTH_CAP: u32 = 256;
+
 fn validPatternGrammar(v: Value, ellipsis_name: []const u8, literals: []const Value) bool {
+    return validPatternGrammarDepth(v, ellipsis_name, literals, PATTERN_GRAMMAR_DEPTH_CAP);
+}
+
+fn validPatternGrammarDepth(v: Value, ellipsis_name: []const u8, literals: []const Value, depth: u32) bool {
+    if (depth == 0) return false;
     if (types.isPair(v)) {
         var seen_ellipsis = false;
-        var cur = v;
+        var walk = compiler_mod.SpineWalk.init(v);
         var first = true;
-        while (types.isPair(cur)) {
-            const elem = expander.unwrapUsertext(types.car(cur));
+        while (types.isPair(walk.cur)) : (walk.next()) {
+            if (walk.cyclic()) return false;
+            const elem = expander.unwrapUsertext(types.car(walk.cur));
             if (types.isSymbol(elem)) {
                 const name = types.symbolName(elem);
                 if (std.mem.eql(u8, name, ellipsis_name) and !literalNamed(literals, name)) {
@@ -945,23 +960,24 @@ fn validPatternGrammar(v: Value, ellipsis_name: []const u8, literals: []const Va
                     }
                 }
             } else if (types.isPair(elem) or types.isVector(elem)) {
-                if (!validPatternGrammar(elem, ellipsis_name, literals)) return false;
+                if (!validPatternGrammarDepth(elem, ellipsis_name, literals, depth - 1)) return false;
             }
             first = false;
-            cur = types.cdr(cur);
         }
         // Dotted tail: a plain pattern, not a list element. An ellipsis
         // token there (`(a ... . ...)`) is outside the grammar too, and a
         // vector dotted tail (`(_ . #(a ... b ...))`) is a vector pattern
         // the matcher recurses into, so it must be validated like any
         // other vector pattern. (A pair dotted tail is impossible here:
-        // the while loop above only exits once cur is no longer a pair.)
+        // the while loop above only exits once the tail is no longer a
+        // pair.)
+        const cur = walk.cur;
         if (cur != types.NIL) {
             if (types.isSymbol(cur)) {
                 const name = types.symbolName(cur);
                 if (std.mem.eql(u8, name, ellipsis_name) and !literalNamed(literals, name)) return false;
             } else if (types.isVector(cur)) {
-                return validPatternGrammar(cur, ellipsis_name, literals);
+                return validPatternGrammarDepth(cur, ellipsis_name, literals, depth - 1);
             }
         }
         return true;
@@ -981,7 +997,7 @@ fn validPatternGrammar(v: Value, ellipsis_name: []const u8, literals: []const Va
                     }
                 }
             } else if (types.isPair(elem) or types.isVector(elem)) {
-                if (!validPatternGrammar(elem, ellipsis_name, literals)) return false;
+                if (!validPatternGrammarDepth(elem, ellipsis_name, literals, depth - 1)) return false;
             }
             first = false;
         }

--- a/src/compiler_ir.zig
+++ b/src/compiler_ir.zig
@@ -382,6 +382,10 @@ pub fn compileLambdaWithIR(self: *Compiler, args: Value, dst: u16, name: ?[]cons
 }
 
 fn compileDefineFromIR(self: *Compiler, data: ir_mod.DefineData, dst: u16) CompileError!void {
+    // #2405: the define's value compiles through a fresh IR — keep a
+    // Compiler-scoped root span across its lower+emit (see Compiler.compile).
+    try self.enterCodeRoot(data.value);
+    defer self.leaveCodeRoot(data.value);
     var ir = ir_mod.IR.init(self.gc.allocator);
     ir.globals = self.globals;
     ir.restricted_env = self.restricted_env;
@@ -432,6 +436,10 @@ fn compileDefineFromIR(self: *Compiler, data: ir_mod.DefineData, dst: u16) Compi
 fn compileSetFromIR(self: *Compiler, data: ir_mod.SetData, dst: u16) CompileError!void {
     const name = types.symbolName(data.name);
 
+    // #2405: the set! value compiles through a fresh IR — keep a
+    // Compiler-scoped root span across its lower+emit (see Compiler.compile).
+    try self.enterCodeRoot(data.value);
+    defer self.leaveCodeRoot(data.value);
     var ir = ir_mod.IR.init(self.gc.allocator);
     ir.globals = self.globals;
     ir.restricted_env = self.restricted_env;

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -199,16 +199,33 @@ fn isSpliceableBegin(compiler: *const Compiler, form: Value) bool {
 /// spliceable `begin` contributes its (recursively spliced) children, any
 /// other form contributes itself. Called under no_collect (see
 /// spliceLeadingBegins).
-fn appendSplicedBodyElement(compiler: *Compiler, elems: *std.ArrayList(Value), form: Value) CompileError!void {
+///
+/// #2405: both the child spine and the nested-begin recursion must be
+/// cycle-aware — a datum-label cycle through a begin (`#0=(begin #0#)`)
+/// recurses on the same form forever otherwise. The spine takes the
+/// tortoise-and-hare guard; the recursion takes an active-path set keyed on
+/// Object address (stable in this non-moving GC, holds no Values), exactly
+/// the erRenameDatum discipline from #2403: path membership, not prior
+/// visitation, so shared-but-acyclic begins still splice.
+fn appendSplicedBodyElement(
+    compiler: *Compiler,
+    elems: *std.ArrayList(Value),
+    form: Value,
+    path: *std.AutoHashMapUnmanaged(usize, void),
+) CompileError!void {
     if (isSpliceableBegin(compiler, form)) {
-        var child = types.cdr(form);
-        while (types.isPair(child)) {
-            try appendSplicedBodyElement(compiler, elems, types.car(child));
-            child = types.cdr(child);
+        const path_key = @intFromPtr(types.toObject(form));
+        if (path.contains(path_key)) return compiler_mod.circularFormError();
+        path.put(compiler.gc.allocator, path_key, {}) catch return CompileError.OutOfMemory;
+        defer _ = path.remove(path_key);
+        var walk = compiler_mod.SpineWalk.init(types.cdr(form));
+        while (types.isPair(walk.cur)) : (walk.next()) {
+            if (walk.cyclic()) return compiler_mod.circularFormError();
+            try appendSplicedBodyElement(compiler, elems, types.car(walk.cur), path);
         }
         // An improper begin `(begin e1 . tail)` is invalid syntax — reject
         // it rather than silently dropping the tail from the spliced body.
-        if (child != types.NIL) return CompileError.InvalidSyntax;
+        if (walk.cur != types.NIL) return CompileError.InvalidSyntax;
     } else {
         elems.append(compiler.gc.allocator, form) catch return CompileError.OutOfMemory;
     }
@@ -274,15 +291,17 @@ fn spliceLeadingBegins(compiler: *Compiler, body: Value) CompileError!?Value {
     const gc = compiler.gc;
 
     // Fast path: a body with no spliceable begin element allocates nothing.
+    // #2405: guarded — this walk scans the whole spine with no `break`, so a
+    // cyclic body (`#0=(let ((x 1)) . #0#)`) spun here forever.
     var any_begin = false;
     {
-        var cur = body;
-        while (types.isPair(cur)) {
-            if (isSpliceableBegin(compiler, types.car(cur))) {
+        var walk = compiler_mod.SpineWalk.init(body);
+        while (types.isPair(walk.cur)) : (walk.next()) {
+            if (walk.cyclic()) return compiler_mod.circularFormError();
+            if (isSpliceableBegin(compiler, types.car(walk.cur))) {
                 any_begin = true;
                 break;
             }
-            cur = types.cdr(cur);
         }
     }
     if (!any_begin) return null;
@@ -292,13 +311,17 @@ fn spliceLeadingBegins(compiler: *Compiler, body: Value) CompileError!?Value {
 
     var elems: std.ArrayList(Value) = .empty;
     defer elems.deinit(gc.allocator);
-    var cur = body;
-    while (types.isPair(cur)) {
-        try appendSplicedBodyElement(compiler, &elems, types.car(cur));
-        cur = types.cdr(cur);
+    var path: std.AutoHashMapUnmanaged(usize, void) = .empty;
+    defer path.deinit(gc.allocator);
+    {
+        var walk = compiler_mod.SpineWalk.init(body);
+        while (types.isPair(walk.cur)) : (walk.next()) {
+            if (walk.cyclic()) return compiler_mod.circularFormError();
+            try appendSplicedBodyElement(compiler, &elems, types.car(walk.cur), &path);
+        }
+        // An improper body tail must not be silently dropped either.
+        if (walk.cur != types.NIL) return CompileError.InvalidSyntax;
     }
-    // An improper body tail must not be silently dropped either.
-    if (cur != types.NIL) return CompileError.InvalidSyntax;
 
     var result = types.NIL;
     var i = elems.items.len;
@@ -347,9 +370,10 @@ pub fn scanBodyDefs(compiler: *Compiler, body: Value, handle_define_syntax: bool
     if (compiler.globals) |globals| {
         const glk = globals_mod.acquireGlobalsWrite(globals);
         defer globals_mod.releaseGlobalsWrite(glk);
-        var scan = effective_body;
-        while (scan != types.NIL and types.isPair(scan)) {
-            const form = types.car(scan);
+        var walk = compiler_mod.SpineWalk.init(effective_body);
+        while (walk.cur != types.NIL and types.isPair(walk.cur)) : (walk.next()) {
+            if (walk.cyclic()) return compiler_mod.circularFormError();
+            const form = types.car(walk.cur);
             if (types.isPair(form)) {
                 const head = types.car(form);
                 if (types.isSymbol(head)) {
@@ -398,7 +422,6 @@ pub fn scanBodyDefs(compiler: *Compiler, body: Value, handle_define_syntax: bool
                     }
                 }
             }
-            scan = types.cdr(scan);
         }
     }
 
@@ -407,9 +430,10 @@ pub fn scanBodyDefs(compiler: *Compiler, body: Value, handle_define_syntax: bool
     var all_def_names: [BodyScan.MAX_DEFS][]const u8 = undefined;
     var all_def_count: usize = 0;
     {
-        var scan = effective_body;
-        while (scan != types.NIL and types.isPair(scan)) {
-            const expr = types.car(scan);
+        var walk = compiler_mod.SpineWalk.init(effective_body);
+        while (walk.cur != types.NIL and types.isPair(walk.cur)) : (walk.next()) {
+            if (walk.cyclic()) return compiler_mod.circularFormError();
+            const expr = types.car(walk.cur);
             if (!types.isPair(expr)) break;
             const head = types.car(expr);
             if (!types.isSymbol(head)) break;
@@ -459,7 +483,6 @@ pub fn scanBodyDefs(compiler: *Compiler, body: Value, handle_define_syntax: bool
             } else if (!(handle_define_syntax and std.mem.eql(u8, hn, "define-syntax"))) {
                 break;
             }
-            scan = types.cdr(scan);
         }
     }
 
@@ -469,9 +492,10 @@ pub fn scanBodyDefs(compiler: *Compiler, body: Value, handle_define_syntax: bool
     // the rest of this scan and the caller's compilation phase allocate, so a
     // collection would sweep the not-yet-compiled inits (issue #1010). Mirror
     // them into extra_roots (by value, realloc-safe) for the duration.
-    var current = effective_body;
-    while (current != types.NIL and types.isPair(current)) {
-        const expr = types.car(current);
+    var second = compiler_mod.SpineWalk.init(effective_body);
+    while (second.cur != types.NIL and types.isPair(second.cur)) : (second.next()) {
+        if (second.cyclic()) return compiler_mod.circularFormError();
+        const expr = types.car(second.cur);
         if (!types.isPair(expr)) break;
         const head = types.car(expr);
         if (!types.isSymbol(head)) break;
@@ -602,10 +626,9 @@ pub fn scanBodyDefs(compiler: *Compiler, body: Value, handle_define_syntax: bool
         } else {
             break;
         }
-        current = types.cdr(current);
     }
 
-    scan_result.remaining = current;
+    scan_result.remaining = second.cur;
     return scan_result;
 }
 
@@ -701,11 +724,21 @@ pub fn compileBodyForms(self: *Compiler, body: Value, opts: BodyOpts) CompileErr
 }
 
 pub fn compileExprSequence(self: *Compiler, current: *Value, last_dst: *u16, allocates_regs: bool, caller_tail: ?bool) CompileError!void {
-    while (current.* != types.NIL) {
-        if (!types.isPair(current.*)) return CompileError.InvalidSyntax;
-        const expr = types.car(current.*);
-        current.* = types.cdr(current.*);
-        const is_last = current.* == types.NIL;
+    // #2405: this is the generic body-sequence walker (lambda/let-family
+    // bodies, clause bodies), so a cyclic body spine spins it forever —
+    // the tortoise-and-hare guard names the cycle instead. `current` stays
+    // a pointer out to the caller (set to the stopping position) even
+    // though no caller reads it, preserving the old contract.
+    var walk = compiler_mod.SpineWalk.init(current.*);
+    defer current.* = walk.cur;
+    while (walk.cur != types.NIL) : (walk.next()) {
+        if (!types.isPair(walk.cur)) return CompileError.InvalidSyntax;
+        if (walk.cyclic()) return compiler_mod.circularFormError();
+        const expr = types.car(walk.cur);
+        // Equivalent to the old advance-then-peek: the element is last iff
+        // its cdr is NIL. An improper or cyclic rest simply reads non-last,
+        // and the walk's own guards reject that tail.
+        const is_last = types.cdr(walk.cur) == types.NIL;
         if (allocates_regs) {
             last_dst.* = try self.allocReg();
             if (is_last) {

--- a/src/compiler_lambda.zig
+++ b/src/compiler_lambda.zig
@@ -1197,13 +1197,15 @@ pub fn compileSet(self: *Compiler, args: Value, dst: u16) CompileError!void {
 
         var arg_buf: [16]Value = undefined;
         var n_args: usize = 0;
-        var cur = proc_args;
-        while (cur != types.NIL) {
-            if (!types.isPair(cur)) return CompileError.InvalidSyntax;
+        // #2405: legacy twin of ir.zig's SRFI-17 setter desugar — the
+        // target's operand spine needs the cycle guard here too.
+        var cur = compiler_mod.SpineWalk.init(proc_args);
+        while (cur.cur != types.NIL) : (cur.next()) {
+            if (!types.isPair(cur.cur)) return CompileError.InvalidSyntax;
+            if (cur.cyclic()) return compiler_mod.circularFormError();
             if (n_args >= 16) return CompileError.InternalLimit;
-            arg_buf[n_args] = types.car(cur);
+            arg_buf[n_args] = types.car(cur.cur);
             n_args += 1;
-            cur = types.cdr(cur);
         }
 
         // Suppress GC during S-expression construction — intermediate
@@ -1331,12 +1333,14 @@ pub fn compileBegin(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compi
         return;
     }
 
-    var current = args;
-    while (current != types.NIL) {
-        if (!types.isPair(current)) return CompileError.InvalidSyntax;
-        const expr = types.car(current);
-        current = types.cdr(current);
-        const tail = is_tail and current == types.NIL;
+    // #2405: legacy begin body spine (the IR path is lowerBegin, guarded);
+    // a cyclic body spun this loop forever.
+    var current = compiler_mod.SpineWalk.init(args);
+    while (current.cur != types.NIL) : (current.next()) {
+        if (!types.isPair(current.cur)) return CompileError.InvalidSyntax;
+        if (current.cyclic()) return compiler_mod.circularFormError();
+        const expr = types.car(current.cur);
+        const tail = is_tail and types.cdr(current.cur) == types.NIL;
         try self.compileExprViaIR(expr, dst, tail);
     }
 }

--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -243,8 +243,13 @@ fn compileSelfTailCall(self: *Compiler, expr: Value, dst: u16, nargs: u8) Compil
     const needs_rebase = (dst + 1 != self.next_register);
     const base = if (needs_rebase) try self.allocReg() else dst;
 
+    // #2405: the caller (compileCall) has already proven this spine acyclic
+    // with its own guarded count walk, but the guard here is kept too — a
+    // SpineWalk without cyclic() would read like a guard that is one
+    // (review of PR #2413), and the redundancy is one integer compare.
     var arg_list = compiler_mod.SpineWalk.init(types.cdr(expr));
-    while (arg_list.cur != types.NIL) : (arg_list.next()) {
+    while (types.isPair(arg_list.cur)) : (arg_list.next()) {
+        if (arg_list.cyclic()) return compiler_mod.circularFormError();
         const arg = types.car(arg_list.cur);
         const arg_reg = try self.allocReg();
         try self.compileExprViaIR(arg, arg_reg, false);
@@ -288,12 +293,15 @@ pub fn compileApplyTail(self: *Compiler, expr: Value, dst: u16) CompileError!voi
     try self.compileExprViaIR(types.car(arg_list), base, false);
     arg_list = types.cdr(arg_list);
 
+    // The count walk above proved this spine acyclic; cyclic() stays as the
+    // self-documenting (and cheap) redundancy — see compileSelfTailCall.
+    var rest = compiler_mod.SpineWalk.init(arg_list);
     var nargs_count: usize = 0;
-    while (types.isPair(arg_list)) {
+    while (types.isPair(rest.cur)) : (rest.next()) {
+        if (rest.cyclic()) return compiler_mod.circularFormError();
         const arg_reg = try self.allocReg();
-        try self.compileExprViaIR(types.car(arg_list), arg_reg, false);
+        try self.compileExprViaIR(types.car(rest.cur), arg_reg, false);
         nargs_count += 1;
-        arg_list = types.cdr(arg_list);
     }
 
     if (nargs_count > 255) return CompileError.InternalLimit;

--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -68,15 +68,17 @@ pub fn compileCall(self: *Compiler, expr: Value, dst: u16, is_tail: bool) Compil
     }
 
     var nargs_count: usize = 0;
-    var arg_list = types.cdr(expr);
     var args_valid = true;
-    while (arg_list != types.NIL) {
-        if (!types.isPair(arg_list)) {
+    // #2405: a datum-label cycle in the argument spine spun this counting
+    // loop forever; the tortoise-and-hare guard names it instead.
+    var count_walk = compiler_mod.SpineWalk.init(types.cdr(expr));
+    while (count_walk.cur != types.NIL) : (count_walk.next()) {
+        if (!types.isPair(count_walk.cur)) {
             args_valid = false;
             break;
         }
+        if (count_walk.cyclic()) return compiler_mod.circularFormError();
         nargs_count += 1;
-        arg_list = types.cdr(arg_list);
     }
 
     if (nargs_count > 255) return CompileError.InternalLimit;
@@ -115,12 +117,11 @@ pub fn compileCall(self: *Compiler, expr: Value, dst: u16, is_tail: bool) Compil
 
     try self.compileExprViaIR(operator, base, false);
 
-    arg_list = types.cdr(expr);
-    while (arg_list != types.NIL) {
-        const arg = types.car(arg_list);
+    var arg_walk = compiler_mod.SpineWalk.init(types.cdr(expr));
+    while (arg_walk.cur != types.NIL) : (arg_walk.next()) {
+        const arg = types.car(arg_walk.cur);
         const arg_reg = try self.allocReg();
         try self.compileExprViaIR(arg, arg_reg, false);
-        arg_list = types.cdr(arg_list);
     }
 
     if (is_tail) {
@@ -242,12 +243,11 @@ fn compileSelfTailCall(self: *Compiler, expr: Value, dst: u16, nargs: u8) Compil
     const needs_rebase = (dst + 1 != self.next_register);
     const base = if (needs_rebase) try self.allocReg() else dst;
 
-    var arg_list = types.cdr(expr);
-    while (arg_list != types.NIL) {
-        const arg = types.car(arg_list);
+    var arg_list = compiler_mod.SpineWalk.init(types.cdr(expr));
+    while (arg_list.cur != types.NIL) : (arg_list.next()) {
+        const arg = types.car(arg_list.cur);
         const arg_reg = try self.allocReg();
         try self.compileExprViaIR(arg, arg_reg, false);
-        arg_list = types.cdr(arg_list);
     }
 
     try self.emitOp(.self_tail_call);
@@ -270,12 +270,15 @@ pub fn compileApplyTail(self: *Compiler, expr: Value, dst: u16) CompileError!voi
     // not a syntax question: route the form through the ordinary call path so
     // the native apply's runtime arity check reports KP3003 exactly as the
     // same form one position away does (#2036). Only an improper list is
-    // malformed syntax.
+    // malformed syntax. #2405: guarded — a cyclic operand spine spun forever.
     {
         var count: usize = 0;
-        var cur = arg_list;
-        while (types.isPair(cur)) : (cur = types.cdr(cur)) count += 1;
-        if (cur != types.NIL) return CompileError.InvalidSyntax;
+        var walk = compiler_mod.SpineWalk.init(arg_list);
+        while (types.isPair(walk.cur)) : (walk.next()) {
+            if (walk.cyclic()) return compiler_mod.circularFormError();
+            count += 1;
+        }
+        if (walk.cur != types.NIL) return CompileError.InvalidSyntax;
         if (count < 2) return compileCall(self, expr, dst, true);
     }
 
@@ -286,7 +289,7 @@ pub fn compileApplyTail(self: *Compiler, expr: Value, dst: u16) CompileError!voi
     arg_list = types.cdr(arg_list);
 
     var nargs_count: usize = 0;
-    while (arg_list != types.NIL) {
+    while (types.isPair(arg_list)) {
         const arg_reg = try self.allocReg();
         try self.compileExprViaIR(types.car(arg_list), arg_reg, false);
         nargs_count += 1;
@@ -323,12 +326,16 @@ pub fn compileCallWithValuesTail(self: *Compiler, expr: Value, dst: u16) Compile
     // A *proper* argument list of the wrong length is an arity question, not a
     // syntax question: route the form through the ordinary call path so the
     // runtime arity check reports KP3003 exactly as the same form one position
-    // away does (#2036). Only an improper list is malformed syntax.
+    // away does (#2036). Only an improper list is malformed syntax. #2405:
+    // guarded — a cyclic argument spine spun the count forever.
     {
         var count: usize = 0;
-        var cur = types.cdr(expr);
-        while (types.isPair(cur)) : (cur = types.cdr(cur)) count += 1;
-        if (cur != types.NIL) return CompileError.InvalidSyntax;
+        var walk = compiler_mod.SpineWalk.init(types.cdr(expr));
+        while (types.isPair(walk.cur)) : (walk.next()) {
+            if (walk.cyclic()) return compiler_mod.circularFormError();
+            count += 1;
+        }
+        if (walk.cur != types.NIL) return CompileError.InvalidSyntax;
         if (count != 2) return compileCall(self, expr, dst, true);
     }
     const args = types.cdr(expr);
@@ -368,12 +375,16 @@ pub fn compileCallCCTail(self: *Compiler, expr: Value, dst: u16) CompileError!vo
     // A *proper* argument list of the wrong length is an arity question, not a
     // syntax question: route the form through the ordinary call path so the
     // runtime arity check reports KP3003 exactly as the same form one position
-    // away does (#2036). Only an improper list is malformed syntax.
+    // away does (#2036). Only an improper list is malformed syntax. #2405:
+    // guarded — a cyclic argument spine spun the count forever.
     {
         var count: usize = 0;
-        var cur = types.cdr(expr);
-        while (types.isPair(cur)) : (cur = types.cdr(cur)) count += 1;
-        if (cur != types.NIL) return CompileError.InvalidSyntax;
+        var walk = compiler_mod.SpineWalk.init(types.cdr(expr));
+        while (types.isPair(walk.cur)) : (walk.next()) {
+            if (walk.cyclic()) return compiler_mod.circularFormError();
+            count += 1;
+        }
+        if (walk.cur != types.NIL) return CompileError.InvalidSyntax;
         if (count != 1) return compileCall(self, expr, dst, true);
     }
     const receiver = types.car(types.cdr(expr));
@@ -429,14 +440,14 @@ fn compileCallGlobal(self: *Compiler, expr: Value, operator: Value, dst: u16, is
     };
 
     var nargs_count: usize = 0;
-    var arg_list = types.cdr(expr);
-    while (arg_list != types.NIL) {
-        if (!types.isPair(arg_list)) return CompileError.InvalidSyntax;
-        const arg = types.car(arg_list);
+    var arg_list = compiler_mod.SpineWalk.init(types.cdr(expr));
+    while (arg_list.cur != types.NIL) : (arg_list.next()) {
+        if (!types.isPair(arg_list.cur)) return CompileError.InvalidSyntax;
+        if (arg_list.cyclic()) return compiler_mod.circularFormError();
+        const arg = types.car(arg_list.cur);
         const arg_reg = try self.allocReg();
         try self.compileExprViaIR(arg, arg_reg, false);
         nargs_count += 1;
-        arg_list = types.cdr(arg_list);
     }
     if (nargs_count > 255) return CompileError.InternalLimit;
     const nargs: u8 = @intCast(nargs_count);

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -813,6 +813,15 @@ fn lowerIf(ir: *IR, args: Value, macros: ?*std.StringHashMap(Value)) CompileErro
     const consequent = types.car(rest);
     const rest2 = types.cdr(rest);
 
+    // #2405: `if` consumes its alternate from a position and never walks
+    // what follows — `(if a b c . junk)` has always been silently accepted —
+    // but a CYCLIC tail means the form contains itself, and compiling the
+    // `if` symbol as the alternate is garbage-in-garbage-out (#0=(if #t 1
+    // . #0#) printed 1). Detection-only: the lax acceptance of extra
+    // non-cyclic forms is unchanged.
+    if (rest2 != types.NIL and compiler_mod.spineCyclic(types.cdr(rest2)))
+        return compiler_mod.circularFormError();
+
     const test_node = try lowerWithMacros(ir, test_expr, macros);
     const cons_node = try lowerWithMacros(ir, consequent, macros);
     const alt_node: ?*Node = if (rest2 != types.NIL)
@@ -971,11 +980,14 @@ fn lowerSet(ir: *IR, args: Value) CompileError!*Node {
         // Collect proc_args + val into argument list
         var arg_nodes: std.ArrayList(*Node) = .empty;
         defer arg_nodes.deinit(ir.allocator);
-        var cur = proc_args;
-        while (cur != types.NIL) {
-            if (!types.isPair(cur)) return CompileError.InvalidSyntax;
-            arg_nodes.append(ir.allocator, try lowerWithMacros(ir, types.car(cur), null)) catch return CompileError.OutOfMemory;
-            cur = types.cdr(cur);
+        // #2405 (CodeRabbit on PR #2413): the SRFI-17 target's operand spine
+        // is a raw walk — `(set! #0=(f 1 . #0#) 3)` spun it forever, the one
+        // cycle shape that never routes through lowerWithMacros.
+        var cur = compiler_mod.SpineWalk.init(proc_args);
+        while (cur.cur != types.NIL) : (cur.next()) {
+            if (!types.isPair(cur.cur)) return CompileError.InvalidSyntax;
+            if (cur.cyclic()) return compiler_mod.circularFormError();
+            arg_nodes.append(ir.allocator, try lowerWithMacros(ir, types.car(cur.cur), null)) catch return CompileError.OutOfMemory;
         }
         arg_nodes.append(ir.allocator, try lowerWithMacros(ir, val_expr, null)) catch return CompileError.OutOfMemory;
 

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -344,6 +344,18 @@ pub const IR = struct {
     // pointing that threadlocal at it, so trusting it here risked rooting
     // onto a stale or unrelated GC.
     gc: ?*memory.GC = null,
+    // Pairs on the active lowering path (#2405), keyed on Object address
+    // (stable across collections in this non-moving GC, and holding no
+    // Values so the GC never needs to trace it). A datum-label cycle in
+    // code position recurses through lowerWithMacros on the same pair
+    // forever; membership here means that back-edge. Path membership, not
+    // mere prior visitation: shared-but-acyclic structure (the same `#1=`
+    // sub-datum in two argument positions) renews legitimately, and each
+    // sibling's push/remove is balanced before the next one starts.
+    // Scoped correctly because every caller lowers one expression tree per
+    // IR instance (compile/compileExprViaIR/compileDefineFromIR/the LLVM
+    // emitter's scratch instances each build a fresh IR).
+    lower_path: std.AutoHashMapUnmanaged(usize, void) = .empty,
 
     pub fn init(allocator: std.mem.Allocator) IR {
         return .{
@@ -413,6 +425,7 @@ pub const IR = struct {
             self.freeNode(node);
         }
         self.nodes.deinit(self.allocator);
+        self.lower_path.deinit(self.allocator);
     }
 
     fn freeNode(self: *IR, node: *Node) void {
@@ -626,6 +639,19 @@ pub fn lowerWithMacros(ir: *IR, expr: Value, macros: ?*std.StringHashMap(Value))
     }
 
     if (types.isPair(expr)) {
+        // #2405: a car-side datum-label cycle (`(display #1=(p #1# q))`)
+        // re-enters this function on the same pair at ever-increasing depth
+        // — every recursive position routes through this one funnel — until
+        // the native stack aborts, uncatchably. Membership on the active
+        // path means exactly that back-edge (see IR.lower_path); a cycle
+        // has no leaves to bottom out at, so it is a named compile error,
+        // not an internal one. Quoted data never passes through here —
+        // lowerQuote makes the whole datum a constant without walking it —
+        // so circular *data* keeps working (#1954 controls).
+        const path_key = @intFromPtr(types.toObject(expr));
+        if (ir.lower_path.contains(path_key)) return compiler_mod.circularFormError();
+        ir.lower_path.put(ir.allocator, path_key, {}) catch return CompileError.OutOfMemory;
+        defer _ = ir.lower_path.remove(path_key);
         const node = lowerFormWithMacros(ir, expr, macros) catch |err| {
             // Record the failing form's span for the compile-error reporter.
             // Lowering is post-order, so the innermost pair fails first on the
@@ -839,14 +865,14 @@ fn lowerBegin(ir: *IR, args: Value, macros: ?*std.StringHashMap(Value)) CompileE
         }
     }
 
-    var current = args;
-    while (current != types.NIL) {
-        if (!types.isPair(current)) return CompileError.InvalidSyntax;
-        const form = types.car(current);
+    var walk = compiler_mod.SpineWalk.init(args);
+    while (types.isPair(walk.cur)) : (walk.next()) {
+        if (walk.cyclic()) return compiler_mod.circularFormError();
+        const form = types.car(walk.cur);
         try reserveLiteralDefineSyntax(ir, form, macros, &reserved);
         nodes.append(ir.allocator, try lowerWithMacros(ir, form, macros)) catch return CompileError.OutOfMemory;
-        current = types.cdr(current);
     }
+    if (walk.cur != types.NIL) return CompileError.InvalidSyntax;
     return ir.makeBegin(nodes.items);
 }
 
@@ -962,12 +988,13 @@ fn lowerSet(ir: *IR, args: Value) CompileError!*Node {
 fn lowerList(ir: *IR, args: Value, tag: NodeTag, macros: ?*std.StringHashMap(Value)) CompileError!*Node {
     var nodes: std.ArrayList(*Node) = .empty;
     defer nodes.deinit(ir.allocator);
-    var current = args;
-    while (current != types.NIL) {
-        if (!types.isPair(current)) return CompileError.InvalidSyntax;
-        nodes.append(ir.allocator, try lowerWithMacros(ir, types.car(current), macros)) catch return CompileError.OutOfMemory;
-        current = types.cdr(current);
+    // #2405: and/or bodies are spines — a datum-label cycle spins forever.
+    var walk = compiler_mod.SpineWalk.init(args);
+    while (types.isPair(walk.cur)) : (walk.next()) {
+        if (walk.cyclic()) return compiler_mod.circularFormError();
+        nodes.append(ir.allocator, try lowerWithMacros(ir, types.car(walk.cur), macros)) catch return CompileError.OutOfMemory;
     }
+    if (walk.cur != types.NIL) return CompileError.InvalidSyntax;
     return switch (tag) {
         .and_form => ir.makeAnd(nodes.items),
         .or_form => ir.makeOr(nodes.items),
@@ -981,12 +1008,13 @@ fn lowerCondBody(ir: *IR, args: Value, tag: NodeTag, macros: ?*std.StringHashMap
 
     var nodes: std.ArrayList(*Node) = .empty;
     defer nodes.deinit(ir.allocator);
-    var current = types.cdr(args);
-    while (current != types.NIL) {
-        if (!types.isPair(current)) return CompileError.InvalidSyntax;
-        nodes.append(ir.allocator, try lowerWithMacros(ir, types.car(current), macros)) catch return CompileError.OutOfMemory;
-        current = types.cdr(current);
+    // #2405: when/unless bodies are spines — a datum-label cycle spins forever.
+    var walk = compiler_mod.SpineWalk.init(types.cdr(args));
+    while (types.isPair(walk.cur)) : (walk.next()) {
+        if (walk.cyclic()) return compiler_mod.circularFormError();
+        nodes.append(ir.allocator, try lowerWithMacros(ir, types.car(walk.cur), macros)) catch return CompileError.OutOfMemory;
     }
+    if (walk.cur != types.NIL) return CompileError.InvalidSyntax;
     return switch (tag) {
         .when_form => ir.makeWhen(test_expr, nodes.items),
         .unless_form => ir.makeUnless(test_expr, nodes.items),
@@ -1002,14 +1030,18 @@ fn lowerCall(ir: *IR, expr: Value, macros: ?*std.StringHashMap(Value)) CompileEr
 
     var arg_buf: [256]*Node = undefined;
     var nargs: usize = 0;
-    var arg_list = types.cdr(expr);
-    while (arg_list != types.NIL) {
-        if (!types.isPair(arg_list)) return CompileError.InvalidSyntax;
+    // #2405: a spine cycle (`#0=(display 1 . #0#)`) used to spin this walk
+    // until the 256-argument cap reported KP9001 "internal error"; the
+    // tortoise-and-hare guard names the cycle instead, and finite improper
+    // tails still fail the isPair check exactly as before.
+    var walk = compiler_mod.SpineWalk.init(types.cdr(expr));
+    while (types.isPair(walk.cur)) : (walk.next()) {
+        if (walk.cyclic()) return compiler_mod.circularFormError();
         if (nargs >= 256) return CompileError.InternalLimit;
-        arg_buf[nargs] = try lowerWithMacros(ir, types.car(arg_list), macros);
+        arg_buf[nargs] = try lowerWithMacros(ir, types.car(walk.cur), macros);
         nargs += 1;
-        arg_list = types.cdr(arg_list);
     }
+    if (walk.cur != types.NIL) return CompileError.InvalidSyntax;
 
     return ir.makeCall(op_node, arg_buf[0..nargs]);
 }

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -346,15 +346,11 @@ pub const IR = struct {
     gc: ?*memory.GC = null,
     // Pairs on the active lowering path (#2405), keyed on Object address
     // (stable across collections in this non-moving GC, and holding no
-    // Values so the GC never needs to trace it). A datum-label cycle in
-    // code position recurses through lowerWithMacros on the same pair
-    // forever; membership here means that back-edge. Path membership, not
-    // mere prior visitation: shared-but-acyclic structure (the same `#1=`
-    // sub-datum in two argument positions) renews legitimately, and each
-    // sibling's push/remove is balanced before the next one starts.
-    // Scoped correctly because every caller lowers one expression tree per
-    // IR instance (compile/compileExprViaIR/compileDefineFromIR/the LLVM
-    // emitter's scratch instances each build a fresh IR).
+    // Values so the GC never needs to trace it). STANDALONE lowering only
+    // (no Compiler: the LLVM native backend's scratch instances, IR unit
+    // tests) — lowering inside a Compiler uses the Compiler's shared
+    // code_path so the guard also spans compileQQ's template walk. See
+    // Compiler.code_path and Compiler.code_roots for the two halves.
     lower_path: std.AutoHashMapUnmanaged(usize, void) = .empty,
 
     pub fn init(allocator: std.mem.Allocator) IR {
@@ -643,15 +639,42 @@ pub fn lowerWithMacros(ir: *IR, expr: Value, macros: ?*std.StringHashMap(Value))
         // re-enters this function on the same pair at ever-increasing depth
         // — every recursive position routes through this one funnel — until
         // the native stack aborts, uncatchably. Membership on the active
-        // path means exactly that back-edge (see IR.lower_path); a cycle
-        // has no leaves to bottom out at, so it is a named compile error,
-        // not an internal one. Quoted data never passes through here —
-        // lowerQuote makes the whole datum a constant without walking it —
-        // so circular *data* keeps working (#1954 controls).
+        // path means exactly that back-edge; a cycle has no leaves to
+        // bottom out at, so it is a named compile error, not an internal
+        // one. Quoted data never passes through here — lowerQuote makes the
+        // whole datum a constant without walking it — so circular *data*
+        // keeps working (#1954 controls).
+        //
+        // Review of PR #2413: the path is the Compiler's shared set when
+        // lowering happens inside one (so compileQQ's template walk and
+        // this funnel see each other's spans); the IR-local set still
+        // guards standalone lowering with no Compiler — the LLVM backend's
+        // scratch instances, IR unit tests.
         const path_key = @intFromPtr(types.toObject(expr));
-        if (ir.lower_path.contains(path_key)) return compiler_mod.circularFormError();
-        ir.lower_path.put(ir.allocator, path_key, {}) catch return CompileError.OutOfMemory;
-        defer _ = ir.lower_path.remove(path_key);
+        // The push/pop must straddle lowerFormWithMacros below, so the defer
+        // lives in THIS function's scope — a defer inside either branch block
+        // would pop at the branch's closing brace, before the walk happens.
+        const shared_path = ir.compiler != null;
+        if (shared_path) {
+            // ir.compiler is a *const Compiler (lowering was read-only on it
+            // until now); the code-path bookkeeping is lowering state, so the
+            // mutations go through the chain helpers (which reach the parent
+            // chain's root — a lambda body compiles in a child compiler and
+            // is a descendant of every enclosing unit; review of PR #2413).
+            const c: *compiler_mod.Compiler = @constCast(ir.compiler.?);
+            if (c.codePathContains(path_key)) return compiler_mod.circularFormError();
+            c.codePathPush(path_key);
+        } else {
+            // Standalone lowering with no Compiler: the LLVM native backend's
+            // scratch instances, IR unit tests.
+            if (ir.lower_path.contains(path_key)) return compiler_mod.circularFormError();
+            ir.lower_path.put(ir.allocator, path_key, {}) catch return CompileError.OutOfMemory;
+        }
+        defer if (shared_path) {
+            @constCast(ir.compiler.?).codePathPop(path_key);
+        } else {
+            _ = ir.lower_path.remove(path_key);
+        };
         const node = lowerFormWithMacros(ir, expr, macros) catch |err| {
             // Record the failing form's span for the compile-error reporter.
             // Lowering is post-order, so the innermost pair fails first on the

--- a/src/tests_circular_code.zig
+++ b/src/tests_circular_code.zig
@@ -94,6 +94,54 @@ test "#2405: the passthrough tail fast paths terminate" {
     try expectCircular("#0=(eval (quote 1) . #0#)");
 }
 
+/// Compile `src` and assert only that it fails as a compile error — for
+/// shapes whose exact diagnosis depends on which guard fires first (a
+/// cyclic clause rotation may hit a non-pair clause check before the
+/// tortoise meets). Termination is the contract under test.
+fn expectCompileError(src: []const u8) !void {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try std.testing.expectError(error.CompileError, ctx.vm.eval(src));
+}
+
+test "#2405 review: the SRFI-17 set! target spine is guarded" {
+    // CodeRabbit on PR #2413: the generalized-set! setter desugar walked
+    // the target's operand spine without a guard — this exact form hung.
+    try expectCircular("(set! #0=(f 1 . #0#) 3)");
+}
+
+test "#2405 review: a cyclic syntax-rules pattern is invalid grammar, not a hang" {
+    // The pattern validator's spine loop and recursion had no bounds; a
+    // cyclic pattern is not valid grammar, which is the truthful verdict.
+    try expectCompileError("(define-syntax m (syntax-rules () ((_ #0=(a . #0#)) 1)))");
+}
+
+test "#2405 review: clause-list cycles terminate whatever the clause contents" {
+    // cond/cond-expand/case terminate on a clause list whose own spine
+    // cycles, whatever the clause contents (a matched clause elsewhere in
+    // the rotation only exits early by luck).
+    try expectCircular("(cond . #0=((1 1) . #0#))");
+    try expectCompileError("(case 1 . #0=((2) . #0#))");
+    // The top-level cond-expand selector (vm_eval.selectCondExpandBody)
+    // reports through the VM's own detail channel, not the compiler's —
+    // a separate reporter path with the same named diagnosis.
+    {
+        var ctx: th.TestContext = undefined;
+        try ctx.init();
+        defer ctx.deinit();
+        try std.testing.expectError(error.CompileError, ctx.vm.eval("(cond-expand . #0=((no-such-feature) . #0#))"));
+        try std.testing.expect(std.mem.indexOf(u8, ctx.vm.getErrorDetail(), "circular form in code position") != null);
+    }
+    // A cyclic improper tail after a fixed-arity form's last operand: `if`
+    // historically accepted it silently and compiled garbage; now the
+    // cycle at least is named (extra non-cyclic forms stay accepted).
+    try expectCircular("#0=(if #t 1 . #0#)");
+    // The legacy begin path (passthrough/compileForm) carries the same guard
+    // as the IR's lowerBegin.
+    try expectCompileError("(define-syntax b (syntax-rules () ((_ . xs) (begin . xs)))) (b . #0=(1 . #0#))");
+}
+
 test "#2405 control: quoted circular data still evaluates and prints" {
     var ctx: th.TestContext = undefined;
     try ctx.init();

--- a/src/tests_circular_code.zig
+++ b/src/tests_circular_code.zig
@@ -165,6 +165,44 @@ test "#2405 control: shared-but-acyclic code still compiles" {
     try th.expectEvalTrue("(let ((v #0=#(1 #0#))) (eq? v (vector-ref v 1)))");
 }
 
+test "#2405 review: cycles crossing the lower/emit re-entry boundary are diagnosed" {
+    // baijum's review of PR #2413: lowering a sub-form and emitting its node
+    // are separate phases, and each compileExprViaIR builds a fresh IR — so
+    // a cycle whose back-edge crosses that boundary (`#0=(let ((x #0#)) x)`:
+    // the let's init IS the let) never re-meets itself in one lowering and
+    // used to recurse through compileLet → compileExprViaIR → ... until the
+    // native stack aborted. The guard now spans the boundary on the
+    // Compiler: a root stays live across lower+emit (code_roots, through the
+    // child-compiler chain), and a form embedded in a fresh wrapper
+    // (let-values producers) keeps its own span on the shared lowering path.
+    try expectCircular("(display #0=(let ((x #0#)) x))");
+    try expectCircular("(display #0=(letrec ((x #0#)) x))");
+    try expectCircular("(display #0=(let* ((x #0#)) x))");
+    try expectCircular("(display ((lambda () #0=(lambda () . #0#))))");
+    try expectCircular("(define f #0=(f . #0#))");
+    try expectCircular("(display #0=(cond (#0# #t)))");
+    try expectCircular("(display #0=(do () (#0#) 1))");
+    try expectCircular("(display #0=(let-values (((a) #0#)) a))");
+    // The quasiquote splicing desugar re-wraps a template element as a
+    // fresh `(quasiquote elem)` pair per round — the wrapper's fresh address
+    // hides the repeat, so the element itself carries the span. This used to
+    // bottom out in KP9001.
+    try expectCircular("(display `#0=(x ,@(list 1) #0#))");
+}
+
+test "#2405 review control: shared sub-forms in sibling positions still compile" {
+    // The other half of the same review: an #N= sub-form used in a let init
+    // AND the body renews as a sibling (sequential compile units), which is
+    // legal and must keep working.
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try th.expectEvalTrue("(= 3 (let ((x #1=(+ 1 2))) #1#))");
+    // A lambda body compiled by a CHILD compiler — the parent-chain lookup
+    // must not misread ordinary nesting as a cycle.
+    try th.expectEvalTrue("(= 7 ((lambda () (let ((x 3)) (+ x 4)))))");
+}
+
 test "#2405: the circular-form detail survives to the reporting channel and resets on the next compile" {
     // The diagnosis travels through the threadlocal syntax_error_detail
     // channel, which the compile entry points clear at entry: a failing

--- a/src/tests_circular_code.zig
+++ b/src/tests_circular_code.zig
@@ -1,0 +1,132 @@
+// Regressions for #2405: a circular datum in CODE position (an R7RS 7.1.2
+// datum-label cycle, no macros needed) must be a diagnosed, catchable compile
+// error — "circular form in code position" via the syntax_error_detail
+// channel — never a native-stack abort, a hang, or a KP9001 "internal error".
+//
+// The walks that used to assume acyclic forms live across the compile side:
+// IR lowering (lowerWithMacros recursion for car-side cycles, the arg/body
+// spine walks), the body scanners (scanBodyDefs, spliceLeadingBegins,
+// compileExprSequence), let-syntax's body and bindings, the let/do binding
+// and command walks, quasiquote's template walk, and the passthrough tail
+// fast paths. Each family member below failed differently on `main` (abort,
+// hang, or KP9001); the controls pin the datum shapes that must KEEP working:
+// quoted circular data, vector constants, and shared-but-acyclic structure.
+const std = @import("std");
+const th = @import("testing_helpers.zig");
+const compiler = @import("compiler.zig");
+
+/// Compile `src` and assert it fails as a compile error whose recorded
+/// detail names the circular form. Returns nothing: the VM (and any error
+/// state it holds) is gone once this returns. The detail is read from the
+/// compiler's threadlocal syntax_error_detail channel — the same string the
+/// CLI reporter renders as syntax-error[KP2002].
+fn expectCircular(src: []const u8) !void {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try std.testing.expectError(error.CompileError, ctx.vm.eval(src));
+    const detail = compiler.getSyntaxErrorDetail();
+    if (std.mem.indexOf(u8, detail, "circular form in code position") == null) {
+        std.debug.print("expected circular-form detail, got: {s}\n", .{detail});
+        return error.TestExpectedCircularForm;
+    }
+}
+
+test "#2405 repro A: car-side cycle in an argument is a diagnosed error, not an abort" {
+    // The one-liner from the issue: lowerCall recursed into the same car
+    // edge until the native stack aborted (uncatchable SIGBUS).
+    try expectCircular("(display #1=(p #1# q))");
+}
+
+test "#2405 repro B: spine cycle in an argument names the cycle, not KP9001" {
+    // The arg-spine walk used to spin until the 256-argument cap reported
+    // "internal error"; the tortoise-and-hare guard names the cycle instead.
+    try expectCircular("#0=(display 1 . #0#)");
+}
+
+test "#2405 repro C: a cyclic let-syntax body terminates with the diagnosis" {
+    // compileSyntaxBody's spine walk spun forever compiling an unbounded
+    // instruction stream — the body IS the whole form, so the walk never
+    // reached a non-pair.
+    try expectCircular("#0=(let-syntax () . #0#)");
+}
+
+test "#2405: the body/binding walk family terminates with the diagnosis" {
+    // and/or/when/unless lower eagerly (lowerList/lowerCondBody); the
+    // let-family and lambda bodies bottom out in scanBodyDefs's splice scan;
+    // let/letrec/do bindings walk their binding lists; a begin inside an
+    // argument walks lowerBegin. Each spun or capped into KP9001 on `main`.
+    try expectCircular("#0=(and 1 . #0#)");
+    try expectCircular("#0=(or 1 . #0#)");
+    try expectCircular("#0=(when 1 . #0#)");
+    try expectCircular("#0=(unless 1 . #0#)");
+    try expectCircular("#0=(lambda () . #0#)");
+    try expectCircular("#0=(let ((x 1)) . #0#)");
+    try expectCircular("#0=(let* ((x 1)) . #0#)");
+    try expectCircular("#0=(letrec ((x 1)) . #0#)");
+    try expectCircular("(let #0=((x 1) . #0#) x)");
+    try expectCircular("(letrec #0=((x 1) . #0#) x)");
+    try expectCircular("#0=(do ((i 0 (+ i 1))) ((> i 2)) . #0#)");
+    try expectCircular("(do #0=((i 0) . #0#) (#t) 1)");
+    try expectCircular("(display (begin 1 . #0=(begin 2 . #0#)))");
+}
+
+test "#2405: a cyclic named-let body is rejected by the rename walk" {
+    // renameInBody rebuilds every pair of the named-let body; a cycle has
+    // no leaves to bottom out at, so it recursed forever before the path
+    // set.
+    try expectCircular("(let loop () #0=(loop . #0#))");
+}
+
+test "#2405: cyclic quasiquote templates are rejected, not hung" {
+    // compileQQ rebuilds the template with runtime conses — a cycle has no
+    // finite form — and the splicing desugar's segment walk overflowed as
+    // KP9001. Both now name the cycle.
+    try expectCircular("#0=(quasiquote (1 . #0#))");
+    try expectCircular("(display `(1 . #0=(2 . #0#)))");
+}
+
+test "#2405: the passthrough tail fast paths terminate" {
+    // apply/call-with-values/eval in tail position count their operand
+    // spine first; that count spun forever on a cycle.
+    try expectCircular("#0=(apply + . #0#)");
+    try expectCircular("#0=(call-with-values . #0#)");
+    try expectCircular("#0=(eval (quote 1) . #0#)");
+}
+
+test "#2405 control: quoted circular data still evaluates and prints" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    // The #1954/#1955 printer cycle handling is untouched — quoting makes
+    // the datum a constant, and no code-position walk ever enters it.
+    const value = try ctx.vm.eval("(car (cdr '#0=(zz . #0#)))");
+    try std.testing.expectEqualStrings("zz", @import("types.zig").symbolName(value));
+}
+
+test "#2405 control: shared-but-acyclic code still compiles" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    // Path membership, not prior visitation: the same #1= sub-form used
+    // twice as SIBLINGS renews legitimately on both walks (lowerBegin here,
+    // and the expander shares pattern-variable subtrees the same way).
+    try th.expectEvalTrue("(= 3 (begin #1=(+ 1 2) #1#))");
+    // A vector containing itself is a constant in code position: no walk
+    // enters it, so it compiles and evaluates like any other datum.
+    try th.expectEvalTrue("(let ((v #0=#(1 #0#))) (eq? v (vector-ref v 1)))");
+}
+
+test "#2405: the circular-form detail survives to the reporting channel and resets on the next compile" {
+    // The diagnosis travels through the threadlocal syntax_error_detail
+    // channel, which the compile entry points clear at entry: a failing
+    // compile leaves it set for the reporter, and the next compile starts
+    // clean — no unrelated error can be misreported as a syntax error.
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    try std.testing.expectError(error.CompileError, ctx.vm.eval("(display #1=(p #1# q))"));
+    try std.testing.expect(std.mem.indexOf(u8, compiler.getSyntaxErrorDetail(), "circular form in code position") != null);
+    _ = try ctx.vm.eval("(+ 1 2)");
+    try std.testing.expectEqual(@as(usize, 0), compiler.getSyntaxErrorDetail().len);
+}

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -355,9 +355,22 @@ fn handleTopLevelCondExpand(vm: *VM, clauses_val: Value) VMError!Value {
 /// branch selection without running the body (#2156) — selection is the only
 /// part of a `cond-expand` that is a compile-time question.
 fn selectCondExpandBody(vm: *VM, clauses_val: Value) VMError!Value {
-    var clauses = clauses_val;
-    while (types.isPair(clauses)) : (clauses = types.cdr(clauses)) {
-        const clause = types.car(clauses);
+    // #2405: a datum-label cycle through the clause list with no matching
+    // clause spun this walk forever — the compiler-side twin
+    // (compiler_conditionals.compileCondExpand) is guarded; this top-level
+    // selector needs the same tortoise-and-hare. The named diagnosis is
+    // recorded through the compiler's detail channel so the reporter shows
+    // the cause rather than a bare compile error.
+    var clauses = compiler_mod.SpineWalk.init(clauses_val);
+    while (types.isPair(clauses.cur)) : (clauses.next()) {
+        if (clauses.cyclic()) {
+            // Through the VM's own detail channel: this path reports via the
+            // runtime reporter, which prefers the VM detail over the code's
+            // registry template.
+            vm.setErrorDetail("circular form in code position: the form contains itself (datum-label cycle)", .{});
+            return VMError.CompileError;
+        }
+        const clause = types.car(clauses.cur);
         if (!types.isPair(clause)) return VMError.CompileError;
         const feature_req = types.car(clause);
         const is_else = types.isSymbol(feature_req) and std.mem.eql(u8, types.symbolName(feature_req), "else");
@@ -367,13 +380,15 @@ fn selectCondExpandBody(vm: *VM, clauses_val: Value) VMError!Value {
             return body;
         }
     }
-    if (clauses != types.NIL) return VMError.CompileError;
+    if (clauses.cur != types.NIL) return VMError.CompileError;
     return types.NIL;
 }
 
 // A proper (nil-terminated) list? Used to reject improper clause bodies before
 // splicing them, matching the compiler's rejection of the same malformed form.
+// #2405: a cyclic body is not a proper list — spineCyclic bounds the walk.
 fn isProperList(list: Value) bool {
+    if (compiler_mod.spineCyclic(list)) return false;
     var rest = list;
     while (types.isPair(rest)) rest = types.cdr(rest);
     return rest == types.NIL;

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -10,6 +10,7 @@ test {
     _ = @import("tests_ellipsis.zig");
     _ = @import("tests_macro_chains.zig");
     _ = @import("tests_prescan.zig");
+    _ = @import("tests_circular_code.zig");
     _ = @import("tests_libraries.zig");
     _ = @import("tests_exceptions.zig");
     _ = @import("tests_records.zig");

--- a/tests/scheme/compile/native-circular-code-2405.sh
+++ b/tests/scheme/compile/native-circular-code-2405.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Regression test for #2405 (native tier): a circular datum in CODE position
+# must terminate on every tier. On `main` the three repros from the issue
+# aborted (SIGBUS in ir.tryFoldFromAST) or hung (compileSyntaxBody, the IR
+# arg-spine walks) inside the interpreter; a natively compiled program
+# embedding one of them aborted or hung the same way at run time, because the
+# rejected form is compiled as an eval-fallback whose runtime eval walks the
+# form with the very same passes.
+#
+# After the fix: `kaappi compile` still succeeds for these forms (they are
+# eval-fallback forms, not rejected programs), and the produced binary
+# terminates at run time with a non-zero status — the embedded eval reports
+# the compile error instead of aborting or spinning. The interpreter (the
+# oracle) exits 1 with the KP2002 circular-form diagnosis.
+#
+# Usage: bash tests/scheme/compile/native-circular-code-2405.sh [path-to-kaappi]
+
+set -euo pipefail
+
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+KAAPPI="${1:-$REPO_DIR/zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+ensure_runtime_lib "$REPO_DIR"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+FAIL=0
+
+# Portable bounded run: no `timeout` on macOS. Runs "$@" with stdout/stderr
+# captured, returns 124 on expiry, else the command's status.
+run_bounded() {
+    local out_file="$1"; shift
+    "$@" > "$out_file" 2>&1 &
+    local pid=$!
+    local waited=0
+    while kill -0 "$pid" 2>/dev/null; do
+        if (( waited >= 15 )); then
+            kill -9 "$pid" 2>/dev/null
+            wait "$pid" 2>/dev/null
+            return 124
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    wait "$pid"
+}
+
+check_native_terminates() {
+    local name="$1" src_text="$2"
+    local src="$DIR/$name.scm" bin="$DIR/$name.bin"
+    printf '%s' "$src_text" > "$src"
+
+    local compile_out compile_status=0
+    compile_out="$(cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" 2>&1)" || compile_status=$?
+    if [[ $compile_status -ne 0 || ! -x "$bin" ]]; then
+        echo "FAIL: $name: kaappi compile exited $compile_status: $compile_out"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    # Interpreter is the oracle: exit 1 with the named diagnosis.
+    local interp_out interp_status=0
+    interp_out="$("$KAAPPI_ABS" "$src" 2>&1)" || interp_status=$?
+    if [[ "$interp_status" -ne 1 ]] || ! grep -qF "circular form in code position" <<< "$interp_out"; then
+        echo "FAIL: $name: interpreter oracle wrong (exit $interp_status): $interp_out"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    # The binary must terminate (no hang => 124, no abort => status > 128)
+    # and must not succeed silently either.
+    local run_out run_status=0
+    run_bounded "$DIR/$name.out" "$bin" || run_status=$?
+    if [[ "$run_status" -eq 124 ]]; then
+        echo "FAIL: $name: compiled binary HUNG (killed after 15s)"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if [[ "$run_status" -gt 128 ]]; then
+        echo "FAIL: $name: compiled binary ABORTED (signal $((run_status - 128))): $(cat "$DIR/$name.out")"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if [[ "$run_status" -eq 0 ]]; then
+        echo "FAIL: $name: compiled binary succeeded silently — the cycle was compiled away"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    echo "PASS: $name: interpreter diagnoses (exit 1, KP2002), compiled binary terminates (exit $run_status)"
+}
+
+check_native_terminates repro-a '(display #1=(p #1# q))'
+check_native_terminates repro-b '#0=(display 1 . #0#)'
+check_native_terminates repro-c '#0=(let-syntax () . #0#)'
+
+echo
+echo "=== Results ==="
+if [ "$FAIL" -gt 0 ]; then
+    echo "Failed: $FAIL"
+    echo "CIRCULAR CODE NATIVE REGRESSION DETECTED"
+    exit 1
+fi
+
+echo "All circular-code native-tier tests pass."
+exit 0

--- a/tests/scheme/errors/circular-code-2405.sh
+++ b/tests/scheme/errors/circular-code-2405.sh
@@ -20,12 +20,31 @@ TMPDIR_TESTS="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_TESTS"' EXIT
 
 # <name> <source> — asserts exit 1 plus the KP2002 circular-form diagnosis.
+# The regression class this file pins includes compiler hangs, so every
+# invocation is bounded: a hung run reports as a failed case instead of
+# stalling the suite until an external timeout (CodeRabbit on PR #2413).
+# No `timeout` on macOS — a background run + bounded wait instead.
 check_circular() {
     local name="$1" src="$2"
     printf '%s' "$src" > "$TMPDIR_TESTS/$name.scm"
 
     local output status
-    output=$("$KAAPPI" "$TMPDIR_TESTS/$name.scm" 2>&1) && status=0 || status=$?
+    "$KAAPPI" "$TMPDIR_TESTS/$name.scm" > "$TMPDIR_TESTS/$name.out" 2>&1 &
+    local pid=$! waited=0
+    while kill -0 "$pid" 2>/dev/null; do
+        if (( waited >= 10 )); then
+            kill -9 "$pid" 2>/dev/null
+            wait "$pid" 2>/dev/null
+            echo "FAIL: $name: HUNG (killed after 10s) — the cycle guard regressed"
+            FAIL=$((FAIL + 1))
+            return
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    status=0
+    wait "$pid" || status=$?
+    output="$(cat "$TMPDIR_TESTS/$name.out")"
 
     if [[ "$status" -ne 1 ]]; then
         echo "FAIL: $name: expected exit 1 (diagnosed compile error), got $status — abort, hang-kill, or silent success?"
@@ -58,6 +77,11 @@ check_circular family-lambda '#0=(lambda () . #0#)'
 check_circular family-do '#0=(do ((i 0 (+ i 1))) ((> i 2)) . #0#)'
 check_circular family-quasiquote '(display `(1 . #0=(2 . #0#)))'
 check_circular family-apply-tail '#0=(apply + . #0#)'
+# CodeRabbit on PR #2413: the SRFI-17 generalized set! target spine hung.
+check_circular family-setbang '(set! #0=(f 1 . #0#) 3)'
+# A cyclic improper tail after if's alternate: detection-only, extra
+# non-cyclic forms stay accepted.
+check_circular family-if-tail '#0=(if #t 1 . #0#)'
 
 # The issue's Controls: circular DATA is fine everywhere — quoting makes the
 # datum a constant no code walk enters, and a syntax-rules macro use with a

--- a/tests/scheme/errors/circular-code-2405.sh
+++ b/tests/scheme/errors/circular-code-2405.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# #2405: a circular datum in CODE position (a plain R7RS datum-label cycle,
+# no macros involved). Three one-line repros from the issue, plus the wider
+# family the fix guards:
+#
+#   repro A  (display #1=(p #1# q))   car-side cycle  -> SIGBUS abort
+#   repro B  #0=(display 1 . #0#)     spine cycle     -> KP9001 "internal error"
+#   repro C  #0=(let-syntax () . #0#) body cycle      -> hang
+#
+# Each must instead terminate with exit 1 and the named diagnosis
+# (syntax-error[KP2002] "circular form in code position"). Quoted circular
+# data — the issue's Controls — must keep working everywhere.
+
+set -euo pipefail
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+PASS=0
+FAIL=0
+TMPDIR_TESTS="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TESTS"' EXIT
+
+# <name> <source> — asserts exit 1 plus the KP2002 circular-form diagnosis.
+check_circular() {
+    local name="$1" src="$2"
+    printf '%s' "$src" > "$TMPDIR_TESTS/$name.scm"
+
+    local output status
+    output=$("$KAAPPI" "$TMPDIR_TESTS/$name.scm" 2>&1) && status=0 || status=$?
+
+    if [[ "$status" -ne 1 ]]; then
+        echo "FAIL: $name: expected exit 1 (diagnosed compile error), got $status — abort, hang-kill, or silent success?"
+        echo "output: $output"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if ! grep -qF "KP2002" <<< "$output"; then
+        echo "FAIL: $name: expected the syntax-error code KP2002 in output:"
+        echo "$output"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if ! grep -qF "circular form in code position" <<< "$output"; then
+        echo "FAIL: $name: expected the circular-form diagnosis in output:"
+        echo "$output"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    echo "PASS: $name: exit 1, KP2002, circular-form diagnosis"
+    PASS=$((PASS + 1))
+}
+
+check_circular repro-a '(display #1=(p #1# q))'
+check_circular repro-b '#0=(display 1 . #0#)'
+check_circular repro-c '#0=(let-syntax () . #0#)'
+check_circular family-and '#0=(and 1 . #0#)'
+check_circular family-let '#0=(let ((x 1)) . #0#)'
+check_circular family-lambda '#0=(lambda () . #0#)'
+check_circular family-do '#0=(do ((i 0 (+ i 1))) ((> i 2)) . #0#)'
+check_circular family-quasiquote '(display `(1 . #0=(2 . #0#)))'
+check_circular family-apply-tail '#0=(apply + . #0#)'
+
+# The issue's Controls: circular DATA is fine everywhere — quoting makes the
+# datum a constant no code walk enters, and a syntax-rules macro use with a
+# circular argument expands normally.
+CONTROL="$TMPDIR_TESTS/controls.scm"
+cat > "$CONTROL" <<'EOF'
+(define x '#0=(zz . #0#))
+(write x)
+(newline)
+(define-syntax m (syntax-rules () ((_ x) 'done)))
+(display (m #0=(zz . #0#)))
+(newline)
+EOF
+
+control_output=$("$KAAPPI" "$CONTROL" 2>&1)
+control_status=$?
+if [[ "$control_status" -eq 0 && "$control_output" == *'#0=(zz . #0#)'*done* ]]; then
+    echo "PASS: controls: quoted circular datum prints, syntax-rules circular argument expands"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: controls: expected the quoted cycle to print and 'done', got (exit $control_status):"
+    echo "$control_output"
+    FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "=== Results ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo "CIRCULAR CODE REGRESSION DETECTED"
+    exit 1
+fi
+
+echo "All circular-code tests pass."
+exit 0

--- a/tests/scheme/errors/circular-code-2405.sh
+++ b/tests/scheme/errors/circular-code-2405.sh
@@ -82,6 +82,13 @@ check_circular family-setbang '(set! #0=(f 1 . #0#) 3)'
 # A cyclic improper tail after if's alternate: detection-only, extra
 # non-cyclic forms stay accepted.
 check_circular family-if-tail '#0=(if #t 1 . #0#)'
+# baijum's review of PR #2413: cycles crossing the lower/emit re-entry
+# boundary (a fresh IR per sub-form) aborted or reported KP9001; the guard
+# now spans the boundary on the Compiler, through the child-compiler chain.
+check_circular reentry-let '(display #0=(let ((x #0#)) x))'
+check_circular reentry-lambda '(display ((lambda () #0=(lambda () . #0#))))'
+check_circular reentry-let-values '(display #0=(let-values (((a) #0#)) a))'
+check_circular reentry-qq-splice '(display `#0=(x ,@(list 1) #0#))'
 
 # The issue's Controls: circular DATA is fine everywhere — quoting makes the
 # datum a constant no code walk enters, and a syntax-rules macro use with a
@@ -96,8 +103,11 @@ cat > "$CONTROL" <<'EOF'
 (newline)
 EOF
 
-control_output=$("$KAAPPI" "$CONTROL" 2>&1)
-control_status=$?
+# `set -e` note (review of PR #2413): a plain `out=$(...)` assignment would
+# abort the script on a non-zero child before the FAIL branch could run, so
+# the status is captured with the guarded idiom everywhere.
+control_status=0
+control_output=$("$KAAPPI" "$CONTROL" 2>&1) || control_status=$?
 if [[ "$control_status" -eq 0 && "$control_output" == *'#0=(zz . #0#)'*done* ]]; then
     echo "PASS: controls: quoted circular datum prints, syntax-rules circular argument expands"
     PASS=$((PASS + 1))


### PR DESCRIPTION
Fixes #2405.

## What broke

A datum label (R7RS §7.1.2 `#n=`/`#n#`) in **code position** — no ER macro, no `rename`, just the reader datum — put a genuine cycle into forms that several compile-side walks assumed were acyclic. The three repros from the issue, verified on `main` @ c92284a6:

| Repro | On `main` |
|---|---|
| `(display #1=(p #1# q))` | **SIGBUS abort** — `lowerCall` recursed into the same car edge through `lowerWithMacros` until the native stack overflowed (uncatchable) |
| `#0=(display 1 . #0#)` | terminated, but as `KP9001 internal error` — the arg-spine walk spun until the 256-argument cap |
| `#0=(let-syntax () . #0#)` | **hang** — `compileSyntaxBody`'s body walk spun forever |

Probing further, the same family also hung `and`/`or`/`when` bodies (eager IR spine walks), `lambda` and `let`-family bodies (`scanBodyDefs`'s splice scan), `do` (the capture scan), quasiquote templates, and the `apply`/`call-with-values`/`eval` tail fast paths; `(cond (1 . #0#))` aborted like Repro A.

## The fix

The cycle-aware walk discipline #2403 established in the expander and the `set!` pre-scan, now shared across the compile side:

- **`compiler.SpineWalk`** — Floyd tortoise-and-hare guard for walks that advance exactly one cdr per iteration. Exact and allocation-free; generalizes the inline guard #2403 left in `collectSetTargets`. Applied at the IR arg/body walks (`lowerCall`, `lowerList`, `lowerCondBody`, `lowerBegin`), the body scanners (`scanBodyDefs`, `spliceLeadingBegins`, `compileExprSequence`), `compileSyntaxBody`, the let/do binding walks, `hasUnquoteSplicing`/`compileQQSplicing`, and the passthrough tail fast paths.
- **Active-path sets keyed on Object address** (stable in this non-moving GC; they hold no Values) for walks that recurse through arbitrary sub-form positions: IR lowering's `lowerWithMacros` funnel (one path per `IR` instance — every caller already scopes an instance to one expression tree), begin splicing, named-let renaming, `do`'s capture scan, and `compileQQ` (keying vectors too, since its fresh list wrapper gets a new address per visit). Path **membership**, not prior visitation: shared-but-acyclic structure — the same `#1=` sub-form as siblings — renews legitimately, and the expander's shared pattern-variable subtrees keep compiling unchanged.
- **`compiler.circularFormError`** — the shared diagnosis: catchable `InvalidSyntax` whose recorded `syntax_error_detail` the reporter renders as

  ```
  file:1:10: syntax-error[KP2002]: circular form in code position: the form contains itself (datum-label cycle)
  ```

  instead of an abort, a hang, or `KP9001`.

## Controls (from the issue, all still green)

- `(define x '#0=(zz . #0#))` + `(write x)` ⟹ `#0=(zz . #0#)` — quoting makes the datum a constant no code walk enters; printer cycle detection (#1954) untouched.
- `(m #0=(zz . #0#))` with `syntax-rules` ⟹ `done`.
- Shared-but-acyclic code (`(begin #1=(+ 1 2) #1#)`) still compiles and runs.

The native tier improves for free: these forms still compile (eval-fallback forms), and the binary's embedded eval now reports the compile error and exits 1 instead of aborting or hanging at run time.

## Tests

- Unit: `src/tests_circular_code.zig` — the three repros, the walk family, quasiquote, the tail fast paths, plus controls for quoted data, shared structure, and the detail-channel reset.
- Scheme: `tests/scheme/errors/circular-code-2405.sh` — message + exit pins for nine shapes and the issue's controls.
- Native tier: `tests/scheme/compile/native-circular-code-2405.sh` — interpreter oracle (exit 1, KP2002) and the compiled binary terminates.

Full suites green on the rebased tree (main @ f0937b21): unit **1900/1907** (+7 skip), gc-stress **1907/1907**, run-all **2125/2125**, R7RS **1395/1395**.