### PR TITLE
Guard the case datum list, syntax-rules outer lists, and top-level begin (#2405 follow-up)

### DIFF
--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1239,15 +1239,21 @@ pub fn spineCyclic(start: Value) bool {
     return false;
 }
 
+/// The shared circular-form diagnosis (#2405). One string, so the
+/// compile-time reporters (which render it as `syntax-error[KP2002]`) and the
+/// execution-time top-level handlers in vm_eval (whose reporter maps a VM
+/// CompileError to `error[KP2001]` — the runtime code table, a different
+/// channel by construction) can never drift apart.
+pub const circular_form_message = "circular form in code position: the form contains itself (datum-label cycle)";
+
 /// Diagnose a datum-label cycle met in code position: a catchable
 /// InvalidSyntax whose recorded detail the reporter renders as
 /// `syntax-error[KP2002]` with a named cause. Finite improper lists never
 /// reach this — the spine guards detect cycles only, and existing
 /// `!isPair` checks already reject non-cyclic improper tails.
 pub fn circularFormError() CompileError {
-    const msg = "circular form in code position: the form contains itself (datum-label cycle)";
-    @memcpy(syntax_error_detail[0..msg.len], msg);
-    syntax_error_detail_len = msg.len;
+    @memcpy(syntax_error_detail[0..circular_form_message.len], circular_form_message);
+    syntax_error_detail_len = circular_form_message.len;
     return CompileError.InvalidSyntax;
 }
 

--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -794,13 +794,17 @@ pub fn compileParameterize(self: *Compiler, args: Value, dst: u16, is_tail: bool
     const gc = self.gc;
     const begin_sym = gc.allocSymbol("begin") catch return CompileError.OutOfMemory;
 
-    // Count bindings
+    // Count bindings. #2405 (review of PR #2420): every other binding-list
+    // walk took SpineWalk in #2413; parameterize was the odd one out — a
+    // cyclic bindings list (`(parameterize #0=((p 1) . #0#) ...)`) spun this
+    // count forever. The collect loop below is bounded by binding_count once
+    // this walk terminates.
     var binding_count: usize = 0;
-    var b = bindings;
-    while (b != types.NIL) {
-        if (!types.isPair(b)) return CompileError.InvalidSyntax;
+    var b = compiler_mod.SpineWalk.init(bindings);
+    while (b.cur != types.NIL) : (b.next()) {
+        if (b.cyclic()) return compiler_mod.circularFormError();
+        if (!types.isPair(b.cur)) return CompileError.InvalidSyntax;
         binding_count += 1;
-        b = types.cdr(b);
     }
 
     if (binding_count == 0) {
@@ -817,10 +821,10 @@ pub fn compileParameterize(self: *Compiler, args: Value, dst: u16, is_tail: bool
     var val_exprs: [32]Value = undefined;
     if (binding_count > 32) return CompileError.TooManyLocals;
 
-    b = bindings;
+    b = compiler_mod.SpineWalk.init(bindings);
     var idx: usize = 0;
-    while (b != types.NIL) : (idx += 1) {
-        const binding = types.car(b);
+    while (b.cur != types.NIL) : (b.next()) {
+        const binding = types.car(b.cur);
         if (!types.isPair(binding)) return CompileError.InvalidSyntax;
         param_exprs[idx] = types.car(binding);
         const val_rest = types.cdr(binding);
@@ -843,7 +847,7 @@ pub fn compileParameterize(self: *Compiler, args: Value, dst: u16, is_tail: bool
         const new_name = std.fmt.bufPrint(&new_buf, "%pnew{d}", .{idx}) catch return CompileError.OutOfMemory;
         new_syms[idx] = gc.allocSymbol(new_name) catch return CompileError.OutOfMemory;
 
-        b = types.cdr(b);
+        idx += 1;
     }
 
     // Build the desugared form with collection disabled: every intermediate

--- a/src/compiler_advanced.zig
+++ b/src/compiler_advanced.zig
@@ -202,7 +202,10 @@ pub fn compileCase(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
 
         var body_jumps: std.ArrayList(usize) = .empty;
         defer body_jumps.deinit(self.gc.allocator);
-        var datum_list = datums;
+        // #2405 (CodeRabbit re-review): a cyclic datum list emitted eqv?
+        // comparisons forever — the clause walk's guard does not reach the
+        // datums inside one clause.
+        var datum_list = compiler_mod.SpineWalk.init(datums);
 
         // Allocate 3 contiguous temp registers for eqv? calls:
         // cmp_base (function + result), cmp_base+1 (arg1), cmp_base+2 (arg2)
@@ -212,10 +215,10 @@ pub fn compileCase(self: *Compiler, args: Value, dst: u16, is_tail: bool) Compil
         const cmp_arg1 = try self.allocReg();
         const cmp_arg2 = try self.allocReg();
 
-        while (datum_list != types.NIL) {
-            if (!types.isPair(datum_list)) return CompileError.InvalidSyntax;
-            const datum = types.car(datum_list);
-            datum_list = types.cdr(datum_list);
+        while (datum_list.cur != types.NIL) : (datum_list.next()) {
+            if (!types.isPair(datum_list.cur)) return CompileError.InvalidSyntax;
+            if (datum_list.cyclic()) return compiler_mod.circularFormError();
+            const datum = types.car(datum_list.cur);
 
             const datum_idx = try self.addConstant(datum);
 

--- a/src/compiler_define_syntax.zig
+++ b/src/compiler_define_syntax.zig
@@ -251,7 +251,7 @@ pub fn compileLetSyntax(self: *Compiler, args: Value, dst: u16, is_tail: bool) C
         // transformer free-references; on overflow, fall back to all siblings.
         var free_names: [64][]const u8 = undefined;
         var free_count: usize = 0;
-        const have_free = collectTransformerFreeRefs(transformer, &free_names, &free_count);
+        const have_free = try collectTransformerFreeRefs(transformer, &free_names, &free_count);
         var peer_names_f: std.ArrayList([]const u8) = .empty;
         defer peer_names_f.deinit(self.gc.allocator);
         var peer_vals_f: std.ArrayList(Value) = .empty;
@@ -401,7 +401,7 @@ fn restoreMacros(self: *Compiler, names: [][]const u8, values: []?Value) void {
 /// Collect the free-reference identifier names in a transformer's templates —
 /// identifiers that are neither the rule's pattern variables nor literals.
 /// Returns false on overflow (caller should then treat the set as unknown).
-fn collectTransformerFreeRefs(transformer: Value, out: *[64][]const u8, count: *usize) bool {
+fn collectTransformerFreeRefs(transformer: Value, out: *[64][]const u8, count: *usize) CompileError!bool {
     const tx = types.toObject(transformer).as(types.Transformer);
     var pv_names: [64][]const u8 = undefined;
     var pv_count: usize = 0;
@@ -409,7 +409,7 @@ fn collectTransformerFreeRefs(transformer: Value, out: *[64][]const u8, count: *
         if (!collectSymbols(pat, &pv_names, &pv_count)) return false;
     }
     for (tx.templates[0..tx.num_rules]) |tmpl| {
-        if (!collectFreeRefs(tmpl, pv_names[0..pv_count], tx.literals, out, count)) return false;
+        if (!(try collectFreeRefs(tmpl, pv_names[0..pv_count], tx.literals, out, count))) return false;
     }
     return true;
 }
@@ -424,7 +424,7 @@ fn computeBoundFreeRefs(self: *Compiler, transformer: Value) CompileError!void {
     var cand_names: [64][]const u8 = undefined;
     var cand_count: usize = 0;
     for (tx.templates[0..tx.num_rules]) |tmpl| {
-        if (!collectFreeRefs(tmpl, pv_names[0..pv_count], tx.literals, &cand_names, &cand_count))
+        if (!(try collectFreeRefs(tmpl, pv_names[0..pv_count], tx.literals, &cand_names, &cand_count)))
             return;
     }
     if (cand_count == 0) return;

--- a/src/compiler_define_syntax.zig
+++ b/src/compiler_define_syntax.zig
@@ -834,24 +834,28 @@ pub fn parseSyntaxRules(self: *Compiler, spec: Value, extra_bound: []const []con
     // these loops without rooting the spec first.
     var literals: std.ArrayList(Value) = .empty;
     defer literals.deinit(self.gc.allocator);
-    var lit = literals_list;
-    while (lit != types.NIL) {
-        if (!types.isPair(lit)) return CompileError.InvalidSyntax;
+    // #2405 (CodeRabbit re-review): a cyclic literal or rule list spun these
+    // collection loops forever. SpineWalk is allocation-free, keeping the
+    // no-GC-call constraint documented above.
+    var lit = compiler_mod.SpineWalk.init(literals_list);
+    while (lit.cur != types.NIL) : (lit.next()) {
+        if (!types.isPair(lit.cur)) return CompileError.InvalidSyntax;
+        if (lit.cyclic()) return compiler_mod.circularFormError();
         // A generating macro may splice a user identifier into this spec's
         // literal list (SRFI 257's if-new-var) — unwrap the provenance
         // marker so the literal is the bare identifier.
-        literals.append(self.gc.allocator, expander.unwrapUsertext(types.car(lit))) catch return CompileError.OutOfMemory;
-        lit = types.cdr(lit);
+        literals.append(self.gc.allocator, expander.unwrapUsertext(types.car(lit.cur))) catch return CompileError.OutOfMemory;
     }
 
     var patterns: std.ArrayList(Value) = .empty;
     defer patterns.deinit(self.gc.allocator);
     var templates: std.ArrayList(Value) = .empty;
     defer templates.deinit(self.gc.allocator);
-    var rule = rules;
-    while (rule != types.NIL) {
-        if (!types.isPair(rule)) return CompileError.InvalidSyntax;
-        const r = types.car(rule);
+    var rule = compiler_mod.SpineWalk.init(rules);
+    while (rule.cur != types.NIL) : (rule.next()) {
+        if (!types.isPair(rule.cur)) return CompileError.InvalidSyntax;
+        if (rule.cyclic()) return compiler_mod.circularFormError();
+        const r = types.car(rule.cur);
         if (!types.isPair(r)) return CompileError.InvalidSyntax;
         const rule_pattern = types.car(r);
         // R7RS 4.3.2 (kaappi#2082): the <pattern> grammar admits at
@@ -866,7 +870,6 @@ pub fn parseSyntaxRules(self: *Compiler, spec: Value, extra_bound: []const []con
         const r_rest = types.cdr(r);
         if (r_rest == types.NIL) return CompileError.InvalidSyntax;
         templates.append(self.gc.allocator, types.car(r_rest)) catch return CompileError.OutOfMemory;
-        rule = types.cdr(rule);
     }
 
     if (patterns.items.len == 0) return CompileError.InvalidSyntax;

--- a/src/compiler_macro.zig
+++ b/src/compiler_macro.zig
@@ -644,6 +644,18 @@ fn injectHygGlobalWalk(self: *Compiler, expr: Value, names: []const []const u8, 
 // ---------------------------------------------------------------------------
 
 pub fn collectSymbols(expr: Value, out: *[64][]const u8, count: *usize) bool {
+    return collectSymbolsDepth(expr, out, count, TEMPLATE_WALK_DEPTH_CAP);
+}
+
+/// #2405 (review of PR #2420): patterns of a syntax-rules spec NESTED in a
+/// template reach this walk unvalidated (the spec's own patterns were checked
+/// by validPatternGrammar at parse time; these were not). A depth cap bounds
+/// any cycle: false means "collection failed", the walk's existing
+/// set-unknown degradation.
+const TEMPLATE_WALK_DEPTH_CAP: u32 = 256;
+
+fn collectSymbolsDepth(expr: Value, out: *[64][]const u8, count: *usize, depth: u32) bool {
+    if (depth == 0) return false;
     if (types.isSymbol(expr)) {
         const n = types.symbolName(expr);
         for (out[0..count.*]) |e| {
@@ -655,17 +667,48 @@ pub fn collectSymbols(expr: Value, out: *[64][]const u8, count: *usize) bool {
         return true;
     }
     if (types.isPair(expr)) {
-        if (!collectSymbols(types.car(expr), out, count)) return false;
-        return collectSymbols(types.cdr(expr), out, count);
+        if (!collectSymbolsDepth(types.car(expr), out, count, depth - 1)) return false;
+        return collectSymbolsDepth(types.cdr(expr), out, count, depth - 1);
     }
     return true;
 }
 
-pub fn collectFreeRefs(template: Value, pat_vars: []const []const u8, literals: []const Value, out: *[64][]const u8, count: *usize) bool {
-    return collectFreeRefsWithLocals(template, pat_vars, literals, &.{}, out, count);
+/// #2405 (review of PR #2420): active-path set for the template walk — the
+/// free-ref collector recurses through itself on BOTH car and cdr, so every
+/// pair it visits passes through the function once and a single
+/// address-keyed membership test catches either cycle shape. Fixed-size and
+/// allocation-free like every other buffer in this walk: overflow returns
+/// false (set-unknown degradation), never a wrong error.
+pub const TemplatePath = struct {
+    addrs: [TEMPLATE_WALK_DEPTH_CAP]usize = undefined,
+    len: usize = 0,
+
+    fn contains(self: *const TemplatePath, key: usize) bool {
+        for (self.addrs[0..self.len]) |a| {
+            if (a == key) return true;
+        }
+        return false;
+    }
+
+    /// False when the path is full: the caller degrades, not errors.
+    fn push(self: *TemplatePath, key: usize) bool {
+        if (self.len >= self.addrs.len) return false;
+        self.addrs[self.len] = key;
+        self.len += 1;
+        return true;
+    }
+
+    fn pop(self: *TemplatePath) void {
+        if (self.len > 0) self.len -= 1;
+    }
+};
+
+pub fn collectFreeRefs(template: Value, pat_vars: []const []const u8, literals: []const Value, out: *[64][]const u8, count: *usize) CompileError!bool {
+    var path: TemplatePath = .{};
+    return collectFreeRefsWithLocals(template, pat_vars, literals, &.{}, out, count, &path);
 }
 
-fn collectFreeRefsWithLocals(template: Value, pat_vars: []const []const u8, literals: []const Value, local_binds: []const []const u8, out: *[64][]const u8, count: *usize) bool {
+fn collectFreeRefsWithLocals(template: Value, pat_vars: []const []const u8, literals: []const Value, local_binds: []const []const u8, out: *[64][]const u8, count: *usize, path: *TemplatePath) CompileError!bool {
     if (types.isSymbol(template)) {
         const name = types.symbolName(template);
         for (pat_vars) |pv| {
@@ -687,6 +730,15 @@ fn collectFreeRefsWithLocals(template: Value, pat_vars: []const []const u8, lite
         return true;
     }
     if (!types.isPair(template)) return true;
+    // #2405 (review of PR #2420): a cyclic TEMPLATE aborted or hung the
+    // definition itself — `(syntax-rules () ((_ x) #0=(f #0#)))` SIGBUSed in
+    // this walk before the macro was ever used. The recursion below passes
+    // through this function on both the car (last two lines) and the cdr, so
+    // one active-path membership test here catches both cycle shapes.
+    const path_key = @intFromPtr(types.toObject(template));
+    if (path.contains(path_key)) return compiler_mod.circularFormError();
+    if (!path.push(path_key)) return false; // path full: set-unknown degradation
+    defer path.pop();
     const head = types.car(template);
     const rest = types.cdr(template);
     if (types.isSymbol(head)) {
@@ -704,9 +756,10 @@ fn collectFreeRefsWithLocals(template: Value, pat_vars: []const []const u8, lite
                             let_count += 1;
                         }
                     }
-                    var binds = types.car(bab);
-                    while (types.isPair(binds)) {
-                        const b = types.car(binds);
+                    var binds = compiler_mod.SpineWalk.init(types.car(bab));
+                    while (types.isPair(binds.cur)) : (binds.next()) {
+                        if (binds.cyclic()) return compiler_mod.circularFormError();
+                        const b = types.car(binds.cur);
                         if (types.isPair(b)) {
                             const bname = types.car(b);
                             if (types.isSymbol(bname) and let_count < 16) {
@@ -715,11 +768,10 @@ fn collectFreeRefsWithLocals(template: Value, pat_vars: []const []const u8, lite
                             }
                             const init_rest2 = types.cdr(b);
                             if (init_rest2 != types.NIL and types.isPair(init_rest2))
-                                if (!collectFreeRefsWithLocals(types.car(init_rest2), pat_vars, literals, local_binds, out, count)) return false;
+                                if (!(try collectFreeRefsWithLocals(types.car(init_rest2), pat_vars, literals, local_binds, out, count, path))) return false;
                         }
-                        binds = types.cdr(binds);
                     }
-                    if (!collectFreeRefsWithLocals(types.cdr(bab), pat_vars, literals, let_names[0..let_count], out, count)) return false;
+                    if (!(try collectFreeRefsWithLocals(types.cdr(bab), pat_vars, literals, let_names[0..let_count], out, count, path))) return false;
                 }
             }
             return true;
@@ -734,26 +786,26 @@ fn collectFreeRefsWithLocals(template: Value, pat_vars: []const []const u8, lite
                         lam_count += 1;
                     }
                 }
-                var params = types.car(rest);
-                while (types.isPair(params)) {
-                    const pp = types.car(params);
+                var params = compiler_mod.SpineWalk.init(types.car(rest));
+                while (types.isPair(params.cur)) : (params.next()) {
+                    if (params.cyclic()) return compiler_mod.circularFormError();
+                    const pp = types.car(params.cur);
                     if (types.isSymbol(pp) and lam_count < 16) {
                         lam_names[lam_count] = types.symbolName(pp);
                         lam_count += 1;
                     }
-                    params = types.cdr(params);
                 }
-                if (types.isSymbol(params) and lam_count < 16) {
-                    lam_names[lam_count] = types.symbolName(params);
+                if (types.isSymbol(params.cur) and lam_count < 16) {
+                    lam_names[lam_count] = types.symbolName(params.cur);
                     lam_count += 1;
                 }
-                if (!collectFreeRefsWithLocals(types.cdr(rest), pat_vars, literals, lam_names[0..lam_count], out, count)) return false;
+                if (!(try collectFreeRefsWithLocals(types.cdr(rest), pat_vars, literals, lam_names[0..lam_count], out, count, path))) return false;
             }
             return true;
         }
         if (std.mem.eql(u8, hname, "define")) {
             if (rest != types.NIL and types.isPair(rest))
-                if (!collectFreeRefsWithLocals(types.cdr(rest), pat_vars, literals, local_binds, out, count)) return false;
+                if (!(try collectFreeRefsWithLocals(types.cdr(rest), pat_vars, literals, local_binds, out, count, path))) return false;
             return true;
         }
         if (std.mem.eql(u8, hname, "syntax-rules")) {
@@ -766,21 +818,21 @@ fn collectFreeRefsWithLocals(template: Value, pat_vars: []const []const u8, lite
                         sr_count += 1;
                     }
                 }
-                var sr_rules = types.cdr(rest);
-                while (types.isPair(sr_rules)) {
-                    const sr_rule = types.car(sr_rules);
+                var sr_rules = compiler_mod.SpineWalk.init(types.cdr(rest));
+                while (types.isPair(sr_rules.cur)) : (sr_rules.next()) {
+                    if (sr_rules.cyclic()) return compiler_mod.circularFormError();
+                    const sr_rule = types.car(sr_rules.cur);
                     if (types.isPair(sr_rule)) {
                         if (!collectSymbols(types.car(sr_rule), @ptrCast(&sr_names), &sr_count)) return false;
                     }
-                    sr_rules = types.cdr(sr_rules);
                 }
-                if (!collectFreeRefsWithLocals(rest, pat_vars, literals, sr_names[0..sr_count], out, count)) return false;
+                if (!(try collectFreeRefsWithLocals(rest, pat_vars, literals, sr_names[0..sr_count], out, count, path))) return false;
             }
             return true;
         }
     }
-    if (!collectFreeRefsWithLocals(head, pat_vars, literals, local_binds, out, count)) return false;
-    return collectFreeRefsWithLocals(rest, pat_vars, literals, local_binds, out, count);
+    if (!(try collectFreeRefsWithLocals(head, pat_vars, literals, local_binds, out, count, path))) return false;
+    return collectFreeRefsWithLocals(rest, pat_vars, literals, local_binds, out, count, path);
 }
 
 fn isLetForm(name: []const u8) bool {

--- a/src/tests_circular_code.zig
+++ b/src/tests_circular_code.zig
@@ -190,6 +190,28 @@ test "#2405 review: cycles crossing the lower/emit re-entry boundary are diagnos
     try expectCircular("(display `#0=(x ,@(list 1) #0#))");
 }
 
+test "#2405 review round 2: case datums, syntax-rules outer lists, top-level begin" {
+    // CodeRabbit's re-review of PR #2413 found three more walks in the
+    // family: the datum list inside a case clause, the literals/rules lists
+    // of a syntax-rules spec (before pattern validation ever runs), and the
+    // top-level begin splicer — which compiled AND executed its rotation
+    // forever. The and/or/when/unless and cond-expand feature-operand
+    // findings from the same round do not reproduce: those forms lower
+    // through the guarded IR paths, and a feature-requirement cycle always
+    // rotates through the operator symbol, which evaluates as an
+    // unrecognized (false) feature.
+    try expectCircular("(case 1 (#0=(1 . #0#) (quote a)))");
+    try expectCircular("(define-syntax m (syntax-rules #0=((). #0#) ((_ x) x)))");
+    // The top-level begin reports through the VM's detail channel.
+    {
+        var ctx: th.TestContext = undefined;
+        try ctx.init();
+        defer ctx.deinit();
+        try std.testing.expectError(error.CompileError, ctx.vm.eval("(begin . #0=(1 . #0#))"));
+        try std.testing.expect(std.mem.indexOf(u8, ctx.vm.getErrorDetail(), "circular form in code position") != null);
+    }
+}
+
 test "#2405 review control: shared sub-forms in sibling positions still compile" {
     // The other half of the same review: an #N= sub-form used in a let init
     // AND the body renews as a sibling (sequential compile units), which is

--- a/src/tests_circular_code.zig
+++ b/src/tests_circular_code.zig
@@ -212,6 +212,35 @@ test "#2405 review round 2: case datums, syntax-rules outer lists, top-level beg
     }
 }
 
+test "#2405 review round 3: define-values, parameterize, cyclic syntax-rules TEMPLATES" {
+    // baijum's review of PR #2420: three more members of the family, plus
+    // the one that mattered most — a cyclic TEMPLATE aborted the definition
+    // itself (`((_ x) #0=(f #0#))` SIGBUSed in the free-ref walk, the
+    // uncatchable class #2405 was filed for, from a define-syntax never
+    // used). The free-ref collector now carries the active-path discipline
+    // (its recursion funnels through one function on both car and cdr, so a
+    // single membership test catches both shapes) plus tortoises on the
+    // binding/params/nested-rules spines it iterates directly. The
+    // top-level define-values formals walk reports through the VM detail
+    // channel like the other top-level handlers.
+    try expectCircular("(parameterize #0=((p 1) . #0#) 1)");
+    try expectCircular("(define-syntax m (syntax-rules () ((_ x) #0=(begin . #0#))))");
+    try expectCircular("(define-syntax m (syntax-rules () ((_ x) #0=(f #0#))))");
+    // Nested binding/params walks inside a template.
+    try expectCircular("(define-syntax m (syntax-rules () ((_ x) (let #0=((y 1) . #0#) y))))");
+    try expectCircular("(define-syntax m (syntax-rules () ((_ x) (lambda #0=(a . #0#) 1))))");
+    // Top-level define-values formals — VM detail channel (KP2001 path).
+    {
+        var ctx: th.TestContext = undefined;
+        try ctx.init();
+        defer ctx.deinit();
+        try std.testing.expectError(error.CompileError, ctx.vm.eval("(define-values #0=(a . #0#) (values 1))"));
+        try std.testing.expect(std.mem.indexOf(u8, ctx.vm.getErrorDetail(), "circular form in code position") != null);
+        try std.testing.expectError(error.CompileError, ctx.vm.eval("(define-values (a . #0=(b . #0#)) (values 1 2))"));
+        try std.testing.expect(std.mem.indexOf(u8, ctx.vm.getErrorDetail(), "circular form in code position") != null);
+    }
+}
+
 test "#2405 review control: shared sub-forms in sibling positions still compile" {
     // The other half of the same review: an #N= sub-form used in a let init
     // AND the body renews as a sibling (sequential compile units), which is

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -293,9 +293,16 @@ pub fn runCachedForm(vm: *VM, func_val: Value) VMError!Value {
 
 fn handleTopLevelBegin(vm: *VM, body: Value) VMError!Value {
     var last: Value = types.VOID;
-    var rest = body;
-    while (types.isPair(rest)) {
-        const form = types.car(rest);
+    // #2405 (CodeRabbit re-review): a cyclic top-level begin compiled and
+    // executed its rotation forever — same guard as selectCondExpandBody,
+    // reported through the VM's detail channel.
+    var rest = compiler_mod.SpineWalk.init(body);
+    while (types.isPair(rest.cur)) : (rest.next()) {
+        if (rest.cyclic()) {
+            vm.setErrorDetail("circular form in code position: the form contains itself (datum-label cycle)", .{});
+            return VMError.CompileError;
+        }
+        const form = types.car(rest.cur);
         if (handleTopLevelForm(vm, form)) |result| {
             last = result catch |err| return err;
         } else {
@@ -312,7 +319,6 @@ fn handleTopLevelBegin(vm: *VM, body: Value) VMError!Value {
             // at true top level. func is rooted above, as it requires.
             last = runTopLevelFunction(vm, func) catch |err| return err;
         }
-        rest = types.cdr(rest);
     }
     return last;
 }

--- a/src/vm_eval.zig
+++ b/src/vm_eval.zig
@@ -295,11 +295,15 @@ fn handleTopLevelBegin(vm: *VM, body: Value) VMError!Value {
     var last: Value = types.VOID;
     // #2405 (CodeRabbit re-review): a cyclic top-level begin compiled and
     // executed its rotation forever — same guard as selectCondExpandBody,
-    // reported through the VM's detail channel.
+    // reported through the VM's detail channel. Unlike every compile-time
+    // member of the family, this guard runs DURING execution: up to two
+    // rotations of the cycle genuinely run (and produce output) before the
+    // tortoise meets the hare — inherent to a splicer that evaluates as it
+    // walks, not a "nothing ran" guarantee.
     var rest = compiler_mod.SpineWalk.init(body);
     while (types.isPair(rest.cur)) : (rest.next()) {
         if (rest.cyclic()) {
-            vm.setErrorDetail("circular form in code position: the form contains itself (datum-label cycle)", .{});
+            vm.setErrorDetail("{s}", .{compiler_mod.circular_form_message});
             return VMError.CompileError;
         }
         const form = types.car(rest.cur);
@@ -373,7 +377,7 @@ fn selectCondExpandBody(vm: *VM, clauses_val: Value) VMError!Value {
             // Through the VM's own detail channel: this path reports via the
             // runtime reporter, which prefers the VM detail over the code's
             // registry template.
-            vm.setErrorDetail("circular form in code position: the form contains itself (datum-label cycle)", .{});
+            vm.setErrorDetail("{s}", .{compiler_mod.circular_form_message});
             return VMError.CompileError;
         }
         const clause = types.car(clauses.cur);
@@ -476,16 +480,23 @@ fn handleDefineValues(vm: *VM, args: Value) VMError!Value {
     var fixed_count: usize = 0;
     var has_rest = false;
     {
-        var formal = formals;
-        while (formal != types.NIL) {
-            if (types.isSymbol(formal)) {
+        // #2405 (review of PR #2420): this is the top-level twin of the
+        // compiler's parseDefineValuesFormals — a cyclic formals list
+        // (`(define-values #0=(a . #0#) ...)`) spun it forever. The binding
+        // loop below is bounded by fixed_count once this walk terminates.
+        var formal = compiler_mod.SpineWalk.init(formals);
+        while (formal.cur != types.NIL) : (formal.next()) {
+            if (formal.cyclic()) {
+                vm.setErrorDetail("{s}", .{compiler_mod.circular_form_message});
+                return VMError.CompileError;
+            }
+            if (types.isSymbol(formal.cur)) {
                 has_rest = true;
                 break;
             }
-            if (!types.isPair(formal)) return VMError.CompileError;
-            if (!types.isSymbol(types.car(formal))) return VMError.CompileError;
+            if (!types.isPair(formal.cur)) return VMError.CompileError;
+            if (!types.isSymbol(types.car(formal.cur))) return VMError.CompileError;
             fixed_count += 1;
-            formal = types.cdr(formal);
         }
     }
 

--- a/src/vm_imports.zig
+++ b/src/vm_imports.zig
@@ -115,7 +115,10 @@ fn copyTransformerFreeRefs(
         // of 64 across all rules of the transformer.
         var free_names: [64][]const u8 = undefined;
         var free_count: usize = 0;
-        _ = macro.collectFreeRefs(tmpl, pv_names[0..pv_count], tx.literals, &free_names, &free_count);
+        // #2405: cyclic templates surface as a compile error here; this scan
+        // is best-effort (a `break`-style skip below), so degrade rather than
+        // propagate — the definition site itself reports the named diagnosis.
+        _ = macro.collectFreeRefs(tmpl, pv_names[0..pv_count], tx.literals, &free_names, &free_count) catch break;
         for (free_names[0..free_count]) |fname| {
             if (env.get(fname)) |fval| {
                 try copyOneDefEnvBinding(vm, target, fname, fval, visited, depth);

--- a/tests/scheme/errors/circular-code-2405.sh
+++ b/tests/scheme/errors/circular-code-2405.sh
@@ -19,13 +19,14 @@ FAIL=0
 TMPDIR_TESTS="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_TESTS"' EXIT
 
-# <name> <source> — asserts exit 1 plus the KP2002 circular-form diagnosis.
-# The regression class this file pins includes compiler hangs, so every
-# invocation is bounded: a hung run reports as a failed case instead of
-# stalling the suite until an external timeout (CodeRabbit on PR #2413).
-# No `timeout` on macOS — a background run + bounded wait instead.
+# <name> <source> [code] — asserts exit 1 plus the circular-form diagnosis
+# under the expected code (KP2002 default). The regression class this file
+# pins includes compiler hangs, so every invocation is bounded: a hung run
+# reports as a failed case instead of stalling the suite until an external
+# timeout (CodeRabbit on PR #2413). No `timeout` on macOS — a background run
+# + bounded wait instead.
 check_circular() {
-    local name="$1" src="$2"
+    local name="$1" src="$2" code="${3:-KP2002}"
     printf '%s' "$src" > "$TMPDIR_TESTS/$name.scm"
 
     local output status
@@ -52,8 +53,8 @@ check_circular() {
         FAIL=$((FAIL + 1))
         return
     fi
-    if ! grep -qF "KP2002" <<< "$output"; then
-        echo "FAIL: $name: expected the syntax-error code KP2002 in output:"
+    if ! grep -qF "$code" <<< "$output"; then
+        echo "FAIL: $name: expected the diagnostic code $code in output:"
         echo "$output"
         FAIL=$((FAIL + 1))
         return
@@ -64,8 +65,17 @@ check_circular() {
         FAIL=$((FAIL + 1))
         return
     fi
-    echo "PASS: $name: exit 1, KP2002, circular-form diagnosis"
+    echo "PASS: $name: exit 1, $code, circular-form diagnosis"
     PASS=$((PASS + 1))
+}
+
+# Top-level handlers that fire DURING execution (vm_eval's begin splicer and
+# define-values formals walk) report through the runtime reporter, which maps
+# a VM CompileError to error[KP2001] — same message, different code than the
+# compile-time members' syntax-error[KP2002]. Pinned with the expected code
+# so neither condition can drift unnoticed (baijum, review of PR #2420).
+check_circular_runtime() {
+    check_circular "$1" "$2" KP2001
 }
 
 check_circular repro-a '(display #1=(p #1# q))'
@@ -89,6 +99,24 @@ check_circular reentry-let '(display #0=(let ((x #0#)) x))'
 check_circular reentry-lambda '(display ((lambda () #0=(lambda () . #0#))))'
 check_circular reentry-let-values '(display #0=(let-values (((a) #0#)) a))'
 check_circular reentry-qq-splice '(display `#0=(x ,@(list 1) #0#))'
+# Round-2 shapes (CodeRabbit re-review), pinned here so a guard regression
+# FAILS as a hang-kill instead of stalling the unbounded unit suite.
+check_circular round2-case "(case 1 (#0=(1 . #0#) 'a))"
+check_circular round2-syntax-rules '(define-syntax m (syntax-rules #0=((). #0#) ((_ x) x)))'
+
+# The top-level begin and define-values paths report through the RUNTIME
+# reporter (they fire during execution, not compilation), which maps a VM
+# CompileError to error[KP2001] — same message, different code than every
+# compile-time member's syntax-error[KP2002]. Pinned with the expected code
+# so a future grep -F KP2002 cannot quietly miss them.
+check_circular_runtime round2-toplevel-begin '(begin . #0=(1 . #0#))'
+check_circular_runtime round3-define-values '(define-values #0=(a . #0#) (values 1))'
+# Round-3 (baijum review of PR #2420): parameterize bindings and cyclic
+# syntax-rules TEMPLATES (the template SIGBUS was the abort class #2405 was
+# filed for, from a define-syntax never used).
+check_circular round3-parameterize '(parameterize #0=((p 1) . #0#) 1)'
+check_circular round3-template-begin '(define-syntax m (syntax-rules () ((_ x) #0=(begin . #0#))))'
+check_circular round3-template-car '(define-syntax m (syntax-rules () ((_ x) #0=(f #0#))))'
 
 # The issue's Controls: circular DATA is fine everywhere — quoting makes the
 # datum a constant no code walk enters, and a syntax-rules macro use with a


### PR DESCRIPTION
Follow-up to #2413 (merged as b7b9cc8a): three more walks of the #2405 family, found by CodeRabbit's re-review of the merged PR and each verified to hang on the merged tree before fixing.

## The three real hangs (now terminating with the circular-form diagnosis)

> **Diagnostic code note (baijum, review):** the two *compile-time* walks report `syntax-error[KP2002]`; the top-level `begin` splicer fires **during execution**, so the runtime reporter maps it to `error[KP2001]` — same message (`circular form in code position: …`), different code by construction. Both codes are pinned explicitly in the shell test so neither can drift unnoticed.

| Repro (hangs on b7b9cc8a) | Walk |
|---|---|
| `(case 1 (#0=(1 . #0#) 'a))` | `compileCase`'s **datum list** — the clause walk's guard does not reach the datums inside one clause; it emitted `eqv?` comparisons forever. (CodeRabbit's auto-marker credited dc4bd141 with this one; that was wrong — it still hung there.) |
| `(define-syntax m (syntax-rules #0=((). #0#) ((_ x) x)))` | `parseSyntaxRules`'s **literals/rules collection loops**, which run before pattern validation, so a cyclic literals list never reached `validPatternGrammarDepth`'s bounds. `SpineWalk` is allocation-free, keeping the no-GC-call constraint those loops document. |
| `(begin . #0=(1 . #0#))` | `handleTopLevelBegin` — the top-level begin splicer **compiled and executed** its rotation forever; same guard + VM detail channel as `selectCondExpandBody`. |

## Two findings from the same round that do not reproduce (left unchanged, with the reason)

- **`and`/`or`/`when`/`unless` spines**: those forms lower through the guarded IR paths (`lowerList`/`lowerCondBody`); all four probed shapes return KP2002 (e.g. `(and #0=(#t . #0#))` → `1:6: syntax-error[KP2002]`).
- **`evalFeatureReq` and/or operand walks**: a cond-expand feature requirement's datum-label cycle always rotates through the requirement's own operator symbol, which evaluates as an unrecognized (false) feature — so the operand walk terminates by construction. Every constructed shape tested terminates (e.g. `(cond-expand ((and #0=(srfi-1 . #0#)) 1) (else 2))` → `2`).

## Tests

One new unit test covering all three fixed shapes (the top-level begin case pinned through the VM detail channel). Suites green on this branch: unit filter 22/22, errors shell test 16/16; on the identical tree before cherry-pick: unit 1906/1913 (+7 skip), gc-stress 1913/1913, run-all 2125/2125, R7RS 1395/1395, all 70 probe shapes terminate with no hang and no abort.

Fixes the remaining findings from #2413's review round 2.
