### PR TITLE
Avoid float constant-pool in angleFn on wasm32-wasi (#2421)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1317,6 +1317,14 @@ jobs:
           zig build test -Dtarget=wasm32-wasi
           wasmtime run --dir=. --dir=/tmp zig-out/bin/unit-tests.wasm
 
+      # kaappi#2421: the generic cross build of the real executables
+      # (kaappi + kaappi-lsp, ReleaseSafe) is a different LLVM shape from
+      # both `zig build wasm` (ReleaseSmall) and the unit-test compile gate
+      # above, and it was the only path that hit the un-selectable float
+      # constant-pool in angleFn. Compile-only canary; nothing to run.
+      - name: Generic wasm32-wasi build (ReleaseSafe compile canary, kaappi#2421)
+        run: zig build -Dtarget=wasm32-wasi
+
       - name: Parallel pool test (fiber-degraded, KEP-0002 Phase 5)
         run: wasmtime run --dir=. zig-out/bin/kaappi.wasm tests/wasm/parallel.scm
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1317,14 +1317,6 @@ jobs:
           zig build test -Dtarget=wasm32-wasi
           wasmtime run --dir=. --dir=/tmp zig-out/bin/unit-tests.wasm
 
-      # kaappi#2421: the generic cross build of the real executables
-      # (kaappi + kaappi-lsp, ReleaseSafe) is a different LLVM shape from
-      # both `zig build wasm` (ReleaseSmall) and the unit-test compile gate
-      # above, and it was the only path that hit the un-selectable float
-      # constant-pool in angleFn. Compile-only canary; nothing to run.
-      - name: Generic wasm32-wasi build (ReleaseSafe compile canary, kaappi#2421)
-        run: zig build -Dtarget=wasm32-wasi
-
       - name: Parallel pool test (fiber-degraded, KEP-0002 Phase 5)
         run: wasmtime run --dir=. zig-out/bin/kaappi.wasm tests/wasm/parallel.scm
 
@@ -1348,6 +1340,17 @@ jobs:
 
       - name: WASM cross-tier differential (audit v2, Phase 4D)
         run: bash tests/scheme/differential/run-wasm-differential.sh
+
+      # kaappi#2421: the generic cross build of the real executables
+      # (kaappi + kaappi-lsp, ReleaseSafe) is a different LLVM shape from
+      # both `zig build wasm` (ReleaseSmall) and the unit-test compile gate
+      # above, and it was the only path that hit the un-selectable float
+      # constant-pool in angleFn. Compile-only canary; nothing to run.
+      # Must stay the LAST step: it installs a ReleaseSafe
+      # zig-out/bin/kaappi.wasm over the ReleaseSmall artifact every
+      # wasmtime step and the differential above actually test.
+      - name: Generic wasm32-wasi build (ReleaseSafe compile canary, kaappi#2421)
+        run: zig build -Dtarget=wasm32-wasi
 
   coverage:
     needs: test

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -1670,7 +1670,13 @@ fn angleFn(args: []const Value) PrimitiveError!Value {
     }
     if (types.isFlonum(args[0])) {
         const f = types.toFlonum(args[0]);
-        return makeFlonumVal(std.math.atan2(@as(f64, 0.0), f));
+        // Branch on the sign bit instead of computing atan2(0.0, f): the
+        // constant-zero first argument materialized a float constant-pool
+        // load that LLVM's baseline-wasm ISel cannot select in ReleaseSafe
+        // (kaappi#2421). Bit-exact with atan2(0.0, f) for every input,
+        // including -0.0 (pi), infinities, and NaN (propagated).
+        if (std.math.isNan(f)) return makeFlonumVal(f);
+        return makeFlonumVal(if (std.math.signbit(f)) std.math.pi else 0.0);
     }
     if (types.isBignum(args[0])) {
         return makeFlonumVal(if (bignum_mod.isNegative(args[0])) std.math.pi else 0.0);

--- a/src/tests_numeric.zig
+++ b/src/tests_numeric.zig
@@ -660,3 +660,45 @@ test "string->number accepts the unprefixed decimal spelling of 2^63 (#1921)" {
     try th.expectEvalBool("(string->number \"92233720368547758081abc\")", false);
     try th.expectEvalBool("(string->number \"9223372036854775808.0.0\")", false);
 }
+
+test "angle of real arguments matches atan2(0.0, x) exactly (#2421)" {
+    // The flonum arm of angleFn no longer calls atan2 with a constant-zero
+    // first argument (that constant crashed LLVM's baseline-wasm ISel in
+    // ReleaseSafe); this pins the branch rewrite to atan2's exact results,
+    // sign bits included.
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pos_zero_bits: u64 = @bitCast(@as(f64, 0.0));
+
+    // Positive flonum and +0.0 -> exactly +0.0 (sign bit clear).
+    const pos = try vm.eval("(angle 3.5)");
+    try std.testing.expect(types.isFlonum(pos));
+    try std.testing.expectEqual(pos_zero_bits, @as(u64, @bitCast(types.toFlonum(pos))));
+    const pzero = try vm.eval("(angle 0.0)");
+    try std.testing.expectEqual(pos_zero_bits, @as(u64, @bitCast(types.toFlonum(pzero))));
+
+    // Negative flonum and -0.0 -> pi (atan2(+0.0, -0.0) is +pi).
+    const neg = try vm.eval("(angle -3.5)");
+    try std.testing.expectEqual(std.math.pi, types.toFlonum(neg));
+    const nzero = try vm.eval("(angle -0.0)");
+    try std.testing.expectEqual(std.math.pi, types.toFlonum(nzero));
+
+    // Infinities follow the sign bit like finite values.
+    const pinf = try vm.eval("(angle +inf.0)");
+    try std.testing.expectEqual(pos_zero_bits, @as(u64, @bitCast(types.toFlonum(pinf))));
+    const ninf = try vm.eval("(angle -inf.0)");
+    try std.testing.expectEqual(std.math.pi, types.toFlonum(ninf));
+
+    // NaN propagates.
+    const nan_r = try vm.eval("(angle +nan.0)");
+    try std.testing.expect(std.math.isNan(types.toFlonum(nan_r)));
+
+    // Fixnums keep the existing sign-based rule.
+    const fpos = try vm.eval("(angle 42)");
+    try std.testing.expectEqual(pos_zero_bits, @as(u64, @bitCast(types.toFlonum(fpos))));
+    const fneg = try vm.eval("(angle -42)");
+    try std.testing.expectEqual(std.math.pi, types.toFlonum(fneg));
+}


### PR DESCRIPTION
Closes #2421

## What

`zig build -Dtarget=wasm32-wasi` (the generic ReleaseSafe cross build of both `kaappi` and `kaappi-lsp`) aborted the compiler with:

```
LLVM ERROR: Cannot select: i32 = ConstantPool<float 0.000000e+00> 0
In function: primitives_numeric.angleFn
```

Reproduced on pristine `main` (13fdfd04) with Homebrew zig 0.16.0_1 on aarch64 macOS before touching anything.

## The workaround

The only site in `angleFn` that materializes a float constant is the flonum arm's `std.math.atan2(@as(f64, 0.0), f)`. The arm now branches on the sign bit instead:

- NaN input: propagated (returned through `makeFlonumVal`, which canonicalizes — identical Value to before)
- sign bit set (negative, `-0.0`, `-inf.0`): `pi`
- sign bit clear (positive, `+0.0`, `+inf.0`): `+0.0`

Verified bit-exact against `std.math.atan2(0.0, f)` for all eight sign/zero/inf/NaN cases before rewriting, so `(angle x)` semantics are unchanged — including `(angle -0.0)` = pi and the exact `+0.0` (sign bit clear) for positive arguments. A new unit test in `src/tests_numeric.zig` pins all of these plus the fixnum arm.

This was the only `atan2` call in the tree with a constant float argument; the other six sites all pass runtime values, and the full generic WASI build now succeeds end to end (both executables), so no sibling has the same shape.

## CI canary

`zig build wasm` (ReleaseSmall) and `zig build test -Dtarget=wasm32-wasi` were already green — those are the two shapes CI exercised, which is why this regressed invisibly. The `wasm` job gains a compile-only step building the failing shape, `zig build -Dtarget=wasm32-wasi`, so the generic ReleaseSafe path is now guarded where it matters.

## Verification

- `zig build -Dtarget=wasm32-wasi`: was ABRT at angleFn, now exits 0 (both `kaappi` and `kaappi-lsp`)
- `zig build wasm`: still exits 0
- `zig build test`: 13/13 steps, 1908/1915 tests passed (7 skipped, 0 failed)
- New regression test passes (`-Dtest-filter='angle of real arguments'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)