### PR TITLE
Set FD_CLOEXEC on isocline history/debug files (#2423)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,14 +421,16 @@ It holds a whole form in one buffer, which is why `repl.zig` no longer joins
 continuation lines: `ic_readline` returns a finished expression, newlines
 included, and every line of it stays editable until submit.
 
-**The copy is patched** — four changes, each marked `KAAPPI PATCH` in the
+**The copy is patched** — six changes, each marked `KAAPPI PATCH` in the
 source and documented in `vendor/isocline/PATCHES.md`: an input-completeness
 callback (upstream's Enter always submits), a configurable history size
 (upstream caps at 200), structural s-expression editing — slurp, barf,
 raise, rotate, whose transforms live in `src/repl_sexp.zig` (`docs/dev/repl.md`)
-— and `TCSADRAIN` instead of `TCSAFLUSH` around raw-mode transitions, so a
+— `TCSADRAIN` instead of `TCSAFLUSH` around raw-mode transitions, so a
 multi-line paste that submits partway through doesn't get its still-unread
-tail silently discarded (kaappi#2226). Re-apply all four when updating;
+tail silently discarded (kaappi#2226), click-to-reposition mouse support
+(kaappi#2264), and `FD_CLOEXEC` on the history/debug files so spawned
+children inherit only stdio (kaappi#2423). Re-apply all six when updating;
 `grep -rn 'KAAPPI PATCH' vendor/isocline/` finds every site.
 
 ## Package manager (thottam)

--- a/vendor/isocline/PATCHES.md
+++ b/vendor/isocline/PATCHES.md
@@ -4,7 +4,7 @@ Vendored from <https://github.com/daanx/isocline> at commit
 `8d6dc1ef95b1b46711e66eb23d39d4467a0fcdac` (2026-04-23, v1.1.0), MIT licensed —
 see `LICENSE`.
 
-**This is a patched copy.** Five changes diverge from upstream. Each is marked
+**This is a patched copy.** Six changes diverge from upstream. Each is marked
 in the source with a `KAAPPI PATCH <n>` comment pointing here. When updating
 isocline, re-apply them; `grep -rn 'KAAPPI PATCH' vendor/isocline/` finds every
 site.
@@ -237,6 +237,39 @@ known limitation of the first cut.
 A delayed DSR response arriving *after* its query timed out decodes to
 `KEY_NONE`; the edit loop now ignores `KEY_NONE` in its default case, where
 previously it fell through to `code_is_unicode(0)` and inserted a NUL.
+
+## Patch 6 — close-on-exec on the history and debug files
+
+**Files:** `src/history.c`, `src/common.c`
+
+Upstream opens its files with plain `fopen`, whose descriptors are inheritable
+across `exec`. Four sites: the history file read (`history_load`) and
+write/truncate (`history_save`) in `history.c`, and the `IC_DEBUG_TO_FILE`
+debug log's create-probe and per-message append in `common.c` (debug builds
+only).
+
+Every one of these handles is transient — each `fopen` is paired with an
+`fclose` in the same function, so the fd exists only for the duration of one
+load/save/log call. But the host (Kaappi's `spawn-process`, KEP-0022) promises
+that a child inherits only the three stdio slots, and a spawn racing one of
+these windows from another thread would hand the child the fd on Linux
+(macOS is separately covered by `POSIX_SPAWN_CLOEXEC_DEFAULT`). The patch
+adds, after each successful `fopen`:
+
+```c
+#ifndef _WIN32
+fcntl(fileno(f), F_SETFD, FD_CLOEXEC);
+#endif
+```
+
+plus the matching `<fcntl.h>`/`<unistd.h>` includes, all guarded for POSIX —
+Windows has no `fcntl`, and its `CreateProcess` handle inheritance is opt-in
+per handle anyway. (`fopen("...e")` and `open(O_CLOEXEC)+fdopen` were
+rejected: the `"e"` mode flag is glibc-specific, and reshaping the open calls
+is a bigger diff to re-apply than a post-open `fcntl`.) The wasm32-wasi build
+never compiles isocline (`use_isocline = !is_wasm_target` in `build.zig`), so
+no WASI guard is needed. Fixes kaappi#2423; found by the KEP-0022 CLOEXEC
+audit (kaappi#2414).
 
 ## Deliberately not patched
 

--- a/vendor/isocline/src/common.c
+++ b/vendor/isocline/src/common.c
@@ -9,6 +9,10 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
+#ifndef _WIN32
+#include <fcntl.h>   // KAAPPI PATCH 6: FD_CLOEXEC on the IC_DEBUG file
+#include <unistd.h>
+#endif
 #include "common.h"
 
 
@@ -282,6 +286,10 @@ ic_private void debug_msg(const char* fmt, ...) {
     if (rdebug!=NULL && strcmp(rdebug,"1") == 0) {
       FILE* fdbg = fopen(debug_fname, "w");
       if (fdbg!=NULL) {
+        // KAAPPI PATCH 6: see vendor/isocline/PATCHES.md — close-on-exec
+        #ifndef _WIN32
+        fcntl(fileno(fdbg), F_SETFD, FD_CLOEXEC);
+        #endif
         debug_init = 1;
         fclose(fdbg);
       }
@@ -292,6 +300,11 @@ ic_private void debug_msg(const char* fmt, ...) {
   // write debug messages
   FILE* fdbg = fopen(debug_fname, "a");
   if (fdbg==NULL) return;
+  // KAAPPI PATCH 6: see vendor/isocline/PATCHES.md — close-on-exec, so a
+  // child spawned from the host never inherits the debug-log fd.
+  #ifndef _WIN32
+  fcntl(fileno(fdbg), F_SETFD, FD_CLOEXEC);
+  #endif
   va_list args;
   va_start(args, fmt);
   vfprintf(fdbg, fmt, args);

--- a/vendor/isocline/src/history.c
+++ b/vendor/isocline/src/history.c
@@ -7,6 +7,10 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
+#ifndef _WIN32
+#include <fcntl.h>   // KAAPPI PATCH 6: FD_CLOEXEC on the history file
+#include <unistd.h>
+#endif
 
 #include "../include/isocline.h"
 #include "common.h"
@@ -252,6 +256,11 @@ ic_private void history_load( history_t* h ) {
   if (h->fname == NULL) return;
   FILE* f = fopen(h->fname, "r");
   if (f == NULL) return;
+  // KAAPPI PATCH 6: see vendor/isocline/PATCHES.md — close-on-exec, so a
+  // child spawned from the host never inherits the history fd.
+  #ifndef _WIN32
+  fcntl(fileno(f), F_SETFD, FD_CLOEXEC);
+  #endif
   stringbuf_t* sbuf = sbuf_new(h->mem);
   if (sbuf != NULL) {
     while (!feof(f)) {
@@ -267,6 +276,9 @@ ic_private void history_save( const history_t* h ) {
   FILE* f = fopen(h->fname, "w");
   if (f == NULL) return;
   #ifndef _WIN32
+  // KAAPPI PATCH 6: see vendor/isocline/PATCHES.md — close-on-exec, so a
+  // child spawned from the host never inherits the history fd.
+  fcntl(fileno(f), F_SETFD, FD_CLOEXEC);
   chmod(h->fname,S_IRUSR|S_IWUSR);
   #endif
   stringbuf_t* sbuf = sbuf_new(h->mem);


### PR DESCRIPTION
Closes #2423

## What

Adds **KAAPPI PATCH 6** to the vendored isocline copy: after each successful `fopen`, set close-on-exec with `fcntl(fileno(f), F_SETFD, FD_CLOEXEC)`, guarded `#ifndef _WIN32` (Windows has no `fcntl`, and its `CreateProcess` handle inheritance is opt-in per handle anyway). The wasm32-wasi build never compiles isocline (`use_isocline = !is_wasm_target` in `build.zig`), so no WASI guard is needed.

Patched sites (all four the issue names, verified against source):

| Site | What it opens |
|------|---------------|
| `vendor/isocline/src/history.c` `history_load` | history file, read (`fopen(..., "r")`) |
| `vendor/isocline/src/history.c` `history_save` | history file, write/truncate (`fopen(..., "w")`) |
| `vendor/isocline/src/common.c` `debug_msg` (init probe) | `IC_DEBUG_TO_FILE` log, `"w"` — debug builds only |
| `vendor/isocline/src/common.c` `debug_msg` (per message) | `IC_DEBUG_TO_FILE` log, `"a"` — debug builds only |

Each site carries a `// KAAPPI PATCH 6` marker in the style of the existing patches, and the patch is documented in `vendor/isocline/PATCHES.md` so it is re-applied on the next vendor update. `CLAUDE.md`'s patch count is also brought up to date (it still said four; main already carried five with the mouse patch).

## Real exposure window

Contrary to a first read of the issue, **every one of these handles is transient** — each `fopen` is paired with an `fclose` in the same function, including the `IC_DEBUG` `"a"` handle, which is reopened and closed per `debug_msg` call rather than kept open. So the descriptor never persists across a REPL evaluation: the exposure is a `spawn-process` racing one of those brief open windows from another thread. Narrow, but real on Linux once KEP-0022 lands (macOS is separately masked by `POSIX_SPAWN_CLOEXEC_DEFAULT`), and setting the flag is correct hygiene either way.

## Regression testing

No test is added, deliberately: because every fd here is closed before the isocline API call returns, `FD_CLOEXEC` on it cannot be observed from outside the open/close window without interposition (LD_PRELOAD or source instrumentation) — every option I considered was contrived. The issue's acceptance probe uses `spawn-process`, which does not exist on main yet; the **KEP-0022 Phase 1 fd-hygiene suite (#2414) is the designated end-to-end regression guard** for this once that branch lands (see also the audit trail in #2423).

## Verification

- `zig build` — succeeds
- `zig build -Dtarget=x86_64-windows` — succeeds (exercises the `#ifndef _WIN32` guard)
- `zig build wasm` — succeeds
- REPL smoke: piped eval works; a pty-driven session (fresh `KAAPPI_HOME`) saves and reloads history through the patched `history_save`/`history_load` paths
- `zig build test` — 13/13 steps, 1908/1915 tests passed, 7 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
