### PR TITLE
Pin er-macro keyword reuse across evals; drop q2388- workaround prefixes (#2400)

### DIFF
--- a/src/tests_macros_procedural.zig
+++ b/src/tests_macros_procedural.zig
@@ -67,37 +67,40 @@ test "SRFI 211: compare answers free-identifier equality for else" {
 // reserved (bare-rename) and renamed (global-name) keyword shapes, while
 // an unshadowed use still compares equal. End-to-end parity against a
 // syntax-rules cond-style transformer is pinned in
-// tests/scheme/srfi/srfi211.scm (KEP-0018 UQ6). The macro names carry a
-// q2388- prefix because a vm.eval'd define-syntax re-using a keyword
-// already defined by an earlier test in this process trips a pre-existing
-// quirk unrelated to compare (kaappi#2400).
+// tests/scheme/srfi/srfi211.scm (KEP-0018 UQ6). These tests deliberately
+// re-use keyword spellings that earlier tests in this same process already
+// defined (`is-else?` above): kaappi#2400 reported that such reuse could
+// fail with a bare CompileError, which is why they originally carried
+// q2388- prefixes — the report never reproduced on any landed commit, so
+// the shared spellings now stand as the regression pin (see the
+// "keyword reuse scenario sweep" test below).
 test "SRFI 211: compare refuses a locally rebound keyword spelling (#2388)" {
     try th.expectEvalTrue(
         \\(begin
-        \\  (define-syntax q2388-else?
+        \\  (define-syntax is-else?
         \\    (er-macro-transformer
         \\     (lambda (form rename compare)
         \\       (list (rename 'quote) (compare (car (cdr form)) (rename 'else))))))
-        \\  (define-syntax q2388-arrow?
+        \\  (define-syntax is-arrow?
         \\    (er-macro-transformer
         \\     (lambda (form rename compare)
         \\       (list (rename 'quote) (compare (car (cdr form)) (rename '=>))))))
-        \\  (and (q2388-else? else)
-        \\       (q2388-arrow? =>)
-        \\       (not (let ((else 1)) (q2388-else? else)))
-        \\       (not (let ((=> 1)) (q2388-arrow? =>)))))
+        \\  (and (is-else? else)
+        \\       (is-arrow? =>)
+        \\       (not (let ((else 1)) (is-else? else)))
+        \\       (not (let ((=> 1)) (is-arrow? =>)))))
     );
 }
 
 test "SRFI 211: compare refuses a locally rebound rename of a global name (#2388)" {
     try th.expectEvalTrue(
         \\(begin
-        \\  (define-syntax q2388-values?
+        \\  (define-syntax is-values?
         \\    (er-macro-transformer
         \\     (lambda (form rename compare)
         \\       (list (rename 'quote) (compare (car (cdr form)) (rename 'values))))))
-        \\  (and (q2388-values? values)
-        \\       (not (let ((values 1)) (q2388-values? values)))))
+        \\  (and (is-values? values)
+        \\       (not (let ((values 1)) (is-values? values)))))
     );
 }
 
@@ -108,13 +111,13 @@ test "SRFI 211: compare refuses a locally rebound rename of a global name (#2388
 test "SRFI 211: compare stays reflexive on plain use-site tokens (#2388)" {
     try th.expectEvalTrue(
         \\(begin
-        \\  (define-syntax q2388-tok=?
+        \\  (define-syntax is-tok=?
         \\    (er-macro-transformer
         \\     (lambda (form rename compare)
         \\       (list (rename 'quote)
         \\             (compare (car (cdr form)) (car (cddr form)))))))
-        \\  (and (q2388-tok=? vv vv)
-        \\       (let ((vv 1)) (q2388-tok=? vv vv))))
+        \\  (and (is-tok=? vv vv)
+        \\       (let ((vv 1)) (is-tok=? vv vv))))
     );
 }
 
@@ -126,15 +129,15 @@ test "SRFI 211: compare stays reflexive on plain use-site tokens (#2388)" {
 test "SRFI 211: a macro-introduced keyword stays hygienic under shadowing (#2388)" {
     try th.expectEvalTrue(
         \\(begin
-        \\  (define-syntax q2388-arrow2?
+        \\  (define-syntax is-arrow2?
         \\    (er-macro-transformer
         \\     (lambda (form rename compare)
         \\       (list (rename 'quote) (compare (car (cdr form)) (rename '=>))))))
-        \\  (define-syntax q2388-probe
+        \\  (define-syntax is-probe
         \\    (er-macro-transformer
         \\     (lambda (form rename compare)
-        \\       (list 'q2388-arrow2? (rename '=>)))))
-        \\  (and (q2388-probe) (let ((=> 1)) (q2388-probe))))
+        \\       (list 'is-arrow2? (rename '=>)))))
+        \\  (and (is-probe) (let ((=> 1)) (is-probe))))
     );
 }
 
@@ -474,6 +477,96 @@ test "#2403: a transformer's guard catches the circular-datum rejection" {
         \\         (rename (car (cdr form)))))))
         \\  (eq? 'caught (g #0=(zz . #0#))))
     );
+}
+
+// ---------------------------------------------------------------------------
+// #2400: a vm.eval'd define-syntax re-using an er-macro keyword spelling
+// already defined by an earlier eval in the same process was reported to
+// fail with a bare CompileError and an empty syntax_error_detail. The
+// report never reproduced on any landed commit (verified at the
+// issue-era main tip, at the #2401 merge, and on current main — full
+// suites, gc-stress, CLI, and the (scheme eval) path); the sweep below
+// pins the correct behavior for every reuse shape the report implicated,
+// so a regression in this area fails loudly with a labeled scenario.
+// ---------------------------------------------------------------------------
+
+const repro2400_snippet =
+    \\(begin
+    \\  (define-syntax is-else?
+    \\    (er-macro-transformer
+    \\     (lambda (form rename compare)
+    \\       (list (rename 'quote) (compare (car (cdr form)) (rename 'else))))))
+    \\  (define-syntax is-arrow?
+    \\    (er-macro-transformer
+    \\     (lambda (form rename compare)
+    \\       (list (rename 'quote) (compare (car (cdr form)) (rename '=>))))))
+    \\  (and (is-else? else)
+    \\       (is-arrow? =>)
+    \\       (not (let ((else 1)) (is-else? else)))
+    \\       (not (let ((=> 1)) (is-arrow? =>)))))
+;
+
+fn repro2400Expect(vm: *th.VM, label: []const u8) !void {
+    const result = vm.eval(repro2400_snippet) catch |err| {
+        std.debug.print("\nrepro2400[{s}] FAILED: {any}; detail='{s}' vmdetail='{s}'\n", .{ label, err, compiler.getSyntaxErrorDetail(), vm.getErrorDetail() });
+        return err;
+    };
+    if (result != types.TRUE) {
+        std.debug.print("\nrepro2400[{s}] wrong value: 0x{x}\n", .{ label, result });
+        return error.TestUnexpectedResult;
+    }
+}
+
+test "#2400: er keyword-spelling reuse across evals and VMs (scenario sweep)" {
+    // (1) prior er define+use in another VM
+    {
+        var a: th.TestContext = undefined;
+        try a.init();
+        defer a.deinit();
+        _ = try a.vm.eval(
+            \\(begin
+            \\  (define-syntax is-else?
+            \\    (er-macro-transformer
+            \\     (lambda (form rename compare)
+            \\       (list (rename 'quote) (compare (car (cdr form)) (rename 'else))))))
+            \\  (and (is-else? else) (not (is-else? other))))
+        );
+    }
+    {
+        var b: th.TestContext = undefined;
+        try b.init();
+        defer b.deinit();
+        try repro2400Expect(b.vm, "fresh-vm-after-er-define");
+        // (2) same VM, immediate re-eval: er keyword redefines er keyword
+        try repro2400Expect(b.vm, "same-vm-redefine");
+        // (3) same VM: separate evals — defines first, use later
+        _ = try b.vm.eval(
+            \\(define-syntax is-else?
+            \\  (er-macro-transformer
+            \\   (lambda (form rename compare)
+            \\     (list (rename 'quote) (compare (car (cdr form)) (rename 'else))))))
+        );
+        try repro2400Expect(b.vm, "same-vm-after-separate-define");
+    }
+    // (4) prior syntax-rules define of the same keyword in another VM,
+    // then er redefinition over syntax-rules in the SAME VM
+    {
+        var c: th.TestContext = undefined;
+        try c.init();
+        defer c.deinit();
+        _ = try c.vm.eval("(define-syntax is-else? (syntax-rules () ((_ x) 'sr)))");
+        _ = try c.vm.eval("(define-syntax is-arrow? (syntax-rules () ((_ x) 'sr)))");
+        try repro2400Expect(c.vm, "same-vm-er-over-syntax-rules");
+    }
+    {
+        var d: th.TestContext = undefined;
+        try d.init();
+        defer d.deinit();
+        try repro2400Expect(d.vm, "fresh-vm-after-sr-define");
+        // (5) prior plain-variable binding of the spelling, then redefine
+        _ = try d.vm.eval("(define is-else2x 1)");
+        try repro2400Expect(d.vm, "after-unrelated-define");
+    }
 }
 
 test "#2403: shared-but-acyclic datum still renames (no false cycle)" {


### PR DESCRIPTION
Closes #2400

## Not reproducible on any landed commit — pinned instead

#2400 reported that a `vm.eval`'d `define-syntax` re-using an er-macro keyword spelling already defined by an earlier eval in the same process can fail with a bare `CompileError` and an empty `syntax_error_detail`. After an investigation-first pass, the failure did not reproduce in any configuration on any landed commit, and the audit found no mechanism that could produce it — so this PR ships the pin, not a fix: it strips the `q2388-` workaround prefixes from the #2388 tests (the shared spellings themselves now exercise the reported hazard on every suite run) and adds a labeled scenario-sweep regression test for every reuse shape the report implicated.

## Negative repro matrix

The issue's exact snippet, evaluated through `vm.eval` in a fresh `TestContext`:

| Commit | Configuration | Result |
|---|---|---|
| `5e1680f2` (main tip when #2400 was filed) | snippet test at the reporter's exact file position, after the pre-existing `is-else?` test; `-Dtest-filter="SRFI 211"` subset, full suite, and `-Dgc-stress=true` subset | passes (`#f` under the old name-based compare — the same value the issue's own CLI check got; never `CompileError`) |
| `a12406bd` (the #2401 merge) | all five #2388 tests with the `q2388-` prefixes stripped; subset and full suite | all green |
| current main | same un-prefixing; full suite; 7-scenario sweep; CLI and the `(scheme eval)` path after a same-process prior definition of the same keyword (isolated `KAAPPI_HOME`) | all green, snippet yields `#t` |

The sweep covers: fresh-VM eval after a prior VM defined+expanded the same er keyword; same-VM immediate re-eval (er redefining er); same-VM separate-eval define then use; er redefinition over a prior `syntax-rules` macro of the same name; fresh VM after a `syntax-rules` definition; and eval after unrelated defines. Each scenario is labeled, so a future regression fails loudly with the scenario named.

## Audit conclusion

No name-keyed state survives a VM in a way that could carry this failure:

- The `globals.zig` hook pointers (`eval_datum_for_macro`, `call_proc_for_macro`, …) are process-global, but every one dereferences the `vm_instance` threadlocal, which `vm.eval` resets on entry and `th.makeTestVM` resets at init — no dead-VM capture.
- The expander threadlocals (`scope_table`, `er_scope`/`er_globals`/`er_macros`, `active_def_env`, `er_input_slot`) are save/restored by `defer` on success and error alike, and `scope_table` entries are keyed by process-monotonic scope ids (`next_scope_id`, atomic) that are never reused — the scope comparison short-circuits before a stale entry's (potentially dangling) name slice is even read.
- Everything name-keyed (`vm.macros`, `vm.globals`, symbol interning) is per-VM and dies with it; a grep of every file-scope `var`/`threadlocal` in `src/` turned up nothing else.

## Probable explanation

The failure was observed in the mid-#2388 working tree. The issue's "reproduces on origin/main" cross-check stashed **only `src/expander.zig`**, while the #2388 work touched multiple files — so the cross-check ran a mixed tree, and the keyword-spelling correlation was most plausibly an artifact of that WIP state rather than of any landed commit.

If the failure resurfaces with a reproduction on a clean landed commit, reopen #2400 — the sweep test's labels should say exactly which reuse shape broke.

## Testing

- `zig build test` — full suite green: 1821 pass, 7 skip (unit), 88 pass (thottam), including the new sweep test with all prefixes stripped.
- CLI + `(scheme eval)` check: the snippet prints `#t` after a same-process prior definition of `is-else?`, with an isolated `KAAPPI_HOME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
