### PR TITLE
Wake cross-thread SRFI-18 waits with the reactor notifier (#2395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   test id (16 storage-class rows re-use one id) can no longer hide behind a
   documented divergence.
 
+### Fixed
+
+- **A "never" reactor deadline no longer fails the poll** (#2395) — SRFI-18
+  reads `+inf.0` as "never times out" and saturates it to a maxInt-nanosecond
+  deadline ~585 years out; handed to `kevent` as a timespec that far ahead,
+  macOS rejected the call and the park surfaced as `KP9002: out of memory`
+  instead of blocking. `(thread-sleep! 1e18)` raised instead of sleeping. The
+  reactor now clamps a single blocking wait to 24 hours, well inside every
+  backend's range, and re-loops.
+
 ### Changed
 
+- **Cross-thread SRFI-18 waits are woken by the reactor notifier instead of a
+  1 ms poll** (#2395, KEP-0002 unresolved question 3) — `thread-join!` on a
+  running OS thread, `mutex-lock!` and condition-variable waits contended
+  across threads, and a `thread-sleep!` that must still observe
+  `thread-terminate!`, all used to re-check their own state every
+  millisecond. They now enrol in a per-thread registry and are rung awake by
+  whichever thread performs the state change (unlock, signal/broadcast,
+  terminate, or thread exit), the same mechanism promoted channels already
+  used. A `(thread-sleep! 60)` on a child thread costs one wakeup rather than
+  60,000, and a cross-thread hand-off is delivered in a syscall rather than
+  within a millisecond. Two behaviour changes fall out of the timed
+  `thread-join!` no longer being a whole-thread `nanosleep`: this thread's
+  own fibers now run while it is parked (so a fiber can start a `make-thread`
+  handle another fiber is joining, and joining a never-started handle with no
+  timeout reports a deadlock instead of hanging forever), and a timed
+  `thread-join!` from inside a SRFI 181 custom-port callback is now rejected
+  with the same catchable error every other blocking primitive raises there
+  (#2000).
 - **SRFI 231 c64/c128 array bodies use the reference implementation's
   interleaved-float representation** (#2382) — an `f32vector`/`f64vector`
   of twice the logical length holding real/imaginary pairs, instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   that, and a timed wait's deadline timer keeps the reactor busy, so the wait
   never re-evaluated: the remote unlock or signal reached nobody and the wait
   ran to its deadline. `(mutex-lock! m 2)` returned `#f` after 2.002s for an
-  unlock that happened at 0.1s. Present on main too (the pre-existing 1 ms
-  poll cap was decided the same way, once).
+  unlock that happened at 0.1s. These waits now enrol **unconditionally**,
+  before the first park, rather than re-evaluating the condition afterwards —
+  re-evaluation would not help, because the first park is already unbounded
+  and nothing brings control back to the retry loop that could re-check.
+  Present on main too (the pre-existing 1 ms poll cap was decided the same
+  way, once).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   instead of blocking. `(thread-sleep! 1e18)` raised instead of sleeping. The
   reactor now clamps a single blocking wait to 24 hours, well inside every
   backend's range, and re-loops.
+- **A cross-thread hand-off is no longer missed when the wait becomes
+  cross-thread after it parks** (#2395) — `mutex-lock!`, the
+  condition-variable wait and `thread-sleep!` decided whether another OS
+  thread could resolve them once, on entry. A sibling fiber dispatched by the
+  wait's own scheduler drive can start the process's *first* OS thread after
+  that, and a timed wait's deadline timer keeps the reactor busy, so the wait
+  never re-evaluated: the remote unlock or signal reached nobody and the wait
+  ran to its deadline. `(mutex-lock! m 2)` returned `#f` after 2.002s for an
+  unlock that happened at 0.1s. Present on main too (the pre-existing 1 ms
+  poll cap was decided the same way, once).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `thread-terminate!`, all used to re-check their own state every
   millisecond. They now enrol in a per-thread registry and are rung awake by
   whichever thread performs the state change (unlock, signal/broadcast,
-  terminate, or thread exit), the same mechanism promoted channels already
-  used. A `(thread-sleep! 60)` on a child thread costs one wakeup rather than
+  terminate, or thread exit) — the same mechanism that promoted channels
+  already use. A `(thread-sleep! 60)` on a child thread costs one wakeup rather than
   60,000, and a cross-thread hand-off is delivered in a syscall rather than
   within a millisecond. Two behaviour changes fall out of the timed
   `thread-join!` no longer being a whole-thread `nanosleep`: this thread's

--- a/docs/dev/fibers-and-reactor.md
+++ b/docs/dev/fibers-and-reactor.md
@@ -40,6 +40,73 @@ called from inside a SRFI 181 callback is rejected with a catchable error
 instead of recursively driving the scheduler. See the SRFI 181 section of
 `docs/dev/srfi-implementation-notes.md`.
 
+## Cross-thread wakeups (kaappi#2395)
+
+Each `Reactor` owns a `ThreadNotifier` (KEP-0002 §5) — a kqueue `EVFILT.USER`
+trigger, an eventfd, or a Windows auto-reset event — that any other OS thread
+may ring to interrupt this one's `reactor.poll`. Promoted channels ring it
+through per-channel waiter lists (`src/shared_channel.zig`).
+
+The SRFI-18 waits have no per-object waiter list to hang a notifier off: a
+mutex or condition variable is an ordinary GC object reached through the
+globals route (`docs/dev/thread-value-sharing.md`), with no cross-thread
+bookkeeping of its own. So `src/reactor.zig` keeps a process-global registry
+keyed by **thread**, not by object:
+
+| | |
+|---|---|
+| enrol | `enrollCrossThreadWaiter` / `withdrawCrossThreadWaiter`, wrapped per wait by `fiber_wait.CrossThreadEnrolment` |
+| ring | `wakeCrossThreadWaiters` — every enrolled thread, on any state change one of these waits could observe |
+| who enrols | `thread-join!` on a running OS thread, `mutex-lock!`, a condition-variable wait, and `thread-sleep!` when another OS thread exists to `thread-terminate!` it |
+| who rings | `mutex-unlock!`, a mutex abandoned by a dying fiber or thread (`abandonFiberMutexes`), `condition-variable-signal!`/`-broadcast!`, `thread-terminate!`, and an OS thread's exit (`threadEntryFn`) |
+
+A ring wakes *every* enrolled thread; each re-checks its own condition and
+re-parks, so a spurious wake costs one loop iteration. Before kaappi#2395 all
+of these waits instead re-checked their own state every millisecond
+(`sleepNs(CROSS_THREAD_POLL_NS)` and the `pollCapNs` caps), which is why a
+`(thread-sleep! 60)` on a child thread used to wake 60,000 times.
+
+Three things load-bearing enough to be worth knowing before touching this:
+
+- **An enrolment is deliberately invisible to `hasRunnableFibers`**, unlike a
+  `shared_waiters` entry. A *timed* wait needs nothing there — its own
+  deadline timer already keeps the reactor non-empty, so it parks inside
+  `runSchedulerStep` with no cap and the ring is what ends it. An *untimed*
+  one needs `parkOnReactor`'s "nothing local can happen" verdict to keep
+  coming back, because that verdict is what returns control to the
+  mutex/condvar retry loop, where `crossThreadWaitPossible()` decides between
+  waiting longer and raising the deadlock diagnostic. That loop then blocks on
+  the ring itself, via `fiber_wait.awaitCrossThreadRing` — the same poll
+  `parkOnReactor` does, minus the empty-reactor refusal, bounded by
+  `CROSS_THREAD_RING_WAIT_NS` (100 ms) so the liveness check still gets its
+  turn. Counting enrolments in `hasRunnableFibers` instead turns that
+  diagnostic into a hang.
+- **`parkOnReactor` returns `true` as soon as it consumes a pending notify**,
+  rather than going on to poll. Consuming the flag does not consume the OS
+  trigger, so the poll normally returns at once anyway — except when the same
+  tick's `reactor.poll(0)` (`runReactorTick`, taken whenever an fd is
+  registered) already drained the trigger. That interleaving would otherwise
+  block on an event already delivered.
+- **`wakeCrossThreadWaiters` takes the registry lock even to find it empty.**
+  An atomic length gate read outside the lock is a store-buffering pattern
+  against the enroller — both sides can miss the other's store — and with no
+  poll cap left as a backstop that is a hang, not a latency blip.
+
+A "never" deadline is a real one and reaches the backends: SRFI-18 reads
+`+inf.0` as "never times out", `saturatedNsFromSeconds` turns that into
+`maxInt(u64)` nanoseconds, and a timespec ~585 years out is one `kevent`
+rejects with `EINVAL` — surfacing as `KP9002: out of memory` rather than a
+block. `Reactor.effectiveTimeout` therefore clamps any single blocking wait to
+`MAX_POLL_WAIT_NS` (24 hours) and lets the caller re-loop. This was already
+reachable before kaappi#2395 — `(thread-sleep! 1e18)` raised instead of
+sleeping — and became unavoidable once `thread-join!`'s timed wait stopped
+being a `nanosleep` loop.
+
+The caps survive as a *degraded* path only: `enrollCrossThreadWaiter` returns
+false if the registry cannot allocate, and each wait's `pollCapNs` then falls
+back to the pre-kaappi#2395 1 ms cadence rather than parking on a ring that
+will never come.
+
 ## Non-blocking mode is lazy, and is the platform probe
 
 Port fds (never 0/1/2) flip to `O_NONBLOCK` lazily, only once a scheduler

--- a/docs/dev/fibers-and-reactor.md
+++ b/docs/dev/fibers-and-reactor.md
@@ -57,7 +57,7 @@ keyed by **thread**, not by object:
 |---|---|
 | enrol | `enrollCrossThreadWaiter` / `withdrawCrossThreadWaiter`, wrapped per wait by `fiber_wait.CrossThreadEnrolment` |
 | ring | `wakeCrossThreadWaiters` — every enrolled thread, on any state change one of these waits could observe |
-| who enrols | `thread-join!` on a running OS thread, `mutex-lock!`, a condition-variable wait, and `thread-sleep!` when another OS thread exists to `thread-terminate!` it |
+| who enrols | `thread-join!` on a running OS thread, `mutex-lock!`, a condition-variable wait, and `thread-sleep!` — **unconditionally**, never gated on whether another OS thread exists yet |
 | who rings | `mutex-unlock!`, a mutex abandoned by a dying fiber or thread (`abandonFiberMutexes`), `condition-variable-signal!`/`-broadcast!`, `thread-terminate!`, and an OS thread's exit (`threadEntryFn`) |
 
 A ring wakes *every* enrolled thread; each re-checks its own condition and
@@ -66,7 +66,19 @@ of these waits instead re-checked their own state every millisecond
 (`sleepNs(CROSS_THREAD_POLL_NS)` and the `pollCapNs` caps), which is why a
 `(thread-sleep! 60)` on a child thread used to wake 60,000 times.
 
-Three things load-bearing enough to be worth knowing before touching this:
+Four things load-bearing enough to be worth knowing before touching this:
+
+- **Enrolment is unconditional, and must stay that way.** Gating it on
+  `crossThreadWaitPossible()` at entry looks like an obvious saving and is a
+  hole: `runSchedulerStep` evaluates `pollCapNs` once, before dispatching
+  anything, and a timed wait's own deadline timer keeps the reactor non-empty
+  — so a sibling fiber that the wait's own drive dispatches can start the
+  process's *first* OS thread, whose unlock or signal then rings a registry
+  the wait never joined. The park runs to its deadline and reports a timeout
+  for a hand-off that happened (measured: `(mutex-lock! m 2)` returning `#f`
+  at 2.002s for an unlock at 0.1s). The cost of enrolling always is that a
+  purely local wait also holds a slot, so an unlock on the same thread rings
+  its own notifier — one syscall, only while a fiber is actually parked.
 
 - **An enrolment is deliberately invisible to `hasRunnableFibers`**, unlike a
   `shared_waiters` entry. A *timed* wait needs nothing there — its own

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -21,6 +21,8 @@ pub const waitForFd = fiber_wait.waitForFd;
 pub const raiseCustomPortCallbackBlocked = fiber_wait.raiseCustomPortCallbackBlocked;
 pub const parkOnReactor = fiber_wait.parkOnReactor;
 pub const runSchedulerStep = fiber_wait.runSchedulerStep;
+pub const CrossThreadEnrolment = fiber_wait.CrossThreadEnrolment;
+pub const awaitCrossThreadRing = fiber_wait.awaitCrossThreadRing;
 
 pub fn clockNs() u64 {
     return platform.monotonicNs();
@@ -817,6 +819,16 @@ pub const FiberScheduler = struct {
         // matches none of the local wait categories below -- another OS
         // thread may still send/receive and wake it via sweepSharedWaiters.
         if (self.shared_waiters.items.len != 0) return true;
+        // A cross-thread SRFI-18 wait (#2395) is deliberately NOT counted
+        // here, even though its enrolment means another OS thread can still
+        // ring this reactor. Counting it would defeat this function's whole
+        // purpose for those waits: the `false` verdict it produces is what
+        // returns control to the mutex/condvar retry loop, which is where the
+        // `crossThreadWaitPossible()` liveness check and the deadlock
+        // diagnostic live. That loop does its own bounded reactor wait
+        // (`awaitCrossThreadRing`) instead of the 1 ms sleep it used to spin
+        // on; a *timed* cross-thread wait needs nothing here either, since
+        // its own deadline timer already keeps the reactor non-empty.
         for (self.fibers.items) |f| {
             if (f) |fiber| {
                 if ((fiber.status == .created or fiber.status == .suspended) and !fiber.driving)
@@ -1135,6 +1147,12 @@ pub fn abandonFiberMutexes(fiber: *Fiber, sched: ?*FiberScheduler) void {
             m.owner_thread = types.VOID;
             @atomicStore(bool, &m.locked, false, .release);
             if (sched) |s| s.wakeMutexWaiters(m_val);
+            // #2395: the local wake above reaches only this scheduler's own
+            // fibers. A waiter on another OS thread observes the release
+            // through m.locked alone, so it has to be rung — this is a
+            // dying fiber's mutexes becoming available, the one "mutex was
+            // released" event that does not go through mutex-unlock!.
+            reactor_mod.wakeCrossThreadWaiters();
         }
     }
     fiber.owned_mutexes.clearRetainingCapacity();

--- a/src/fiber_wait.zig
+++ b/src/fiber_wait.zig
@@ -205,6 +205,42 @@ pub fn raiseCustomPortCallbackBlocked(vm: *VM) VMError {
     return VMError.ExceptionRaised;
 }
 
+/// #2395: a wait's registration in reactor.zig's cross-thread wake registry,
+/// scoped to one primitive call. The SRFI-18 waits that can only be resolved
+/// by another OS thread (`thread-join!` on a running child, `mutex-lock!`,
+/// a condition-variable wait, and a `thread-sleep!` that must still observe a
+/// cross-thread `thread-terminate!`) enrol before they park, so the resolving
+/// thread rings this reactor instead of them waking 1000 times a second to
+/// look for themselves.
+///
+/// `ensure` is idempotent and `release` is safe to `defer` on a never-enrolled
+/// value, because enrolment is decided *inside* the retry loop: a wait may
+/// start out purely local (no other OS thread exists yet) and become
+/// cross-thread when a sibling fiber spawns one mid-drive.
+///
+/// A failed enrolment (`active()` still false) is not an error — the caller
+/// keeps its bounded poll cap, which is exactly the pre-#2395 behaviour.
+pub const CrossThreadEnrolment = struct {
+    notifier: ?*reactor_mod.ThreadNotifier = null,
+
+    pub fn ensure(self: *CrossThreadEnrolment, reactor: *reactor_mod.Reactor) void {
+        if (self.notifier != null) return;
+        const n = reactor.notifyHandle();
+        if (!reactor_mod.enrollCrossThreadWaiter(n)) return;
+        self.notifier = n;
+    }
+
+    pub fn release(self: *CrossThreadEnrolment) void {
+        const n = self.notifier orelse return;
+        self.notifier = null;
+        reactor_mod.withdrawCrossThreadWaiter(n);
+    }
+
+    pub fn active(self: CrossThreadEnrolment) bool {
+        return self.notifier != null;
+    }
+};
+
 /// Called when sched.schedule() finds nothing immediately runnable. Blocks
 /// in the reactor — bounded by its own timer heap, so no separate
 /// "nearest deadline" computation is needed here — and flips every fiber
@@ -228,9 +264,35 @@ pub fn parkOnReactor(vm: *VM, sched: *FiberScheduler, cap_ns: ?u64) VMError!bool
     // that arrived just before this call must not be missed by
     // hasRunnableFibers() reading a shared_waiters entry the sweep would
     // otherwise have already cleared.
-    while (reactor.notifier.wake_pending.swap(false, .acq_rel)) sched.sweepSharedWaiters();
+    var notified = false;
+    while (reactor.notifier.wake_pending.swap(false, .acq_rel)) {
+        sched.sweepSharedWaiters();
+        notified = true;
+    }
+    // A notify observed *here* must not be followed by a blocking poll
+    // (#2395). Consuming the flag does not consume the OS-level trigger, so
+    // in the common case poll() would return immediately anyway — but not
+    // when the same tick's earlier `reactor.poll(0)` (runReactorTick, taken
+    // only when an fd is registered) already drained the trigger while
+    // leaving `wake_pending` set. The wake would then be latched nowhere:
+    // this call blocks in an unbounded poll() for an event that has already
+    // been delivered. Returning "progress happened" instead costs one extra
+    // loop iteration in the caller, which re-evaluates its own condition —
+    // exactly what a cross-thread wakeup is asking it to do. This is what
+    // lets the SRFI-18 waits (thread-join!, mutex-lock!, condvar waits)
+    // park with no poll cap at all and rely on the notifier alone.
+    if (notified) return true;
     if (!sched.hasRunnableFibers() and reactor.isEmpty()) return false;
 
+    try pollAndWake(vm, sched, reactor, cap_ns);
+    return true;
+}
+
+/// The blocking half of `parkOnReactor`, split out so `awaitCrossThreadRing`
+/// can reuse it verbatim: block in the reactor for at most `cap_ns`, consume
+/// any notify the poll was interrupted by, and flip every fiber the poll
+/// reported ready back to runnable.
+fn pollAndWake(vm: *VM, sched: *FiberScheduler, reactor: *reactor_mod.Reactor, cap_ns: ?u64) VMError!void {
     var ready: std.ArrayList(*Fiber) = .empty;
     defer ready.deinit(vm.gc.allocator);
     // #1933: a child OS thread blocked in the reactor poll is quiescent; a
@@ -256,7 +318,39 @@ pub fn parkOnReactor(vm: *VM, sched: *FiberScheduler, cap_ns: ?u64) VMError!bool
         wakeReadyFiber(f);
         sched.markRunnable(f);
     }
-    return true;
+}
+
+/// #2395: what the SRFI-18 cross-thread retry loops wait on, replacing the
+/// `sleepNs(CROSS_THREAD_POLL_NS)` they used to spin. Blocks until the
+/// resolving thread rings this thread's notifier, or `cap_ns` elapses.
+///
+/// Correct **only** in the position those loops call it from: right after
+/// `runSchedulerStep` returned "not done", which means `parkOnReactor` found
+/// nothing locally runnable *and an empty reactor* — so the notifier's own
+/// trigger is the only event this poll can observe, and the caller's own
+/// state is exactly the parked state it wants to keep. It deliberately does
+/// not go through `parkOnReactor`, whose empty-reactor refusal is what
+/// produced the verdict that got us here.
+///
+/// `cap_ns` is the bound, not the mechanism: the caller re-runs its
+/// `crossThreadWaitPossible()` liveness check on every return, and that check
+/// is what turns "the last other OS thread has exited" into the deadlock
+/// diagnostic rather than an unbounded block.
+pub fn awaitCrossThreadRing(vm: *VM, sched: *FiberScheduler, cap_ns: u64) VMError!void {
+    const reactor = vm.reactor orelse {
+        platform.sleepNs(cap_ns);
+        return;
+    };
+    // A ring that landed before we got here is the wake: consume it and
+    // return rather than blocking on a trigger the last poll may already
+    // have drained.
+    var notified = false;
+    while (reactor.notifier.wake_pending.swap(false, .acq_rel)) {
+        sched.sweepSharedWaiters();
+        notified = true;
+    }
+    if (notified) return;
+    try pollAndWake(vm, sched, reactor, cap_ns);
 }
 
 /// thread-terminate! sets the *handle's* `terminated` flag, which an

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -364,6 +364,24 @@ fn ensureScheduler() @TypeOf(fiber_mod.ensureScheduler(undefined)) {
 // only when it isn't.
 const CROSS_THREAD_POLL_NS: u64 = 1_000_000;
 
+// Why the waits below enrol UNCONDITIONALLY rather than gating on
+// crossThreadWaitPossible() (PR #2428 review): a wait can *become*
+// cross-thread after it has already parked. `runSchedulerStep` evaluates
+// `pollCapNs` once, before dispatching anything, and a timed wait's own
+// deadline timer keeps the reactor non-empty -- so a sibling fiber that this
+// very drive dispatches can start the process's first OS thread, and that
+// thread's unlock/signal then rings a registry this wait never joined. The
+// park runs to its deadline and reports a timeout for a hand-off that
+// happened. Measured before the fix, and equally on main (the pre-#2395 cap
+// was snapshotted the same way): a child unlocking after 0.1s left
+// `(mutex-lock! m 2)` returning #f at 2.002s.
+//
+// Enrolling up front removes the entry-time condition entirely. The cost is
+// that a purely local wait also holds a registry slot, so an unlock on THIS
+// thread rings its own notifier -- one syscall, only while some fiber is
+// actually parked, and the parked fiber was going to be woken by the local
+// wakeMutexWaiters path anyway. Cheap next to reopening the window above.
+
 // How long an untimed cross-thread wait blocks on the notifier before its
 // enclosing loop gets another turn (#2395). Not a resolution latency: a real
 // unlock/signal/exit rings and the block ends immediately. It bounds only how
@@ -951,8 +969,7 @@ pub const SleepWait = struct {
     // behaviour, kept because losing termination visibility would hang the
     // joining thread in reapOsThread's thread.join().
     pub fn pollCapNs(self: SleepWait) ?u64 {
-        if (self.enrolment.active()) return null;
-        return if (crossThreadWaitPossible()) CROSS_THREAD_POLL_NS else null;
+        return if (self.enrolment.active()) null else CROSS_THREAD_POLL_NS;
     }
 };
 
@@ -1035,12 +1052,13 @@ fn threadSleepFn(args: []const Value) PrimitiveError!Value {
 
     // #2395: enrol so a cross-thread thread-terminate! can ring this park
     // awake instead of it having to wake every millisecond to look (#1982).
-    // Only when another OS thread could exist to terminate us -- a solo
-    // sleep has nothing to hear from and stays a single reactor block, as
-    // it already was.
+    // Unconditional -- see CROSS_THREAD_POLL_NS's second comment for why the
+    // crossThreadWaitPossible() gate this used to carry was a hole: a fiber
+    // this sleep's own drive dispatches can spawn the first OS thread, and
+    // the terminate that follows would ring a registry we never joined.
     var enrolment: fiber_mod.CrossThreadEnrolment = .{};
     defer enrolment.release();
-    if (crossThreadWaitPossible()) enrolment.ensure(ctx.reactor);
+    enrolment.ensure(ctx.reactor);
 
     _ = try fiber_mod.runSchedulerStep(SleepWait, .{ .enrolment = &enrolment }, ctx.vm, ctx.sched, me);
     me.timed_out = false;
@@ -1217,6 +1235,12 @@ fn parkForThreadStatus(
     const me = ctx.vm.current_fiber orelse return PrimitiveError.OutOfMemory;
 
     me.waiting_on = waiting_on;
+    // Barriered like the channel waits' own `waiting_on` stores
+    // (primitives_fiber.zig). Belt-and-braces for a scheduler-resident
+    // fiber, which markFiberState re-traces as a root every collection --
+    // but the fiber stops being resident the moment retireSlot runs, and
+    // the barrier costs a deduplicated remembered-set append.
+    ctx.vm.gc.writeBarrier(&me.header, waiting_on);
     me.status = .waiting;
     me.timed_out = false;
     // A local thread-terminate! on the target wakes waiters keyed on the
@@ -1224,19 +1248,36 @@ fn parkForThreadStatus(
     // enrolment below is for.
     ctx.sched.enrollWaiter(me);
 
+    // Every error exit below must leave `me` runnable again (PR #2428
+    // review). A primitive that returns a *catchable* error -- OutOfMemory
+    // from addTimer or from runSchedulerStep's own allocations -- can be
+    // caught by a Scheme `guard`, and this fiber then keeps executing while
+    // the scheduler still believes it is parked. "Running fiber marked
+    // parked" is the precondition for the #1487 dispatch-from-stale-snapshot
+    // corruption, and the waiter_index's tolerance of a stale entry
+    // (indexWakeOn revalidates `status == .waiting`) is exactly what a lying
+    // `.waiting` defeats. Mirrors the channel waits' catch blocks in
+    // primitives_fiber.zig and runSchedulerStep's own custom-port-callback
+    // guard, which undo the same three fields.
+    const Unpark = struct {
+        fn run(c: @TypeOf(ctx), f: *fiber_mod.Fiber) void {
+            if (f.deadline_ns != null) {
+                c.reactor.removeTimer(f);
+                f.deadline_ns = null;
+            }
+            f.status = .running;
+            f.timed_out = false;
+            f.waiting_on = types.VOID;
+        }
+    };
+    errdefer Unpark.run(ctx, me);
+
     var enrolment: fiber_mod.CrossThreadEnrolment = .{};
     defer enrolment.release();
     if (comptime cross_thread) enrolment.ensure(ctx.reactor);
 
     if (deadline) |d| {
         me.deadline_ns = d;
-        // Detach the timer on every exit, including an unwind: left pending
-        // it would fire later against whatever fiber reuses this slot -- the
-        // same discipline mutexLockFn's cross-thread path documents.
-        errdefer {
-            ctx.reactor.removeTimer(me);
-            me.deadline_ns = null;
-        }
         try ctx.reactor.addTimer(d, me);
     }
 
@@ -1244,13 +1285,7 @@ fn parkForThreadStatus(
         Ctx{ .target = target, .enrolment = &enrolment }
     else
         Ctx{ .target = target };
-    const done = fiber_mod.runSchedulerStep(Ctx, wait_ctx, ctx.vm, ctx.sched, me) catch |err| {
-        if (deadline != null) {
-            ctx.reactor.removeTimer(me);
-            me.deadline_ns = null;
-        }
-        return err;
-    };
+    const done = try fiber_mod.runSchedulerStep(Ctx, wait_ctx, ctx.vm, ctx.sched, me);
     if (deadline != null) ctx.reactor.removeTimer(me);
     me.deadline_ns = null;
 
@@ -1830,12 +1865,13 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
 
     // #2395: enrol before the first park, so the unlocking thread's ring
     // (mutexUnlockFn / abandonFiberMutexes / a dying thread's exit) is what
-    // ends this wait. Re-attempted inside the loop below because the wait can
-    // *become* cross-thread: a sibling fiber this drive dispatches may spawn
-    // the first OS thread while we are parked.
+    // ends this wait. Unconditional, NOT gated on crossThreadWaitPossible():
+    // see that gate's post-mortem at CROSS_THREAD_POLL_NS. Re-attempted in
+    // the loop below only to recover from an enrolment that could not
+    // allocate.
     var enrolment: fiber_mod.CrossThreadEnrolment = .{};
     defer enrolment.release();
-    if (crossThreadWaitPossible()) enrolment.ensure(ctx.reactor);
+    enrolment.ensure(ctx.reactor);
 
     // runSchedulerStep only returns done once it *observes* m.locked ==
     // false; claiming it is still a race against any other thread making
@@ -1881,11 +1917,9 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
         // #2395: nothing LOCAL can make progress, but another OS thread can
         // still unlock this mutex -- so instead of the 1 ms sleep this used
         // to spin on, block until that thread rings this reactor. The
-        // enrolment is (re-)attempted here as well as before the first park,
-        // because a wait can *become* cross-thread while it runs: a sibling
-        // fiber this drive dispatched may have spawned the first OS thread.
-        // Without one there is no ring to wait for, so fall back to the
-        // pre-#2395 sleep.
+        // enrolment is retried here only to recover from one that could not
+        // allocate at entry; without one there is no ring to wait for, so
+        // fall back to the pre-#2395 sleep.
         enrolment.ensure(ctx.reactor);
         if (enrolment.active())
             try fiber_mod.awaitCrossThreadRing(ctx.vm, ctx.sched, CROSS_THREAD_RING_WAIT_NS)
@@ -1968,8 +2002,7 @@ pub const MutexWait = struct {
     // another OS thread sooner. See crossThreadWaitPossible's doc comment for
     // when a wait counts as cross-thread at all.
     pub fn pollCapNs(self: MutexWait) ?u64 {
-        if (self.enrolment.active()) return null;
-        return if (crossThreadWaitPossible()) CROSS_THREAD_POLL_NS else null;
+        return if (self.enrolment.active()) null else CROSS_THREAD_POLL_NS;
     }
 };
 
@@ -2032,10 +2065,10 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
 
         // #2395: as in mutex-lock!, enrol so the signaling thread's ring ends
         // this park instead of a 1 ms cadence rediscovering the generation
-        // bump for itself.
+        // bump for itself -- and unconditionally, for the same reason.
         var enrolment: fiber_mod.CrossThreadEnrolment = .{};
         defer enrolment.release();
-        if (crossThreadWaitPossible()) enrolment.ensure(ctx.reactor);
+        enrolment.ensure(ctx.reactor);
 
         // Each OS thread owns an independent FiberScheduler, so
         // condition-variable-signal!/-broadcast! called on *another*
@@ -2114,8 +2147,7 @@ pub const CondVarWait = struct {
     }
     // See MutexWait.pollCapNs.
     pub fn pollCapNs(self: CondVarWait) ?u64 {
-        if (self.enrolment.active()) return null;
-        return if (crossThreadWaitPossible()) CROSS_THREAD_POLL_NS else null;
+        return if (self.enrolment.active()) null else CROSS_THREAD_POLL_NS;
     }
 };
 

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -6,6 +6,7 @@ const vm_mod = @import("vm.zig");
 const primitives = @import("primitives.zig");
 const primitives_fiber = @import("primitives_fiber.zig");
 const fiber_mod = @import("fiber.zig");
+const reactor_mod = @import("reactor.zig");
 const memory = @import("memory.zig");
 const shared_channel = @import("shared_channel.zig");
 const gc_deep_copy = @import("gc_deep_copy.zig");
@@ -354,8 +355,23 @@ fn ensureScheduler() @TypeOf(fiber_mod.ensureScheduler(undefined)) {
     return fiber_mod.ensureScheduler(vm);
 }
 
-// 1ms, matching thread-join!'s existing OS-thread poll cadence.
+// 1ms. Since #2395 this is no longer how a cross-thread wait normally
+// resolves -- the resolving thread rings this one's reactor notifier
+// (reactor.zig's cross-thread wake registry) and the wait blocks on that
+// ring. It survives as the degraded fallback for the one case that has no
+// notifier to ring: an enrolment that could not allocate its registry slot.
+// Every `pollCapNs` below therefore returns null once enrolled, and this
+// only when it isn't.
 const CROSS_THREAD_POLL_NS: u64 = 1_000_000;
+
+// How long an untimed cross-thread wait blocks on the notifier before its
+// enclosing loop gets another turn (#2395). Not a resolution latency: a real
+// unlock/signal/exit rings and the block ends immediately. It bounds only how
+// stale that loop's `crossThreadWaitPossible()` answer may be -- the check
+// that turns "the last other OS thread has exited without ever releasing
+// this" into the deadlock diagnostic instead of an unbounded block. 100ms
+// keeps that diagnostic prompt at 1/100th of the pre-#2395 wakeup rate.
+const CROSS_THREAD_RING_WAIT_NS: u64 = 100_000_000;
 
 // Number of thread-start!-spawned OS threads currently alive (incremented in
 // threadStartFn, decremented via defer in threadEntryFn on every exit path).
@@ -747,6 +763,14 @@ fn threadEntryFn(fiber: *fiber_mod.Fiber, spawner: ?*fiber_mod.Fiber, allocator:
     // envelopes built below, which escape into child_registry for the
     // parent to consume) -- every exit path needs it freed exactly once.
     defer envelope.deinit();
+    // #2395: ring every thread parked in a cross-OS-thread SRFI-18 wait as
+    // this one ends. Two of them care: a `thread-join!` on this thread (the
+    // status store every path below performs is what the joiner's isDone
+    // reads) and a `mutex-lock!` on a mutex this thread held (the unwind
+    // paths below abandon those through abandonFiberMutexes). Declared last
+    // of this prologue's defers so it runs first -- a joiner has no reason
+    // to wait out this thread's descendant drain before being told to look.
+    defer reactor_mod.wakeCrossThreadWaiters();
 
     const child_gc = allocator.create(memory.GC) catch {
         @atomicStore(fiber_mod.FiberStatus, &fiber.status, .errored, .release);
@@ -907,6 +931,7 @@ fn threadYieldFn(_: []const Value) PrimitiveError!Value {
 }
 
 pub const SleepWait = struct {
+    enrolment: *const fiber_mod.CrossThreadEnrolment,
     pub fn isDone(_: SleepWait) bool {
         return false; // a pure sleep only ever ends via me.timed_out
     }
@@ -918,15 +943,15 @@ pub const SleepWait = struct {
     // flag at this cadence. Solo (no other OS thread can exist to
     // terminate this one) it stays a single true reactor block.
     //
-    // Cost of the cap: crossThreadWaitPossible() is unconditionally true on
-    // a child thread (!vm.owns_globals), so a child's (thread-sleep! 60)
-    // wakes 60,000 times -- measured ~5k involuntary context switches and
-    // ~0.04s CPU for a pair of 2.5s/3.0s sleeps vs 33 switches and 0.00s
-    // without the cap. Small per-sleep, linear in duration and thread
-    // count. A notifier-based interrupt (thread-terminate! notifying the
-    // victim's reactor) would make termination immediate and remove the
-    // wakeups; the cap is the minimal correct fix.
-    pub fn pollCapNs(_: SleepWait) ?u64 {
+    // #2395 took that notifier-based interrupt: thread-terminate! now rings
+    // every enrolled thread, so an enrolled sleep is one uninterrupted park
+    // for its whole duration and a (thread-sleep! 60) on a child thread
+    // costs one wakeup rather than 60,000. The cap is what a sleep falls
+    // back to when the enrolment could not allocate -- the pre-#2395
+    // behaviour, kept because losing termination visibility would hang the
+    // joining thread in reapOsThread's thread.join().
+    pub fn pollCapNs(self: SleepWait) ?u64 {
+        if (self.enrolment.active()) return null;
         return if (crossThreadWaitPossible()) CROSS_THREAD_POLL_NS else null;
     }
 };
@@ -1008,7 +1033,16 @@ fn threadSleepFn(args: []const Value) PrimitiveError!Value {
         return fiber_mod.raiseCustomPortCallbackBlocked(ctx.vm);
     }
 
-    _ = try fiber_mod.runSchedulerStep(SleepWait, .{}, ctx.vm, ctx.sched, me);
+    // #2395: enrol so a cross-thread thread-terminate! can ring this park
+    // awake instead of it having to wake every millisecond to look (#1982).
+    // Only when another OS thread could exist to terminate us -- a solo
+    // sleep has nothing to hear from and stays a single reactor block, as
+    // it already was.
+    var enrolment: fiber_mod.CrossThreadEnrolment = .{};
+    defer enrolment.release();
+    if (crossThreadWaitPossible()) enrolment.ensure(ctx.reactor);
+
+    _ = try fiber_mod.runSchedulerStep(SleepWait, .{ .enrolment = &enrolment }, ctx.vm, ctx.sched, me);
     me.timed_out = false;
     me.deadline_ns = null;
     return types.VOID;
@@ -1111,11 +1145,124 @@ fn threadTerminateFn(args: []const Value) PrimitiveError!Value {
         }
         ctx.vm.yielded = true;
     }
+    // #2395: a victim parked in a cross-thread wait (thread-sleep!,
+    // mutex-lock!, a condvar wait, thread-join!) observes `terminated` only
+    // at runSchedulerStep's per-iteration `waitTerminated` check, which a
+    // parked drive reaches only when something wakes it. Before #2395 that
+    // was the 1 ms poll cap every one of those waits carried for exactly
+    // this reason (#1982); now it is this ring, which reaches the victim
+    // whichever OS thread it is on.
+    reactor_mod.wakeCrossThreadWaiters();
     return types.VOID;
 }
 
 fn sleepNs(ns: u64) void {
     platform.sleepNs(ns);
+}
+
+/// A `thread-start!`ed OS thread has run its thunk to a conclusion (result or
+/// exception) and is safe to reap. Both stores are release-ordered in
+/// threadEntryFn; the acquire loads here are the matching half.
+fn osThreadFinished(target: *fiber_mod.Fiber) bool {
+    const st = @atomicLoad(fiber_mod.FiberStatus, &target.status, .acquire);
+    return st == .completed or st == .errored;
+}
+
+/// thread-join!'s OS-thread wait. Resolved by the child's own exit, which
+/// stores its status and then rings every enrolled thread (threadEntryFn).
+pub const OsThreadWait = struct {
+    target: *fiber_mod.Fiber,
+    enrolment: *const fiber_mod.CrossThreadEnrolment,
+    pub fn isDone(self: OsThreadWait) bool {
+        return osThreadFinished(self.target);
+    }
+    /// Null once enrolled -- the child's exit ring is what ends this park.
+    /// Un-enrolled (the registry could not allocate) it falls back to the
+    /// pre-#2395 1 ms cadence, which matters more here than anywhere else:
+    /// without it a long-timeout join would sleep out its whole deadline and
+    /// report a timeout for a child that had finished a second in.
+    pub fn pollCapNs(self: OsThreadWait) ?u64 {
+        return if (self.enrolment.active()) null else CROSS_THREAD_POLL_NS;
+    }
+};
+
+/// thread-join!'s wait on a make-thread handle that has not been started.
+/// Resolvable only from this OS thread (thread-start! rejects a handle it
+/// does not own), so it takes no cap and no cross-thread enrolment: the
+/// drive re-checks between dispatches, which is exactly when a sibling fiber
+/// could have started it.
+pub const UnstartedThreadWait = struct {
+    target: *fiber_mod.Fiber,
+    pub fn isDone(self: UnstartedThreadWait) bool {
+        return @atomicLoad(fiber_mod.FiberStatus, &self.target.status, .acquire) != .created;
+    }
+};
+
+const ThreadWaitOutcome = enum { resolved, timed_out, deadlocked };
+
+/// #2395: park the current fiber until `Ctx.isDone()`, rather than sleeping
+/// the whole OS thread in a 1 ms status-poll loop. Siblings run while we
+/// wait, and the wake is a notifier ring rather than the next tick of a
+/// cadence. `deadline` null means "no timeout"; `cross_thread` enrols in the
+/// cross-thread wake registry (see CrossThreadEnrolment) for the waits whose
+/// resolution comes from another OS thread.
+fn parkForThreadStatus(
+    comptime Ctx: type,
+    target: *fiber_mod.Fiber,
+    deadline: ?u64,
+    waiting_on: Value,
+    comptime cross_thread: bool,
+) PrimitiveError!ThreadWaitOutcome {
+    const ctx = try ensureScheduler();
+    const me = ctx.vm.current_fiber orelse return PrimitiveError.OutOfMemory;
+
+    me.waiting_on = waiting_on;
+    me.status = .waiting;
+    me.timed_out = false;
+    // A local thread-terminate! on the target wakes waiters keyed on the
+    // handle (#1530); an OS thread's own exit does not, which is what the
+    // enrolment below is for.
+    ctx.sched.enrollWaiter(me);
+
+    var enrolment: fiber_mod.CrossThreadEnrolment = .{};
+    defer enrolment.release();
+    if (comptime cross_thread) enrolment.ensure(ctx.reactor);
+
+    if (deadline) |d| {
+        me.deadline_ns = d;
+        // Detach the timer on every exit, including an unwind: left pending
+        // it would fire later against whatever fiber reuses this slot -- the
+        // same discipline mutexLockFn's cross-thread path documents.
+        errdefer {
+            ctx.reactor.removeTimer(me);
+            me.deadline_ns = null;
+        }
+        try ctx.reactor.addTimer(d, me);
+    }
+
+    const wait_ctx = if (comptime cross_thread)
+        Ctx{ .target = target, .enrolment = &enrolment }
+    else
+        Ctx{ .target = target };
+    const done = fiber_mod.runSchedulerStep(Ctx, wait_ctx, ctx.vm, ctx.sched, me) catch |err| {
+        if (deadline != null) {
+            ctx.reactor.removeTimer(me);
+            me.deadline_ns = null;
+        }
+        return err;
+    };
+    if (deadline != null) ctx.reactor.removeTimer(me);
+    me.deadline_ns = null;
+
+    if (done) {
+        me.timed_out = false;
+        return .resolved;
+    }
+    if (me.timed_out) {
+        me.timed_out = false;
+        return .timed_out;
+    }
+    return .deadlocked;
 }
 
 fn threadJoinFn(args: []const Value) PrimitiveError!Value {
@@ -1150,57 +1297,81 @@ fn threadJoinFn(args: []const Value) PrimitiveError!Value {
         }
     }
 
-    // OS thread path
-    if (target.os_thread != null) {
-        if (deadline_ns) |deadline| {
-            while (@atomicLoad(fiber_mod.FiberStatus, &target.status, .acquire) != .completed and
-                @atomicLoad(fiber_mod.FiberStatus, &target.status, .acquire) != .errored)
-            {
-                if (fiber_mod.clockNs() >= deadline) {
-                    if (has_timeout_val) return timeout_val;
-                    return raiseError(.join_timeout, "thread-join! timed out", types.VOID);
-                }
-                sleepNs(1_000_000);
-            }
-        }
-        return reapOsThread(target, args[0]);
-    }
+    // args is a slice into vm.registers, which the scheduler drives below can
+    // reallocate out from under it while running other fibers (the same
+    // capture mutexLockFn makes for the same reason). Everything read after
+    // the first drive must come from these locals.
+    const fiber_val = args[0];
 
-    // Never-started target, in two kinds discriminated by sched_idx (set only
-    // by addFiber; a make-thread object is never added to any scheduler and
-    // leaves it at 0):
-    //
-    //  * A make-thread handle awaiting thread-start! (sched_idx == 0): poll.
-    //    The status is changed from outside this loop, so polling observes it
-    //    (#878). os_thread alone is NOT a safe discriminator here -- a handle
-    //    about to be started has os_thread == null for the whole window before
-    //    thread-start!'s std.Thread.spawn, and must keep polling, not fall
-    //    through to the cooperative path.
-    //
-    //  * A (kaappi fibers) spawn'd fiber (sched_idx != 0) still in .created:
-    //    only THIS thread's cooperative scheduler can dispatch it, and the
-    //    poll loop below is exactly what starves it -- the status can never
-    //    change from outside, so without a timeout the loop is unbounded and
-    //    thread-join! hangs on a fiber that would have completed instantly
-    //    (#2194). Fall through to the fiber path below, which drives the
-    //    scheduler.
-    if (target.sched_idx == 0 and
-        @atomicLoad(fiber_mod.FiberStatus, &target.status, .acquire) == .created)
-    {
-        while (@atomicLoad(fiber_mod.FiberStatus, &target.status, .acquire) != .completed and
-            @atomicLoad(fiber_mod.FiberStatus, &target.status, .acquire) != .errored)
+    // Two pre-cooperative kinds, both of which used to poll `target.status`
+    // at 1 ms; both now park on the reactor instead (#2395). Looped rather
+    // than straight-lined because the second can turn into the first: a
+    // handle joined before it was started becomes an OS thread the moment
+    // some other fiber on this thread calls thread-start! on it, and the
+    // remaining timeout then belongs to the OS-thread wait.
+    while (true) {
+        // OS thread path
+        if (target.os_thread != null) {
+            if (deadline_ns) |deadline| {
+                if (!osThreadFinished(target)) {
+                    // Zero (and already-elapsed) timeouts stay an immediate
+                    // answer, never a park: `(thread-join! t 0 'x)` must not
+                    // pay a scheduler drive to learn what it already knows.
+                    // A `.deadlocked` verdict is unreachable while our own
+                    // deadline timer keeps the reactor non-empty; reporting
+                    // it as the timeout is the honest fallback if it ever
+                    // becomes reachable -- the join demonstrably cannot
+                    // complete, and the caller asked to be told so.
+                    if (fiber_mod.clockNs() >= deadline or
+                        try parkForThreadStatus(OsThreadWait, target, deadline, fiber_val, true) != .resolved)
+                    {
+                        if (has_timeout_val) return timeout_val;
+                        return raiseError(.join_timeout, "thread-join! timed out", types.VOID);
+                    }
+                }
+            }
+            return reapOsThread(target, fiber_val);
+        }
+
+        // Never-started target, in two kinds discriminated by sched_idx (set
+        // only by addFiber; a make-thread object is never added to any
+        // scheduler and leaves it at 0):
+        //
+        //  * A make-thread handle awaiting thread-start! (sched_idx == 0):
+        //    wait for its status to leave .created (#878). os_thread alone is
+        //    NOT a safe discriminator here -- a handle about to be started has
+        //    os_thread == null for the whole window before thread-start!'s
+        //    std.Thread.spawn, and must keep waiting, not fall through to the
+        //    cooperative path.
+        //
+        //  * A (kaappi fibers) spawn'd fiber (sched_idx != 0) still in
+        //    .created: only THIS thread's cooperative scheduler can dispatch
+        //    it, and a wait that starves it is exactly what hung #2194. Fall
+        //    through to the fiber path below, which drives the scheduler.
+        if (target.sched_idx == 0 and
+            @atomicLoad(fiber_mod.FiberStatus, &target.status, .acquire) == .created)
         {
             if (deadline_ns) |deadline| {
-                if (fiber_mod.clockNs() >= deadline) {
+                if (fiber_mod.clockNs() >= deadline or
+                    try parkForThreadStatus(UnstartedThreadWait, target, deadline, fiber_val, false) != .resolved)
+                {
                     if (has_timeout_val) return timeout_val;
                     return raiseError(.join_timeout, "thread-join! timed out", types.VOID);
                 }
+            } else {
+                // Untimed. Only thread-start! can resolve this, and only from
+                // this thread -- the handle's owner check rejects every other
+                // one -- so the wait is really "let my own fibers run until
+                // one of them starts it". The drive replaces a poll loop that
+                // could not observe such a fiber at all (it never yielded the
+                // thread), which is also why a `false` return here can now be
+                // reported as the deadlock it is instead of hanging forever.
+                if (try parkForThreadStatus(UnstartedThreadWait, target, null, fiber_val, false) != .resolved)
+                    return raiseError(.general, "thread-join!: deadlock — thread was never started (all fibers blocked)", fiber_val);
             }
-            sleepNs(1_000_000);
+            continue;
         }
-        if (target.os_thread != null)
-            return reapOsThread(target, args[0]);
-        return threadJoinResult(target);
+        break;
     }
 
     // Fiber path (cooperative scheduling)
@@ -1209,7 +1380,7 @@ fn threadJoinFn(args: []const Value) PrimitiveError!Value {
         const ctx = try ensureScheduler();
         const me = ctx.vm.current_fiber orelse return PrimitiveError.OutOfMemory;
 
-        me.waiting_on = args[0];
+        me.waiting_on = fiber_val;
         me.status = .waiting;
         me.timed_out = false;
         ctx.sched.enrollWaiter(me); // #1530: O(1) wake when the joined fiber completes
@@ -1608,6 +1779,9 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
                 // until its poll cap or the deadlock error. Mirrors the
                 // slow path's wake below.
                 ctx.sched.wakeMutexWaiters(args[0]);
+                // #2395: and any cross-thread waiter, which the local wake
+                // above cannot reach.
+                reactor_mod.wakeCrossThreadWaiters();
                 return types.TRUE;
             }
             m.owner_thread = owner_thread;
@@ -1654,6 +1828,15 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
         try ctx.reactor.addTimer(d, me);
     }
 
+    // #2395: enrol before the first park, so the unlocking thread's ring
+    // (mutexUnlockFn / abandonFiberMutexes / a dying thread's exit) is what
+    // ends this wait. Re-attempted inside the loop below because the wait can
+    // *become* cross-thread: a sibling fiber this drive dispatches may spawn
+    // the first OS thread while we are parked.
+    var enrolment: fiber_mod.CrossThreadEnrolment = .{};
+    defer enrolment.release();
+    if (crossThreadWaitPossible()) enrolment.ensure(ctx.reactor);
+
     // runSchedulerStep only returns done once it *observes* m.locked ==
     // false; claiming it is still a race against any other thread making
     // the same observation, so retry the claim and go back to waiting on
@@ -1661,9 +1844,9 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
     // "not done" (parkOnReactor found nothing locally runnable and no
     // pending timer/fd event), that's only a genuine deadlock if no other
     // OS thread could plausibly still unlock this mutex from the outside —
-    // otherwise poll briefly and retry.
+    // otherwise enrol for that thread's ring (#2395) and retry.
     while (true) {
-        const done = try fiber_mod.runSchedulerStep(MutexWait, .{ .m = m }, ctx.vm, ctx.sched, me);
+        const done = try fiber_mod.runSchedulerStep(MutexWait, .{ .m = m, .enrolment = &enrolment }, ctx.vm, ctx.sched, me);
         if (me.timed_out) {
             me.timed_out = false;
             me.deadline_ns = null;
@@ -1695,7 +1878,19 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
             me.deadline_ns = null;
             return raiseError(.general, "mutex-lock!: deadlock — mutex will never be released (all fibers blocked)", types.VOID);
         }
-        sleepNs(CROSS_THREAD_POLL_NS);
+        // #2395: nothing LOCAL can make progress, but another OS thread can
+        // still unlock this mutex -- so instead of the 1 ms sleep this used
+        // to spin on, block until that thread rings this reactor. The
+        // enrolment is (re-)attempted here as well as before the first park,
+        // because a wait can *become* cross-thread while it runs: a sibling
+        // fiber this drive dispatched may have spawned the first OS thread.
+        // Without one there is no ring to wait for, so fall back to the
+        // pre-#2395 sleep.
+        enrolment.ensure(ctx.reactor);
+        if (enrolment.active())
+            try fiber_mod.awaitCrossThreadRing(ctx.vm, ctx.sched, CROSS_THREAD_RING_WAIT_NS)
+        else
+            sleepNs(CROSS_THREAD_POLL_NS);
         // Same timer restoration as above: a local wake earlier in this
         // loop (see the `done` branch) may have already canceled the
         // timer, and that state persists into this branch too.
@@ -1743,6 +1938,7 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
         @atomicStore(bool, &m.abandoned, true, .release);
         @atomicStore(bool, &m.locked, false, .release);
         ctx.sched.wakeMutexWaiters(mutex_val);
+        reactor_mod.wakeCrossThreadWaiters(); // #2395, as in the fast path
         return types.TRUE;
     }
     m.owner_thread = owner_thread;
@@ -1760,16 +1956,19 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
 
 pub const MutexWait = struct {
     m: *types.Mutex,
+    enrolment: *const fiber_mod.CrossThreadEnrolment,
     pub fn isDone(self: MutexWait) bool {
         return !@atomicLoad(bool, &self.m.locked, .acquire);
     }
-    // Caps parkOnReactor's blocking wait so a long real timeout (registered
-    // separately on `me`) can't make it block for the whole duration on the
-    // offhand chance the mutex is unlocked by another OS thread sooner --
-    // that thread's own scheduler has no way to signal this one directly.
-    // See crossThreadWaitPossible's doc comment for when this applies.
+    // #2395: an enrolled wait needs no cap -- the unlocking thread rings this
+    // reactor directly, so the park can be as long as the timeout is. The cap
+    // is the fallback for an enrolment that could not allocate: without it, a
+    // long real timeout (registered separately on `me`) would make this block
+    // for its whole duration on the offhand chance the mutex is unlocked by
+    // another OS thread sooner. See crossThreadWaitPossible's doc comment for
+    // when a wait counts as cross-thread at all.
     pub fn pollCapNs(self: MutexWait) ?u64 {
-        _ = self;
+        if (self.enrolment.active()) return null;
         return if (crossThreadWaitPossible()) CROSS_THREAD_POLL_NS else null;
     }
 };
@@ -1805,6 +2004,12 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
     // the locked CAS after it is guaranteed to see not-abandoned.
     @atomicStore(bool, &m.abandoned, false, .release);
     @atomicStore(bool, &m.locked, false, .release);
+    // #2395: the local wake below reaches only this scheduler's fibers. A
+    // waiter on another OS thread sees the release only through m.locked, and
+    // used to have to poll for it -- ring it awake instead. Before
+    // ensureScheduler, which can fail: the release above is already published
+    // and the wake must not be lost with it.
+    reactor_mod.wakeCrossThreadWaiters();
 
     const ctx = try ensureScheduler();
     ctx.sched.wakeMutexWaiters(args[0]);
@@ -1825,6 +2030,13 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
             try ctx.reactor.addTimer(d, me);
         }
 
+        // #2395: as in mutex-lock!, enrol so the signaling thread's ring ends
+        // this park instead of a 1 ms cadence rediscovering the generation
+        // bump for itself.
+        var enrolment: fiber_mod.CrossThreadEnrolment = .{};
+        defer enrolment.release();
+        if (crossThreadWaitPossible()) enrolment.ensure(ctx.reactor);
+
         // Each OS thread owns an independent FiberScheduler, so
         // condition-variable-signal!/-broadcast! called on *another*
         // thread only wakes fibers local to that thread's own scheduler
@@ -1834,7 +2046,7 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
         // instead of treating it as a genuine deadlock whenever another OS
         // thread could plausibly still signal from the outside.
         while (true) {
-            const done = try fiber_mod.runSchedulerStep(CondVarWait, .{ .me = me, .cv = c, .start_gen = start_gen }, ctx.vm, ctx.sched, me);
+            const done = try fiber_mod.runSchedulerStep(CondVarWait, .{ .me = me, .cv = c, .start_gen = start_gen, .enrolment = &enrolment }, ctx.vm, ctx.sched, me);
             if (me.timed_out) {
                 me.timed_out = false;
                 me.deadline_ns = null;
@@ -1846,7 +2058,15 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
                 me.deadline_ns = null;
                 return raiseError(.general, "mutex-unlock!: deadlock — condition variable will never be signaled (all fibers blocked)", types.VOID);
             }
-            sleepNs(CROSS_THREAD_POLL_NS);
+            // See mutexLockFn's matching branch (#2395): block on the
+            // signaling thread's ring rather than a 1 ms sleep, enrolling
+            // first if this wait has only just become cross-thread, and
+            // sleeping as before only if the registry could not take us.
+            enrolment.ensure(ctx.reactor);
+            if (enrolment.active())
+                try fiber_mod.awaitCrossThreadRing(ctx.vm, ctx.sched, CROSS_THREAD_RING_WAIT_NS)
+            else
+                sleepNs(CROSS_THREAD_POLL_NS);
             me.status = .waiting;
             ctx.sched.enrollWaiter(me); // #1530: re-index after this spin (see mutexLockFn)
         }
@@ -1887,13 +2107,14 @@ pub const CondVarWait = struct {
     me: *fiber_mod.Fiber,
     cv: *types.ConditionVariable,
     start_gen: u64,
+    enrolment: *const fiber_mod.CrossThreadEnrolment,
     pub fn isDone(self: CondVarWait) bool {
         return self.me.status != .waiting or
             loadSignalGeneration(self.cv) != self.start_gen;
     }
     // See MutexWait.pollCapNs.
     pub fn pollCapNs(self: CondVarWait) ?u64 {
-        _ = self;
+        if (self.enrolment.active()) return null;
         return if (crossThreadWaitPossible()) CROSS_THREAD_POLL_NS else null;
     }
 };
@@ -1938,8 +2159,12 @@ fn condvarSignalFn(args: []const Value) PrimitiveError!Value {
     const ctx = try ensureScheduler();
     ctx.sched.wakeOneCondVarWaiter(args[0]);
     // Bump the generation so a waiter parked on a different OS thread's
-    // scheduler (which never sees the local wake above) can poll for this.
+    // scheduler (which never sees the local wake above) can observe this.
     bumpSignalGeneration(types.toConditionVariable(args[0]));
+    // #2395: and ring it, so observing costs one wakeup rather than a 1 ms
+    // cadence of them. The bump is published first -- a ring whose state
+    // write is not yet visible is a wake the waiter would re-park through.
+    reactor_mod.wakeCrossThreadWaiters();
     return types.VOID;
 }
 
@@ -1949,6 +2174,7 @@ fn condvarBroadcastFn(args: []const Value) PrimitiveError!Value {
     const ctx = try ensureScheduler();
     ctx.sched.wakeAllCondVarWaiters(args[0]);
     bumpSignalGeneration(types.toConditionVariable(args[0]));
+    reactor_mod.wakeCrossThreadWaiters();
     return types.VOID;
 }
 

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -23,6 +23,9 @@ const linux = std.os.linux;
 /// performs naturally.
 const max_events_per_poll: usize = 256;
 
+/// Upper bound on a single blocking poll (see `Reactor.effectiveTimeout`).
+const MAX_POLL_WAIT_NS: u64 = 24 * 60 * 60 * std.time.ns_per_s;
+
 pub const Interest = enum { read, write };
 
 /// A backend-normalized readiness result: which directions fired for `fd`.
@@ -197,6 +200,124 @@ pub fn releaseNotifier(n: *ThreadNotifier) void {
         std.heap.c_allocator.destroy(n);
         _ = notifier_live_count.fetchSub(1, .monotonic);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Cross-thread wait registry (KEP-0002 unresolved question 3, kaappi#2395)
+// ---------------------------------------------------------------------------
+
+/// The notifiers of every OS thread currently parked in a SRFI-18 wait whose
+/// resolution can only come from *another* OS thread: `thread-join!` on a
+/// running child, `mutex-lock!` on a mutex another thread holds, a
+/// condition-variable wait, and a `thread-sleep!` that must still observe a
+/// cross-thread `thread-terminate!`.
+///
+/// Those waits have no per-object waiter list to hang a notifier off — a
+/// mutex or condition variable is an ordinary GC object reached through the
+/// globals route (`docs/dev/thread-value-sharing.md`), owned by whichever
+/// heap allocated it, with no cross-thread bookkeeping of its own — so the
+/// unit of registration is the *thread*, not the object, and a state change
+/// rings every parked thread rather than a selected few. The waiters then
+/// re-check their own condition and re-park; a spurious wake costs one loop
+/// iteration. This is what replaces the 1 ms `sleepNs` poll those waits used
+/// before (KEP-0002 UQ3): the list is empty in every program where nothing is
+/// cross-thread blocked, so `wakeCrossThreadWaiters` costs one uncontended
+/// lock acquisition on every unlock/signal/exit that has nobody to wake.
+///
+/// One entry per *thread*, not per wait: a fiber blocked in `mutex-lock!` can
+/// drive a sibling that itself blocks in a condition-variable wait, and both
+/// resolve through the same reactor. `depth` counts those nested enrolments so
+/// the inner one's withdrawal doesn't unregister the outer.
+const WaitEntry = struct {
+    notifier: *ThreadNotifier,
+    depth: u32,
+};
+
+var wait_registry: std.ArrayList(WaitEntry) = .empty;
+var wait_registry_lock: std.atomic.Mutex = .unlocked;
+
+/// `wait_registry.items.len`, published under the lock so `crossThreadWaiterCount`
+/// can be read without taking it. Deliberately NOT a lock-free fast-path gate
+/// for `wakeCrossThreadWaiters` — see that function for why the ring must go
+/// through the lock even when there is nobody to wake.
+var wait_registry_len: std.atomic.Value(usize) = std.atomic.Value(usize).init(0);
+
+/// Registers this thread's notifier for cross-thread wakeups. Returns false
+/// if the registry could not grow, which is a *degradation, not a failure*:
+/// the caller falls back to its old bounded poll (`CROSS_THREAD_POLL_NS`),
+/// which is exactly the pre-#2395 behaviour. Balanced by
+/// `withdrawCrossThreadWaiter` — call it only when this returned true.
+pub fn enrollCrossThreadWaiter(n: *ThreadNotifier) bool {
+    memory.spinLock(&wait_registry_lock);
+    defer memory.spinUnlock(&wait_registry_lock);
+    for (wait_registry.items) |*e| {
+        if (e.notifier == n) {
+            e.depth += 1;
+            return true;
+        }
+    }
+    wait_registry.append(std.heap.c_allocator, .{ .notifier = n, .depth = 1 }) catch return false;
+    retainNotifier(n);
+    wait_registry_len.store(wait_registry.items.len, .release);
+    return true;
+}
+
+pub fn withdrawCrossThreadWaiter(n: *ThreadNotifier) void {
+    memory.spinLock(&wait_registry_lock);
+    var released = false;
+    for (wait_registry.items, 0..) |*e, i| {
+        if (e.notifier != n) continue;
+        e.depth -= 1;
+        if (e.depth == 0) {
+            _ = wait_registry.swapRemove(i);
+            wait_registry_len.store(wait_registry.items.len, .release);
+            released = true;
+        }
+        break;
+    }
+    memory.spinUnlock(&wait_registry_lock);
+    // Outside the lock, mirroring shared_channel's `ring`: the zero
+    // transition frees the notifier and closes its backend fd, neither of
+    // which should happen with the registry lock held.
+    if (released) releaseNotifier(n);
+}
+
+/// Rings every thread parked in a cross-thread SRFI-18 wait. Called from the
+/// state changes those waits observe — a mutex unlock or abandonment, a
+/// condition-variable signal/broadcast, a `thread-terminate!`, and an OS
+/// thread's exit.
+///
+/// **Takes the lock unconditionally, even to discover the registry is empty.**
+/// An atomic length gate read outside the lock would be a store-buffering
+/// (Dekker) pattern — waiter enrols then re-checks the shared state; ringer
+/// writes the state then reads the length — in which *both* sides may miss
+/// the other's store, since the state accesses are the plain acquire/release
+/// ones the mutex and condvar already use. That is a lost wakeup, and with no
+/// poll cap left to paper it over (see CROSS_THREAD_POLL_NS in
+/// primitives_srfi18.zig), a hang. Going through the lock replaces that
+/// argument with mutual exclusion: a ringer that finds the registry empty
+/// released the lock before the enroller acquired it, so the enroller's own
+/// state re-check — which follows its enrolment — necessarily observes the
+/// state the ringer had already published. The cost is one uncontended atomic
+/// RMW on paths (`mutex-unlock!`, `condition-variable-signal!`) that already
+/// perform several atomic stores and a hash lookup.
+///
+/// Rings *under* the lock too, unlike `shared_channel.ring`'s
+/// snapshot-then-ring: the list is one entry per blocked OS thread (single
+/// digits in any real program), `notify()` takes no lock of its own so there
+/// is no lock-order hazard, and holding the lock is what keeps each entry
+/// alive without a retain/release round trip per ring. The alternative —
+/// snapshotting — would need an allocation on a path that must not fail.
+pub fn wakeCrossThreadWaiters() void {
+    memory.spinLock(&wait_registry_lock);
+    defer memory.spinUnlock(&wait_registry_lock);
+    for (wait_registry.items) |e| e.notifier.notify();
+}
+
+/// Test/leak-check hook, mirroring `notifierLiveCount`: every enrolment must
+/// be withdrawn, so this is 0 between waits.
+pub fn crossThreadWaiterCount() usize {
+    return wait_registry_len.load(.acquire);
 }
 
 pub const Reactor = struct {
@@ -455,6 +576,20 @@ pub const Reactor = struct {
             const until: u64 = if (top.deadline_ns <= now) 0 else top.deadline_ns - now;
             result = if (result) |r| @min(r, until) else until;
         }
+        // Clamp, because a "never" deadline is a real, reachable one: SRFI-18
+        // reads `+inf.0` as "never times out" and `saturatedNsFromSeconds`
+        // turns it into `maxInt(u64)` nanoseconds, ~585 years out. Handed to
+        // kevent as a timespec that far in the future, macOS rejects the call
+        // outright (EINVAL) -- `wait` returns error.Unexpected and the park
+        // surfaces as KP9002 "out of memory" instead of blocking, which is
+        // what `(thread-sleep! 1e18)` did before kaappi#2395 and what
+        // `(thread-join! t +inf.0)` started doing once its wait became a real
+        // reactor park rather than a nanosleep loop. A day is far longer than
+        // any wait that matters and is safely inside every backend's range
+        // (epoll's own msFromNs cap is 24.8 days, Windows' DWORD ms is 49
+        // days); the cost of a genuinely unbounded wait is one spurious
+        // wakeup per day, which every caller already re-loops through.
+        if (result) |r| return @min(r, MAX_POLL_WAIT_NS);
         return result;
     }
 };

--- a/src/tests_reactor.zig
+++ b/src/tests_reactor.zig
@@ -784,3 +784,73 @@ test "#1608: pipe pair — a write end with buffer space is ready for write inte
     try std.testing.expectEqual(@as(usize, 1), ready.items.len);
     try std.testing.expectEqual(&fiber_a, ready.items[0]);
 }
+
+// ---------------------------------------------------------------------------
+// #2395: the cross-thread wait registry
+//
+// The SRFI-18 waits resolvable only by another OS thread (thread-join! on a
+// running child, mutex-lock!, a condition-variable wait, and a thread-sleep!
+// that must still observe thread-terminate!) used to poll their own state at
+// 1 ms. They now enrol here and are woken by a notifier ring from whichever
+// thread performs the state change. These tests pin the two properties that
+// makes correct: enrolment is balanced (a leaked entry would ring a freed
+// notifier; a lost one would hang the wait), and a ring really does end a
+// blocking poll rather than only setting a flag.
+// ---------------------------------------------------------------------------
+
+test "#2395: cross-thread waiter enrolment nests and stays balanced" {
+    const notifier_baseline = reactor_mod.notifierLiveCount();
+    try std.testing.expectEqual(@as(usize, 0), reactor_mod.crossThreadWaiterCount());
+
+    var reactor = try reactor_mod.Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+    const n = reactor.notifyHandle();
+
+    try std.testing.expect(reactor_mod.enrollCrossThreadWaiter(n));
+    try std.testing.expectEqual(@as(usize, 1), reactor_mod.crossThreadWaiterCount());
+    // The registry keys on the THREAD, not the wait: a fiber blocked in
+    // mutex-lock! can drive a sibling that blocks in a condvar wait, and both
+    // enrol the one reactor. The second enrolment must not add a row, and the
+    // inner withdrawal must not unregister the outer wait.
+    try std.testing.expect(reactor_mod.enrollCrossThreadWaiter(n));
+    try std.testing.expectEqual(@as(usize, 1), reactor_mod.crossThreadWaiterCount());
+    // Enrolment holds a reference, so the notifier survives its Reactor.
+    try std.testing.expectEqual(notifier_baseline + 1, reactor_mod.notifierLiveCount());
+
+    reactor_mod.withdrawCrossThreadWaiter(n);
+    try std.testing.expectEqual(@as(usize, 1), reactor_mod.crossThreadWaiterCount());
+    reactor_mod.withdrawCrossThreadWaiter(n);
+    try std.testing.expectEqual(@as(usize, 0), reactor_mod.crossThreadWaiterCount());
+    try std.testing.expectEqual(notifier_baseline + 1, reactor_mod.notifierLiveCount()); // reactor's own +1
+}
+
+test "#2395: wakeCrossThreadWaiters rings an enrolled reactor out of a blocking poll" {
+    var reactor = try reactor_mod.Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+    const n = reactor.notifyHandle();
+
+    // Nothing enrolled: the fast path must not touch this reactor at all —
+    // that gate is what keeps an unlock/signal free in every program with no
+    // cross-thread waiter.
+    n.wake_pending.store(false, .release);
+    reactor_mod.wakeCrossThreadWaiters();
+    try std.testing.expect(!n.wake_pending.load(.acquire));
+
+    try std.testing.expect(reactor_mod.enrollCrossThreadWaiter(n));
+    defer reactor_mod.withdrawCrossThreadWaiter(n);
+    reactor_mod.wakeCrossThreadWaiters();
+    try std.testing.expect(n.wake_pending.load(.acquire));
+
+    // And it is a real OS event, not just the flag: a poll that would
+    // otherwise wait out its whole timeout returns at once. Asserted on
+    // elapsed time rather than by blocking forever, so a regression fails
+    // the test instead of hanging the suite.
+    var ready: std.ArrayList(*fiber_mod.Fiber) = .empty;
+    defer ready.deinit(std.testing.allocator);
+    const t0 = fiber_mod.clockNs();
+    try reactor.poll(5 * std.time.ns_per_s, &ready);
+    try std.testing.expect(fiber_mod.clockNs() - t0 < 2 * std.time.ns_per_s);
+    // The notifier's own event is filtered out of the ready list (reactor.zig
+    // wait()): it is a wakeup, never a runnable fiber.
+    try std.testing.expectEqual(@as(usize, 0), ready.items.len);
+}

--- a/src/tests_reactor.zig
+++ b/src/tests_reactor.zig
@@ -824,14 +824,13 @@ test "#2395: cross-thread waiter enrolment nests and stays balanced" {
     try std.testing.expectEqual(notifier_baseline + 1, reactor_mod.notifierLiveCount()); // reactor's own +1
 }
 
-test "#2395: wakeCrossThreadWaiters rings an enrolled reactor out of a blocking poll" {
+test "#2395: wakeCrossThreadWaiters sets wake_pending only for enrolled reactors" {
     var reactor = try reactor_mod.Reactor.init(std.testing.allocator);
     defer reactor.deinit();
     const n = reactor.notifyHandle();
 
-    // Nothing enrolled: the fast path must not touch this reactor at all —
-    // that gate is what keeps an unlock/signal free in every program with no
-    // cross-thread waiter.
+    // Not enrolled: the ring must not touch this reactor at all — an
+    // unlock/signal in a program with no cross-thread waiter reaches nobody.
     n.wake_pending.store(false, .release);
     reactor_mod.wakeCrossThreadWaiters();
     try std.testing.expect(!n.wake_pending.load(.acquire));
@@ -840,18 +839,27 @@ test "#2395: wakeCrossThreadWaiters rings an enrolled reactor out of a blocking 
     defer reactor_mod.withdrawCrossThreadWaiter(n);
     reactor_mod.wakeCrossThreadWaiters();
     try std.testing.expect(n.wake_pending.load(.acquire));
+}
 
-    // And it is a real OS event, not just the flag: a poll that would
-    // otherwise wait out its whole timeout returns at once. Asserted on
-    // elapsed time rather than by blocking forever, so a regression fails
-    // the test instead of hanging the suite.
-    //
-    // Not on WASI: `ThreadNotifier.notify` has no OS primitive to ring there
-    // (reactor.zig's `.wasi => {}` arm), because wasm32-wasi is
-    // single-threaded and no other thread can exist to do the ringing. The
-    // flag half above is still meaningful — it is the same bookkeeping — but
-    // the poll below would genuinely wait out its whole timeout.
-    if (comptime platform.is_wasm) return;
+// Split from the bookkeeping assertions above rather than folded into them
+// with an early `return`, which would report this half as *passed* on WASI
+// while never running it (PR #2428 review). `ThreadNotifier.notify` has no OS
+// primitive to ring on WASI (reactor.zig's `.wasi => {}` arm), because
+// wasm32-wasi is single-threaded and no other thread can exist to do the
+// ringing — so the poll below would genuinely wait out its whole timeout.
+test "#2395: a ring is a real OS event that ends a blocking reactor poll" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no notifier primitive on WASI (single-threaded)
+    var reactor = try reactor_mod.Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+    const n = reactor.notifyHandle();
+
+    try std.testing.expect(reactor_mod.enrollCrossThreadWaiter(n));
+    defer reactor_mod.withdrawCrossThreadWaiter(n);
+    reactor_mod.wakeCrossThreadWaiters();
+
+    // A poll that would otherwise wait out its whole timeout returns at once.
+    // Asserted on elapsed time rather than by blocking forever, so a
+    // regression fails the test instead of hanging the suite.
     var ready: std.ArrayList(*fiber_mod.Fiber) = .empty;
     defer ready.deinit(std.testing.allocator);
     const t0 = fiber_mod.clockNs();

--- a/src/tests_reactor.zig
+++ b/src/tests_reactor.zig
@@ -845,6 +845,13 @@ test "#2395: wakeCrossThreadWaiters rings an enrolled reactor out of a blocking 
     // otherwise wait out its whole timeout returns at once. Asserted on
     // elapsed time rather than by blocking forever, so a regression fails
     // the test instead of hanging the suite.
+    //
+    // Not on WASI: `ThreadNotifier.notify` has no OS primitive to ring there
+    // (reactor.zig's `.wasi => {}` arm), because wasm32-wasi is
+    // single-threaded and no other thread can exist to do the ringing. The
+    // flag half above is still meaningful — it is the same bookkeeping — but
+    // the poll below would genuinely wait out its whole timeout.
+    if (comptime platform.is_wasm) return;
     var ready: std.ArrayList(*fiber_mod.Fiber) = .empty;
     defer ready.deinit(std.testing.allocator);
     const t0 = fiber_mod.clockNs();

--- a/src/tests_waitforfd.zig
+++ b/src/tests_waitforfd.zig
@@ -340,6 +340,8 @@ const unwind_table = [_]UnwindRow{
     // deadline, so parkOnReactor's deadlock check already covers the idle
     // case and a timed wait must run its full duration.
     .{ .name = "TargetWait (fiber-join / thread-join!)", .Ctx = fiber_mod.TargetWait, .unwinds = false },
+    .{ .name = "OsThreadWait (thread-join! on an OS thread)", .Ctx = primitives_srfi18.OsThreadWait, .unwinds = false },
+    .{ .name = "UnstartedThreadWait (thread-join! before thread-start!)", .Ctx = primitives_srfi18.UnstartedThreadWait, .unwinds = false },
     .{ .name = "SleepWait (thread-sleep!)", .Ctx = primitives_srfi18.SleepWait, .unwinds = false },
     .{ .name = "MutexWait (mutex-lock!)", .Ctx = primitives_srfi18.MutexWait, .unwinds = false },
     .{ .name = "CondVarWait (condition-variable-wait!)", .Ctx = primitives_srfi18.CondVarWait, .unwinds = false },
@@ -380,13 +382,20 @@ test "#1625: every wait context still satisfies runSchedulerStep's duck type" {
         if (!@hasDecl(row.Ctx, "isDone")) return error.MissingIsDone;
         if (@hasDecl(row.Ctx, "pollCapNs")) with_cap += 1;
     }
-    // The two SRFI-18 waits resolvable by another OS thread (mutex unlock,
-    // condvar signal) plus SleepWait, whose cap exists not for resolution
-    // but so a sleeping thread observes thread-terminate! from another OS
-    // thread within a poll cadence (#1982) -- the only way a terminate can
-    // interrupt an otherwise timer-bounded sleep park. A new cap beyond
-    // these three means a new cross-thread path worth reviewing.
-    try std.testing.expectEqual(@as(usize, 3), with_cap);
+    // Every wait resolvable by another OS thread declares a cap: the two
+    // mutex/condvar waits, thread-join! on a running OS thread, and
+    // SleepWait -- whose cap exists not for resolution but so a sleeping
+    // thread observes thread-terminate! from another OS thread (#1982).
+    //
+    // Since #2395 none of them USES its cap in the normal case: each enrols
+    // in reactor.zig's cross-thread wake registry and returns null while
+    // enrolled, so the resolving thread's notifier ring ends the park. The
+    // cap is the degraded path for an enrolment that could not allocate, and
+    // declaring one is still the marker of "this wait can be resolved from
+    // another OS thread" -- a new one beyond these four means a new
+    // cross-thread path worth reviewing. UnstartedThreadWait deliberately
+    // has none: only its own thread can start a thread it holds a handle to.
+    try std.testing.expectEqual(@as(usize, 4), with_cap);
 }
 
 // --- anyAncestorWaitResolved, directly ------------------------------------
@@ -1055,4 +1064,39 @@ test "two fibers parked on the same fd are both listed and both woken by close" 
     const s = try printer.valueToString(std.testing.allocator, r, .write);
     defer std.testing.allocator.free(s);
     try std.testing.expectEqualStrings("(caught caught)", s);
+}
+
+// ===========================================================================
+// Group F — parkOnReactor's consumed-notify escape (#2395)
+//
+// The SRFI-18 cross-thread waits park with no poll cap, so a notify that
+// parkOnReactor's own consume protocol swallows must never be followed by a
+// blocking poll. The OS-level trigger usually saves it — but not when the
+// same tick's `reactor.poll(0)` (runReactorTick, taken whenever an fd is
+// registered) already drained the trigger while leaving `wake_pending` set.
+// parkOnReactor therefore reports progress instead of blocking, and the
+// caller re-checks its own condition, which is what the wakeup was asking
+// for. Set up directly — the flag is plain state, so no race is needed.
+// ===========================================================================
+
+test "#2395: parkOnReactor returns without blocking when it consumes a notify" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const ctx = try fiber_mod.ensureScheduler(vm);
+    // No runnable fiber and an empty reactor: without the notify this call is
+    // the deadlock verdict (`false`), and with a cap it would be a wait. The
+    // discriminating control is the second half of this test.
+    ctx.reactor.notifier.wake_pending.store(true, .release);
+    const t0 = fiber_mod.clockNs();
+    try std.testing.expect(try fiber_mod.parkOnReactor(vm, ctx.sched, null));
+    try std.testing.expect(fiber_mod.clockNs() - t0 < std.time.ns_per_s);
+    // Consumed, not left set for the next park to trip over again.
+    try std.testing.expect(!ctx.reactor.notifier.wake_pending.load(.acquire));
+
+    // Control: same state with no notify pending is still reported as the
+    // deadlock it is, so the escape above is the notify and not the setup.
+    try std.testing.expect(!try fiber_mod.parkOnReactor(vm, ctx.sched, null));
 }

--- a/tests/scheme/smoke/thread-notifier-waits-2395.scm
+++ b/tests/scheme/smoke/thread-notifier-waits-2395.scm
@@ -114,7 +114,43 @@
     (test-equal "terminate ends a long sleep" 'terminated (car r))
     (test-assert "terminated child is joined promptly" (< (cdr r) 10))))
 
-;; 8. A "never" deadline is a real reactor park, not an error. SRFI-18 reads
+;; 8. A wait that BECOMES cross-thread after it has already parked (PR #2428
+;;    review). At the moment each of these enters its wait no OS thread
+;;    exists, so a wait that decided whether to enrol from
+;;    crossThreadWaitPossible() at entry would not enrol -- and would then
+;;    park with no cap at all, because runSchedulerStep evaluates pollCapNs
+;;    once and the deadline timer keeps the reactor non-empty. The sibling
+;;    fiber that this very drive dispatches starts the process's first OS
+;;    thread, whose unlock/signal rings a registry the wait never joined:
+;;    measured at `#f` after the full 2s, for a hand-off that happened at
+;;    0.1s. Enrolling unconditionally is what closes it.
+(define m3 (make-mutex))
+(let ()
+  (mutex-lock! m3)
+  (spawn (lambda ()
+           (thread-start! (make-thread (lambda () (thread-sleep! 0.1) (mutex-unlock! m3))))))
+  (let ((r (elapsed (lambda () (mutex-lock! m3 2)))))
+    (test-equal "timed mutex-lock! sees an unlock from the first OS thread started mid-wait"
+                #t (car r))
+    (test-assert "and sees it promptly, not at its deadline" (< (cdr r) 1.5))))
+
+(define m4 (make-mutex))
+(define cv4 (make-condition-variable))
+(let ()
+  (mutex-lock! m4)
+  (spawn (lambda ()
+           (thread-start! (make-thread (lambda ()
+                                         (thread-sleep! 0.1)
+                                         (condition-variable-broadcast! cv4))))))
+  ;; start_gen is snapshotted inside mutex-unlock! before it releases m4 and
+  ;; before the drive can dispatch the sibling, so the broadcast below cannot
+  ;; be missed -- only the enrolment timing is under test here.
+  (let ((r (elapsed (lambda () (mutex-unlock! m4 cv4 3)))))
+    (test-equal "condvar wait sees a signal from the first OS thread started mid-wait"
+                #t (car r))
+    (test-assert "and sees it promptly, not at its deadline" (< (cdr r) 2))))
+
+;; 9. A "never" deadline is a real reactor park, not an error. SRFI-18 reads
 ;;    +inf.0 as "never times out", which saturates to a maxInt-nanosecond
 ;;    deadline ~585 years out -- a timespec kqueue rejects outright unless the
 ;;    reactor clamps its own blocking wait. Before #2395 thread-join! reached

--- a/tests/scheme/smoke/thread-notifier-waits-2395.scm
+++ b/tests/scheme/smoke/thread-notifier-waits-2395.scm
@@ -61,17 +61,46 @@
 
 ;; 6. Cross-thread condition variable: the child waits on cv, and
 ;;    condition-variable-signal! from here is what must wake it.
+;;
+;;    Signalled in a retry loop rather than once after a fixed delay. A
+;;    signal that lands before the child has snapshotted the generation
+;;    inside mutex-unlock! reaches no waiter at all, and a fixed delay makes
+;;    that unlikely rather than impossible -- the child would then sit out
+;;    its whole cv timeout and this would fail on a loaded machine for a
+;;    reason unrelated to what it tests. Extra signals are harmless: each is
+;;    a generation bump the child has either already accounted for or is
+;;    about to observe.
+;;
+;;    The retry cannot mask a lost wake, which is the point. The wait is
+;;    parked on the notifier with no poll cadence to fall back on, so
+;;    without the ring the child never wakes however many times we signal --
+;;    it runs out its own 15s cv timeout and reports 'cv-timed-out, which
+;;    fails this assertion rather than hanging the suite.
+;;
+;;    Signalled WITHOUT holding m2, departing from the usual SRFI-18
+;;    convention on purpose: it is the retry loop, not the mutex, that
+;;    closes the lost-wakeup window here, and taking m2 would make this
+;;    thread's own mutex-unlock! ring the notifier -- masking the thing
+;;    under test. Measured: with the ring in condition-variable-signal!
+;;    removed, the mutex-held version of this loop still passed.
 (define m2 (make-mutex))
 (define cv (make-condition-variable))
 (let ((t (thread-start! (make-thread (lambda ()
                                        (mutex-lock! m2)
-                                       (if (mutex-unlock! m2 cv 5) 'signaled 'cv-timed-out))))))
-  (thread-sleep! 0.2)
-  (mutex-lock! m2)
-  (condition-variable-signal! cv)
-  (mutex-unlock! m2)
-  (test-equal "child wakes from the condition variable when signaled"
-              'signaled (thread-join! t 5 'timed-out)))
+                                       (if (mutex-unlock! m2 cv 15) 'signaled 'cv-timed-out))))))
+  (let loop ((tries 0))
+    (let ((r (thread-join! t 0.2 'still-waiting)))
+      (cond ((not (eq? r 'still-waiting))
+             (test-equal "child wakes from the condition variable when signaled"
+                         'signaled r))
+            ((< tries 40)
+             (condition-variable-signal! cv)
+             (loop (+ tries 1)))
+            (else
+             ;; Out of retries (~8s): collect whatever the child ends up
+             ;; reporting so the failure names the cause.
+             (test-equal "child wakes from the condition variable when signaled"
+                         'signaled (thread-join! t 20 'never-finished)))))))
 
 ;; 7. thread-terminate! reaches a child parked in a long thread-sleep!. The
 ;;    sleep is 30 s; the terminate ring is the only thing that can end it in

--- a/tests/scheme/smoke/thread-notifier-waits-2395.scm
+++ b/tests/scheme/smoke/thread-notifier-waits-2395.scm
@@ -124,31 +124,41 @@
 ;;    thread, whose unlock/signal rings a registry the wait never joined:
 ;;    measured at `#f` after the full 2s, for a hand-off that happened at
 ;;    0.1s. Enrolling unconditionally is what closes it.
+;;    Each case must therefore START with no OS thread alive, which means
+;;    REAPING the previous one -- not merely observing its side effect. The
+;;    unlock below is published well before threadEntryFn returns and
+;;    decrements live_child_threads, so without the explicit thread-join!
+;;    the mutex child can still be alive when the condvar case begins, the
+;;    old crossThreadWaitPossible() gate would see it and enrol, and the
+;;    condvar half would false-green (PR #2428 review). Every handle is
+;;    created outside its sibling and retained so it can be joined.
 (define m3 (make-mutex))
-(let ()
+(let ((t (make-thread (lambda () (thread-sleep! 0.1) (mutex-unlock! m3)))))
   (mutex-lock! m3)
-  (spawn (lambda ()
-           (thread-start! (make-thread (lambda () (thread-sleep! 0.1) (mutex-unlock! m3))))))
+  (spawn (lambda () (thread-start! t)))
   (let ((r (elapsed (lambda () (mutex-lock! m3 2)))))
     (test-equal "timed mutex-lock! sees an unlock from the first OS thread started mid-wait"
                 #t (car r))
-    (test-assert "and sees it promptly, not at its deadline" (< (cdr r) 1.5))))
+    (test-assert "and sees it promptly, not at its deadline" (< (cdr r) 1.5)))
+  ;; Reap before the next case (see above). Asserted rather than discarded so
+  ;; the join's value does not reach stdout.
+  (test-equal "mutex child is reaped before the next case" #t (thread-join! t)))
 
 (define m4 (make-mutex))
 (define cv4 (make-condition-variable))
-(let ()
+(let ((t (make-thread (lambda ()
+                        (thread-sleep! 0.1)
+                        (condition-variable-broadcast! cv4)))))
   (mutex-lock! m4)
-  (spawn (lambda ()
-           (thread-start! (make-thread (lambda ()
-                                         (thread-sleep! 0.1)
-                                         (condition-variable-broadcast! cv4))))))
+  (spawn (lambda () (thread-start! t)))
   ;; start_gen is snapshotted inside mutex-unlock! before it releases m4 and
   ;; before the drive can dispatch the sibling, so the broadcast below cannot
   ;; be missed -- only the enrolment timing is under test here.
   (let ((r (elapsed (lambda () (mutex-unlock! m4 cv4 3)))))
     (test-equal "condvar wait sees a signal from the first OS thread started mid-wait"
                 #t (car r))
-    (test-assert "and sees it promptly, not at its deadline" (< (cdr r) 2))))
+    (test-assert "and sees it promptly, not at its deadline" (< (cdr r) 2)))
+  (thread-join! t))  ; reap; the broadcast thunk's void result prints nothing
 
 ;; 9. A "never" deadline is a real reactor park, not an error. SRFI-18 reads
 ;;    +inf.0 as "never times out", which saturates to a maxInt-nanosecond

--- a/tests/scheme/smoke/thread-notifier-waits-2395.scm
+++ b/tests/scheme/smoke/thread-notifier-waits-2395.scm
@@ -1,0 +1,110 @@
+;; Regression tests for #2395 (KEP-0002 unresolved question 3): the SRFI-18
+;; waits that can only be resolved by another OS thread now park on the
+;; reactor and are woken by a ThreadNotifier ring, instead of polling their
+;; own state at 1 ms.
+;;
+;; Every case below is a cross-thread hand-off with a generous timeout: if a
+;; wake is ever lost, the wait runs out its whole timeout and the test fails
+;; with the timeout value rather than hanging the suite.
+
+(import (scheme base) (scheme write) (scheme process-context)
+        (srfi 18) (kaappi fibers) (srfi 64))
+
+(test-begin "thread-notifier-waits-2395")
+
+(define (elapsed thunk)
+  (let* ((t0 (time->seconds (current-time)))
+         (r (thunk)))
+    (cons r (- (time->seconds (current-time)) t0))))
+
+;; 1. thread-join! with a timeout wakes on the child's exit, not on the
+;;    timeout. The 5 s timeout is 50x the child's runtime: a lost wake would
+;;    return 'timed-out.
+(let* ((t (thread-start! (make-thread (lambda () (thread-sleep! 0.1) 'done))))
+       (r (elapsed (lambda () (thread-join! t 5 'timed-out)))))
+  (test-equal "timed thread-join! returns the child's result" 'done (car r))
+  (test-assert "timed thread-join! returns when the child exits, not at its deadline"
+               (< (cdr r) 4)))
+
+;; 2. A timed thread-join! no longer freezes this thread's own fibers: a
+;;    sibling fiber must get dispatched while the join is parked. Before
+;;    #2395 the join was a bare nanosleep loop and `ran` stayed #f.
+(let ((ran #f))
+  (let ((t (thread-start! (make-thread (lambda () (thread-sleep! 0.2) 'done)))))
+    (spawn (lambda () (set! ran #t)))
+    (test-equal "join still returns the result" 'done (thread-join! t 5 'timed-out))
+    (test-assert "a sibling fiber runs while a timed thread-join! is parked" ran)))
+
+;; 3. thread-join! on a handle that has not been started yet is resolved by a
+;;    fiber on this same thread calling thread-start! -- only reachable now
+;;    that the wait drives the scheduler instead of sleeping through it.
+(let ((t (make-thread (lambda () 'started-late))))
+  (spawn (lambda () (thread-start! t)))
+  (test-equal "join of an unstarted handle waits for a sibling fiber to start it"
+              'started-late (thread-join! t 5 'timed-out)))
+
+;; 4. A never-started handle nobody starts still times out.
+(let ((t (make-thread (lambda () 42))))
+  (test-equal "unstarted handle nobody starts still times out"
+              'timed-out (thread-join! t 0.05 'timed-out)))
+
+;; 5. Cross-thread mutex hand-off: the child blocks in mutex-lock! on a mutex
+;;    this thread holds, and the unlock is what must wake it.
+(define m (make-mutex))
+(let ()
+  (mutex-lock! m)
+  (let ((t (thread-start! (make-thread (lambda () (mutex-lock! m) (mutex-unlock! m) 'locked)))))
+    (thread-sleep! 0.1)
+    (mutex-unlock! m)
+    (test-equal "child acquires the mutex once this thread unlocks it"
+                'locked (thread-join! t 5 'timed-out))))
+
+;; 6. Cross-thread condition variable: the child waits on cv, and
+;;    condition-variable-signal! from here is what must wake it.
+(define m2 (make-mutex))
+(define cv (make-condition-variable))
+(let ((t (thread-start! (make-thread (lambda ()
+                                       (mutex-lock! m2)
+                                       (if (mutex-unlock! m2 cv 5) 'signaled 'cv-timed-out))))))
+  (thread-sleep! 0.2)
+  (mutex-lock! m2)
+  (condition-variable-signal! cv)
+  (mutex-unlock! m2)
+  (test-equal "child wakes from the condition variable when signaled"
+              'signaled (thread-join! t 5 'timed-out)))
+
+;; 7. thread-terminate! reaches a child parked in a long thread-sleep!. The
+;;    sleep is 30 s; the terminate ring is the only thing that can end it in
+;;    time (before #2395 it was the sleep's own 1 ms poll cap).
+(let ((t (thread-start! (make-thread (lambda () (thread-sleep! 30) 'slept)))))
+  (thread-sleep! 0.1)
+  (thread-terminate! t)
+  (let ((r (elapsed (lambda ()
+                      (guard (e ((terminated-thread-exception? e) 'terminated))
+                        (thread-join! t))))))
+    (test-equal "terminate ends a long sleep" 'terminated (car r))
+    (test-assert "terminated child is joined promptly" (< (cdr r) 10))))
+
+;; 8. A "never" deadline is a real reactor park, not an error. SRFI-18 reads
+;;    +inf.0 as "never times out", which saturates to a maxInt-nanosecond
+;;    deadline ~585 years out -- a timespec kqueue rejects outright unless the
+;;    reactor clamps its own blocking wait. Before #2395 thread-join! reached
+;;    that deadline through a nanosleep loop and never handed it to the
+;;    reactor; (thread-sleep! 1e18) did, and raised KP9002 "out of memory"
+;;    instead of sleeping.
+(let ((t (thread-start! (make-thread (lambda () (thread-sleep! 0.1) 'inf-done)))))
+  (test-equal "thread-join! with an infinite timeout waits and returns the result"
+              'inf-done (thread-join! t +inf.0)))
+
+(let ((t (thread-start! (make-thread (lambda () (thread-sleep! +inf.0) 'slept)))))
+  (thread-sleep! 0.1)
+  (thread-terminate! t)
+  (test-equal "an infinite thread-sleep! parks (and terminate ends it)"
+              'terminated
+              (guard (e ((terminated-thread-exception? e) 'terminated)
+                        (#t 'other-exception))
+                (thread-join! t))))
+
+(let ((runner (test-runner-current)))
+  (test-end "thread-notifier-waits-2395")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Closes #2395 (KEP-0002 unresolved question 3).

## The problem

Four SRFI-18 waits polled their own state at 1 ms whenever another OS thread was the only thing that could resolve them:

| Wait | How it polled |
|---|---|
| `thread-join!` on a running OS thread | a bare `sleepNs(1_000_000)` loop — the whole thread, fibers included, frozen |
| `thread-join!` on an unstarted `make-thread` handle | the same loop |
| `mutex-lock!` on a contended mutex | `sleepNs(CROSS_THREAD_POLL_NS)` + a 1 ms `pollCapNs` |
| the condition-variable wait | same |

`thread-sleep!` carried the same cap for a different reason (#1982): it is the only way a parked sleep observes `thread-terminate!` from another thread. A `(thread-sleep! 60)` on a child thread woke 60,000 times.

## The mechanism

The `ThreadNotifier` from KEP-0002 Phase 3 was already there but reachable only from promoted channels, which hang notifiers off per-channel waiter lists. A mutex or condition variable has no such list — it is an ordinary GC object reached through the globals route, owned by whichever heap allocated it. So `reactor.zig` gains a registry keyed by **thread**, not by object, and any state change one of these waits could observe rings every entry:

- enrol: `enrollCrossThreadWaiter` / `withdrawCrossThreadWaiter`, wrapped per wait by `fiber_wait.CrossThreadEnrolment`
- ring: `mutex-unlock!`, a mutex abandoned by a dying fiber or thread (`abandonFiberMutexes`), `condition-variable-signal!`/`-broadcast!`, `thread-terminate!`, and an OS thread's exit (`threadEntryFn`)

Waiters re-check their own condition and re-park, so a spurious wake costs one loop iteration.

## Three things that had to be right for the caps to come off

1. **`parkOnReactor` returns "progress" as soon as it consumes a pending notify**, instead of going on to poll. Consuming the flag does not consume the OS trigger, so the poll usually returns anyway — except when the same tick's `reactor.poll(0)` (`runReactorTick`, taken whenever an fd is registered) already drained it. That interleaving would block on an event already delivered.

2. **An enrolment is deliberately invisible to `hasRunnableFibers`**, unlike a `shared_waiters` entry. A *timed* wait needs nothing there (its own deadline timer keeps the reactor non-empty). An *untimed* one needs `parkOnReactor`'s "nothing local can happen" verdict to keep coming back, because that verdict is what returns control to the retry loop where `crossThreadWaitPossible()` decides between waiting longer and raising the deadlock diagnostic. That loop blocks on the ring itself via `fiber_wait.awaitCrossThreadRing`, bounded at 100 ms so the liveness check still gets its turn. Counting enrolments there instead turns that diagnostic into a hang — I built it that way first and had to back it out.

3. **`wakeCrossThreadWaiters` takes the registry lock even to find it empty.** An atomic length gate read outside the lock is a store-buffering (Dekker) pattern against the enroller — both sides can miss the other's store, since the state accesses are the plain acquire/release ones the mutex and condvar already use. With no cap left as a backstop that is a hang, not a latency blip.

The caps survive as a **degraded path only**: `enrollCrossThreadWaiter` returns false if the registry cannot allocate, and each wait's `pollCapNs` then falls back to the pre-#2395 cadence rather than parking on a ring that will never come.

## Behaviour changes worth calling out

Both fall out of the timed `thread-join!` no longer being a whole-thread `nanosleep`:

- **This thread's own fibers now run while a timed `thread-join!` is parked.** So a fiber can start a `make-thread` handle another fiber is joining (previously unreachable — the join never yielded the thread), and joining a never-started handle with *no* timeout now reports a deadlock instead of hanging forever.
- **A timed `thread-join!` from inside a SRFI 181 custom-port callback is now rejected** with the same catchable error every other blocking primitive raises there (#2000). The untimed fiber path already did this.

## Rides along: a pre-existing reactor bug

SRFI-18 reads `+inf.0` as "never times out" and `saturatedNsFromSeconds` saturates it to a maxInt-nanosecond deadline ~585 years out. Handed to `kevent` as a timespec that far ahead, macOS rejects the call outright, so the park surfaced as `KP9002: out of memory` instead of blocking — `(thread-sleep! 1e18)` raised instead of sleeping, on current `main`. `thread-join!` reached that deadline through a nanosleep loop and never handed it to the reactor, which is why it only became unavoidable here. `Reactor.effectiveTimeout` now clamps a single blocking wait to 24 hours — inside every backend's range — and lets the caller re-loop.

## Tests

`tests/scheme/smoke/thread-notifier-waits-2395.scm` (12 assertions), plus three Zig unit tests. Every case is a cross-thread hand-off with a generous timeout, so a lost wake fails with the timeout value rather than hanging the suite. Mutation-verified — each of these was reverted in turn and the named tests failed:

| Reverted | Fails |
|---|---|
| the exit ring in `threadEntryFn` | "timed thread-join! returns when the child exits, not at its deadline" |
| the rings in `mutex-unlock!` and `condition-variable-signal!` | the mutex hand-off and condvar cases |
| the `effectiveTimeout` clamp | both `+inf.0` cases |

`zig build test`: 1912/1919 pass (7 skipped). `bash tests/scheme/run-all.sh`: 2126 pass, 0 fail.

## Not in scope

Two other `sleepNs(CROSS_THREAD_POLL_NS)` sites in `primitives_srfi18.zig` are left alone — the `live_descendants` teardown drain and the `collection_in_progress` startup handshake. Both are GC/teardown handshakes on a thread with no VM to park, not timeout waits.

The KEP-0002 unresolved-question ledger lives in the `keps` repo and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)