### PR TITLE
Restore fiber state on every wait error exit; cut the 2200 compile test to one build (#2429, #2430, #2431)

### DIFF
--- a/docs/dev/test-runner.md
+++ b/docs/dev/test-runner.md
@@ -312,20 +312,39 @@ Three things make that safe and worthwhile (kaappi#1926):
   were 85% of the shell suites' entire wall time. They now share the fixture
   in `tests/scheme/compile/fixtures/bundle-replay/`, so the second build is a
   ~0.2s hit in Zig's own content-addressed cache. `bundle_fixture_binary`
-  first builds the interpreter from current source into an isolated prefix
-  and produces the `.sbc` with *that* binary, so the `.sbc` and the bundler
-  always share one build id (kaappi#1930) — a `.sbc` made by whatever
-  `zig-out/bin/kaappi` was lying around would go stale against the rebuilt
-  bundler's build id and fail with `invalid embedded bytecode` whenever the
-  tree moved (see [cache.md](cache.md)). Regenerating the `.sbc` on every
-  call is what keeps it honest: identical sources give identical bytes and
-  the hit, while an edit under `src/` changes them and forces exactly the
-  rebuild it must.
+  produces the `.sbc` with `fixture_interpreter`'s binary (below), so the
+  `.sbc` and the bundler always share one build id (kaappi#1930) — a `.sbc`
+  made by whatever `zig-out/bin/kaappi` was lying around would go stale
+  against the rebuilt bundler's build id and fail with `invalid embedded
+  bytecode` whenever the tree moved (see [cache.md](cache.md)). Regenerating
+  the `.sbc` on every call is what keeps it honest: identical sources give
+  identical bytes and the hit, while an edit under `src/` changes them and
+  forces exactly the rebuild it must.
+- **One interpreter for every script that needs one.**
+  `fixture_interpreter <repo>` builds it into a shared isolated prefix under
+  `.zig-cache/kaappi-test-fixtures/interp` and prints the path, leaving
+  `zig-out/` and the binary under test alone (kaappi#2163). Any script that
+  produces a `.sbc` to feed a `-Dbundle=` of its own needs one for the
+  build-id reason above; the first caller in a run pays, the rest get a cache
+  hit. It runs `zig build` unconditionally — `zig build` *is* the freshness
+  check, so it is a no-op when nothing moved and exactly the right rebuild
+  when something did.
+
+  It pins `-Doptimize=ReleaseSafe`, and so must every `-Dbundle=` build
+  downstream of it. That is also `build.zig`'s default, so a bare `zig build`
+  compiles the same thing — but naming it is what keeps every caller on one
+  cache key instead of inheriting whatever mode a job happens to pass.
+  kaappi#2431 is the failure mode: `test (ubuntu-latest, Debug)` fills the
+  cache with Debug artefacts, so these ReleaseSafe builds ran stone cold on
+  that leg alone, and `compile-define-values-order-2200.sh` — three full
+  builds at the time — sat close enough to the 600s `KAAPPI_SHELL_TEST_TIMEOUT`
+  that ordinary runner variance decided it, failing a *required* check about
+  one run in fourteen. Keep the count of full builds per script at one.
 
 Dispatch inside a suite is longest-first — scripts that shell out to a full
-`zig build -D…` go first, found by grep rather than a hand-kept list of names.
-Reporting still walks the glob-sorted order, so a transcript diff between two
-runs stays meaningful at any job count.
+`zig build -D…`, or to either shared builder, go first, found by grep rather
+than a hand-kept list of names. Reporting still walks the glob-sorted order, so
+a transcript diff between two runs stays meaningful at any job count.
 
 ## Tests
 

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -894,6 +894,50 @@ pub const FiberScheduler = struct {
         };
     }
 
+    /// Retire `fiber`'s enrolment under `key` — the exact inverse of
+    /// `enrollWaiter`, for a park that is being undone rather than woken
+    /// (#2430's error exits, via `primitives_srfi18.unparkOnError`).
+    ///
+    /// A wake retires the entry as a side effect: `indexWakeOn` compacts out
+    /// every stale index it walks and frees the key once the list empties. An
+    /// *abandoned* park gets no such visit. Clearing `status` is enough to stop
+    /// the entry ever waking the wrong fiber — that is the validation
+    /// `indexWakeOn` already performs — but it does not remove it, and nothing
+    /// else will unless some later wake happens to name the same key. A wait
+    /// abandoned on an object that is then never woken (a condition variable
+    /// nobody signals, a mutex nobody unlocks, a fiber that never completes)
+    /// therefore strands one map key and list for the scheduler's lifetime, and
+    /// a program that fails such a park repeatedly on FRESH objects strands one
+    /// per failure. `markRoots` does not trace these keys either, so once the
+    /// unpark clears `waiting_on` the key is no longer rooted by the fiber:
+    /// harmless for lookup (the map hashes the Value, never dereferences it)
+    /// and for correctness (a recycled address still meets the per-entry
+    /// validation), but it makes the entry pure garbage that can never be
+    /// matched again.
+    ///
+    /// Removes every occurrence of this fiber's slot, not just the first:
+    /// `enrollWaiter`'s dedup only skips a duplicate at the tail, so a fiber
+    /// that re-parked on the same key around another waiter's entry can appear
+    /// more than once.
+    pub fn withdrawWaiter(self: *FiberScheduler, fiber: *Fiber, key: Value) void {
+        if (self.waiter_index_degraded) return;
+        if (key == types.VOID) return;
+        const entry = self.waiter_index.getEntry(key) orelse return;
+        const list = entry.value_ptr;
+        var w: usize = 0; // write cursor: entries to keep, compacted in place
+        for (list.items) |idx| {
+            if (idx == fiber.sched_idx) continue;
+            list.items[w] = idx;
+            w += 1;
+        }
+        if (w == 0) {
+            list.deinit(self.vm.gc.allocator);
+            _ = self.waiter_index.remove(key);
+        } else {
+            list.shrinkRetainingCapacity(w);
+        }
+    }
+
     /// The common tail of every wake path: move `fiber` from `.waiting` back
     /// to `.suspended`, hand off any join result, cancel a pending timeout
     /// timer, and enqueue it on the ready ring. Factored out so the index and

--- a/src/fiber_wait.zig
+++ b/src/fiber_wait.zig
@@ -457,6 +457,48 @@ pub fn runSchedulerStep(comptime Ctx: type, ctx: Ctx, vm: *VM, sched: *FiberSche
     }
     const my_idx = sched.current_idx;
     try sched.saveCurrentFiber();
+
+    // #2429: run the epilogue's restore on EVERY exit, not just the normal
+    // one. Five `try`s below return without reaching it — parkOnReactor,
+    // restoreFiber(next_idx), and the three saveCurrentFiber calls (the
+    // Yielded, errored-dispatch and completed-dispatch paths) — and all
+    // five surface VMError.OutOfMemory, which is *catchable*, unlike the
+    // `return VMError.Terminated` above that errors.isUncatchable unwinds
+    // past every handler.
+    //
+    // By the time the three saveCurrentFiber calls run, restoreFiber has
+    // already loaded a SIBLING's registers, frames, handler stack and wind
+    // stack into the VM, and saveCurrentFiber only copies VM→fiber — it
+    // never puts `me` back. parkOnReactor is reached at the top of a later
+    // iteration with that same sibling state still loaded. So returning OOM
+    // from any of them leaves vm.current_fiber, sched.current_idx and the
+    // whole VM window belonging to the sibling, and a Scheme `guard` that
+    // catches the OOM resumes `me`'s bytecode against another fiber's
+    // registers: the #1487 dispatch-from-stale-snapshot corruption reached
+    // by a different route, in the single shared body behind
+    // channel-receive/-send, fiber-join, thread-join!, mutex-lock!,
+    // condition-variable waits and thread-sleep!.
+    //
+    // Ordering: declared before `driving`/driving_waits below, so on unwind
+    // it runs after both of their defers — the same order as the normal
+    // epilogue, which is reached with both already popped.
+    //
+    // The `catch {}` cannot fire. restoreFiber is fallible only through its
+    // four ensureXxxCapacity calls, each of which returns early when the
+    // need is already met and never shrinks; `me` was current on entry, so
+    // the VM stacks were already big enough for the snapshot saveCurrentFiber
+    // just took of them and have only grown since. Swallowing beats any
+    // alternative anyway: the capacity check precedes every memcpy, so a
+    // failure is all-or-nothing and leaves exactly today's state — and
+    // returning a second error, or panicking, while already unwinding an
+    // allocation failure has nothing better to offer.
+    errdefer {
+        sched.restoreFiber(my_idx) catch {};
+        sched.current_idx = my_idx;
+        me.status = .running;
+        vm.current_fiber = me;
+    }
+
     const poll_cap_ns: ?u64 = if (@hasDecl(Ctx, "pollCapNs")) ctx.pollCapNs() else null;
 
     me.driving = true;

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -355,6 +355,43 @@ fn ensureScheduler() @TypeOf(fiber_mod.ensureScheduler(undefined)) {
     return fiber_mod.ensureScheduler(vm);
 }
 
+/// Undo the parked state a SRFI-18 wait site arms (`.waiting` status, the
+/// `timed_out` flag, `waiting_on`, and any reactor deadline timer) on an
+/// error exit, so every such site can `errdefer` it.
+///
+/// Every error exit from a park must leave `me` runnable again (#2430, and
+/// PR #2428 review for the one site that already did). Both failure sources
+/// at these sites -- `reactor.addTimer` and `runSchedulerStep`'s own
+/// allocations -- return `VMError.OutOfMemory`, which is *catchable*: a
+/// Scheme `guard` can swallow it, and the fiber then keeps executing while
+/// the scheduler still believes it is parked. "Running fiber marked parked"
+/// is the precondition for the #1487 dispatch-from-stale-snapshot
+/// corruption, and the `waiter_index`'s deliberate tolerance of a stale
+/// entry (`indexWakeOn` revalidates `status == .waiting`, which is also how
+/// the success path disposes of one) is exactly what a lying `.waiting`
+/// defeats -- so clearing the status is what retires the index entry too,
+/// and no explicit de-enrolment is needed.
+///
+/// The timer is the part that outlives the fiber: `threadJoinFn` used to
+/// leave a pending deadline behind on its error path, and a timer that
+/// survives its fiber can later fire against whatever `addFiber` reuses that
+/// slot for. `removeTimer` is remove-first, so a caller's own cleanup after
+/// catching the error stays correct.
+///
+/// Mirrors the channel waits' `catch` blocks in `primitives_fiber.zig` and
+/// `runSchedulerStep`'s custom-port-callback guard, which undo the same
+/// fields. It is the caller-side half of #2429's fix, which restores the
+/// register window one level down; neither fixes the other.
+fn unparkOnError(reactor: *reactor_mod.Reactor, f: *fiber_mod.Fiber) void {
+    if (f.deadline_ns != null) {
+        reactor.removeTimer(f);
+        f.deadline_ns = null;
+    }
+    f.status = .running;
+    f.timed_out = false;
+    f.waiting_on = types.VOID;
+}
+
 // 1ms. Since #2395 this is no longer how a cross-thread wait normally
 // resolves -- the resolving thread rings this one's reactor notifier
 // (reactor.zig's cross-thread wake registry) and the wait blocks on that
@@ -1248,29 +1285,7 @@ fn parkForThreadStatus(
     // enrolment below is for.
     ctx.sched.enrollWaiter(me);
 
-    // Every error exit below must leave `me` runnable again (PR #2428
-    // review). A primitive that returns a *catchable* error -- OutOfMemory
-    // from addTimer or from runSchedulerStep's own allocations -- can be
-    // caught by a Scheme `guard`, and this fiber then keeps executing while
-    // the scheduler still believes it is parked. "Running fiber marked
-    // parked" is the precondition for the #1487 dispatch-from-stale-snapshot
-    // corruption, and the waiter_index's tolerance of a stale entry
-    // (indexWakeOn revalidates `status == .waiting`) is exactly what a lying
-    // `.waiting` defeats. Mirrors the channel waits' catch blocks in
-    // primitives_fiber.zig and runSchedulerStep's own custom-port-callback
-    // guard, which undo the same three fields.
-    const Unpark = struct {
-        fn run(c: @TypeOf(ctx), f: *fiber_mod.Fiber) void {
-            if (f.deadline_ns != null) {
-                c.reactor.removeTimer(f);
-                f.deadline_ns = null;
-            }
-            f.status = .running;
-            f.timed_out = false;
-            f.waiting_on = types.VOID;
-        }
-    };
-    errdefer Unpark.run(ctx, me);
+    errdefer unparkOnError(ctx.reactor, me); // PR #2428 review; see the helper
 
     var enrolment: fiber_mod.CrossThreadEnrolment = .{};
     defer enrolment.release();
@@ -1416,15 +1431,29 @@ fn threadJoinFn(args: []const Value) PrimitiveError!Value {
         const me = ctx.vm.current_fiber orelse return PrimitiveError.OutOfMemory;
 
         me.waiting_on = fiber_val;
+        // #2430: barriered like the channel waits' own `waiting_on` stores
+        // (primitives_fiber.zig) and parkForThreadStatus's. Belt-and-braces
+        // for a scheduler-resident fiber, which markFiberState re-traces as a
+        // root every collection -- but residency ends the moment retireSlot
+        // runs, and the barrier costs a deduplicated remembered-set append.
+        ctx.vm.gc.writeBarrier(&me.header, fiber_val);
         me.status = .waiting;
         me.timed_out = false;
         ctx.sched.enrollWaiter(me); // #1530: O(1) wake when the joined fiber completes
+        errdefer unparkOnError(ctx.reactor, me); // #2430
         if (deadline_ns) |d| {
             me.deadline_ns = d;
             try ctx.reactor.addTimer(d, me);
         }
 
         const done = try fiber_mod.runSchedulerStep(fiber_mod.TargetWait, .{ .target = target }, ctx.vm, ctx.sched, me);
+        // Matches parkForThreadStatus and mutexLockFn, which this site alone
+        // was missing: a local wake cancels the timer for us, but clearing
+        // `deadline_ns` without it would strand any that survived — and a
+        // null `deadline_ns` is exactly what stops a later unparkOnError from
+        // finding it, leaving it to fire against a reused fiber slot.
+        // removeTimer is remove-first, so it is a no-op in the normal case.
+        if (deadline_ns != null) ctx.reactor.removeTimer(me);
         me.deadline_ns = null;
 
         if (me.timed_out) {
@@ -1855,9 +1884,11 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
     const me = ctx.vm.current_fiber orelse return PrimitiveError.OutOfMemory;
 
     me.waiting_on = mutex_val;
+    ctx.vm.gc.writeBarrier(&me.header, mutex_val); // #2430, see threadJoinFn
     me.status = .waiting;
     me.timed_out = false;
     ctx.sched.enrollWaiter(me); // #1530: O(1) wake on mutex unlock / abandonment
+    errdefer unparkOnError(ctx.reactor, me); // #2430
     if (deadline) |d| {
         me.deadline_ns = d;
         try ctx.reactor.addTimer(d, me);
@@ -2055,9 +2086,11 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
 
         const me = ctx.vm.current_fiber orelse return PrimitiveError.OutOfMemory;
         me.waiting_on = args[1];
+        ctx.vm.gc.writeBarrier(&me.header, args[1]); // #2430, see threadJoinFn
         me.status = .waiting;
         me.timed_out = false;
         ctx.sched.enrollWaiter(me); // #1530: O(1) wake on signal / broadcast
+        errdefer unparkOnError(ctx.reactor, me); // #2430
         if (deadline) |d| {
             me.deadline_ns = d;
             try ctx.reactor.addTimer(d, me);

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -369,8 +369,14 @@ fn ensureScheduler() @TypeOf(fiber_mod.ensureScheduler(undefined)) {
 /// corruption, and the `waiter_index`'s deliberate tolerance of a stale
 /// entry (`indexWakeOn` revalidates `status == .waiting`, which is also how
 /// the success path disposes of one) is exactly what a lying `.waiting`
-/// defeats -- so clearing the status is what retires the index entry too,
-/// and no explicit de-enrolment is needed.
+/// defeats.
+///
+/// That tolerance stops a stale entry waking the wrong fiber; it does not
+/// remove it. Only a later wake naming the same key would, so the enrolment
+/// is withdrawn explicitly here -- before `waiting_on` is cleared, since that
+/// field IS the key -- or an abandoned park on an object nothing ever wakes
+/// would strand a map key and list for the scheduler's lifetime, one per
+/// failure on a fresh object (PR #2432 review).
 ///
 /// The timer is the part that outlives the fiber: `threadJoinFn` used to
 /// leave a pending deadline behind on its error path, and a timer that
@@ -382,13 +388,14 @@ fn ensureScheduler() @TypeOf(fiber_mod.ensureScheduler(undefined)) {
 /// `runSchedulerStep`'s custom-port-callback guard, which undo the same
 /// fields. It is the caller-side half of #2429's fix, which restores the
 /// register window one level down; neither fixes the other.
-fn unparkOnError(reactor: *reactor_mod.Reactor, f: *fiber_mod.Fiber) void {
+fn unparkOnError(sched: *fiber_mod.FiberScheduler, reactor: *reactor_mod.Reactor, f: *fiber_mod.Fiber) void {
     if (f.deadline_ns != null) {
         reactor.removeTimer(f);
         f.deadline_ns = null;
     }
     f.status = .running;
     f.timed_out = false;
+    sched.withdrawWaiter(f, f.waiting_on);
     f.waiting_on = types.VOID;
 }
 
@@ -1285,7 +1292,7 @@ fn parkForThreadStatus(
     // enrolment below is for.
     ctx.sched.enrollWaiter(me);
 
-    errdefer unparkOnError(ctx.reactor, me); // PR #2428 review; see the helper
+    errdefer unparkOnError(ctx.sched, ctx.reactor, me); // PR #2428 review; see the helper
 
     var enrolment: fiber_mod.CrossThreadEnrolment = .{};
     defer enrolment.release();
@@ -1440,7 +1447,7 @@ fn threadJoinFn(args: []const Value) PrimitiveError!Value {
         me.status = .waiting;
         me.timed_out = false;
         ctx.sched.enrollWaiter(me); // #1530: O(1) wake when the joined fiber completes
-        errdefer unparkOnError(ctx.reactor, me); // #2430
+        errdefer unparkOnError(ctx.sched, ctx.reactor, me); // #2430
         if (deadline_ns) |d| {
             me.deadline_ns = d;
             try ctx.reactor.addTimer(d, me);
@@ -1888,7 +1895,7 @@ fn mutexLockFn(args: []const Value) PrimitiveError!Value {
     me.status = .waiting;
     me.timed_out = false;
     ctx.sched.enrollWaiter(me); // #1530: O(1) wake on mutex unlock / abandonment
-    errdefer unparkOnError(ctx.reactor, me); // #2430
+    errdefer unparkOnError(ctx.sched, ctx.reactor, me); // #2430
     if (deadline) |d| {
         me.deadline_ns = d;
         try ctx.reactor.addTimer(d, me);
@@ -2090,7 +2097,7 @@ fn mutexUnlockFn(args: []const Value) PrimitiveError!Value {
         me.status = .waiting;
         me.timed_out = false;
         ctx.sched.enrollWaiter(me); // #1530: O(1) wake on signal / broadcast
-        errdefer unparkOnError(ctx.reactor, me); // #2430
+        errdefer unparkOnError(ctx.sched, ctx.reactor, me); // #2430
         if (deadline) |d| {
             me.deadline_ns = d;
             try ctx.reactor.addTimer(d, me);

--- a/src/tests_fibers.zig
+++ b/src/tests_fibers.zig
@@ -985,3 +985,98 @@ test "channel-comparator is cached: repeat calls return the same record (#2394)"
     const result = try ctx.vm.eval("(eq? (channel-comparator) (channel-comparator))");
     try std.testing.expectEqual(types.TRUE, result);
 }
+
+// ---------------------------------------------------------------------------
+// An error exit from a drive must put the waiting fiber's window back (#2429)
+// ---------------------------------------------------------------------------
+//
+// runSchedulerStep restored `me` in its epilogue only, and five `try`s inside
+// the dispatch loop return without ever reaching it — parkOnReactor,
+// restoreFiber(next_idx), and the three saveCurrentFiber calls (Yielded,
+// errored-dispatch, completed-dispatch). All five surface OutOfMemory, which
+// is catchable, so a Scheme `guard` could resume the waiting fiber's bytecode
+// against a *sibling's* registers, frames, handler and wind stacks: the #1487
+// dispatch-from-stale-snapshot corruption reached by a different route.
+//
+// The probe uses Terminated rather than an injected OOM because it is
+// deterministic and reaches the identical exit — the fix is the one errdefer
+// that covers every error return, not a per-error patch. (An OOM here would
+// come from ensureXxxCapacity/growFiberXxx, which allocate from the raw
+// allocator and so are not reachable by gc.oom_countdown.)
+
+const TerminateAfterDispatches = struct {
+    me: *fiber_mod.Fiber,
+    calls: *usize,
+    /// Never resolves. Once the drive has been round the loop three times —
+    /// long enough to have dispatched a sibling and left it suspended
+    /// mid-body, with its window loaded into the VM — ask for termination, so
+    /// the next `waitTerminated` check at the top of the loop takes an error
+    /// exit from exactly that state.
+    pub fn isDone(self: TerminateAfterDispatches) bool {
+        self.calls.* += 1;
+        if (self.calls.* > 3) @atomicStore(bool, &self.me.terminated, true, .monotonic);
+        return false;
+    }
+};
+
+test "a drive that errors out mid-dispatch restores the waiting fiber's window (#2429)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // needs the reactor-backed scheduler
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // TWO siblings, and each yields rather than completing. Yielding is what
+    // leaves one suspended with a real frame stack when the drive errors out
+    // (a fiber that ran to completion leaves a zero-length window behind, and
+    // the frame_count assertion below would be vacuous) — but `thread-yield!`
+    // is advisory and no-ops unless some OTHER fiber is runnable. `me` is
+    // excluded from that for the whole drive (it is `driving`), so with a
+    // single sibling the yield never fires and the sibling spins inside
+    // `runUntil` forever.
+    _ = try vm.eval(
+        \\(define (spin) (let loop ((i 0)) (thread-yield!) (loop (+ i 1))))
+        \\(define sib-a (spawn spin))
+        \\(define sib-b (spawn spin))
+    );
+    const sib_a = types.toObject(try vm.eval("sib-a")).as(fiber_mod.Fiber);
+    const sib_b = types.toObject(try vm.eval("sib-b")).as(fiber_mod.Fiber);
+
+    const ctx = try fiber_mod.ensureScheduler(vm);
+    const my_idx = ctx.sched.current_idx;
+    const me = ctx.sched.fibers.items[my_idx].?;
+    me.status = .waiting;
+    me.timed_out = false;
+
+    var calls: usize = 0;
+    try std.testing.expectError(
+        vm_mod.VMError.Terminated,
+        fiber_mod.runSchedulerStep(TerminateAfterDispatches, .{ .me = me, .calls = &calls }, vm, ctx.sched, me),
+    );
+
+    // Non-vacuity: a sibling really was dispatched and really was left holding
+    // a window, so pre-fix there was something to be stranded on.
+    const ran = if (sib_a.status == .suspended and sib_a.frame_count > 0) sib_a else sib_b;
+    if (ran.status != .suspended or ran.frame_count == 0) {
+        std.debug.print(
+            "no sibling was left suspended mid-body: a={s}/{d} b={s}/{d} (loop ran {d}x)\n",
+            .{ @tagName(sib_a.status), sib_a.frame_count, @tagName(sib_b.status), sib_b.frame_count, calls },
+        );
+        return error.SiblingNeverDispatched;
+    }
+
+    // The fix. Pre-fix all three name the sibling instead.
+    if (ctx.sched.current_idx != my_idx or vm.current_fiber.? != me or
+        vm.frame_count != me.frame_count)
+    {
+        std.debug.print(
+            "drive errored out on a sibling's window — current_idx={d} (want {d}) " ++
+                "current_fiber_is_me={} vm.frame_count={d} (want {d}, sibling has {d})\n",
+            .{
+                ctx.sched.current_idx, my_idx,         vm.current_fiber.? == me,
+                vm.frame_count,        me.frame_count, ran.frame_count,
+            },
+        );
+        return error.WaitingFiberWindowNotRestored;
+    }
+}

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -853,32 +853,63 @@ fn expectUnparked(vm: *vm_mod.VM, me: *fiber_mod.Fiber, label: []const u8) !void
             if (entry.fiber == me) pending_timer = true;
         }
     }
+    // The abandoned park must also be out of the #1530 waiter_index. Nothing
+    // else would remove it: only a later wake naming the same key compacts
+    // stale entries, and these probes abandon the wait on an object that is
+    // never woken (PR #2432 review).
+    var indexed = false;
+    if (vm.scheduler) |sched| {
+        var it = sched.waiter_index.valueIterator();
+        while (it.next()) |list| {
+            for (list.items) |idx| {
+                if (idx == me.sched_idx) indexed = true;
+            }
+        }
+    }
     if (me.waiting_on == types.VOID and me.deadline_ns == null and
-        !me.timed_out and !pending_timer) return;
+        !me.timed_out and !pending_timer and !indexed) return;
 
     std.debug.print(
         "{s}: fiber still parked after a failed park — " ++
-            "waiting_on=0x{x} deadline_ns={?d} timed_out={} pending_timer={} status={s}\n",
-        .{ label, me.waiting_on, me.deadline_ns, me.timed_out, pending_timer, @tagName(me.status) },
+            "waiting_on=0x{x} deadline_ns={?d} timed_out={} pending_timer={} indexed={} status={s}\n",
+        .{ label, me.waiting_on, me.deadline_ns, me.timed_out, pending_timer, indexed, @tagName(me.status) },
     );
     return error.FiberLeftParked;
 }
 
-fn expectUnparkedAfterBlockedCallback(source: []const u8, label: []const u8) !void {
+fn expectUnparkedAfterBlockedCallback(setup: []const u8, probe: []const u8, label: []const u8) !void {
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
 
+    // Split from the probe so the waiter_index baseline is measured with the
+    // fixtures already in place: mutex-lock!'s holder fiber is legitimately
+    // parked on a channel by now and owns a key of its own, so the assertion
+    // has to be "the failed park added none", not "the index is empty".
+    // Scheduler-optional: the condvar probe's setup never spawns, so nothing
+    // has forced one into existence yet.
+    _ = try ctx.vm.eval(setup);
+    const baseline = if (ctx.vm.scheduler) |s| s.waiter_index.count() else 0;
+
     // The guard catches and the program runs on — which is the hazard, not
     // an incidental detail of the probe.
-    const msg_val = try ctx.vm.eval(source);
+    const msg_val = try ctx.vm.eval(probe);
     try std.testing.expect(types.isString(msg_val));
     const msg = types.toObject(msg_val).as(types.SchemeString);
     try std.testing.expect(std.mem.startsWith(u8, msg.data[0..msg.len], "custom port callback blocked"));
 
     // Index 0, not vm.current_fiber: the callback runs on the main fiber, but
     // a probe that dispatched a sibling can leave the VM pointing at that one.
-    try expectUnparked(ctx.vm, ctx.vm.scheduler.?.fibers.items[0].?, label);
+    const sched = ctx.vm.scheduler.?;
+    try expectUnparked(ctx.vm, sched.fibers.items[0].?, label);
+
+    if (sched.waiter_index.count() != baseline) {
+        std.debug.print(
+            "{s}: waiter_index grew from {d} to {d} key(s) across the failed park\n",
+            .{ label, baseline, sched.waiter_index.count() },
+        );
+        return error.WaiterIndexLeaked;
+    }
 }
 
 test "a thread-join! park that errors out leaves the fiber runnable (#2430)" {
@@ -887,6 +918,7 @@ test "a thread-join! park that errors out leaves the fiber runnable (#2430)" {
         \\(define blocked (spawn (lambda () (channel-receive (make-channel)))))
         \\(define p (make-custom-binary-input-port "cb"
         \\  (lambda (bv start count) (thread-join! blocked 10) 0) #f #f #f))
+    ,
         \\(guard (e (#t (error-object-message e))) (read-bytevector 4 p))
     , "thread-join!");
 }
@@ -901,6 +933,7 @@ test "a mutex-lock! park that errors out leaves the fiber runnable (#2430)" {
         \\(thread-yield!)
         \\(define p (make-custom-binary-input-port "cb"
         \\  (lambda (bv start count) (mutex-lock! m 10) 0) #f #f #f))
+    ,
         \\(guard (e (#t (error-object-message e))) (read-bytevector 4 p))
     , "mutex-lock!");
 }
@@ -913,6 +946,7 @@ test "a condition-variable park that errors out leaves the fiber runnable (#2430
         \\(mutex-lock! m)
         \\(define p (make-custom-binary-input-port "cb"
         \\  (lambda (bv start count) (mutex-unlock! m cv 10) 0) #f #f #f))
+    ,
         \\(guard (e (#t (error-object-message e))) (read-bytevector 4 p))
     , "condition-variable");
 }

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -812,3 +812,107 @@ test "huge and infinite timeouts saturate instead of aborting (#1983)" {
     _ = try vm.eval("(define t (thread-start! (make-thread (lambda () 42))))");
     try std.testing.expectEqual(@as(i64, 42), types.toFixnum(try vm.eval("(thread-join! t +inf.0)")));
 }
+
+// ---------------------------------------------------------------------------
+// A park that errors out must leave the fiber runnable (#2430)
+// ---------------------------------------------------------------------------
+//
+// thread-join!'s fiber path, mutex-lock! and mutex-unlock!'s condition-
+// variable branch each arm the parked state — `.waiting`, `timed_out`,
+// `waiting_on`, a waiter_index enrolment and (when timed) a reactor timer —
+// and then reached both `try ctx.reactor.addTimer` and `try runSchedulerStep`
+// with nothing to undo it. Both failure sources return catchable errors, so a
+// Scheme `guard` could resume on a fiber the scheduler still believed was
+// parked: the "running fiber marked parked" state that is the precondition
+// for the #1487 dispatch-from-stale-snapshot corruption, and exactly what
+// defeats the waiter_index's deliberate tolerance of a stale entry.
+//
+// The probe is a SRFI 181 custom port whose read! callback blocks. That is a
+// real program reaching a real catchable error (runSchedulerStep's
+// custom-port-callback guard, which exists because such a callback may not
+// block) rather than an injected OOM — and it is deterministic, where the OOM
+// the issue describes has no reproducer. `waiting_on` is what discriminates
+// here: that guard already restores `status`/`timed_out` and drops the timer
+// for its own return, so it is the one armed field left lying pre-fix. The
+// assertions cover the rest anyway, since the sites' other error sources
+// (addTimer, and mutex-lock!'s awaitCrossThreadRing) reach no such guard.
+//
+// A stale `waiting_on` is not cosmetic: thread-join! and mutex-lock! report
+// it as the irritant of their deadlock errors, and it is a GC-traced field.
+//
+// `status` is deliberately not asserted. It is the field the issue names, but
+// it is not observable from here: `vm_calls.prepareTopLevelFrame` documents
+// that the main fiber is left `.completed` when its form finishes, so by the
+// time eval returns every run says `.completed` whether the park was undone or
+// not. The armed state that survives to be seen is `waiting_on` and the timer.
+
+fn expectUnparked(vm: *vm_mod.VM, me: *fiber_mod.Fiber, label: []const u8) !void {
+    var pending_timer = false;
+    if (vm.reactor) |r| {
+        for (r.timers.items) |entry| {
+            if (entry.fiber == me) pending_timer = true;
+        }
+    }
+    if (me.waiting_on == types.VOID and me.deadline_ns == null and
+        !me.timed_out and !pending_timer) return;
+
+    std.debug.print(
+        "{s}: fiber still parked after a failed park — " ++
+            "waiting_on=0x{x} deadline_ns={?d} timed_out={} pending_timer={} status={s}\n",
+        .{ label, me.waiting_on, me.deadline_ns, me.timed_out, pending_timer, @tagName(me.status) },
+    );
+    return error.FiberLeftParked;
+}
+
+fn expectUnparkedAfterBlockedCallback(source: []const u8, label: []const u8) !void {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    // The guard catches and the program runs on — which is the hazard, not
+    // an incidental detail of the probe.
+    const msg_val = try ctx.vm.eval(source);
+    try std.testing.expect(types.isString(msg_val));
+    const msg = types.toObject(msg_val).as(types.SchemeString);
+    try std.testing.expect(std.mem.startsWith(u8, msg.data[0..msg.len], "custom port callback blocked"));
+
+    // Index 0, not vm.current_fiber: the callback runs on the main fiber, but
+    // a probe that dispatched a sibling can leave the VM pointing at that one.
+    try expectUnparked(ctx.vm, ctx.vm.scheduler.?.fibers.items[0].?, label);
+}
+
+test "a thread-join! park that errors out leaves the fiber runnable (#2430)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // custom ports need the reactor
+    try expectUnparkedAfterBlockedCallback(
+        \\(define blocked (spawn (lambda () (channel-receive (make-channel)))))
+        \\(define p (make-custom-binary-input-port "cb"
+        \\  (lambda (bv start count) (thread-join! blocked 10) 0) #f #f #f))
+        \\(guard (e (#t (error-object-message e))) (read-bytevector 4 p))
+    , "thread-join!");
+}
+
+test "a mutex-lock! park that errors out leaves the fiber runnable (#2430)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest;
+    // A live holder keeps the mutex locked, so mutex-lock! takes the slow
+    // path that arms the park instead of claiming it outright.
+    try expectUnparkedAfterBlockedCallback(
+        \\(define m (make-mutex))
+        \\(define holder (spawn (lambda () (mutex-lock! m) (channel-receive (make-channel)))))
+        \\(thread-yield!)
+        \\(define p (make-custom-binary-input-port "cb"
+        \\  (lambda (bv start count) (mutex-lock! m 10) 0) #f #f #f))
+        \\(guard (e (#t (error-object-message e))) (read-bytevector 4 p))
+    , "mutex-lock!");
+}
+
+test "a condition-variable park that errors out leaves the fiber runnable (#2430)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest;
+    try expectUnparkedAfterBlockedCallback(
+        \\(define m (make-mutex))
+        \\(define cv (make-condition-variable))
+        \\(mutex-lock! m)
+        \\(define p (make-custom-binary-input-port "cb"
+        \\  (lambda (bv start count) (mutex-unlock! m cv 10) 0) #f #f #f))
+        \\(guard (e (#t (error-object-message e))) (read-bytevector 4 p))
+    , "condition-variable");
+}

--- a/tests/scheme/compile/compile-define-values-order-2200.sh
+++ b/tests/scheme/compile/compile-define-values-order-2200.sh
@@ -22,6 +22,22 @@
 # The interpreter is this tier's oracle (tests/scheme/CLAUDE.md): the standalone
 # binary's stdout and exit status must match the interpreter's.
 #
+# ONE program, deliberately (kaappi#2431). This used to bundle two — the repro,
+# and a control proving an `import` alongside `define-values` still works, so
+# that the fix could not have been an over-restriction — and each
+# `zig build -Dbundle=` recompiles the whole interpreter around its embedded
+# bytecode. Together with an interpreter build of its own that was three full
+# builds, which put the script within ordinary runner variance of the 600s
+# shell-test timeout and made `test (ubuntu-latest, Debug)` — a required check
+# — fail roughly one run in fourteen. The program below carries both
+# properties at once: the `define-values` depends on an earlier top-level
+# `define` (the repro), and the file imports `(scheme write)` for its `display`
+# (the control). `topLevelHead` classifies purely on the head symbol, with no
+# dependence on whether an import has been seen, so folding the two together
+# changes nothing about which path either form takes. The interpreter build is
+# now shared with the rest of the suite via `fixture_interpreter`, leaving one
+# `zig build` unique to this script.
+#
 # Usage: bash tests/scheme/compile/compile-define-values-order-2200.sh [path-to-kaappi]
 
 set -euo pipefail
@@ -57,22 +73,31 @@ bad() {
     FAIL=$((FAIL + 1))
 }
 
-# The producer of the define-values depends on an earlier top-level define, so
-# any hoisting into the preamble breaks it.
+# `(define-values (a b) ...)`'s producer reads `x`, bound by an earlier
+# top-level form, so any hoisting into the preamble breaks it. The `import`
+# is the control: it must still reach the preamble and be replayed, which is
+# what a preamble is for, and `display` resolving at all is the proof.
 cat > "$WORK/prog.scm" <<'SCM'
+(import (scheme base) (scheme write))
 (define x 1)
 (define-values (a b) (values x 2))
 (display (list a b))
 (newline)
+(define-values (p q) (values 10 20))
+(display (+ p q))
+(newline)
 SCM
+
+EXPECTED="(1 2)
+30"
 
 echo "=== interpreter (the tier oracle) ==="
 interp_status=0
 interp_out="$(interp_stdout "$KAAPPI_ABS" "$WORK" "$WORK/prog.scm")" || interp_status=$?
-if [ "$interp_out" == "(1 2)" ] && [ "$interp_status" -eq 0 ]; then
-    ok "interpreted run prints (1 2) and exits 0"
+if [ "$interp_out" == "$EXPECTED" ] && [ "$interp_status" -eq 0 ]; then
+    ok "interpreted run prints (1 2) then 30 and exits 0"
 else
-    bad "interpreted run prints (1 2) and exits 0" \
+    bad "interpreted run prints (1 2) then 30 and exits 0" \
         "stdout: $interp_out" "exit: $interp_status"
 fi
 
@@ -81,52 +106,29 @@ skip_without_zig "the standalone-binary check needs a Zig toolchain"
 
 # The .sbc's compiler hash folds in the producing binary's git build id
 # (docs/dev/cache.md), so a .sbc made by a stale zig-out/bin/kaappi goes stale
-# against a bundler rebuilt from current source (kaappi#1930). Build the
-# interpreter into an isolated prefix from the same source the bundler uses, and
-# produce the .sbc with THAT binary. -p keeps zig-out/ and the caller's binary
+# against a bundler rebuilt from current source (kaappi#1930). fixture_interpreter
+# builds one from the same source, with the same -Doptimize, as the bundler
+# below — and shares it with every other script that needs one, so only the
+# first caller in a run pays for it. zig-out/ and the caller's binary are left
 # untouched.
-(cd "$REPO_ROOT" && zig build -p "$WORK/interp" > /dev/null 2>&1)
-"$WORK/interp/bin/kaappi" --compile -o "$WORK/prog.sbc" "$WORK/prog.scm" > /dev/null
+INTERP="$(fixture_interpreter "$REPO_ROOT")"
+"$INTERP" --compile -o "$WORK/prog.sbc" "$WORK/prog.scm" > /dev/null
 
-(cd "$REPO_ROOT" && zig build -Dbundle="$WORK/prog.sbc" -p "$WORK/bundle" > /dev/null 2>&1)
+(cd "$REPO_ROOT" && zig build -Dbundle="$WORK/prog.sbc" -Doptimize=ReleaseSafe \
+    -p "$WORK/bundle" > /dev/null 2>&1)
 native_status=0
 native_out="$("$WORK/bundle/bin/kaappi" 2> /dev/null)" || native_status=$?
 
-if [ "$native_out" == "(1 2)" ] && [ "$native_status" -eq 0 ]; then
-    ok "standalone binary prints (1 2) and exits 0"
+if [ "$native_out" == "$EXPECTED" ] && [ "$native_status" -eq 0 ]; then
+    ok "standalone binary prints (1 2) then 30 and exits 0"
 else
-    bad "standalone binary prints (1 2) and exits 0" \
+    bad "standalone binary prints (1 2) then 30 and exits 0" \
         "stdout: $native_out" "exit: $native_status"
 fi
 
 if assert_tiers_agree "standalone binary vs interpreter" \
     "$interp_out" "$interp_status" "$native_out" "$native_status"; then
     ok "the standalone binary agrees with the interpreter on stdout and exit status"
-else
-    FAIL=$((FAIL + 1))
-fi
-
-echo "=== control: an env-setup declaration is still hoisted and works ==="
-# A top-level `import` must still reach the preamble and be replayed before the
-# compiled forms — that is what a preamble is for. Proving it still works
-# compiled guards against over-restricting the hoisting.
-cat > "$WORK/env.scm" <<'SCM'
-(import (scheme base) (scheme write))
-(define-values (p q) (values 10 20))
-(display (+ p q))
-(newline)
-SCM
-env_interp_status=0
-env_interp_out="$(interp_stdout "$KAAPPI_ABS" "$WORK" "$WORK/env.scm")" || env_interp_status=$?
-
-"$WORK/interp/bin/kaappi" --compile -o "$WORK/env.sbc" "$WORK/env.scm" > /dev/null
-(cd "$REPO_ROOT" && zig build -Dbundle="$WORK/env.sbc" -p "$WORK/envbundle" > /dev/null 2>&1)
-env_native_status=0
-env_native_out="$("$WORK/envbundle/bin/kaappi" 2> /dev/null)" || env_native_status=$?
-
-if assert_tiers_agree "env-setup import + define-values compiled" \
-    "$env_interp_out" "$env_interp_status" "$env_native_out" "$env_native_status"; then
-    ok "an import is still hoisted and the compiled artifact prints 30"
 else
     FAIL=$((FAIL + 1))
 fi

--- a/tests/scheme/compile/compile-define-values-order-2200.sh
+++ b/tests/scheme/compile/compile-define-values-order-2200.sh
@@ -74,18 +74,27 @@ bad() {
 }
 
 # `(define-values (a b) ...)`'s producer reads `x`, bound by an earlier
-# top-level form, so any hoisting into the preamble breaks it. The `import`
-# is the control: it must still reach the preamble and be replayed, which is
-# what a preamble is for, and `display` resolving at all is the proof.
+# top-level form, so any hoisting into the preamble breaks it. The `import` is
+# the control: it must still reach the preamble and be replayed, which is what
+# a preamble is for.
+#
+# The control imports `(srfi 8)` and uses `receive` (PR #2432 review). It has
+# to be a portable `.sld` library: every BUILT-IN library's bindings are also
+# ambient in script mode, so a program importing only `(scheme base)` and
+# `(scheme write)` runs identically with the import line deleted outright —
+# `display` and `write-simple` alike — and such a control asserts nothing about
+# whether the import was ever replayed. `receive` comes only from lib/srfi/8.sld
+# and is unbound without its import, so if the preamble stopped carrying
+# imports this run diverges from the interpreter's.
 cat > "$WORK/prog.scm" <<'SCM'
-(import (scheme base) (scheme write))
+(import (scheme base) (srfi 8))
 (define x 1)
 (define-values (a b) (values x 2))
 (display (list a b))
 (newline)
-(define-values (p q) (values 10 20))
-(display (+ p q))
-(newline)
+(receive (p q) (values 10 20)
+  (display (+ p q))
+  (newline))
 SCM
 
 EXPECTED="(1 2)
@@ -111,7 +120,8 @@ skip_without_zig "the standalone-binary check needs a Zig toolchain"
 # below — and shares it with every other script that needs one, so only the
 # first caller in a run pays for it. zig-out/ and the caller's binary are left
 # untouched.
-INTERP="$(fixture_interpreter "$REPO_ROOT")"
+fixture_interpreter "$REPO_ROOT"
+INTERP="$(fixture_interpreter_path "$REPO_ROOT")"
 "$INTERP" --compile -o "$WORK/prog.sbc" "$WORK/prog.scm" > /dev/null
 
 (cd "$REPO_ROOT" && zig build -Dbundle="$WORK/prog.sbc" -Doptimize=ReleaseSafe \

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -387,13 +387,14 @@ report_shell_result() {
 # script takes seconds. With a pool of N, when those start matters far more than
 # N does, so they go first. Derived by grep rather than a hand-kept list of
 # names, so a future rebuild-shaped script sorts itself; a wrong answer here
-# costs makespan, never a verdict. Both spellings count: a script that runs the
-# build itself, and one that goes through shell-common.sh's shared fixture
-# (where only the first caller pays, but which one that is isn't known here).
+# costs makespan, never a verdict. All three spellings count: a script that
+# runs the build itself, and one that goes through either of shell-common.sh's
+# shared builders (where only the first caller pays, but which one that is
+# isn't known here).
 is_slow_shell_test() {
     # `^[^#]*`: skip comment lines, several of which mention the build they
     # deliberately do not run.
-    grep -Eq '^[^#]*(zig build -D|bundle_fixture_binary)' "$1" 2>/dev/null
+    grep -Eq '^[^#]*(zig build -D|bundle_fixture_binary|fixture_interpreter)' "$1" 2>/dev/null
 }
 
 run_shell_suite() {

--- a/tests/scheme/shell-common.sh
+++ b/tests/scheme/shell-common.sh
@@ -199,9 +199,21 @@ build_lock() {
     echo $$ > "$lock/pid"
 }
 
-# build_unlock <repo-dir> <name>: release it.
+# build_unlock <repo-dir> <name>: release it, but only if it is still ours.
+#
+# Ownership-checked, not a bare `rm -rf` (PR #2432 review). The waiter above
+# steals a lock whose recorded holder is gone, so a holder that was killed --
+# `run-all.sh` kills a script that overruns SHELL_TIMEOUT -- can have its lock
+# handed to someone else while a child it spawned is still running. An
+# unconditional remove would then delete the NEW holder's lock and let a third
+# script in alongside it. Comparing the recorded pid keeps a late unlock from
+# releasing a lock it no longer holds.
 build_unlock() {
-    rm -rf "$(build_lock_dir "$1" "$2")"
+    local lock holder
+    lock=$(build_lock_dir "$1" "$2")
+    holder=$(cat "$lock/pid" 2> /dev/null || true)
+    [ "$holder" = "$$" ] && rm -rf "$lock"
+    return 0
 }
 
 # ensure_runtime_lib <repo-dir>: freshen the native runtime archive via
@@ -234,9 +246,36 @@ ensure_runtime_lib() {
     fi
 }
 
+# fixture_interpreter_path <repo-dir>: where fixture_interpreter installs its
+# binary. Pure — no build, no lock — so it is safe in a command substitution.
+#
+# `.exe` on Windows because `zig build --prefix` installs `kaappi.exe` there
+# (PR #2432 review). Unlike `sibling_tool`, which mirrors the spelling its
+# caller passed, this path names a file WE produce, so `is_windows` is the
+# right source of truth. It matters because the build check below tests the
+# path with `-x`: MSYS appends `.exe` when *executing*, but not when a test
+# operator names the file, so the bare spelling would report a failed fixture
+# build on a Windows box that in fact has a perfectly good interpreter.
+fixture_interpreter_path() {
+    local base="$1/.zig-cache/kaappi-test-fixtures/interp/bin/kaappi"
+    if is_windows; then
+        printf '%s\n' "$base.exe"
+    else
+        printf '%s\n' "$base"
+    fi
+}
+
 # fixture_interpreter <repo-dir>: build an interpreter from current source into
-# a shared isolated prefix and print its path. Callers must have passed
-# skip_without_zig first.
+# a shared isolated prefix. Prints nothing; ask fixture_interpreter_path where
+# it went. Callers must have passed skip_without_zig first.
+#
+# Deliberately NOT a function that prints its path, which would force every
+# caller into a command substitution (PR #2432 review). Bash keeps `$$` equal
+# to the *outer* script's pid inside one, so the pid `build_lock` records
+# would name a process that is not the one holding the lock -- and the waiter's
+# liveness check, which steals a lock whose holder has died, would then be
+# reasoning about the wrong process entirely. Running in the caller's own shell
+# keeps `$$` and the holder the same process.
 #
 # Any script that produces a .sbc to feed its own `zig build -Dbundle=` needs
 # one of these rather than the binary under test. The .sbc's compiler hash
@@ -261,7 +300,7 @@ ensure_runtime_lib() {
 fixture_interpreter() {
     local repo="$1" out interp log rc
     out="$repo/.zig-cache/kaappi-test-fixtures"
-    interp="$out/interp/bin/kaappi"
+    interp="$(fixture_interpreter_path "$repo")"
     log=$(mktemp)
 
     build_lock "$repo" fixture-interp
@@ -280,7 +319,6 @@ fixture_interpreter() {
         return 1
     fi
     rm -f "$log"
-    printf '%s\n' "$interp"
 }
 
 # bundle_fixture_binary <repo-dir> <dest>: build the standalone binary that
@@ -326,7 +364,10 @@ bundle_fixture_binary() {
 
     # Outside the lock below: it takes its own, and the two must not nest in
     # the opposite order anywhere or they could deadlock against each other.
-    interp=$(fixture_interpreter "$repo") || return 1
+    # Called directly rather than in a command substitution, so its build_lock
+    # records this script's pid as the holder — see its own comment.
+    fixture_interpreter "$repo" || return 1
+    interp="$(fixture_interpreter_path "$repo")"
 
     build_lock "$repo" bundle-fixture
     rc=0

--- a/tests/scheme/shell-common.sh
+++ b/tests/scheme/shell-common.sh
@@ -234,6 +234,55 @@ ensure_runtime_lib() {
     fi
 }
 
+# fixture_interpreter <repo-dir>: build an interpreter from current source into
+# a shared isolated prefix and print its path. Callers must have passed
+# skip_without_zig first.
+#
+# Any script that produces a .sbc to feed its own `zig build -Dbundle=` needs
+# one of these rather than the binary under test. The .sbc's compiler hash
+# folds in the producing binary's git build id (docs/dev/cache.md), so a .sbc
+# made by whatever zig-out/bin/kaappi happens to be lying around disagrees with
+# a bundler rebuilt from current source the moment the tree moved — a new
+# commit, or a clean<->dirty flip — and the bundled binary then dies with
+# "invalid embedded bytecode", naming nothing (kaappi#1930). The prefix keeps
+# zig-out/ and the caller's binary untouched (kaappi#2163).
+#
+# Shared across scripts because a full interpreter build is ~180s on a 4-core
+# runner and every caller wants the identical one. The first caller pays; the
+# rest get a Zig cache hit and a no-op reinstall.
+#
+# The explicit -Doptimize=ReleaseSafe is what makes that sharing real. It is
+# also build.zig's default, so a bare `zig build` compiles the same thing — but
+# only pinning it here documents that every caller, and every -Dbundle build
+# that follows, must name the same mode to land on one cache key. kaappi#2431
+# is what happens otherwise: `test (ubuntu-latest, Debug)` fills the cache with
+# Debug artefacts and then runs these ReleaseSafe builds stone cold, which is
+# why that leg alone kept hitting the 600s shell-test timeout.
+fixture_interpreter() {
+    local repo="$1" out interp log rc
+    out="$repo/.zig-cache/kaappi-test-fixtures"
+    interp="$out/interp/bin/kaappi"
+    log=$(mktemp)
+
+    build_lock "$repo" fixture-interp
+    rc=0
+    # Unconditional: `zig build` is itself the freshness check, so this is a
+    # no-op when nothing under src/ moved and exactly the rebuild we need when
+    # it did. Caching the binary ourselves would instead go stale against the
+    # tree it must match.
+    (cd "$repo" && zig build -Doptimize=ReleaseSafe --prefix "$out/interp") > "$log" 2>&1 || rc=$?
+    build_unlock "$repo" fixture-interp
+
+    if [ "$rc" -ne 0 ] || [ ! -x "$interp" ]; then
+        echo "FAIL: could not build the fixture interpreter" >&2
+        cat "$log" >&2
+        rm -f "$log"
+        return 1
+    fi
+    rm -f "$log"
+    printf '%s\n' "$interp"
+}
+
 # bundle_fixture_binary <repo-dir> <dest>: build the standalone binary that
 # embeds tests/scheme/compile/fixtures/bundle-replay, and copy it to <dest>.
 # Callers must have passed skip_without_zig first.
@@ -250,12 +299,11 @@ ensure_runtime_lib() {
 # be lying around disagrees with a bundler rebuilt from current source the
 # moment the tree moved — a new commit, or a clean<->dirty flip — and the
 # bundled binary then dies with "invalid embedded bytecode", naming nothing
-# (kaappi#1930). So this builds the interpreter from the SAME source the
-# bundler comes from, into an isolated prefix, and produces the .sbc with
-# THAT binary. The caller's zig-out/bin/kaappi is never touched (it is the
-# binary under test; kaappi#2163), and the -Dbundle rebuild that follows
-# shares this build's compiled units, so the second `zig build` is a cache
-# hit rather than a second full rebuild (kaappi#1926).
+# (kaappi#1930). So this produces the .sbc with the shared
+# fixture_interpreter above — built from the SAME source, with the same
+# options, as the bundler below — and the -Dbundle rebuild that follows shares
+# that build's compiled units, so this `zig build` is a cache hit rather than a
+# second full rebuild (kaappi#1926).
 #
 # Regenerating the .sbc on every call is what keeps that honest: it is
 # deterministic, so unchanged sources give byte-identical bytes and a cache
@@ -274,21 +322,17 @@ bundle_fixture_binary() {
     fixture="$repo/tests/scheme/compile/fixtures/bundle-replay"
     out="$repo/.zig-cache/kaappi-test-fixtures"
     sbc="$out/bundle-replay.sbc"
-    interp="$out/interp/bin/kaappi"
     log=$(mktemp)
+
+    # Outside the lock below: it takes its own, and the two must not nest in
+    # the opposite order anywhere or they could deadlock against each other.
+    interp=$(fixture_interpreter "$repo") || return 1
 
     build_lock "$repo" bundle-fixture
     rc=0
     (
         mkdir -p "$out"
-        # Build the interpreter from current source with the SAME options as
-        # the bundler below, so the .sbc and the bundler share one build id
-        # (kaappi#1930 — see the header comment). --prefix keeps zig-out/ and
-        # the caller's binary untouched.
-        cd "$repo" &&
-            zig build -Doptimize=ReleaseSafe --prefix "$out/interp" &&
-            [ -x "$interp" ] &&
-            cd "$fixture" &&
+        cd "$fixture" &&
             # Compile from inside the fixture directory so the paths recorded in
             # the .sbc are relative, and its bytes therefore identical run to run.
             "$interp" --lib-path lib --compile -o "$sbc" main.scm &&


### PR DESCRIPTION
## Summary

Three issues. The first two are one bug at two levels of the same call path; the third is unrelated, and rides along because it is the intermittent failure on a *required* check that would otherwise decide this PR's own CI.

### #2429 — a drive that errors out leaves the waiting fiber on a sibling's register window

`runSchedulerStep` restored `me` in its epilogue only, and five `try`s inside the dispatch loop return without reaching it: `parkOnReactor`, `restoreFiber(next_idx)`, and the three `saveCurrentFiber` calls on the Yielded, errored-dispatch and completed-dispatch paths. All five surface `VMError.OutOfMemory`, which is *catchable* — unlike the `Terminated` return above them.

By the time those three run, `restoreFiber` has already loaded a **sibling's** registers, frames, handler stack and wind stack into the VM, and `saveCurrentFiber` only copies VM→fiber. So an OOM left `vm.current_fiber`, `sched.current_idx` and the whole window belonging to the sibling, and a Scheme `guard` catching it resumed `me`'s bytecode against another fiber's registers — the #1487 dispatch-from-stale-snapshot corruption by a different route, in the single shared body behind `channel-receive`/`-send`, `fiber-join`, `thread-join!`, `mutex-lock!`, condition-variable waits and `thread-sleep!`.

One `errdefer` after the entry `saveCurrentFiber` now runs the epilogue's restore on every error exit. Its `catch {}` cannot fire: `restoreFiber` is fallible only through four `ensureXxxCapacity` calls that return early when the need is met and never shrink, and `me` was current on entry.

### #2430 — three SRFI-18 park sites stay `.waiting` on a catchable error

`threadJoinFn`'s fiber path, `mutexLockFn` and `mutexUnlockFn`'s condvar branch arm the parked state and then reach both `addTimer` and `runSchedulerStep` with nothing to undo it. `threadJoinFn` additionally never called `removeTimer` on its error path — and was missing the *success*-path one its two siblings have, so a surviving timer could be stranded by the `deadline_ns = null` that follows and later fire against a reused slot.

PR #2428's local `Unpark` struct becomes the shared `unparkOnError` helper; the three sites `errdefer` it. Their `waiting_on` stores are also barriered, matching the channel waits (not a live bug — `markFiberState` marks resident fibers unconditionally — but residency ends at `retireSlot`).

### #2431 — the diagnosis in the issue is wrong about the mechanism

The issue attributes the 600s timeout to a Debug build being slow. **The script never builds Debug.** `build.zig` defaults to ReleaseSafe and the script ran a bare `zig build`, so on `test (ubuntu-latest, Debug)` it built ReleaseSafe artefacts into a cache holding only Debug ones — three full **cold** builds. The ReleaseSafe legs prime that cache with the job's own build first, which is exactly why only the Debug leg hit the ceiling and why it was intermittent.

Fixed by build count, not by the timeout: a shared `fixture_interpreter` helper (extracted from `bundle_fixture_binary`), one bundled program instead of two, and `-Doptimize=ReleaseSafe` named explicitly so every caller lands on one cache key. Three builds → one unique. Measured on a 4-core box: **1m28s**, all assertions passing.

## Notes for review

- **`gc.oom_countdown` cannot reach #2429's sites**, contrary to the issue's suggestion: the OOM there comes from `ensureXxxCapacity`/`growFiberXxx`, which use the raw allocator the injector does not count. The test forces the identical exit with `Terminated` instead — deterministic, and the fix is one `errdefer` covering every error return rather than a per-error patch.
- **#2430's tests reach the error through a SRFI 181 custom port whose `read!` callback blocks** — a real program raising a real catchable error, where the OOM has no reproducer. `waiting_on` is the discriminator; `status` is deliberately not asserted because `prepareTopLevelFrame` leaves the main fiber `.completed` when a form finishes, so it reads the same either way by the time `eval` returns.
- All four tests were confirmed to **fail against the pre-fix sources** with the tests in place: `waiting_on` still holding the joined fiber / mutex / condition variable, and `current_idx=1 (want 0) current_fiber_is_me=false vm.frame_count=1 (want 0, sibling has 1)`.
- The #2429 test needs **two** spinning siblings: `thread-yield!` is advisory and no-ops unless another fiber is runnable, and `me` is excluded for the whole drive — a lone sibling never yields back and spins inside `runUntil` forever.

## Checklist

- [x] `zig build test` passes
- [x] `zig fmt --check src/` passes
- [ ] Scheme test suites pass (`bash tests/scheme/run-all.sh`) — **not run in full.** Verified the changed script (`compile-define-values-order-2200.sh`, 3/3 pass) and `compile-preamble-gc-700.sh`, which exercises the refactored `bundle_fixture_binary`. The full suite is left to CI.
- [x] New tests added for new behavior — one in `tests_fibers.zig` (#2429), three in `tests_srfi18.zig` (#2430)
- [x] Documentation updated — `docs/dev/test-runner.md` gains `fixture_interpreter` and the cache-mode finding

Closes #2429
Closes #2430
Closes #2431

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mKdjyytpEKCSU2hepD21M

---
_Generated by [Claude Code](https://claude.ai/code/session_016mKdjyytpEKCSU2hepD21M)_