### PR TITLE
Document that import-dependence controls need a portable .sld, not a built-in

### DIFF
--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -264,6 +264,31 @@ can execute one (`kaappi out.sbc` reads it as source), so
 `compile-preamble-699.sh` has no runnable second tier short of a ~180s
 `-Dbundle` rebuild.
 
+**An import-dependence control must import a portable `.sld` library, never a
+built-in one.** A control that means to prove an `import` is load-bearing —
+that it reaches the artifact's preamble and gets replayed, that dropping it
+would break the run — needs a binding that is genuinely unbound without its
+import. Built-in library bindings do not qualify: `(scheme base)`, `(scheme
+write)`, `(scheme process-context)` and the rest are *ambient* in script mode,
+so a top-level `import` of one is purely additive and a program resolves their
+procedures whether it imports them or not. The natural instinct is to reach
+for a `(scheme write)` procedure like `display` or `write-simple`, and that is
+exactly the trap — even `write-simple`, which is exclusive to `(scheme write)`,
+resolves ambiently, so a control built on it asserts nothing (kaappi#2436). Use
+the `(srfi 8)`/`receive` shape instead: `receive` comes only from
+`lib/srfi/8.sld` and is a `KP3001` undefined-variable error without its import,
+so the assertion has teeth.
+
+```scheme
+(import (scheme base) (srfi 8))
+(define-values (p q) (values 10 20))
+(receive (a b) (values p q)          ; drop the (srfi 8) import and this run
+  (display (+ a b)) (newline))       ; diverges from the interpreter's
+```
+
+`compile-define-values-order-2200.sh` is the worked example (fixed in PR #2432,
+which is where this trap surfaced).
+
 ## Quirks
 
 - The R7RS suite's verdict comes from its printed counts, not its exit status:


### PR DESCRIPTION
## What

Adds a note to the "interpreter is the oracle" section of `tests/scheme/CLAUDE.md` recording a trap the suite already walked into once: a test control whose stated job is to prove an `import` is load-bearing is **silently vacuous** when it imports a built-in library.

In script mode every built-in library's bindings are ambient, so a top-level `import` of `(scheme base)`, `(scheme write)`, `(scheme process-context)` etc. is purely additive — the program resolves those procedures whether it imports them or not. The natural instinct is to reach for a `(scheme write)` procedure like `display`, and that is exactly the trap: even `write-simple`, which is *exclusive* to `(scheme write)`, resolves ambiently.

The doc gives the `(srfi 8)`/`receive` shape as the worked example, since `receive` comes only from `lib/srfi/8.sld` and is a `KP3001` undefined-variable error without its import — so the assertion has teeth.

## Premise reproduced

```
$ printf '(import (only (scheme base) car))\n(write-simple "x")(newline)\n' > c.scm
$ kaappi c.scm
"x"                 # write-simple resolves despite an (only ... car) import that does not name it
```

Worked example verified: with `(import (scheme base) (srfi 8))` it prints `30`; drop the `(srfi 8)` import and the same program is a `KP3001` error — a real divergence a preamble-replay control can catch.

## Sweep (the issue asked for one and had not run it)

Scoped to the two places a preamble-replay control makes sense — `tests/scheme/compile/*.sh` (32 files) and `tests/scheme/differential/probes/`:

- **No other instance found.** The remaining built-in imports in the compile suite (`define-library-many-exports-862.sh`, `compile-preamble-699.sh`, `native-external-library-import-1743.sh`) are not import-dependence controls — their load-bearing imports are *user* libraries (`bigexport`, `thirdparty greet`, `my-wrapper`, `my-math`), genuinely unbound without the import; the `(scheme write)` alongside is just ambient `display`.
- The differential probes deliberately never `import` at all (it makes them uncacheable — one even documents that `(scheme write)` bindings are ambient in main mode), so that genre of control cannot live there.
- The one known case, `compile-define-values-order-2200.sh`, was **already fixed by PR #2432** (it now imports `(srfi 8)` and uses `receive`); confirmed, no further change.

## Verification

Documentation-only change. `tests/scheme/compile/*.sh` — all 32 pass.

Closes #2436

🤖 Generated with [Claude Code](https://claude.com/claude-code)