### PR TITLE
Make build_lock's steal group-aware so a killed script can't orphan a build (#2434)

### DIFF
--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -332,13 +332,28 @@ run_suite() {
 run_shell_worker() {
     local script="$1" slot="$2"
     local pid status
+    # Launch under `set -m` so the script leads its own process group (pgid ==
+    # pid): a shell script can fork a whole `zig build`, and on timeout we must
+    # signal that build too. Killing the script pid alone leaves the build
+    # orphaned but still installing into the shared fixture prefix, which the
+    # next writer then interleaves with -- a half-written interpreter that reads
+    # as a flake (kaappi#2434). `set -m` is bash 3.2+ and works under Git Bash;
+    # this runs in the worker's own subshell, so the mode change is local and
+    # `set +m` before wait keeps its async job-control notices off. It also lets
+    # shell-common.sh's build_lock trust the recorded pid: a dead leader whose
+    # group is empty really has no work in flight.
+    set -m
     KAAPPI="$KAAPPI" bash "$script" "$KAAPPI" > "$slot.out" 2>&1 &
     pid=$!
+    set +m
     if wait_with_timeout "$pid" "$SHELL_TIMEOUT"; then
         status=0
         wait "$pid" || status=$?
     else
-        kill "$pid" 2>/dev/null || true
+        # Signal the whole group (negative pid); fall back to the lone pid if it
+        # is somehow not a group leader, so a build orphaned by the timeout dies
+        # with the script rather than racing the next writer's install.
+        kill -- "-$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
         wait "$pid" 2>/dev/null || true
         echo "TIMEOUT" > "$slot.rec"
         return 0

--- a/tests/scheme/shell-common.sh
+++ b/tests/scheme/shell-common.sh
@@ -181,8 +181,22 @@ build_lock() {
         # Steal a lock whose holder is gone. run-all.sh kills a script that
         # overruns SHELL_TIMEOUT, and a dead holder's lock would otherwise
         # stall every later script for the rest of the run.
+        #
+        # "Holder is gone" must mean the WORK is gone, not just the launcher.
+        # A holder that was killed rather than exiting can leave the `zig build`
+        # it forked orphaned but still installing into this same shared prefix;
+        # a next waiter that stole on the dead launcher pid alone would then run
+        # its own build straight into that half-written directory (kaappi#2434).
+        # run-all.sh runs each shell script as its own process-group leader
+        # (pgid == the pid recorded below) and signals the whole group on
+        # timeout, so a clean kill takes the forked build with it and the group
+        # is then empty. Requiring BOTH the leader pid AND its process group to
+        # be gone keeps a build orphaned by any other means -- still a member of
+        # the dead leader's group -- from being mistaken for finished work.
         holder=$(cat "$lock/pid" 2> /dev/null || true)
-        if [ -n "$holder" ] && ! kill -0 "$holder" 2> /dev/null; then
+        if [ -n "$holder" ] \
+            && ! kill -0 "$holder" 2> /dev/null \
+            && ! kill -0 -- "-$holder" 2> /dev/null; then
             rm -rf "$lock"
             continue
         fi

--- a/tests/scheme/smoke/build-lock-orphan-2434.sh
+++ b/tests/scheme/smoke/build-lock-orphan-2434.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Regression test for kaappi#2434:
+#
+# build_lock (tests/scheme/shell-common.sh) steals a lock whose recorded holder
+# pid is dead, treating "the launcher is gone" as "no work is in flight." That
+# is false when the holder was KILLED rather than exiting: the `zig build` it
+# forked can be orphaned and keep installing into the shared fixture prefix. A
+# next writer that stole on the dead launcher pid alone would then interleave
+# its own install with the orphan's -- a half-written interpreter that surfaces
+# as an unrelated-looking flake in whichever script loses.
+#
+# The fix makes the steal group-aware: run-all.sh runs each shell script as its
+# own process-group leader and signals the whole group on SHELL_TIMEOUT, and
+# build_lock refuses to steal while any process is still alive in the recorded
+# holder's process group. So a build orphaned into that group blocks the steal.
+#
+# This is a deterministic simulation of the race -- no real build, no real
+# overrun. We plant a lock whose pid file names a process that has already
+# exited, while a marker process it spawned survives in that same process
+# group (standing in for the orphaned build), then assert a second writer does
+# NOT steal the lock. Without the fix it steals at once (equating dead pid with
+# no work); with the fix it keeps waiting until the group is genuinely empty.
+set -euo pipefail
+
+. "$(dirname "$0")/../shell-common.sh"
+
+# Signalling a whole process group (`kill -- -PGID`) and the leader==group
+# invariant this leans on are POSIX process-group semantics that Git Bash does
+# not emulate reliably; the production fix's group-kill has the same premise.
+skip_on_windows "process-group liveness (kill -- -PGID) is not reliable under Git Bash/MSYS"
+
+REPO=$(mktemp -d)
+PIDFILE=$(mktemp)
+ACQFILE="$REPO/acquired"
+ORPHAN=""
+BLPID=""
+
+cleanup() {
+    [ -n "$BLPID" ] && kill "$BLPID" 2> /dev/null || true
+    [ -n "$ORPHAN" ] && kill "$ORPHAN" 2> /dev/null || true
+    rm -rf "$REPO" "$PIDFILE"
+}
+trap cleanup EXIT
+
+# --- build the simulated orphan -----------------------------------------
+#
+# Under `set -m` the `bash -c` below leads its own process group (pgid == its
+# pid). It forks a long-lived marker (the orphan/in-flight-build stand-in),
+# records both pids, then exits -- leaving the marker alive but its group
+# leaderless, exactly the state a killed script leaves its forked build in.
+set -m
+bash -c 'sleep 60 & printf "%s %s\n" "$$" "$!" > "'"$PIDFILE"'"' &
+set +m
+
+# Wait for the leader to record its pids and exit.
+LEADER=""
+waited=0
+while :; do
+    read -r LEADER ORPHAN < "$PIDFILE" 2> /dev/null || true
+    if [ -n "${LEADER:-}" ] && [ -n "${ORPHAN:-}" ] && ! kill -0 "$LEADER" 2> /dev/null; then
+        break
+    fi
+    sleep 0.1
+    waited=$((waited + 1))
+    if [ "$waited" -ge 100 ]; then
+        echo "FAIL: simulated leader never exited" >&2
+        exit 1
+    fi
+done
+
+# Precondition for the simulation to mean anything: the leader must be dead
+# while its process group is still alive (the orphan). If this platform does
+# not give us that -- the orphan landed in a different group -- we cannot
+# construct the race, so skip rather than report a spurious pass/fail.
+if kill -0 "$LEADER" 2> /dev/null; then
+    echo "SKIP: could not kill the simulated leader while its group survives"
+    exit 77
+fi
+if ! kill -0 -- "-$LEADER" 2> /dev/null; then
+    echo "SKIP: marker did not survive in the leader's process group (no group semantics)"
+    exit 77
+fi
+
+# --- plant the lock the dead leader "held" ------------------------------
+LOCK=$(build_lock_dir "$REPO" orphan-2434)
+mkdir -p "$(dirname "$LOCK")"
+mkdir "$LOCK"
+echo "$LEADER" > "$LOCK/pid"
+
+# --- a second writer must NOT steal it while the group is alive ----------
+( build_lock "$REPO" orphan-2434 && : > "$ACQFILE" ) &
+BLPID=$!
+
+# The steal check runs at the top of build_lock's loop, before its 1s sleep, so
+# a broken build_lock acquires in well under a second. Two seconds is a wide
+# margin without dragging the suite.
+sleep 2
+if [ -f "$ACQFILE" ]; then
+    echo "FAIL: build_lock stole a lock whose holder is dead but whose forked" >&2
+    echo "      work is still alive -- the kaappi#2434 race." >&2
+    exit 1
+fi
+
+# --- once the work really ends, the steal must proceed -------------------
+# Kill the marker: now the leader pid AND its group are both gone, which is the
+# genuine "no work in flight" state the steal is meant to detect.
+kill "$ORPHAN" 2> /dev/null || true
+ORPHAN=""
+
+waited=0
+while [ ! -f "$ACQFILE" ]; do
+    sleep 0.2
+    waited=$((waited + 1))
+    if [ "$waited" -ge 50 ]; then
+        echo "FAIL: build_lock never stole the lock after the group emptied" >&2
+        exit 1
+    fi
+done
+
+echo "PASS: build_lock holds while an orphaned build survives, steals once it exits"


### PR DESCRIPTION
## Problem

`build_lock` (`tests/scheme/shell-common.sh`) steals a lock whenever the recorded holder pid is dead, equating *"the launcher is gone"* with *"no work is in flight."* That does not hold when the holder was **killed** rather than exiting: `run-all.sh` kills a shell script that overruns `SHELL_TIMEOUT`, but the `zig build` the script forked is not necessarily reaped with it. The next waiter sees a dead pid, steals the lock, and starts its own install into the shared fixture prefix (`.zig-cache/kaappi-test-fixtures/`) while the orphan is still writing — producing a half-written interpreter or bundled binary that surfaces as an unrelated-looking failure and gets re-run rather than diagnosed.

PR #2432 fixed the two contributing halves (`fixture_interpreter` no longer prints its path, so `$$` names the right process; `build_unlock` is ownership-checked) but left the steal itself. This closes it.

## Fix — the process-group option

The issue offered two fixes. I took **(a) process groups**, not (b) per-invocation prefix + atomic rename, because `build_lock` is a general-purpose lock guarding *every* script that forks its own `zig build` — the two fixture builders, `ensure_runtime_lib`, and `compile/srfi-241-202-bundle-2391.sh`. Fixing the lock invariant covers all of them at once; per-invocation prefixes would have removed the interleaving window only for the two fixture builders and left the steal unsound for the rest.

- **`run-all.sh`** — `run_shell_worker` launches each script under `set -m`, so it leads its own process group (`pgid == pid`), and the `SHELL_TIMEOUT` path signals the whole group (`kill -- -$pid`) instead of the lone script pid. A clean timeout now takes the forked `zig build` with it. `set -m` is bash 3.2+ (macOS) and works under Git Bash; it runs in the worker's own subshell so the mode change is local, and `set +m` before `wait` keeps its async job-control notices off.
- **`shell-common.sh`** — `build_lock`'s steal now requires **both** the recorded leader pid **and** its process group to be gone (`! kill -0 "$holder"` **and** `! kill -0 -- "-$holder"`). A build orphaned by any means — still a member of the dead leader's group — keeps blocking the steal until it actually exits. Belt-and-suspenders with the group-kill above.

## Regression test

`tests/scheme/smoke/build-lock-orphan-2434.sh` is a deterministic simulation of the race — no real build, no real overrun. It plants a lock whose pid file names a process that has already exited, while a marker it spawned survives in that same process group (standing in for the orphaned build), then asserts a second `build_lock` caller does **not** steal until the group empties.

**How I verified it fails without the fix and passes with it:** reverting only the `shell-common.sh` steal condition makes the test fail (`build_lock stole a lock whose holder is dead but whose forked work is still alive`); with the condition restored it passes. It skips on Windows, where `kill -- -PGID` is not reliable under Git Bash/MSYS.

## Verification

- New test: fails on old `build_lock`, passes on new (confirmed by revert/restore).
- `bash tests/scheme/run-all.sh` (built first, foreground): **732 pass, 0 fail, 1 skipped** (the pre-existing `build-id-untracked-2097` skip); **R7RS 1395 pass, 0 fail**.

## Related

- PR #2432 — fixed the `$$` and unlock-ownership halves
- #1926 — introduced concurrent shell suites and `build_lock`
- #1748 — the timeout-kill behaviour whose orphans this concerns

Closes #2434

🤖 Generated with [Claude Code](https://claude.com/claude-code)