### PR TITLE
Unpark and withdraw local-channel waits on every error exit (#2433)

### DIFF
--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -404,7 +404,17 @@ fn channelSendLocal(ch: *types.Channel, ch_val: Value, payload: Value, deadline_
         if (me.deadline_ns orelse deadline_ns) |d| {
             ctx.reactor.removeTimer(me);
             me.deadline_ns = d;
-            try ctx.reactor.addTimer(d, me);
+            // #2433: this was a bare `try` — the yield-retry re-park armed
+            // .waiting/waiting_on and an enrolment, then returned a catchable
+            // OutOfMemory with nothing to undo it. Mirror the receive side's
+            // dispatched re-park (channelReceiveLocal, below).
+            ctx.reactor.addTimer(d, me) catch |err| {
+                ctx.sched.withdrawWaiter(me, me.waiting_on);
+                me.status = .running;
+                me.waiting_on = types.VOID;
+                me.deadline_ns = null;
+                return err;
+            };
         }
         vm.yield_retry = true;
         return PrimitiveError.Yielded;
@@ -426,9 +436,31 @@ fn channelSendLocal(ch: *types.Channel, ch_val: Value, payload: Value, deadline_
         vm.gc.writeBarrier(&me.header, ch_val);
         ctx.sched.enrollWaiter(me); // #1530: O(1) wake on a freed slot / close
         me.deadline_ns = d;
-        try ctx.reactor.addTimer(d, me);
+        // #2433: both `try`s here armed the park and returned a *catchable*
+        // OutOfMemory with nothing to undo it — a `guard` swallowing it would
+        // resume on a fiber the scheduler still believes is parked (the #1487
+        // precondition). channelReceiveLocal already handles both; the send
+        // side was the odd one out. Mirror it with explicit catch blocks.
+        ctx.reactor.addTimer(d, me) catch |err| {
+            ctx.sched.withdrawWaiter(me, me.waiting_on);
+            me.status = .running;
+            me.waiting_on = types.VOID;
+            me.deadline_ns = null;
+            return err;
+        };
     }
-    _ = try fiber_mod.runSchedulerStep(ChannelSendWait, .{ .ch = ch }, ctx.vm, ctx.sched, me);
+    _ = fiber_mod.runSchedulerStep(ChannelSendWait, .{ .ch = ch }, ctx.vm, ctx.sched, me) catch |err| {
+        // runSchedulerStep's own epilogue (#2429) already restored `me`'s
+        // window and .running status; undo the park state armed above that it
+        // does not touch. Guarded on deadline_ns: with none, nothing above ran.
+        if (deadline_ns != null) {
+            ctx.reactor.removeTimer(me);
+            ctx.sched.withdrawWaiter(me, me.waiting_on);
+            me.waiting_on = types.VOID;
+            me.deadline_ns = null;
+        }
+        return err;
+    };
     if (deadline_ns != null) {
         ctx.reactor.removeTimer(me);
         me.deadline_ns = null;
@@ -1182,6 +1214,7 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
                     ctx.reactor.addTimer(d, me) catch |err| {
                         // Terminal for this wait: don't leak the committed
                         // demand or leave park state behind (#1604 review).
+                        ctx.sched.withdrawWaiter(me, me.waiting_on); // #2433
                         me.status = .running;
                         me.waiting_on = types.VOID;
                         me.deadline_ns = null;
@@ -1215,6 +1248,7 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
         ctx.sched.enrollWaiter(me); // #1530: O(1) wake on a channel send / close
         me.deadline_ns = d;
         ctx.reactor.addTimer(d, me) catch |err| {
+            ctx.sched.withdrawWaiter(me, me.waiting_on); // #2433
             me.status = .running;
             me.waiting_on = types.VOID;
             me.deadline_ns = null;
@@ -1228,6 +1262,11 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
         releaseRvToken(ch, ch_val, me);
         if (deadline_ns != null) {
             ctx.reactor.removeTimer(me);
+            // #2433: withdraw the #1530 enrolment armed above. runSchedulerStep
+            // (#2429) restored status but never clears waiting_on, and only a
+            // later wake naming this key would otherwise compact the entry.
+            ctx.sched.withdrawWaiter(me, me.waiting_on);
+            me.waiting_on = types.VOID;
             me.deadline_ns = null;
         }
         return err;
@@ -1326,7 +1365,11 @@ fn blockOrDeadlock(vm: *vm_mod.VM, me: *fiber_mod.Fiber, my_idx: usize, wait_on:
         me.waiting_on = wait_on;
         vm.gc.writeBarrier(&me.header, wait_on);
         // Index this park so fiber completion (wakeWaiters) or a channel
-        // send/close (wakeChannelWaiters) finds it in O(1) (#1530).
+        // send/close (wakeChannelWaiters) finds it in O(1) (#1530). No #2433
+        // withdraw/unpark here: this park is deliberate and returns the
+        // *uncatchable* Yielded (errors.isUncatchable), so no `guard` can
+        // resume `me` while the scheduler holds it parked — this is a live
+        // waiter a wake will compact, not an abandoned one to withdraw.
         if (vm.scheduler) |sched| sched.enrollWaiter(me);
         vm.yield_retry = true;
         return PrimitiveError.Yielded;

--- a/src/primitives_fiber.zig
+++ b/src/primitives_fiber.zig
@@ -450,9 +450,17 @@ fn channelSendLocal(ch: *types.Channel, ch_val: Value, payload: Value, deadline_
         };
     }
     _ = fiber_mod.runSchedulerStep(ChannelSendWait, .{ .ch = ch }, ctx.vm, ctx.sched, me) catch |err| {
-        // runSchedulerStep's own epilogue (#2429) already restored `me`'s
-        // window and .running status; undo the park state armed above that it
-        // does not touch. Guarded on deadline_ns: with none, nothing above ran.
+        // Restore every park field explicitly rather than leaning on
+        // runSchedulerStep's #2429 epilogue (#2433 review): its first
+        // `try saveCurrentFiber` runs before that errdefer is armed, so an OOM
+        // there returns with `me` still `.waiting`, and the epilogue forces
+        // only `.running` — it never resets a `timed_out` a timer wake set
+        // mid-drive. Matches primitives_srfi18.unparkOnError. Since OutOfMemory
+        // is catchable, a `guard` would otherwise continue with stale state.
+        me.status = .running;
+        me.timed_out = false;
+        // The index/timer/waiting_on cleanup stays guarded: with no deadline
+        // nothing above was armed (and waiting_on may hold an unrelated value).
         if (deadline_ns != null) {
             ctx.reactor.removeTimer(me);
             ctx.sched.withdrawWaiter(me, me.waiting_on);
@@ -1260,11 +1268,18 @@ fn channelReceiveFn(args: []const Value) PrimitiveError!Value {
         // Terminal for this wait (the main fiber has no retireSlot backstop):
         // release the committed demand and detach the timer (#1604 review).
         releaseRvToken(ch, ch_val, me);
+        // Restore every park field explicitly rather than leaning on
+        // runSchedulerStep's #2429 epilogue (#2433 review): its first
+        // `try saveCurrentFiber` runs before that errdefer is armed, so an OOM
+        // there returns with `me` still `.waiting`, and the epilogue forces
+        // only `.running` — it never resets a `timed_out` a timer wake set
+        // mid-drive. Matches primitives_srfi18.unparkOnError.
+        me.status = .running;
+        me.timed_out = false;
         if (deadline_ns != null) {
             ctx.reactor.removeTimer(me);
-            // #2433: withdraw the #1530 enrolment armed above. runSchedulerStep
-            // (#2429) restored status but never clears waiting_on, and only a
-            // later wake naming this key would otherwise compact the entry.
+            // #2433: withdraw the #1530 enrolment armed above; only a later wake
+            // naming this key would otherwise compact the entry.
             ctx.sched.withdrawWaiter(me, me.waiting_on);
             me.waiting_on = types.VOID;
             me.deadline_ns = null;

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -950,3 +950,53 @@ test "a condition-variable park that errors out leaves the fiber runnable (#2430
         \\(guard (e (#t (error-object-message e))) (read-bytevector 4 p))
     , "condition-variable");
 }
+
+// ---------------------------------------------------------------------------
+// The same two defects at the local-channel park sites (#2433)
+// ---------------------------------------------------------------------------
+//
+// primitives_fiber.zig's local channel waits share #2430's shape.
+// channelSendLocal's timed in-call park (Site B) armed .waiting/waiting_on, a
+// #1530 waiter_index enrolment and a reactor timer and then reached both
+// `try addTimer` and `try runSchedulerStep` with no error-path unpark — the
+// send side was the odd one out; the receive side already had catch blocks but
+// none of them withdrew the waiter_index entry (Gap 2), which only a later wake
+// naming the same key would otherwise compact, stranding a map key and list per
+// abandoned park.
+//
+// Same probe as the #2430 tests above: a SRFI 181 custom port whose read!
+// callback blocks on a timed local-channel wait, so runSchedulerStep's
+// custom-port-callback guard raises a real catchable error from inside the
+// armed park — exercising channelSendLocal's and channelReceiveLocal's in-call
+// runSchedulerStep sites on the main fiber. (The dispatched-fiber flat-park
+// re-park sites arm no runSchedulerStep — only addTimer — so their error path
+// is OOM-only, which gc.oom_countdown cannot reach here either, #2435.)
+// `expectUnparkedAfterBlockedCallback` asserts both halves: the park state is
+// restored AND the waiter_index entry is withdrawn.
+
+test "a channel-receive park that errors out leaves the fiber runnable (#2433)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // custom ports need the reactor
+    // An empty unbounded local channel: the timed receive arms the in-call
+    // park (channelReceiveLocal Site D) before its runSchedulerStep drive.
+    try expectUnparkedAfterBlockedCallback(
+        \\(define ch (make-channel))
+        \\(define p (make-custom-binary-input-port "cb"
+        \\  (lambda (bv start count) (channel-receive ch 10) 0) #f #f #f))
+    ,
+        \\(guard (e (#t (error-object-message e))) (read-bytevector 4 p))
+    , "channel-receive");
+}
+
+test "a channel-send park that errors out leaves the fiber runnable (#2433)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest;
+    // A capacity-1 channel filled to the brim, so the timed send blocks on the
+    // in-call park (channelSendLocal Site B) instead of being admitted.
+    try expectUnparkedAfterBlockedCallback(
+        \\(define ch (make-channel 1))
+        \\(channel-send ch 'x)
+        \\(define p (make-custom-binary-input-port "cb"
+        \\  (lambda (bv start count) (channel-send ch 'y 10) 0) #f #f #f))
+    ,
+        \\(guard (e (#t (error-object-message e))) (read-bytevector 4 p))
+    , "channel-send");
+}


### PR DESCRIPTION
## Summary

The two defects PR #2432 fixed for the three SRFI-18 park sites were still
present in `primitives_fiber.zig`'s local-channel waits, which that PR did not
touch. This mirrors that fix (`FiberScheduler.withdrawWaiter`, the
`unparkOnError` shape) at the local-channel sites.

### Gap 1 — `channelSendLocal` armed the park then used bare `try`

`.waiting`, `waiting_on`, a #1530 `waiter_index` enrolment and a live reactor
timer were all armed, and the site then reached both `try addTimer` and
`try runSchedulerStep` with nothing to undo it. Both sources return a
*catchable* `OutOfMemory`, so a Scheme `guard` swallowing it resumes on a fiber
the scheduler still believes is parked — the #1487 dispatch-from-stale-snapshot
precondition. The receive side already had `catch` blocks; the send side was
the odd one out, and now mirrors them with explicit `catch`.

**The issue's site table is one entry short.** It lists `:427`, `:1178`,
`:1215`. There is a **third** Gap-1 instance at the dispatched yield-retry
re-park (`enrollWaiter` at `:403`, bare `try ctx.reactor.addTimer` at `:407`) —
confirmed against current source and covered here, mirroring the receive side's
dispatched re-park.

### Gap 2 — no local cleanup path withdrew the `waiter_index` entry

Clearing `status` stops a stale entry waking the wrong fiber but does not
*remove* it; only a later wake naming the same key would (`indexWakeOn`
compacts as a side effect). A park abandoned on an object nothing ever wakes
stranded one map key and list for the scheduler's lifetime, one per failure on
a fresh object. Every local error path now calls `sched.withdrawWaiter(me,
me.waiting_on)` *before* clearing `waiting_on` (which is the key). The receive
side's `runSchedulerStep` `catch` additionally never cleared `waiting_on` at
all (runSchedulerStep's #2429 epilogue restores `status` but not `waiting_on`);
it does now.

### `blockOrDeadlock` (`:1330`) — the remaining local `enrollWaiter`, left as is

It parks **deliberately** and returns the *uncatchable* `Yielded`
(`errors.isUncatchable`), so no `guard` can resume `me` while the scheduler
holds it parked — this is a live waiter a wake will compact, not an abandoned
one to withdraw. It needs neither an unpark nor a withdraw; documented inline.

### Not touched — promoted/shared-channel paths

`enrollSharedWaiter` / `removeSharedWaiter` (`:656`, `:675`, `:855`, `:873`,
`:1006`, `:1042`) use a different registry, their `catch` blocks already unwind
correctly, and `enrollWaiter`'s doc comment is explicit that a promoted-channel
park must not touch the local index.

## Tests

Two SRFI-181 custom-port probes (the mechanism the #2430 tests use) whose
`read!` callback blocks on a timed local `channel-receive` / `channel-send`,
raising `runSchedulerStep`'s custom-port-callback error from inside the armed
in-call park. Both reach the main-fiber in-call sites (`channelSendLocal` Site
B, `channelReceiveLocal` Site D) deterministically, and both **fail against the
pre-fix source** — `waiting_on` still set, entry still `indexed=true`. They
reuse `expectUnparkedAfterBlockedCallback` / `expectUnparked`, which assert
**both halves**: status/`waiting_on`/timer restored, AND the `waiter_index`
entry withdrawn (plus that the index did not grow across the failed park).

The dispatched flat-park re-park sites (Gap-1 instance at `:403`, and the
receive equivalent) arm **no** `runSchedulerStep` — only `addTimer` — so their
error path is OOM-only, which `gc.oom_countdown` cannot reach (`addTimer`
allocates from the raw allocator the injector does not see, #2435). Their fix
mirrors the tested in-call sites exactly.

## Notes

- `zig build test` passes; `zig fmt --check` on both changed files passes.
- `src/primitives_fiber.zig` is already 1600 lines, over the repo's 1500-line
  policy. This PR adds to it deliberately rather than splitting mid-fix; if a
  split is ever forced, the file's real fault line is local-channel vs.
  promoted/shared-channel paths.

## Related

- #2432 — the same two defects at the SRFI-18 park sites
- #2430 / #2429 — the caller-side and register-window halves one level down
- #1530 — the `waiter_index` this leaks into
- #1487 — the corruption a lying `.waiting` is the precondition for
- #2435 — why `gc.oom_countdown` cannot drive these sites

Closes #2433

🤖 Generated with [Claude Code](https://claude.com/claude-code)