### PR TITLE
Add (kaappi process): posix_spawn subprocess support, POSIX Phase 1 (#2414)

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -57,7 +57,7 @@ Source code
 | `printer.zig` | ~1250 | Value → string: iterative label-aware print engine + hashmap cycle/sharing detection (write/display/write-shared/write-simple; exact at any depth) and the bounded diagnostic `printValue` |
 | `printer_pretty.zig` | ~320 | REPL pretty-printer (fits-or-wraps layout over the bounded diagnostic printer; re-exported as `printer.prettyPrint`) |
 
-### Heap-type domain files (split into 11 files, kaappi#1731)
+### Heap-type domain files (split into 12 files, kaappi#1731)
 
 `types.zig` re-exports every name below (`pub const Foo = types_x.Foo;`), so
 existing `types.Foo` call sites across the codebase are unaffected by which
@@ -79,6 +79,7 @@ domain-mate (`Pair`, `Symbol`, `SchemeString`, `Closure`, `Function`,
 | `types_hashtable.zig` | `HashTable`, `HashEntry`, `HashEntryState`, `CompareMode` (SRFI 69) |
 | `types_filesystem.zig` | `FileInfo`, `UserInfo`, `GroupInfo`, `DirectoryObject` (SRFI 170) |
 | `types_weakrefs.zig` | `Ephemeron`, `Guardian`, `GuardEntry`, `TransportCell` (SRFI 254) |
+| `types_process.zig` | `Process` (KEP-0022, `(kaappi process)`), waitpid status decoders |
 
 `Fiber` (`fiber.zig`) predates this split and follows neither convention:
 its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
@@ -147,6 +148,7 @@ its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 | `primitives_srfi237.zig` | SRFI-237: R6RS record procedural layer (`(srfi 237 primitives)`) |
 | `primitives_srfi254.zig` | SRFI-254: ephemeron/guardian constructors, predicates, accessors (GC half lives in `gc_collect.zig`) |
 | `primitives_fiber.zig` | `(kaappi fibers)`: spawn, yield, fiber-join, channels |
+| `primitives_process.zig` | `(kaappi process)` (KEP-0022): posix_spawnp-based subprocess support — spawn-process, pipe ports, blocking process-wait, process-kill, zombie sweep. POSIX-only (Windows is Phase 3, WASM registers nothing) |
 | `primitives_parallel.zig` | KEP-0002: the single native primitive backing `lib/kaappi/parallel.sld` |
 | `primitives_random_port.zig` | SRFI-271 random port `%`-prefixed internals |
 | `primitives_sysinfo.zig` | System inquiry shared by SRFI 59 (vicinity), 112 (environment), 193 (command line) |

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -33,7 +33,7 @@ Source code
 | **Compiler** | `compiler.zig` + 9 sub-modules | Emits register-based bytecode from IR nodes via `compileFromNode()` (in `compiler_ir.zig`). Retains `compileExpr()` for forms delegated via `passthrough`. See the [Compiler & IR](#compiler--ir-11-files) table for the per-file split. |
 | **VM** | `vm.zig` + 10 sub-modules | Executes bytecode with a growable register file, call frame stack, exception handler stack, and dynamic-wind stack (all heap-allocated, double-on-overflow; exceeding a hard cap is an uncatchable KP3008). First-class continuations via stack copying, plus a stepping debugger. |
 | **GC** | `memory.zig` | Generational (young/old) mark-and-sweep collector over an intrusive linked list, with a write barrier and remembered set for old→young references. Root tracking via `pushRoot`/`popRoot`. Triggered after N allocations. |
-| **Primitives** | 31 `primitives_*.zig` files | 696 built-in procedures organized by domain. |
+| **Primitives** | 32 `primitives_*.zig` files | 696 built-in procedures organized by domain. |
 
 ---
 
@@ -116,7 +116,7 @@ its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 | `vm_continuations.zig` | captureContinuation, restoreContinuation, performWindTransition, callWithCC |
 | `vm_debug.zig` | Stepping debugger: breakpoints (with conditions), watch expressions, step/next/step-out/continue, up/down frame navigation, locals, backtrace |
 
-### Primitives (split into 31 files)
+### Primitives (split into 32 files)
 
 | File | Procedures |
 |------|-----------|

--- a/src/gc_alloc.zig
+++ b/src/gc_alloc.zig
@@ -1085,6 +1085,11 @@ pub fn allocChannel(self: *GC) !Value {
 /// pointer in it is valid for exactly as long as the object is.
 pub fn allocProcess(self: *GC, pid: i32, pgid: i32) !*types.Process {
     try self.maybeCollect();
+    // Reserve the tracking slot first: spawn-process is a user-driven path
+    // whose callers already handle error.OutOfMemory, so a list-growth
+    // failure must raise, not abort — and reserving before the create means
+    // no tracked-but-unenrolled (or enrolled-then-failed) Process can exist.
+    try self.unreaped_processes.ensureUnusedCapacity(self.allocator, 1);
     const proc = try self.allocator.create(types.Process);
     proc.* = .{
         .header = .{ .tag = .process },
@@ -1092,8 +1097,7 @@ pub fn allocProcess(self: *GC, pid: i32, pgid: i32) !*types.Process {
         .pgid = pgid,
     };
     self.finishAlloc(&proc.header, @sizeOf(types.Process));
-    self.unreaped_processes.append(self.allocator, proc) catch
-        @panic("GC: process tracking list OOM");
+    self.unreaped_processes.appendAssumeCapacity(proc);
     return proc;
 }
 

--- a/src/gc_alloc.zig
+++ b/src/gc_alloc.zig
@@ -1073,6 +1073,30 @@ pub fn allocChannel(self: *GC) !Value {
     return types.makePointer(&ch.header);
 }
 
+/// KEP-0022: a spawned-subprocess handle. The three port fields are FALSE
+/// here and are stored by the spawner right after; those stores happen while
+/// the Process is young, but the write barrier is applied anyway per the
+/// gc-safety rule ("when in doubt").
+///
+/// Also enrolls the Process in `unreaped_processes` (zombie discipline,
+/// KEP-0022 unresolved question 3): every unreaped Process of this heap is
+/// swept with waitpid(WNOHANG) on the blocking spawn/wait paths, and
+/// gc_sweep.freeObject removes a collected Process from the list -- so a
+/// pointer in it is valid for exactly as long as the object is.
+pub fn allocProcess(self: *GC, pid: i32, pgid: i32) !*types.Process {
+    try self.maybeCollect();
+    const proc = try self.allocator.create(types.Process);
+    proc.* = .{
+        .header = .{ .tag = .process },
+        .pid = pid,
+        .pgid = pgid,
+    };
+    self.finishAlloc(&proc.header, @sizeOf(types.Process));
+    self.unreaped_processes.append(self.allocator, proc) catch
+        @panic("GC: process tracking list OOM");
+    return proc;
+}
+
 /// KEP-0002 §6: a bounded channel, `(make-channel capacity)`. Separate
 /// from allocChannel (rather than an optional parameter) so the
 /// pre-Phase-4 call sites that construct an unbounded channel need no

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -266,6 +266,12 @@ pub fn referencesYoung(gc: *GC, obj: *Object) bool {
             const ch = obj.as(types.Channel);
             if (isYoungPointer(gc, ch.head) or isYoungPointer(gc, ch.tail)) return true;
         },
+        .process => {
+            const proc = obj.as(types.Process);
+            if (isYoungPointer(gc, proc.stdin_port) or
+                isYoungPointer(gc, proc.stdout_port) or
+                isYoungPointer(gc, proc.stderr_port)) return true;
+        },
         .mutex => {
             const m = obj.as(types.Mutex);
             if (isYoungPointer(gc, m.name) or isYoungPointer(gc, m.owner) or isYoungPointer(gc, m.owner_thread) or isYoungPointer(gc, m.specific)) return true;
@@ -741,6 +747,12 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
             markValue(gc, ch.head);
             markValue(gc, ch.tail);
         },
+        .process => {
+            const proc = obj.as(types.Process);
+            markValue(gc, proc.stdin_port);
+            markValue(gc, proc.stdout_port);
+            markValue(gc, proc.stderr_port);
+        },
         .mutex => {
             const m = obj.as(types.Mutex);
             markValue(gc, m.name);
@@ -1159,6 +1171,12 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
             const ch = obj.as(types.Channel);
             worklist.append(gc.allocator, ch.head) catch @panic("GC mark: worklist OOM");
             worklist.append(gc.allocator, ch.tail) catch @panic("GC mark: worklist OOM");
+        },
+        .process => {
+            const proc = obj.as(types.Process);
+            worklist.append(gc.allocator, proc.stdin_port) catch @panic("GC mark: worklist OOM");
+            worklist.append(gc.allocator, proc.stdout_port) catch @panic("GC mark: worklist OOM");
+            worklist.append(gc.allocator, proc.stderr_port) catch @panic("GC mark: worklist OOM");
         },
         .mutex => {
             const m = obj.as(types.Mutex);

--- a/src/gc_deep_copy.zig
+++ b/src/gc_deep_copy.zig
@@ -641,7 +641,7 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
         // This list governs the *copy* route only -- the thread-start!
         // thunk closure, the thread-join! result, a channel message. A
         // value reached through the shared globals map is never copied and
-        // never reaches this switch, and ten of the eleven
+        // never reaches this switch, and eleven of the twelve
         // tags below are freely usable that way. For .mutex and
         // .condition_variable a global is in fact the *only* supported way
         // to share one, so the refusal here is the opposite of the rule --
@@ -666,6 +666,12 @@ fn deepCopyValue(gc: *GC, src: Value, visited: *std.AutoHashMap(usize, Value)) D
         .ffi_callback,
         .directory_object,
         .scheme_environment,
+        // KEP-0022: a Process is thread-affine -- its pid, unreaped-status
+        // bookkeeping and (Phase 2) reactor registration belong to the
+        // scheduler of the thread that spawned it. Like .channel it is also
+        // owner-checked at every primitive, so the globals route is defended
+        // separately.
+        .process,
         // SRFI-254 weak references are tied to one GC's collection cycle.
         .ephemeron,
         .guardian,

--- a/src/gc_sweep.zig
+++ b/src/gc_sweep.zig
@@ -427,6 +427,19 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
                 // (EAGAIN) or any other failure just drops the remainder —
                 // programs that need the data call flush-output-port or
                 // close-port instead of leaking the port to the collector.
+                //
+                // For that promise to hold, the fd must actually RETURN
+                // EAGAIN: a port the scheduler never touched (a fresh
+                // process pipe, KEP-0022) is still in blocking mode, and a
+                // blocking write into a full pipe whose reader never drains
+                // would wedge the collector itself (kaappi#2442 review).
+                // Flip it non-blocking first — a no-op for regular files,
+                // whose flush still completes in full, and irrelevant to
+                // the fd's future since it is closed right below.
+                if (comptime !platform.is_windows and !platform.is_wasm) {
+                    if (!port.nonblocking and port.write_buf != null)
+                        _ = platform.setFdNonblockingForTeardown(port.fd);
+                }
                 if (port.write_buf) |wb| {
                     var start = port.write_buf_start;
                     while (start < port.write_buf_len) {

--- a/src/gc_sweep.zig
+++ b/src/gc_sweep.zig
@@ -434,33 +434,45 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
                 // blocking write into a full pipe whose reader never drains
                 // would wedge the collector itself (kaappi#2442 review).
                 // Flip it non-blocking first — a no-op for regular files,
-                // whose flush still completes in full, and irrelevant to
-                // the fd's future since it is closed right below.
+                // whose flush still completes in full. O_NONBLOCK lives on
+                // the SHARED open-file description, so the prior flags are
+                // restored before the close — dup/dup2 aliases (a child's
+                // stdio, an fd->port twin) must not come out of a
+                // collection permanently non-blocking — and if the flip
+                // itself fails, the blocking-capable drain is skipped
+                // entirely rather than risked (kaappi#2442 review).
+                var teardown_flags: ?c_int = null;
+                var drain_ok = true;
                 if (comptime !platform.is_windows and !platform.is_wasm) {
-                    if (!port.nonblocking and port.write_buf != null)
-                        _ = platform.setFdNonblockingForTeardown(port.fd);
-                }
-                if (port.write_buf) |wb| {
-                    var start = port.write_buf_start;
-                    while (start < port.write_buf_len) {
-                        // A Windows socket port must send() — CRT _write
-                        // cannot operate on a SOCKET handle — and a pipe
-                        // port in emulated non-blocking mode must keep its
-                        // quota gate: plain _write on a full pipe would
-                        // block this sweep forever, exactly the would-block
-                        // this loop promises to drop (#1608).
-                        const remaining = port.write_buf_len - start;
-                        const rc = if (platform.is_windows and port.fd_state.is_socket)
-                            platform.sockSend(port.fd, wb.ptr + start, remaining)
-                        else if (platform.is_windows and port.fd_state.is_pipe and port.nonblocking)
-                            platform.pipeWrite(port.fd, wb.ptr + start, remaining)
-                        else
-                            platform.write(port.fd, wb.ptr + start, remaining);
-                        if (rc < 0 and platform.errno(rc) == .INTR) continue;
-                        if (rc <= 0) break;
-                        start += @as(usize, @intCast(rc));
+                    if (!port.nonblocking and port.write_buf != null) {
+                        teardown_flags = platform.setFdNonblockingForTeardown(port.fd);
+                        if (teardown_flags == null) drain_ok = false;
                     }
                 }
+                if (drain_ok) {
+                    if (port.write_buf) |wb| {
+                        var start = port.write_buf_start;
+                        while (start < port.write_buf_len) {
+                            // A Windows socket port must send() — CRT _write
+                            // cannot operate on a SOCKET handle — and a pipe
+                            // port in emulated non-blocking mode must keep its
+                            // quota gate: plain _write on a full pipe would
+                            // block this sweep forever, exactly the would-block
+                            // this loop promises to drop (#1608).
+                            const remaining = port.write_buf_len - start;
+                            const rc = if (platform.is_windows and port.fd_state.is_socket)
+                                platform.sockSend(port.fd, wb.ptr + start, remaining)
+                            else if (platform.is_windows and port.fd_state.is_pipe and port.nonblocking)
+                                platform.pipeWrite(port.fd, wb.ptr + start, remaining)
+                            else
+                                platform.write(port.fd, wb.ptr + start, remaining);
+                            if (rc < 0 and platform.errno(rc) == .INTR) continue;
+                            if (rc <= 0) break;
+                            start += @as(usize, @intCast(rc));
+                        }
+                    }
+                }
+                if (teardown_flags) |fl| platform.restoreFdStatusFlags(port.fd, fl);
                 _ = platform.close(port.fd);
             }
             if (port.write_buf) |wb| {

--- a/src/gc_sweep.zig
+++ b/src/gc_sweep.zig
@@ -428,27 +428,27 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
                 // programs that need the data call flush-output-port or
                 // close-port instead of leaking the port to the collector.
                 //
-                // For that promise to hold, the fd must actually RETURN
-                // EAGAIN: a port the scheduler never touched (a fresh
-                // process pipe, KEP-0022) is still in blocking mode, and a
+                // For that promise to hold, the drain must be unable to
+                // block. A port the scheduler never touched (a fresh
+                // process pipe, KEP-0022) is still in BLOCKING mode, and a
                 // blocking write into a full pipe whose reader never drains
-                // would wedge the collector itself (kaappi#2442 review).
-                // Flip it non-blocking first — a no-op for regular files,
-                // whose flush still completes in full. O_NONBLOCK lives on
-                // the SHARED open-file description, so the prior flags are
-                // restored before the close — dup/dup2 aliases (a child's
-                // stdio, an fd->port twin) must not come out of a
-                // collection permanently non-blocking — and if the flip
-                // itself fails, the blocking-capable drain is skipped
-                // entirely rather than risked (kaappi#2442 review).
-                var teardown_flags: ?c_int = null;
-                var drain_ok = true;
-                if (comptime !platform.is_windows and !platform.is_wasm) {
-                    if (!port.nonblocking and port.write_buf != null) {
-                        teardown_flags = platform.setFdNonblockingForTeardown(port.fd);
-                        if (teardown_flags == null) drain_ok = false;
-                    }
-                }
+                // would wedge the collector itself — while toggling
+                // O_NONBLOCK for the drain is no better: the flag lives on
+                // the SHARED open-file description, so every dup/dup2
+                // alias (a child's stdio, an fd->port twin) transiently —
+                // or, on a failed restore, permanently — turns non-blocking
+                // (kaappi#2442 review, twice). So no flag is ever touched;
+                // instead the drain is gated on seekability: a seekable fd
+                // is a regular file, whose blocking write completes without
+                // waiting on a peer (the flush-on-collect file ports have
+                // always had), while an unseekable one (pipe, socket, FIFO,
+                // tty — everything with a peer or flow control) simply
+                // drops its remainder, exactly the best-effort contract.
+                const drain_ok = if (comptime platform.is_windows or platform.is_wasm)
+                    true // the Windows arms below have their own non-blocking gates
+                else
+                    port.nonblocking or port.write_buf == null or
+                        platform.seek(port.fd, 0, platform.SEEK_CUR) >= 0;
                 if (drain_ok) {
                     if (port.write_buf) |wb| {
                         var start = port.write_buf_start;
@@ -472,7 +472,6 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
                         }
                     }
                 }
-                if (teardown_flags) |fl| platform.restoreFdStatusFlags(port.fd, fl);
                 _ = platform.close(port.fd);
             }
             if (port.write_buf) |wb| {

--- a/src/gc_sweep.zig
+++ b/src/gc_sweep.zig
@@ -264,6 +264,7 @@ pub fn objectSize(obj: *Object) usize {
                 fiber.wind_stack.len * @sizeOf(types.WindRecord);
         },
         .channel => @sizeOf(types.Channel),
+        .process => @sizeOf(types.Process),
         .mutex => @sizeOf(types.Mutex),
         .condition_variable => @sizeOf(types.ConditionVariable),
         .srfi18_time => @sizeOf(types.Srfi18Time),
@@ -577,6 +578,30 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
                 sc.release();
             }
             poisonAndDestroy(gc, types.Channel, ch);
+        },
+        .process => {
+            const proc = obj.as(types.Process);
+            // Zombie discipline (KEP-0022 Phase 1): drop the collected
+            // Process from the heap's unreaped list first -- after
+            // poisonAndDestroy the pointer is invalid -- then make one
+            // last-resort non-blocking reap attempt so an already-exited
+            // child of an abandoned Process does not linger as a zombie.
+            // Still-running children are simply no longer tracked; their
+            // zombies (if any) are reparented to init when this process
+            // exits. A BLOCKING wait is never acceptable inside a sweep.
+            for (gc.unreaped_processes.items, 0..) |p, i| {
+                if (p == proc) {
+                    _ = gc.unreaped_processes.swapRemove(i);
+                    break;
+                }
+            }
+            if (proc.status == null) {
+                if (comptime !platform.is_wasm and !platform.is_windows) {
+                    var st: c_int = 0;
+                    _ = platform.waitPid(proc.pid, &st, platform.WNOHANG);
+                }
+            }
+            poisonAndDestroy(gc, types.Process, proc);
         },
         .mutex => {
             poisonAndDestroy(gc, types.Mutex, obj.as(types.Mutex));

--- a/src/library.zig
+++ b/src/library.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const is_wasm = @import("builtin").os.tag == .wasi;
+const is_windows = @import("builtin").os.tag == .windows;
 const types = @import("types.zig");
 const Value = types.Value;
 
@@ -194,7 +195,7 @@ pub fn registerStandardLibraries(registry: *LibraryRegistry, globals: *std.Strin
 
     for (std.enums.values(Lib)) |lib| {
         if (!lib.isRegisterable()) continue;
-        if (!is_wasm or lib.wasmAvailable()) {
+        if ((!is_wasm or lib.wasmAvailable()) and (!is_windows or lib.windowsAvailable())) {
             var library = Library.init(allocator, lib.canonicalName());
             try addExportsForLib(&library, lib, globals, false);
             try registry.register(library);
@@ -214,7 +215,7 @@ pub fn registerSandboxedLibraries(registry: *LibraryRegistry, globals: *std.Stri
     for (std.enums.values(Lib)) |lib| {
         if (!lib.isRegisterable()) continue;
         if (!lib.sandboxAllowed()) continue;
-        if (!is_wasm or lib.wasmAvailable()) {
+        if ((!is_wasm or lib.wasmAvailable()) and (!is_windows or lib.windowsAvailable())) {
             var library = Library.init(allocator, lib.canonicalName());
             try addExportsForLib(&library, lib, globals, true);
             try registry.register(library);

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -414,6 +414,18 @@ pub const GC = struct {
     /// and the FREED_OWNER sentinel the whole #1687 machinery rests on is
     /// overwritten before the parent's next mark can read it.
     quarantine_heir: ?*GC = null,
+    /// KEP-0022 Phase 1 (zombie discipline): every Process this heap spawned
+    /// and has not reaped. The blocking spawn/wait primitives sweep it with
+    /// waitpid(WNOHANG); gc_sweep.freeObject removes a collected Process from
+    /// it (after a last-resort non-blocking reap), so entries are valid
+    /// pointers for exactly as long as the objects are. Deliberately NOT a
+    /// root list: an unreachable unreaped Process must be collectable, so
+    /// that its pipe ports close and a child blocked on a full pipe gets
+    /// EOF/EPIPE instead of hanging forever (Python's Popen semantics).
+    /// Residual window, documented and accepted: a Process collected while
+    /// its child still runs leaves a zombie if the child exits later and
+    /// this Kaappi process keeps running.
+    unreaped_processes: std.ArrayList(*types.Process) = .empty,
 
     pub const QuarantineEntry = struct {
         ptr: [*]u8,
@@ -499,6 +511,7 @@ pub const GC = struct {
         self.symbols.deinit();
         self.allocator.free(self.root_buffer);
         self.extra_roots.deinit(self.allocator);
+        self.unreaped_processes.deinit(self.allocator);
         self.remembered_set.deinit(self.allocator);
         self.mark_worklist.deinit(self.allocator);
         self.pending_ephemerons.deinit(self.allocator);
@@ -657,6 +670,7 @@ pub const GC = struct {
     pub const allocChannel = gc_alloc.allocChannel;
     pub const allocChannelBounded = gc_alloc.allocChannelBounded;
     pub const allocChannelStub = gc_alloc.allocChannelStub;
+    pub const allocProcess = gc_alloc.allocProcess;
     pub const allocMutex = gc_alloc.allocMutex;
     pub const allocConditionVariable = gc_alloc.allocConditionVariable;
     pub const allocSrfi18Time = gc_alloc.allocSrfi18Time;

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -193,15 +193,27 @@ pub fn getFdFlags(fd: fd_t) c_int {
     return fcntlRaw(fd, F_GETFD, 0);
 }
 
-/// Set O_NONBLOCK on an fd about to be closed, so a final best-effort drain
-/// gets EAGAIN instead of blocking (the GC sweep's port flush — a collector
-/// must never wedge on a full pipe, kaappi#2442). POSIX only; best-effort.
-pub fn setFdNonblockingForTeardown(fd: fd_t) bool {
-    if (comptime is_wasm or is_windows) return false;
+/// Set O_NONBLOCK on an fd so a final best-effort drain gets EAGAIN instead
+/// of blocking (the GC sweep's port flush — a collector must never wedge on
+/// a full pipe, kaappi#2442). Returns the PRIOR status flags so the caller
+/// can restore them: O_NONBLOCK lives on the shared open-file description,
+/// and dup/dup2 aliases of this fd — a child's stdio, an `fd->port` twin —
+/// would otherwise be left permanently non-blocking (kaappi#2442 review).
+/// Null when the flags cannot be read or set; the caller must then skip its
+/// blocking-capable drain rather than fall through.
+pub fn setFdNonblockingForTeardown(fd: fd_t) ?c_int {
+    if (comptime is_wasm or is_windows) return null;
     const flags = std.c.fcntl(fd, std.posix.F.GETFL, @as(c_int, 0));
-    if (flags < 0) return false;
+    if (flags < 0) return null;
     const nonblock: c_int = @intCast(@as(u32, @bitCast(std.posix.O{ .NONBLOCK = true })));
-    return std.c.fcntl(fd, std.posix.F.SETFL, flags | nonblock) >= 0;
+    if (std.c.fcntl(fd, std.posix.F.SETFL, flags | nonblock) < 0) return null;
+    return flags;
+}
+
+/// Restore fcntl status flags saved by setFdNonblockingForTeardown.
+pub fn restoreFdStatusFlags(fd: fd_t, flags: c_int) void {
+    if (comptime is_wasm or is_windows) return;
+    _ = std.c.fcntl(fd, std.posix.F.SETFL, flags);
 }
 
 /// dup(2), except the copy is close-on-exec (fcntl F_DUPFD_CLOEXEC, the

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -195,10 +195,24 @@ pub fn getFdFlags(fd: fd_t) c_int {
 
 /// dup(2), except the copy is close-on-exec (fcntl F_DUPFD_CLOEXEC, the
 /// POSIX 2008 replacement for dup-then-F_SETFD that cannot be interrupted
-/// between the two steps). Returns -1 on failure.
+/// between the two steps). Returns -1 on failure. The command value is
+/// per-OS (POSIX names it but does not fix it: 1030 on Linux, 67 on macOS,
+/// 17/12/10 on the BSDs), so take it from std.c's per-target table — a
+/// hardcoded number lands on a different fcntl command entirely on every
+/// other libc (kaappi#2442 review: 6 was macOS's F_SETOWN and Linux's
+/// F_SETLK, so the dup silently never happened).
 pub fn fcntlDupCloexec(fd: fd_t) fd_t {
-    const F_DUPFD_CLOEXEC: c_int = 6;
-    return fcntlRaw(fd, F_DUPFD_CLOEXEC, 0);
+    if (comptime is_wasm or is_windows) return -1;
+    // std.c's per-target F table is the authority where it declares the
+    // command; OpenBSD's entry omits it (an upstream gap — the OS has had
+    // it since 5.0, value 10 per its <fcntl.h>).
+    const cmd: c_int = comptime if (@hasDecl(std.c.F, "DUPFD_CLOEXEC"))
+        @intCast(std.c.F.DUPFD_CLOEXEC)
+    else if (builtin.os.tag == .openbsd)
+        10
+    else
+        @compileError("F_DUPFD_CLOEXEC value unknown for this target");
+    return fcntlRaw(fd, cmd, 0);
 }
 
 /// fcntl(2) MUST be declared variadic — its C prototype is

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -193,29 +193,6 @@ pub fn getFdFlags(fd: fd_t) c_int {
     return fcntlRaw(fd, F_GETFD, 0);
 }
 
-/// Set O_NONBLOCK on an fd so a final best-effort drain gets EAGAIN instead
-/// of blocking (the GC sweep's port flush — a collector must never wedge on
-/// a full pipe, kaappi#2442). Returns the PRIOR status flags so the caller
-/// can restore them: O_NONBLOCK lives on the shared open-file description,
-/// and dup/dup2 aliases of this fd — a child's stdio, an `fd->port` twin —
-/// would otherwise be left permanently non-blocking (kaappi#2442 review).
-/// Null when the flags cannot be read or set; the caller must then skip its
-/// blocking-capable drain rather than fall through.
-pub fn setFdNonblockingForTeardown(fd: fd_t) ?c_int {
-    if (comptime is_wasm or is_windows) return null;
-    const flags = std.c.fcntl(fd, std.posix.F.GETFL, @as(c_int, 0));
-    if (flags < 0) return null;
-    const nonblock: c_int = @intCast(@as(u32, @bitCast(std.posix.O{ .NONBLOCK = true })));
-    if (std.c.fcntl(fd, std.posix.F.SETFL, flags | nonblock) < 0) return null;
-    return flags;
-}
-
-/// Restore fcntl status flags saved by setFdNonblockingForTeardown.
-pub fn restoreFdStatusFlags(fd: fd_t, flags: c_int) void {
-    if (comptime is_wasm or is_windows) return;
-    _ = std.c.fcntl(fd, std.posix.F.SETFL, flags);
-}
-
 /// dup(2), except the copy is close-on-exec (fcntl F_DUPFD_CLOEXEC, the
 /// POSIX 2008 replacement for dup-then-F_SETFD that cannot be interrupted
 /// between the two steps). Returns -1 on failure. The command value is

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -193,6 +193,17 @@ pub fn getFdFlags(fd: fd_t) c_int {
     return fcntlRaw(fd, F_GETFD, 0);
 }
 
+/// Set O_NONBLOCK on an fd about to be closed, so a final best-effort drain
+/// gets EAGAIN instead of blocking (the GC sweep's port flush — a collector
+/// must never wedge on a full pipe, kaappi#2442). POSIX only; best-effort.
+pub fn setFdNonblockingForTeardown(fd: fd_t) bool {
+    if (comptime is_wasm or is_windows) return false;
+    const flags = std.c.fcntl(fd, std.posix.F.GETFL, @as(c_int, 0));
+    if (flags < 0) return false;
+    const nonblock: c_int = @intCast(@as(u32, @bitCast(std.posix.O{ .NONBLOCK = true })));
+    return std.c.fcntl(fd, std.posix.F.SETFL, flags | nonblock) >= 0;
+}
+
 /// dup(2), except the copy is close-on-exec (fcntl F_DUPFD_CLOEXEC, the
 /// POSIX 2008 replacement for dup-then-F_SETFD that cannot be interrupted
 /// between the two steps). Returns -1 on failure. The command value is
@@ -202,6 +213,16 @@ pub fn getFdFlags(fd: fd_t) c_int {
 /// other libc (kaappi#2442 review: 6 was macOS's F_SETOWN and Linux's
 /// F_SETLK, so the dup silently never happened).
 pub fn fcntlDupCloexec(fd: fd_t) fd_t {
+    return dupCloexecAtLeast(fd, 0);
+}
+
+/// F_DUPFD_CLOEXEC with a minimum descriptor number: the returned copy is
+/// the lowest free fd >= `min`. The subprocess spawner uses `min = 3` to
+/// lift pipe ends and redirect sources out of the stdio range, where
+/// posix_spawn file actions would otherwise clobber them (kaappi#2442
+/// review: a launcher that closed fd 0 makes pipe(2) hand back 0, and a
+/// `stdout:`/`stderr:` swap names slots the earlier dup2 already rewrote).
+pub fn dupCloexecAtLeast(fd: fd_t, min: fd_t) fd_t {
     if (comptime is_wasm or is_windows) return -1;
     // std.c's per-target F table is the authority where it declares the
     // command; OpenBSD's entry omits it (an upstream gap — the OS has had
@@ -212,7 +233,7 @@ pub fn fcntlDupCloexec(fd: fd_t) fd_t {
         10
     else
         @compileError("F_DUPFD_CLOEXEC value unknown for this target");
-    return fcntlRaw(fd, cmd, 0);
+    return fcntlRaw(fd, cmd, @intCast(min));
 }
 
 /// fcntl(2) MUST be declared variadic — its C prototype is

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -158,7 +158,86 @@ pub fn isatty(fd: fd_t) bool {
 pub fn pipe(fds: *[2]fd_t) c_int {
     if (comptime is_windows) return win._pipe(fds, 65536, win.O_BINARY | win.O_NOINHERIT);
     if (comptime is_wasm) return -1;
-    return std.c.pipe(fds);
+    const rc = std.c.pipe(fds);
+    if (rc == 0) {
+        // CLOEXEC audit (KEP-0022 Phase 1): pipe(2) takes no flags, so the
+        // descriptors are made close-on-exec here. Every existing caller
+        // installs child ends with dup2 (which clears CLOEXEC on the child's
+        // slot) and keeps parent ends for its own lifetime, which exec never
+        // interrupts -- so this is invisible to them and stops both ends
+        // leaking into a spawned child.
+        _ = setFdCloexec(fds[0]);
+        _ = setFdCloexec(fds[1]);
+    }
+    return rc;
+}
+
+/// Set FD_CLOEXEC on `fd` (the fcntl(2) F_SETFD form; O_CLOEXEC at open is
+/// unavailable for fds other calls hand back -- kqueue(), pipe(2) on
+/// platforms without pipe2). Returns false on failure; callers treat that
+/// as best-effort.
+pub fn setFdCloexec(fd: fd_t) bool {
+    if (comptime is_wasm) return false;
+    const F_SETFD: c_int = 2;
+    const FD_CLOEXEC: usize = 1;
+    return fcntlRaw(fd, F_SETFD, FD_CLOEXEC) != -1;
+}
+
+/// fcntl(F_GETFD): the fd-flags word (bit 0 = FD_CLOEXEC), or -1 when `fd`
+/// is not open. The subprocess spawner's close-by-default scan uses it both
+/// as an is-open probe and to skip descriptors exec will close anyway
+/// (KEP-0022).
+pub fn getFdFlags(fd: fd_t) c_int {
+    if (comptime is_wasm) return -1;
+    const F_GETFD: c_int = 1;
+    return fcntlRaw(fd, F_GETFD, 0);
+}
+
+/// dup(2), except the copy is close-on-exec (fcntl F_DUPFD_CLOEXEC, the
+/// POSIX 2008 replacement for dup-then-F_SETFD that cannot be interrupted
+/// between the two steps). Returns -1 on failure.
+pub fn fcntlDupCloexec(fd: fd_t) fd_t {
+    const F_DUPFD_CLOEXEC: c_int = 6;
+    return fcntlRaw(fd, F_DUPFD_CLOEXEC, 0);
+}
+
+/// fcntl(2) MUST be declared variadic — its C prototype is
+/// `int fcntl(int, int, ...)`. A fixed-arity extern happens to link but is
+/// not the same call: on arm64 macOS the variadic calling convention differs
+/// and the third argument never reaches the kernel, so F_SETFD (and
+/// F_DUPFD_CLOEXEC's min-fd) silently no-ops while returning success — the
+/// exact bug that made every CLOEXEC set here a no-op on that platform
+/// (KEP-0022 audit). Every call site passes a typed argument, as Zig
+/// requires of variadic calls.
+fn fcntlRaw(fd: fd_t, cmd: c_int, arg: usize) c_int {
+    const fcntl_fn = struct {
+        extern "c" fn fcntl(fd: c_int, cmd: c_int, ...) c_int;
+    }.fcntl;
+    return fcntl_fn(fd, cmd, arg);
+}
+
+// ---------------------------------------------------------------------------
+// process control (KEP-0022 Phase 1) -- POSIX only; the Windows tier is
+// Phase 3 and gates every reference comptime.
+// ---------------------------------------------------------------------------
+
+/// waitpid(2)'s WNOHANG: poll without blocking. Same value on every POSIX
+/// platform (0x1).
+pub const WNOHANG: c_int = 1;
+
+extern "c" fn waitpid(pid: c_int, status: *c_int, options: c_int) c_int;
+extern "c" fn kill(pid: c_int, sig: c_int) c_int;
+
+/// waitpid(2). Returns the reaped pid (0 with WNOHANG when the child still
+/// runs, -1 on error).
+pub fn waitPid(pid: i32, status: *c_int, options: c_int) i32 {
+    return waitpid(pid, status, options);
+}
+
+/// kill(2)/killpg semantics in one call: a negative `pid` signals the
+/// process group -pid. Returns 0 on success, -1 on error (errno set).
+pub fn procKill(pid: i32, sig: c_int) c_int {
+    return kill(pid, sig);
 }
 
 pub fn dup2(old: fd_t, new: fd_t) c_int {
@@ -262,7 +341,7 @@ pub fn openRead(path: [:0]const u8) OpenError!fd_t {
         if (rc != .SUCCESS) return error.OpenFailed;
         return @as(fd_t, @intCast(result_fd));
     }
-    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{}, 0) catch |e| classifyOpenError(e);
+    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .CLOEXEC = true }, 0) catch |e| classifyOpenError(e);
 }
 
 /// WASI path resolution, the way wasi-libc's open() does it (kaappi#2153).
@@ -355,19 +434,19 @@ fn wasiOpenWrite(path: [:0]const u8, oflags: std.os.wasi.oflags_t, append: bool)
 pub fn openWriteTrunc(path: [:0]const u8, mode: u16) OpenError!fd_t {
     if (comptime is_windows) return winOpen(path, win.O_WRONLY | win.O_CREAT | win.O_TRUNC, 0o600);
     if (comptime is_wasm) return wasiOpenWrite(path, .{ .CREAT = true, .TRUNC = true }, false);
-    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true }, mode) catch |e| classifyOpenError(e);
+    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true, .CLOEXEC = true }, mode) catch |e| classifyOpenError(e);
 }
 
 pub fn openWriteTruncExcl(path: [:0]const u8, mode: u16) OpenError!fd_t {
     if (comptime is_windows) return winOpen(path, win.O_WRONLY | win.O_CREAT | win.O_TRUNC | win.O_EXCL, 0o600);
     if (comptime is_wasm) return wasiOpenWrite(path, .{ .CREAT = true, .TRUNC = true, .EXCL = true }, false);
-    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true, .EXCL = true }, mode) catch error.OpenFailed;
+    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true, .EXCL = true, .CLOEXEC = true }, mode) catch error.OpenFailed;
 }
 
 pub fn openAppend(path: [:0]const u8, mode: u16) OpenError!fd_t {
     if (comptime is_windows) return winOpen(path, win.O_WRONLY | win.O_CREAT | win.O_APPEND, 0o600);
     if (comptime is_wasm) return wasiOpenWrite(path, .{ .CREAT = true }, true);
-    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .ACCMODE = .WRONLY, .CREAT = true, .APPEND = true }, mode) catch error.OpenFailed;
+    return std.posix.openatZ(std.posix.AT.FDCWD, path, .{ .ACCMODE = .WRONLY, .CREAT = true, .APPEND = true, .CLOEXEC = true }, mode) catch error.OpenFailed;
 }
 
 /// Write-only sink for discarding output (/dev/null, NUL).
@@ -378,7 +457,7 @@ pub fn openNullSink() OpenError!fd_t {
     // harness skips its fd-discarding mode), so a loud OpenFailed is the
     // honest answer rather than substituting some real file.
     if (comptime is_wasm) return error.OpenFailed;
-    return std.posix.openatZ(std.posix.AT.FDCWD, "/dev/null", .{ .ACCMODE = .WRONLY }, 0) catch error.OpenFailed;
+    return std.posix.openatZ(std.posix.AT.FDCWD, "/dev/null", .{ .ACCMODE = .WRONLY, .CLOEXEC = true }, 0) catch error.OpenFailed;
 }
 
 // ---------------------------------------------------------------------------
@@ -737,6 +816,18 @@ pub const DirIter = struct {
             return .{ .state = .{ .fd = result_fd } };
         }
         const dh = opendir_sys(path) orelse return null;
+        // CLOEXEC audit (KEP-0022 Phase 1): modern opendir()s open their
+        // internal fd O_CLOEXEC, but that is not contractual, and an
+        // open-directory port (SRFI 170) is GC-lifetime — exactly the fd a
+        // spawned child must not inherit. Zig's bundled NetBSD libc exports
+        // no dirfd at all (its opendir is CLOEXEC-internal), so that target
+        // is skipped comptime.
+        if (comptime !is_netbsd) {
+            const dirfd_fn = struct {
+                extern "c" fn dirfd(dir: *std.c.DIR) c_int;
+            }.dirfd;
+            _ = setFdCloexec(dirfd_fn(dh));
+        }
         return .{ .state = dh };
     }
 

--- a/src/primitives.zig
+++ b/src/primitives.zig
@@ -99,6 +99,12 @@ pub const Lib = enum {
     // (SRFI 211 is sub-library-only, so the sub-library names must stay
     // file-resolvable).
     srfi_211_primitives,
+    /// `(kaappi process)` (KEP-0022): native subprocess support. Phase 1 is
+    /// POSIX-only (posix_spawnp); the Windows tier is Phase 3, and WASI has
+    /// no process model at all — so the library is registered on neither,
+    /// which makes `(library (kaappi process))` gate false there via the
+    /// registry check in vm_library.libraryIsAvailable.
+    kaappi_process,
     /// `(kaappi primitives)`: the internal helpers a *portable* `.sld` names
     /// in its own Scheme source -- SRFI 27's random-source accessors, SRFI
     /// 74's endianness probe, SRFI 271's random ports, the record substrate
@@ -157,6 +163,7 @@ pub const Lib = enum {
             .scheme_complex => "scheme.complex",
             .kaappi_ffi => "kaappi.ffi",
             .kaappi_fibers => "kaappi.fibers",
+            .kaappi_process => "kaappi.process",
             .kaappi_diagnostics => "kaappi.diagnostics",
             .srfi_1 => "srfi.1",
             .srfi_13 => "srfi.13",
@@ -193,6 +200,7 @@ pub const Lib = enum {
             .scheme_process_context,
             .scheme_r5rs,
             .kaappi_ffi,
+            .kaappi_process,
             .srfi_18,
             .srfi_170,
             .srfi_192,
@@ -216,7 +224,20 @@ pub const Lib = enum {
 
     pub fn wasmAvailable(self: Lib) bool {
         return switch (self) {
-            .kaappi_ffi, .srfi_18, .srfi_170 => false,
+            .kaappi_ffi, .kaappi_process, .srfi_18, .srfi_170 => false,
+            else => true,
+        };
+    }
+
+    /// The Windows analogue of `wasmAvailable`, for libraries whose whole
+    /// implementation is absent on that platform. Only `(kaappi process)`
+    /// today: its Phase 1 surface is posix_spawn-only, and an empty library
+    /// registered there would make `(library (kaappi process))` gate true
+    /// while importing `spawn-process` fails — worse than absent. Phase 3
+    /// (CreateProcess + Job Objects) removes the entry.
+    pub fn windowsAvailable(self: Lib) bool {
+        return switch (self) {
+            .kaappi_process => false,
             else => true,
         };
     }
@@ -316,6 +337,7 @@ const core_specs = [_]PrimSpec{
 };
 
 const no_specs = [0]PrimSpec{};
+const is_windows = @import("builtin").os.tag == .windows;
 
 pub const all_specs = core_specs ++
     @import("primitives_list.zig").specs ++
@@ -345,6 +367,10 @@ pub const all_specs = core_specs ++
     primitives_random.specs ++
     @import("primitives_random_port.zig").specs ++
     (if (is_wasm) no_specs else primitives_filesystem.specs) ++
+    // (kaappi process): POSIX-only in Phase 1 (KEP-0022); the WASM and
+    // Windows gates keep the module — whose libc surface is naked posix —
+    // from even being analyzed on those targets.
+    (if (is_wasm or is_windows) no_specs else @import("primitives_process.zig").specs) ++
     @import("primitives_fiber.zig").specs ++
     @import("primitives_parallel.zig").specs ++
     // SRFI-18's OS-thread machinery cannot exist on WASM, but its
@@ -396,6 +422,15 @@ comptime {
         if (spec.libs.contains(.kaappi_ffi) and spec.wasm)
             @compileError("`.kaappi_ffi` spec \"" ++ spec.name ++
                 "\" must set `.wasm = false`: (kaappi ffi) has no WASM-viable subset (kaappi#2018)");
+    }
+    // Same discipline for (kaappi process): nothing behind these names can
+    // succeed on wasm32-wasi, and a spec that omits `.wasm = false` would
+    // register a global that exists solely to refuse (the kaappi#2018
+    // lesson, applied from day one this time).
+    for (all_specs) |spec| {
+        if (spec.libs.contains(.kaappi_process) and spec.wasm)
+            @compileError("`.kaappi_process` spec \"" ++ spec.name ++
+                "\" must set `.wasm = false`: (kaappi process) has no WASM-viable subset (KEP-0022)");
     }
 }
 

--- a/src/primitives_filesystem.zig
+++ b/src/primitives_filesystem.zig
@@ -1311,6 +1311,10 @@ fn createTempFileFn(args: []const Value) PrimitiveError!Value {
 
     const fd = mkstemp(@ptrCast(template_buf[0 .. prefix.len + 6 :0]));
     if (fd < 0) return raiseFileError(gc, "cannot create temp file", types.FALSE);
+    // mkstemp(3) cannot ask for O_CLOEXEC; set it before anything else so
+    // even this closed-a-moment-later fd can never cross an exec
+    // (KEP-0022 CLOEXEC audit).
+    _ = platform.setFdCloexec(fd);
     _ = platform.close(fd);
 
     // Find actual path length (null-terminated)

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -355,7 +355,37 @@ fn unparkCurrentFiber(port: *types.Port) void {
 /// the writer suspends on write readiness; `write_buf_start` records drain
 /// progress, so the wait can be a parked primitive's full re-execution and
 /// still resume with exactly the remaining slice.
+///
+/// A hard write error (EPIPE from a dead pipe reader — e.g. a spawned child
+/// that already exited (KEP-0022) — EIO, ...) always drops the unwritable
+/// remainder, so the buffer cannot grow without bound against a dead fd.
+/// What happens next depends on the caller: the explicit write/flush paths
+/// raise the errno-carrying file-error a program can `guard` on
+/// (kaappi#2414 — silently losing the bytes violated the KEP-0005 I/O-error
+/// contract), while the close/read-side drains stay non-raising cleanup
+/// (`drainWriteBufferQuiet`).
 fn drainWriteBuffer(port: *types.Port) PrimitiveError!void {
+    return drainWriteBufferInner(port, true);
+}
+
+/// The non-raising drain for cleanup paths: close-port (the historical
+/// contract — closing a dead pipe is not an error) and the flush-before-read
+/// on a bidirectional port (a write error must not masquerade as a read
+/// failure; the read that follows reports its own condition).
+fn drainWriteBufferQuiet(port: *types.Port) PrimitiveError!void {
+    return drainWriteBufferInner(port, false);
+}
+
+/// KEP-0022: flush a caller port's buffered output before its fd is handed
+/// to a spawned child as a redirection target, so bytes the parent wrote
+/// before the spawn reach the file ahead of anything the child writes.
+/// Raising flavor — a redirect onto a port whose backing fd is already dead
+/// should fail the spawn loudly, not silently drop the parent's bytes.
+pub fn drainPortWriteBufferForSpawn(port: *types.Port) PrimitiveError!void {
+    if (port.write_buf_len > port.write_buf_start) return drainWriteBufferInner(port, true);
+}
+
+fn drainWriteBufferInner(port: *types.Port, comptime raise_write_errors: bool) PrimitiveError!void {
     while (port.write_buf_start < port.write_buf_len) {
         // Re-fetch each pass: a scheduler drive inside waitPortFd can run a
         // sibling fiber that appends to this same port and reallocs the
@@ -370,16 +400,32 @@ fn drainWriteBuffer(port: *types.Port) PrimitiveError!void {
                 try waitPortFd(port, .write);
                 continue;
             }
-            // Parity with the historical writeToFd loop: other write errors
-            // (EPIPE, EIO) are swallowed. Drop the unwritable remainder so
-            // the buffer cannot grow without bound against a dead fd.
-            break;
+            port.write_buf_start = 0;
+            port.write_buf_len = 0;
+            if (raise_write_errors) return raiseWriteFailed(e);
+            return;
         }
         if (rc == 0) break;
         port.write_buf_start += @as(usize, @intCast(rc));
     }
     port.write_buf_start = 0;
     port.write_buf_len = 0;
+}
+
+/// KEP-0005 file-error carrying the write errno, so `(guard (e ((file-error?
+/// e) ...)) (flush-output-port dead-child-stdin))` catches EPIPE precisely.
+fn raiseWriteFailed(e: std.c.E) PrimitiveError {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
+    var msg = gc.allocString("cannot write to port") catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&msg);
+    defer gc.popRoot();
+    const err_obj = gc.allocErrorObject(msg, types.NIL) catch return PrimitiveError.OutOfMemory;
+    const err = types.toObject(err_obj).as(types.ErrorObject);
+    err.error_type = .file;
+    err.posix_errno = @intFromEnum(e);
+    vm.current_exception = err_obj;
+    return PrimitiveError.ExceptionRaised;
 }
 
 fn appendWriteBuf(port: *types.Port, bytes: []const u8) PrimitiveError!void {
@@ -865,6 +911,21 @@ fn openBinaryOutputFile(args: []const Value) PrimitiveError!Value {
     return result;
 }
 
+/// Shared constructor for fd-backed binary ports (KEP-0022 Phase 1): the
+/// internals `fd->port` always had, factored out so the subprocess spawner
+/// wraps a pipe's parent end as exactly the same port — non-blocking,
+/// reactor-integrated, `readOneByte`/`portWriteBytes` as its byte source and
+/// sink (see `fdToPort` below for what that buys a fiber).
+///
+/// The returned port owns `fd`: close-port closes it, wakes any fiber parked
+/// on it, and unregisters it from the reactor. The caller must not also
+/// close the fd through its own path.
+pub fn makeFdPort(gc: *memory.GC, fd: platform.fd_t, is_input: bool, is_output: bool, name: []const u8) PrimitiveError!Value {
+    const port_val = gc.allocPort(fd, is_input, is_output, name, false) catch return PrimitiveError.OutOfMemory;
+    types.toObject(port_val).as(types.Port).is_binary = true;
+    return port_val;
+}
+
 /// (fd->port fd) — wrap a raw OS file descriptor as a bidirectional binary
 /// port. Every read/write then goes through the same non-blocking,
 /// reactor-integrated path as file ports (readOneByte/portWriteBytes): an
@@ -896,9 +957,7 @@ fn fdToPort(args: []const Value) PrimitiveError!Value {
     if (fd_i < 0 or fd_i > std.math.maxInt(i32))
         return primitives.argError("fd->port", "{d} is outside the file-descriptor range", .{fd_i});
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const port_val = gc.allocPort(@intCast(fd_i), true, true, "fd", false) catch return PrimitiveError.OutOfMemory;
-    types.toObject(port_val).as(types.Port).is_binary = true;
-    return port_val;
+    return makeFdPort(gc, @intCast(fd_i), true, true, "fd");
 }
 
 fn closePort(args: []const Value) PrimitiveError!Value {
@@ -995,7 +1054,7 @@ pub fn closePortObj(port: *types.Port) PrimitiveError!Value {
     // suspend the calling fiber; a parked close-port re-executes from the
     // top with the drain progress preserved in the port.
     if (port.is_open and !port.is_string_port and port.write_buf_len > port.write_buf_start) {
-        try drainWriteBuffer(port);
+        try drainWriteBufferQuiet(port);
     }
     if (port.read_buf) |rb| {
         if (memory.gc_instance) |gc| {
@@ -1416,7 +1475,7 @@ pub fn readOneByte(port: *types.Port) PrimitiveError!?u8 {
     if (port.transcode) |ts| {
         return readOneByteFromTranscodedPort(port, ts);
     }
-    if (port.write_buf_len > port.write_buf_start) try drainWriteBuffer(port);
+    if (port.write_buf_len > port.write_buf_start) try drainWriteBufferQuiet(port);
     maybeSetNonblocking(port);
     var chunk: [read_chunk_size]u8 = undefined;
     while (true) {
@@ -1976,7 +2035,7 @@ fn readDatumFn(args: []const Value) PrimitiveError!Value {
         // A park in this drain must preserve the bytes already moved out
         // of peek_byte/peek_extra/read_buf into `buf` above — a bare try
         // would unwind without stashing and the retry would lose them.
-        drainWriteBuffer(port) catch |err| return propagateReadErr(port, err, &.{buf.items});
+        drainWriteBufferQuiet(port) catch |err| return propagateReadErr(port, err, &.{buf.items});
     }
     maybeSetNonblocking(port);
     var tmp: [read_chunk_size]u8 = undefined;

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -385,6 +385,31 @@ pub fn drainPortWriteBufferForSpawn(port: *types.Port) PrimitiveError!void {
     if (port.write_buf_len > port.write_buf_start) return drainWriteBufferInner(port, true);
 }
 
+/// KEP-0022, the input mirror of the drain above: an input port's software
+/// read-ahead (peek bytes + `read_buf`) sits BETWEEN the port's logical
+/// position and the fd's kernel offset — a child handed the raw fd would
+/// start past every byte the parent buffered but has not consumed
+/// (kaappi#2442 review). Seek the fd back by the pending count and discard
+/// the buffers so kernel and logical positions coincide; on an unseekable
+/// fd (a pipe, ESPIPE) with pending bytes, report how many bytes cannot be
+/// synchronized so the caller can reject the redirect. Returns 0 when the
+/// port is reconciled.
+pub fn rewindPortReadAheadForSpawn(port: *types.Port) usize {
+    var pending: usize = port.read_buf_len + port.peek_extra_len;
+    if (port.peek_byte != null) pending += 1;
+    if (pending == 0) return 0;
+    if (platform.seek(port.fd, -@as(i64, @intCast(pending)), platform.SEEK_CUR) < 0)
+        return pending;
+    port.peek_byte = null;
+    port.peek_extra_len = 0;
+    if (port.read_buf) |rb| {
+        if (memory.gc_instance) |gc| gc.allocator.free(rb);
+        port.read_buf = null;
+        port.read_buf_len = 0;
+    }
+    return 0;
+}
+
 fn drainWriteBufferInner(port: *types.Port, comptime raise_write_errors: bool) PrimitiveError!void {
     while (port.write_buf_start < port.write_buf_len) {
         // Re-fetch each pass: a scheduler drive inside waitPortFd can run a

--- a/src/primitives_process.zig
+++ b/src/primitives_process.zig
@@ -1,0 +1,973 @@
+//! `(kaappi process)` primitives — KEP-0022 Phase 1 (POSIX).
+//!
+//! Spawn-based subprocess support: `posix_spawnp` with redirections expressed
+//! as `posix_spawn_file_actions_t` entries, pipe parent-ends wrapped as
+//! ordinary fd ports on the reactor-integrated path (via
+//! `primitives_io.makeFdPort`, the constructor `fd->port` shares), a blocking
+//! `process-wait`, and `process-kill` that never re-signals a reaped pid.
+//! There is no fork anywhere and no pre-exec hook; every knob between spawn
+//! and exec is a named option.
+//!
+//! Phase boundaries: reactor child-exit readiness, fiber-parking
+//! `process-wait` with timeouts, and group-kill tests are Phase 2; Windows
+//! (CreateProcess + Job Objects) is Phase 3. On those targets this module is
+//! not registered at all, so `(library (kaappi process))` gates false.
+//!
+//! POSIX-only libc surface lives here, naked: this file is referenced by
+//! `primitives.all_specs` only on POSIX targets, so none of it is analyzed
+//! on Windows or WASM.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const platform = @import("platform.zig");
+const vm_mod = @import("vm.zig");
+const primitives = @import("primitives.zig");
+const primitives_io = @import("primitives_io.zig");
+const primitives_r7rs = @import("primitives_r7rs.zig");
+
+const Value = types.Value;
+const PrimitiveError = primitives.PrimitiveError;
+const LS = primitives.LibSet;
+const GC = memory.GC;
+
+// ---------------------------------------------------------------------------
+// libc: posix_spawn surface
+// ---------------------------------------------------------------------------
+
+const spawn_c = struct {
+    pub const FileActionsPtr = *opaque {};
+    pub const AttrPtr = *opaque {};
+
+    pub extern "c" fn posix_spawn_file_actions_init(actions: *FileActionsPtr) c_int;
+    pub extern "c" fn posix_spawn_file_actions_destroy(actions: *FileActionsPtr) c_int;
+    pub extern "c" fn posix_spawn_file_actions_adddup2(actions: *FileActionsPtr, filedes: c_int, newfiledes: c_int) c_int;
+    pub extern "c" fn posix_spawn_file_actions_addopen(actions: *FileActionsPtr, filedes: c_int, path: [*:0]const u8, oflag: c_int, mode: c_uint) c_int;
+    pub extern "c" fn posix_spawn_file_actions_addclose(actions: *FileActionsPtr, filedes: c_int) c_int;
+    pub extern "c" fn posix_spawnp(
+        pid: *c_int,
+        file: [*:0]const u8,
+        actions: ?*const FileActionsPtr,
+        attrp: ?*const AttrPtr,
+        argv: [*:null]const ?[*:0]const u8,
+        envp: [*:null]const ?[*:0]const u8,
+    ) c_int;
+    pub extern "c" fn posix_spawnattr_init(attr: *AttrPtr) c_int;
+    pub extern "c" fn posix_spawnattr_destroy(attr: *AttrPtr) c_int;
+    pub extern "c" fn posix_spawnattr_setflags(attr: *AttrPtr, flags: c_short) c_int;
+    pub extern "c" fn posix_spawnattr_setpgroup(attr: *AttrPtr, pgroup: c_int) c_int;
+    pub extern "c" fn posix_spawnattr_setsigdefault(attr: *AttrPtr, sigset: *const std.c.sigset_t) c_int;
+
+    /// The spawn attr/file-actions types are `*opaque` in every libc binding
+    /// (macOS and FreeBSD make them pointer types whose `_init` allocates;
+    /// glibc/musl/NetBSD/OpenBSD make them value structs initialized in
+    /// place). Handing both a zeroed, generously-sized aligned buffer
+    /// satisfies each discipline: the pointer flavor stores its allocation
+    /// in the first word, the value flavor (glibc's posix_spawnattr_t with
+    /// two 128-byte sigsets is the largest at ~336 bytes) fits whole.
+    const storage_bytes = 512;
+    pub const Storage = extern struct {
+        _buf: [storage_bytes]u8 align(16),
+    };
+
+    pub fn zeroStorage() Storage {
+        return .{ ._buf = @splat(0) };
+    }
+
+    // POSIX_SPAWN_* flag bits (posix_spawnattr_setflags). POSIX names them
+    // but does NOT fix their values, and they are not uniform: SETPGROUP is
+    // 0x02 everywhere (0x01 is RESETIDS), but SETSIGDEF is 0x04 only on
+    // macOS/glibc/musl — the BSDs (FreeBSD, and NetBSD/OpenBSD which took
+    // FreeBSD's <spawn.h> layout) put SETSCHEDPARAM at 0x04 and SETSIGDEF
+    // at 0x10. Using 0x04 on a BSD silently requests a scheduler-parameter
+    // reset from a zeroed attr instead of the signal-default reset.
+    pub const SPAWN_SETPGROUP: u16 = 0x0002;
+    pub const SPAWN_SETSIGDEF: u16 = switch (builtin.os.tag) {
+        .freebsd, .netbsd, .openbsd, .dragonfly => 0x0010,
+        else => 0x0004, // macOS/iOS, glibc, musl
+    };
+    /// Apple-only: close every fd > 2 in the child regardless of CLOEXEC
+    /// state, keeping only the stdio slots the file actions install. A belt
+    /// over the CLOEXEC audit on macOS (glibc's addclosefrom_np needs 2.34+
+    /// and musl lacks it, so on Linux the audit is the whole story). 0x4000
+    /// per the SDK's sys/spawn.h; std.c.POSIX_SPAWN's packed struct agrees.
+    pub const SPAWN_CLOEXEC_DEFAULT: u16 = 0x4000;
+    pub const apple_cloexec_default = builtin.os.tag.isDarwin();
+
+    /// posix_spawn_file_actions_addchdir_np exists on macOS, Linux
+    /// (glibc >= 2.29, musl >= 1.1.24) and FreeBSD >= 13, but not in
+    /// NetBSD's or OpenBSD's libc (verified at link time per target), so
+    /// `directory:` on those two is rejected at run time with a clear
+    /// message rather than an unresolved symbol at build time.
+    ///
+    /// The glibc floor matters concretely: the release workflow targets
+    /// x86_64-linux-gnu.2.28, where the symbol is absent — referencing it
+    /// unconditionally on Linux fails that link even when `directory:` is
+    /// never used (kaappi#2414 review). Zig only links referenced externs,
+    /// so the version gate must be comptime, mirrored by the `comptime`
+    /// guard at the call site.
+    pub const has_addchdir = switch (builtin.os.tag) {
+        .macos, .ios, .freebsd => true,
+        .linux => blk: {
+            if (!builtin.target.abi.isGnu()) break :blk true; // musl >= 1.1.24 (Zig bundles newer)
+            const v = builtin.target.os.versionRange().gnuLibCVersion() orelse break :blk false;
+            break :blk v.order(.{ .major = 2, .minor = 29, .patch = 0 }) != .lt;
+        },
+        else => false,
+    };
+    pub extern "c" fn posix_spawn_file_actions_addchdir_np(actions: *FileActionsPtr, path: [*:0]const u8) c_int;
+};
+
+const SIGTERM: c_int = 15;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// A catchable `.file` error carrying errno, mirroring
+/// primitives_filesystem.raiseFileErrorCode: spawn failures are the same
+/// family as open failures ("program not found" vs "permission" is exactly
+/// ENOENT vs EACCES), so `file-error?` and `posix-error?` see them. Pass 0
+/// for rejections that never reached a syscall.
+fn raiseProcessError(gc: *GC, msg_text: []const u8, irritant: Value, errno_val: c_int) PrimitiveError!Value {
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
+    var msg = gc.allocString(msg_text) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&msg);
+    defer gc.popRoot();
+    const irritants = gc.allocPair(irritant, types.NIL) catch return PrimitiveError.OutOfMemory;
+    var irritants_root = irritants;
+    gc.pushRoot(&irritants_root);
+    defer gc.popRoot();
+    const err_obj = gc.allocErrorObject(msg, irritants_root) catch return PrimitiveError.OutOfMemory;
+    const err = types.toObject(err_obj).as(types.ErrorObject);
+    err.error_type = .file;
+    err.posix_errno = errno_val;
+    vm.current_exception = err_obj;
+    return PrimitiveError.ExceptionRaised;
+}
+
+fn raiseProcessMessage(comptime msg: []const u8) PrimitiveError!Value {
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode;
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    var msg_val = gc.allocString(msg) catch return PrimitiveError.OutOfMemory;
+    gc.pushRoot(&msg_val);
+    defer gc.popRoot();
+    const err_obj = gc.allocErrorObject(msg_val, types.NIL) catch return PrimitiveError.OutOfMemory;
+    vm.current_exception = err_obj;
+    return PrimitiveError.ExceptionRaised;
+}
+
+// ---------------------------------------------------------------------------
+// Argument checking (owner check = channel precedent, KEP-0022)
+// ---------------------------------------------------------------------------
+
+/// Type-check, owner-check, and unwrap a Process argument. A Process is
+/// thread-affine — its pid, status bookkeeping and (Phase 2) reactor
+/// registration belong to the scheduler of the thread that spawned it —
+/// exactly like a channel (primitives_fiber.zig) and a thread handle
+/// (primitives_srfi18.checkThreadOwner). `process?` stays exempt, exactly
+/// like `channel?`/`thread?`. The irritant is #f rather than the foreign
+/// process: storing a foreign-heap object in a condition the owner's GC may
+/// free would re-open the hazard the check exists to close.
+fn expectProcess(comptime proc: []const u8, val: Value) PrimitiveError!*types.Process {
+    if (!types.isProcess(val)) return primitives.typeError(proc, "process", val);
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const obj = types.toObject(val);
+    if (obj.owner != gc.id) {
+        // Always raises (.ExceptionRaised); `try` propagates it.
+        _ = try raiseProcessMessage(proc ++ ": process belongs to another thread; a process may only be used by the thread that spawned it");
+    }
+    return obj.as(types.Process);
+}
+
+// ---------------------------------------------------------------------------
+// Redirection specs
+// ---------------------------------------------------------------------------
+
+const Redir = union(enum) {
+    inherit,
+    pipe,
+    null_sink,
+    /// stderr only: dup2(1, 2) in the child.
+    merge_stdout,
+    /// Child gets this descriptor (from an fd-backed port); no pipe is
+    /// created and the accessor returns #f.
+    fd: platform.fd_t,
+};
+
+fn parseRedir(comptime proc: []const u8, val: Value) PrimitiveError!Redir {
+    if (val == types.FALSE or val == types.VOID) return .inherit;
+    if (types.isSymbol(val)) {
+        const name = types.symbolName(val);
+        if (std.mem.eql(u8, name, "inherit")) return .inherit;
+        if (std.mem.eql(u8, name, "pipe")) return .pipe;
+        if (std.mem.eql(u8, name, "null")) return .null_sink;
+        if (std.mem.eql(u8, name, "stdout")) return .merge_stdout;
+        return primitives.argError(proc, "unknown redirection spec: {s}", .{name});
+    }
+    if (types.isPort(val)) {
+        // Read the fd before anything can allocate; reject port kinds whose
+        // backing is not an OS descriptor (string/custom/transcoded/random).
+        const port = types.toObject(val).as(types.Port);
+        if (!port.is_open or port.is_string_port or port.custom_backend != null or
+            port.transcode != null or port.random_gen != null)
+        {
+            return primitives.argError(proc, "redirection port must be an open fd-backed port", .{});
+        }
+        if (port.fd < 0) return primitives.argError(proc, "redirection port has no file descriptor", .{});
+        // The child's slot copy would share this fd's open file description
+        // — O_NONBLOCK included. A port the fiber scheduler already flipped
+        // non-blocking would hand the child non-blocking stdio, and the
+        // parent's next I/O would re-flip it even if cleared here; reject
+        // rather than corrupt (kaappi#2414 review).
+        if (port.nonblocking)
+            return primitives.argError(proc, "redirection port is in non-blocking use by the fiber scheduler; pass a port not yet driven by fibers", .{});
+        // Buffered parent output must land in the file before the child's
+        // own writes; the drain can park a fiber, and a re-executed spawn
+        // re-parses the options idempotently.
+        if (port.is_output) try primitives_io.drainPortWriteBufferForSpawn(port);
+        return .{ .fd = port.fd };
+    }
+    return primitives.typeError(proc, "redirection spec (inherit, pipe, null, stdout, or an fd-backed port)", val);
+}
+
+// ---------------------------------------------------------------------------
+// Zombie sweep (KEP-0022 unresolved question 3, settled for Phase 1)
+// ---------------------------------------------------------------------------
+
+/// Reap every already-exited unreaped process of this heap, storing each
+/// status into its Process. Bounded: the list holds only unreaped processes,
+/// so the sweep is O(concurrently-unreaped), and it runs at the top of the
+/// two blocking paths (spawn, wait) — covering the scheduler-less loop that
+/// never runs a reactor tick. Together with freeObject's last-resort reap,
+/// the only escaping window is a Process collected while its child still
+/// runs (documented on `GC.unreaped_processes`).
+fn sweepUnreaped(gc: *GC) void {
+    var i: usize = 0;
+    while (i < gc.unreaped_processes.items.len) {
+        const proc = gc.unreaped_processes.items[i];
+        var st: c_int = 0;
+        const r = platform.waitPid(proc.pid, &st, platform.WNOHANG);
+        if (r == proc.pid) {
+            proc.status = @bitCast(@as(u32, @bitCast(st)));
+            _ = gc.unreaped_processes.swapRemove(i);
+        } else {
+            i += 1;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// %process-spawn / spawn-process
+// ---------------------------------------------------------------------------
+
+const SpawnConfig = struct {
+    argv: []const Value,
+    stdin: Redir = .inherit,
+    stdout: Redir = .inherit,
+    stderr: Redir = .inherit,
+    /// null = inherit the current environment wholesale (posix_spawnp env
+    /// argument = std.c.environ). An alist (including the empty list)
+    /// replaces the environment wholesale — Guile/Python semantics; the
+    /// copy-and-extend idiom starts from (process-environment).
+    env: ?Value = null,
+    directory: ?Value = null,
+    new_group: bool = false,
+};
+
+/// The spawn itself. Everything GC-managed is copied or read before the
+/// first allocation-free syscall section; the Process object and its ports
+/// are allocated only after the child exists.
+fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+
+    // Zombie sweep on the blocking spawn path (see sweepUnreaped).
+    sweepUnreaped(gc);
+
+    // -- argv, env, cwd into Zig-owned memory (an arena freed on every exit
+    // path below): nothing GC-managed may cross the spawn section.
+    var arena = std.heap.ArenaAllocator.init(gc.allocator);
+    defer arena.deinit();
+    const arena_al = arena.allocator();
+
+    const argv = try copyArgv(arena_al, cfg.argv);
+
+    var env_block: ?[*:null]const ?[*:0]const u8 = null;
+    if (cfg.env) |env_val| {
+        env_block = try buildEnvp(arena_al, env_val);
+    }
+
+    var directory_z: ?[*:0]const u8 = null;
+    if (cfg.directory) |dir_val| {
+        if (!types.isString(dir_val)) return primitives.typeError("spawn-process", "string", dir_val);
+        const dir = types.toObject(dir_val).as(types.SchemeString);
+        if (!spawn_c.has_addchdir)
+            return primitives.argError("spawn-process", "directory: is not supported on this platform", .{});
+        directory_z = try dupeZChecked("spawn-process", arena_al, dir.data[0..dir.len], "directory: path");
+    }
+
+    // -- pipes. Cleanup discipline: every path before a successful spawn
+    // closes everything through the `spawned` defer; after it, the ports own
+    // the parent ends and the child ends were closed by hand.
+    var stdin_pipe: [2]platform.fd_t = .{ -1, -1 }; // [0] child read end, [1] parent write end
+    var stdout_pipe: [2]platform.fd_t = .{ -1, -1 };
+    var stderr_pipe: [2]platform.fd_t = .{ -1, -1 };
+    var spawned = false;
+    defer if (!spawned) {
+        closePipePair(&stdin_pipe);
+        closePipePair(&stdout_pipe);
+        closePipePair(&stderr_pipe);
+    };
+    if (cfg.stdin == .pipe and platform.pipe(&stdin_pipe) != 0)
+        return raiseProcessError(gc, "cannot create stdin pipe", types.FALSE, std.c._errno().*);
+    if (cfg.stdout == .pipe and platform.pipe(&stdout_pipe) != 0)
+        return raiseProcessError(gc, "cannot create stdout pipe", types.FALSE, std.c._errno().*);
+    if (cfg.stderr == .pipe and platform.pipe(&stderr_pipe) != 0)
+        return raiseProcessError(gc, "cannot create stderr pipe", types.FALSE, std.c._errno().*);
+
+    // -- file actions + attrs
+    var actions_storage = spawn_c.zeroStorage();
+    const actions: *spawn_c.FileActionsPtr = @ptrCast(&actions_storage);
+    _ = spawn_c.posix_spawn_file_actions_init(actions);
+    // Destroyed on every exit path below (arm the defer immediately; a
+    // mid-setup failure must not leak the malloc'd internals on the
+    // pointer-flavor platforms).
+    defer _ = spawn_c.posix_spawn_file_actions_destroy(actions);
+
+    const O_RDONLY: c_int = 0;
+    const O_WRONLY: c_int = 1;
+    const null_z: [*:0]const u8 = "/dev/null";
+
+    // stdin (slot 0)
+    switch (cfg.stdin) {
+        .inherit => {},
+        .pipe => {
+            if (spawn_c.posix_spawn_file_actions_adddup2(actions, stdin_pipe[0], 0) != 0 or
+                spawn_c.posix_spawn_file_actions_addclose(actions, stdin_pipe[0]) != 0)
+                return spawnFileActionError(gc);
+        },
+        .null_sink => {
+            if (spawn_c.posix_spawn_file_actions_addopen(actions, 0, null_z, O_RDONLY, 0o666) != 0)
+                return spawnFileActionError(gc);
+        },
+        .fd => |fd| {
+            if (spawn_c.posix_spawn_file_actions_adddup2(actions, fd, 0) != 0)
+                return spawnFileActionError(gc);
+        },
+        .merge_stdout => return primitives.argError("spawn-process", "'stdout is a stderr-only redirection spec", .{}),
+    }
+    // stdout (slot 1)
+    switch (cfg.stdout) {
+        .inherit => {},
+        .pipe => {
+            if (spawn_c.posix_spawn_file_actions_adddup2(actions, stdout_pipe[1], 1) != 0 or
+                spawn_c.posix_spawn_file_actions_addclose(actions, stdout_pipe[1]) != 0)
+                return spawnFileActionError(gc);
+        },
+        .null_sink => {
+            if (spawn_c.posix_spawn_file_actions_addopen(actions, 1, null_z, O_WRONLY, 0o666) != 0)
+                return spawnFileActionError(gc);
+        },
+        .fd => |fd| {
+            if (spawn_c.posix_spawn_file_actions_adddup2(actions, fd, 1) != 0)
+                return spawnFileActionError(gc);
+        },
+        .merge_stdout => return primitives.argError("spawn-process", "'stdout is a stderr-only redirection spec", .{}),
+    }
+    // stderr (slot 2) — after stdout, so 'stdout merging duplicates the
+    // child's final slot-1 descriptor, whatever installed it.
+    switch (cfg.stderr) {
+        .inherit => {},
+        .pipe => {
+            if (spawn_c.posix_spawn_file_actions_adddup2(actions, stderr_pipe[1], 2) != 0 or
+                spawn_c.posix_spawn_file_actions_addclose(actions, stderr_pipe[1]) != 0)
+                return spawnFileActionError(gc);
+        },
+        .null_sink => {
+            if (spawn_c.posix_spawn_file_actions_addopen(actions, 2, null_z, O_WRONLY, 0o666) != 0)
+                return spawnFileActionError(gc);
+        },
+        .fd => |fd| {
+            if (spawn_c.posix_spawn_file_actions_adddup2(actions, fd, 2) != 0)
+                return spawnFileActionError(gc);
+        },
+        .merge_stdout => {
+            if (spawn_c.posix_spawn_file_actions_adddup2(actions, 1, 2) != 0)
+                return spawnFileActionError(gc);
+        },
+    }
+    // Comptime gate, not just the run-time one above: the extern is absent
+    // from NetBSD/OpenBSD libc, so the call itself must not be analyzed
+    // there (Zig only links referenced externs).
+    if (comptime spawn_c.has_addchdir) {
+        if (directory_z) |dir| {
+            if (spawn_c.posix_spawn_file_actions_addchdir_np(actions, dir) != 0)
+                return spawnFileActionError(gc);
+        }
+    }
+
+    // Close-by-default (KEP-0022): the child must inherit only the three
+    // stdio slots. CLOEXEC on every Kaappi-opened fd covers Kaappi's own
+    // descriptors, but a descriptor Kaappi itself INHERITED from its
+    // launcher (`kaappi 9</dev/null prog.scm`) or acquired through FFI has
+    // no such guarantee and would otherwise pass into every child —
+    // leaking sockets and lock files, and holding unrelated pipes open
+    // past EOF (kaappi#2414 review). On macOS POSIX_SPAWN_CLOEXEC_DEFAULT
+    // (below) closes everything wholesale; everywhere else, enumerate the
+    // open non-CLOEXEC fds and add an explicit close action for each.
+    // These actions run AFTER the dup2/open actions above, so a caller
+    // redirect port's own fd is closed only after its slot copy exists.
+    if (comptime !spawn_c.apple_cloexec_default) {
+        try addInheritedFdCloses(gc, actions);
+    }
+
+    var attr_storage = spawn_c.zeroStorage();
+    const attr: *spawn_c.AttrPtr = @ptrCast(&attr_storage);
+    _ = spawn_c.posix_spawnattr_init(attr);
+    defer _ = spawn_c.posix_spawnattr_destroy(attr);
+
+    var flags: u16 = 0;
+    if (cfg.new_group) {
+        // pgroup 0 = the child becomes its own group leader
+        // (setpgid(child, 0) semantics), so pgid == pid after spawn.
+        if (spawn_c.posix_spawnattr_setpgroup(attr, 0) != 0)
+            return spawnFileActionError(gc);
+        flags |= spawn_c.SPAWN_SETPGROUP;
+    }
+    {
+        // Reset SIGPIPE to its default in the child: the parent runs with
+        // SIG_IGN (VM.init, KEP-0022) and ignored dispositions survive exec,
+        // which would silently change the behavior of children that rely on
+        // dying on EPIPE (e.g. `yes | head` inside a shell pipeline). The
+        // same restore Python's subprocess performs by default. The set is
+        // built with Zig's own sigset helpers, not libc's sigemptyset/
+        // sigaddset externs — NetBSD's sigset accessors are macros over a
+        // renamed ABI, so the plain symbols are not portably linkable.
+        var sigset = std.posix.sigemptyset();
+        std.posix.sigaddset(&sigset, std.posix.SIG.PIPE);
+        if (spawn_c.posix_spawnattr_setsigdefault(attr, &sigset) != 0)
+            return spawnFileActionError(gc);
+        flags |= spawn_c.SPAWN_SETSIGDEF;
+    }
+    if (spawn_c.apple_cloexec_default) flags |= spawn_c.SPAWN_CLOEXEC_DEFAULT;
+    if (flags != 0 and spawn_c.posix_spawnattr_setflags(attr, @bitCast(flags)) != 0)
+        return spawnFileActionError(gc);
+
+    // -- spawn
+    var pid: c_int = -1;
+    const envp: [*:null]const ?[*:0]const u8 = env_block orelse @ptrCast(std.c.environ);
+    const spawn_rc = spawn_c.posix_spawnp(&pid, argv[0].?, actions, attr, argv, envp);
+    if (spawn_rc != 0) {
+        // posix_spawn returns the errno itself, not -1. ENOENT is the common
+        // case (program not on PATH); the errno rides the condition so
+        // posix-error-name reports it precisely. The `spawned` defer closes
+        // the pipes; the destroy defers release actions/attr.
+        return raiseProcessError(gc, "cannot spawn process", cfg.argv[0], spawn_rc);
+    }
+    spawned = true;
+
+    // The child owns the child ends now; the parent's copies must go.
+    if (stdin_pipe[0] >= 0) _ = platform.close(stdin_pipe[0]);
+    if (stdout_pipe[1] >= 0) _ = platform.close(stdout_pipe[1]);
+    if (stderr_pipe[1] >= 0) _ = platform.close(stderr_pipe[1]);
+
+    // -- Process object + parent-end ports. `proc_val` stays rooted across
+    // the three port allocations; each port is stored into the Process as
+    // soon as it exists so the next allocation sees it reachable.
+    const pgid: i32 = if (cfg.new_group) pid else 0;
+    const proc = gc.allocProcess(pid, pgid) catch return PrimitiveError.OutOfMemory;
+    var proc_val = types.makePointer(&proc.header);
+    gc.pushRoot(&proc_val);
+    defer gc.popRoot();
+
+    if (stdin_pipe[1] >= 0) {
+        const port_val = try primitives_io.makeFdPort(gc, stdin_pipe[1], false, true, "process-stdin");
+        proc.stdin_port = port_val;
+        gc.writeBarrier(&proc.header, port_val);
+    }
+    if (stdout_pipe[0] >= 0) {
+        const port_val = try primitives_io.makeFdPort(gc, stdout_pipe[0], true, false, "process-stdout");
+        proc.stdout_port = port_val;
+        gc.writeBarrier(&proc.header, port_val);
+    }
+    if (stderr_pipe[0] >= 0) {
+        const port_val = try primitives_io.makeFdPort(gc, stderr_pipe[0], true, false, "process-stderr");
+        proc.stderr_port = port_val;
+        gc.writeBarrier(&proc.header, port_val);
+    }
+    return proc_val;
+}
+
+fn spawnFileActionError(gc: *GC) PrimitiveError!Value {
+    const errno_val = std.c._errno().*;
+    return raiseProcessError(gc, "cannot set up process redirection", types.FALSE, errno_val);
+}
+
+/// Add a close file-action for every open fd > 2 that is not close-on-exec
+/// (the non-macOS half of close-by-default; see the call site). Enumeration
+/// is /proc/self/fd on Linux — accurate and O(open fds) even under a huge
+/// RLIMIT_NOFILE — and an fcntl(F_GETFD) probe of 3..RLIMIT_NOFILE (capped)
+/// on the BSDs, whose /dev/fd entries are static device nodes that exist
+/// whether or not the fd is open. Both paths re-probe F_GETFD right before
+/// adding the action, so the Linux directory fd (closed by then) and any
+/// CLOEXEC descriptor are skipped: exec itself closes the latter, and glibc
+/// fails the whole spawn on a close action naming a closed fd.
+///
+/// Known window, documented and accepted for Phase 1: an fd another thread
+/// opens non-CLOEXEC between this scan and the posix_spawnp call can still
+/// slip through — the same race every enumerate-then-spawn implementation
+/// (CPython's subprocess on platforms without close_range) accepts.
+fn addInheritedFdCloses(gc: *GC, actions: *spawn_c.FileActionsPtr) PrimitiveError!void {
+    var fds: std.ArrayList(platform.fd_t) = .empty;
+    defer fds.deinit(gc.allocator);
+
+    var listed = false;
+    if (comptime builtin.os.tag == .linux) {
+        if (platform.DirIter.open("/proc/self/fd")) |it_state| {
+            var it = it_state;
+            listed = true;
+            while (it.next()) |name| {
+                const n = std.fmt.parseInt(platform.fd_t, name, 10) catch continue;
+                fds.append(gc.allocator, n) catch {
+                    it.close();
+                    return PrimitiveError.OutOfMemory;
+                };
+            }
+            it.close();
+        }
+    }
+    if (!listed) {
+        const cap: u64 = 65536;
+        const limit: u64 = blk: {
+            const rl = std.posix.getrlimit(.NOFILE) catch break :blk cap;
+            // rlim_t is signed on some libcs (FreeBSD's i64); a negative
+            // cur (RLIM_INFINITY representations aside) means "no info".
+            const cur = std.math.cast(u64, rl.cur) orelse break :blk cap;
+            break :blk @min(cur, cap);
+        };
+        var fd: platform.fd_t = 3;
+        while (fd < limit) : (fd += 1) {
+            fds.append(gc.allocator, fd) catch return PrimitiveError.OutOfMemory;
+        }
+    }
+
+    const FD_CLOEXEC: c_int = 1;
+    for (fds.items) |fd| {
+        if (fd < 3) continue;
+        const flags = platform.getFdFlags(fd);
+        if (flags < 0) continue; // closed (or the enumeration dir's own fd)
+        if ((flags & FD_CLOEXEC) != 0) continue; // exec closes it anyway
+        if (spawn_c.posix_spawn_file_actions_addclose(actions, fd) != 0) {
+            _ = try spawnFileActionError(gc);
+        }
+    }
+}
+
+fn closePipePair(fds: *[2]platform.fd_t) void {
+    if (fds[0] >= 0) _ = platform.close(fds[0]);
+    if (fds[1] >= 0) _ = platform.close(fds[1]);
+    fds.* = .{ -1, -1 };
+}
+
+/// Duplicate `bytes` as a NUL-terminated C string in the arena, rejecting an
+/// embedded NUL. `dupeZ` alone would silently truncate at the interior NUL
+/// on the OS side — the child would exec or receive something different from
+/// the value the Scheme program supplied (kaappi#2414 review; CWE-626).
+fn dupeZChecked(comptime proc: []const u8, arena: std.mem.Allocator, bytes: []const u8, comptime what: []const u8) PrimitiveError![*:0]const u8 {
+    if (std.mem.indexOfScalar(u8, bytes, 0) != null)
+        return primitives.argError(proc, what ++ " contains an embedded NUL byte", .{});
+    const duped = arena.dupeZ(u8, bytes) catch return PrimitiveError.OutOfMemory;
+    return duped.ptr;
+}
+
+/// Copy the argv list of strings into a null-terminated C array inside the
+/// arena. argv[0] (the program, resolved via PATH by posix_spawnp) must be a
+/// string and the list non-empty.
+fn copyArgv(arena: std.mem.Allocator, argv_list: []const Value) PrimitiveError![*:null]const ?[*:0]const u8 {
+    if (argv_list.len == 0)
+        return primitives.argError("spawn-process", "argv must contain at least the program name", .{});
+    const argv_z = arena.alloc(?[*:0]const u8, argv_list.len + 1) catch return PrimitiveError.OutOfMemory;
+    for (argv_list, 0..) |arg, i| {
+        if (!types.isString(arg)) return primitives.typeError("spawn-process", "string (argv element)", arg);
+        const str = types.toObject(arg).as(types.SchemeString);
+        argv_z[i] = try dupeZChecked("spawn-process", arena, str.data[0..str.len], "argv element");
+    }
+    argv_z[argv_list.len] = null;
+    return @ptrCast(argv_z.ptr);
+}
+
+/// `env:` — an alist of (name . value) string pairs replacing the child's
+/// environment wholesale (an empty list means an empty environment).
+///
+/// Both walks are cycle-guarded: a legal cyclic Scheme list would otherwise
+/// spin forever inside this native primitive, beyond even --timeout's reach
+/// (kaappi#2414 review). Entries are validated so no environment block can
+/// be reinterpreted: names must be non-empty, NUL-free and '='-free, values
+/// NUL-free.
+fn buildEnvp(arena: std.mem.Allocator, env_val: Value) PrimitiveError![*:null]const ?[*:0]const u8 {
+    var count: usize = 0;
+    var cur = env_val;
+    var slow = env_val;
+    var step = false;
+    while (cur != types.NIL) : (step = !step) {
+        if (!types.isPair(cur))
+            return primitives.typeError("spawn-process", "environment alist", env_val);
+        const entry = types.car(cur);
+        if (!types.isPair(entry))
+            return primitives.typeError("spawn-process", "environment alist entry (name . value) pair", entry);
+        const name = types.car(entry);
+        const value = types.cdr(entry);
+        if (!types.isString(name) or !types.isString(value))
+            return primitives.typeError("spawn-process", "environment entry of two strings", entry);
+        const name_str = types.toObject(name).as(types.SchemeString);
+        if (name_str.len == 0)
+            return primitives.argError("spawn-process", "environment variable name is empty", .{});
+        if (std.mem.indexOfScalar(u8, name_str.data[0..name_str.len], '=') != null)
+            return primitives.argError("spawn-process", "environment variable name contains '='", .{});
+        count += 1;
+        cur = types.cdr(cur);
+        if (step) {
+            slow = types.cdr(slow);
+            if (cur == slow)
+                return primitives.argError("spawn-process", "environment alist is cyclic", .{});
+        }
+    }
+    const envp = arena.alloc(?[*:0]const u8, count + 1) catch return PrimitiveError.OutOfMemory;
+    var i: usize = 0;
+    cur = env_val;
+    // Bounded by the first pass's count, so even a list mutated from another
+    // OS thread mid-walk cannot run this loop away.
+    while (cur != types.NIL and i < count) : (cur = types.cdr(cur)) {
+        const entry = types.car(cur);
+        const name = types.toObject(types.car(entry)).as(types.SchemeString);
+        const value = types.toObject(types.cdr(entry)).as(types.SchemeString);
+        const name_bytes = name.data[0..name.len];
+        const value_bytes = value.data[0..value.len];
+        if (std.mem.indexOfScalar(u8, name_bytes, 0) != null or
+            std.mem.indexOfScalar(u8, value_bytes, 0) != null)
+            return primitives.argError("spawn-process", "environment entry contains an embedded NUL byte", .{});
+        const joined = std.fmt.allocPrintSentinel(arena, "{s}={s}", .{ name_bytes, value_bytes }, 0) catch return PrimitiveError.OutOfMemory;
+        envp[i] = joined.ptr;
+        i += 1;
+    }
+    envp[i] = null;
+    return @ptrCast(envp.ptr);
+}
+
+/// Collect an argv list of Values for SpawnConfig. The Values are rooted by
+/// the caller's register file (they are args), so plain ArrayList storage is
+/// GC-safe; the strings themselves are copied into the spawn arena later.
+/// Cycle-guarded like buildEnvp: a cyclic argv must be an error, not an
+/// unbounded native-side loop.
+fn collectArgv(comptime proc: []const u8, list_val: Value, gc: *GC) PrimitiveError!std.ArrayList(Value) {
+    if (!types.isPair(list_val))
+        return primitives.typeError(proc, "argv list of strings", list_val);
+    var list: std.ArrayList(Value) = .empty;
+    errdefer list.deinit(gc.allocator);
+    var cur = list_val;
+    var slow = list_val;
+    var step = false;
+    while (cur != types.NIL) : (step = !step) {
+        if (!types.isPair(cur))
+            return primitives.typeError(proc, "argv list of strings", list_val);
+        list.append(gc.allocator, types.car(cur)) catch return PrimitiveError.OutOfMemory;
+        cur = types.cdr(cur);
+        if (step) {
+            slow = types.cdr(slow);
+            if (cur == slow)
+                return primitives.argError(proc, "argv list is cyclic", .{});
+        }
+    }
+    return list;
+}
+
+/// (spawn-process argv ['stdin: spec] ['stdout: spec] ['stderr: spec]
+///                  ['directory: path] ['env: alist] ['new-group: bool])
+///
+/// Options are quoted keyword symbols followed by their value, Guile-style:
+/// `(spawn-process '("ls" "-l") 'stdout: 'pipe 'new-group: #t)`.
+fn spawnProcessFn(args: []const Value) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    var argv_list = try collectArgv("spawn-process", args[0], gc);
+    defer argv_list.deinit(gc.allocator);
+    var cfg = SpawnConfig{ .argv = argv_list.items };
+
+    var i: usize = 1;
+    while (i < args.len) : (i += 2) {
+        if (!types.isSymbol(args[i]))
+            return primitives.argError("spawn-process", "expected an option symbol like 'stdin:, got a value", .{});
+        if (i + 1 >= args.len)
+            return primitives.argError("spawn-process", "option '{s}' has no value", .{types.symbolName(args[i])});
+        const opt = types.symbolName(args[i]);
+        const val = args[i + 1];
+        if (std.mem.eql(u8, opt, "stdin:")) {
+            cfg.stdin = try parseRedir("spawn-process", val);
+        } else if (std.mem.eql(u8, opt, "stdout:")) {
+            cfg.stdout = try parseRedir("spawn-process", val);
+        } else if (std.mem.eql(u8, opt, "stderr:")) {
+            cfg.stderr = try parseRedir("spawn-process", val);
+        } else if (std.mem.eql(u8, opt, "directory:")) {
+            cfg.directory = val;
+        } else if (std.mem.eql(u8, opt, "env:")) {
+            cfg.env = val;
+        } else if (std.mem.eql(u8, opt, "new-group:")) {
+            cfg.new_group = types.isTruthy(val);
+        } else {
+            return primitives.argError("spawn-process", "unknown option '{s}'", .{opt});
+        }
+    }
+    return spawnImpl(cfg);
+}
+
+/// (%process-spawn argv stdin stdout stderr directory env new-group) — the
+/// normalized positional form of spawn-process with no option parsing: the
+/// stable internal entry point for future Scheme-level layers (run-process,
+/// Phase 4) and compiler-synthesized call sites. Specs are the symbols
+/// inherit/pipe/null/stdout or an fd-backed port (#f = inherit); directory
+/// and env are a string / an alist or #f.
+fn processSpawnRawFn(args: []const Value) PrimitiveError!Value {
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    var argv_list = try collectArgv("%process-spawn", args[0], gc);
+    defer argv_list.deinit(gc.allocator);
+    const cfg = SpawnConfig{
+        .argv = argv_list.items,
+        .stdin = try parseRedir("%process-spawn", args[1]),
+        .stdout = try parseRedir("%process-spawn", args[2]),
+        .stderr = try parseRedir("%process-spawn", args[3]),
+        .directory = if (args[4] == types.FALSE) null else args[4],
+        .env = if (args[5] == types.FALSE) null else args[5],
+        .new_group = types.isTruthy(args[6]),
+    };
+    return spawnImpl(cfg);
+}
+
+// ---------------------------------------------------------------------------
+// Accessors and control
+// ---------------------------------------------------------------------------
+
+fn processP(args: []const Value) PrimitiveError!Value {
+    return if (types.isProcess(args[0])) types.TRUE else types.FALSE;
+}
+
+fn processPid(args: []const Value) PrimitiveError!Value {
+    const proc = try expectProcess("process-pid", args[0]);
+    return types.makeFixnum(proc.pid);
+}
+
+fn processGroup(args: []const Value) PrimitiveError!Value {
+    const proc = try expectProcess("process-group", args[0]);
+    return if (proc.pgid != 0) types.makeFixnum(proc.pgid) else types.FALSE;
+}
+
+fn processStdin(args: []const Value) PrimitiveError!Value {
+    const proc = try expectProcess("process-stdin", args[0]);
+    return proc.stdin_port;
+}
+
+fn processStdout(args: []const Value) PrimitiveError!Value {
+    const proc = try expectProcess("process-stdout", args[0]);
+    return proc.stdout_port;
+}
+
+fn processStderr(args: []const Value) PrimitiveError!Value {
+    const proc = try expectProcess("process-stderr", args[0]);
+    return proc.stderr_port;
+}
+
+/// Non-blocking targeted reap: if `proc`'s child has exited, store its
+/// status and drop it from the unreaped list. Shared by process-status (so
+/// polling reflects an exit without an intervening wait — and doubles as the
+/// KEP's zombie-discipline hook on the polling path) and by the wait path.
+fn tryReapOne(gc: *GC, proc: *types.Process) void {
+    if (proc.status != null) return;
+    var st: c_int = 0;
+    if (platform.waitPid(proc.pid, &st, platform.WNOHANG) == proc.pid) {
+        proc.status = @bitCast(st);
+        removeFromUnreaped(gc, proc);
+    }
+}
+
+fn removeFromUnreaped(gc: *GC, proc: *types.Process) void {
+    for (gc.unreaped_processes.items, 0..) |p, idx| {
+        if (p == proc) {
+            _ = gc.unreaped_processes.swapRemove(idx);
+            break;
+        }
+    }
+}
+
+fn processStatus(args: []const Value) PrimitiveError!Value {
+    const proc = try expectProcess("process-status", args[0]);
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    tryReapOne(gc, proc);
+    // Scalar out before the allocating decode (gc-safety: no raw pointer
+    // across allocation).
+    const status = proc.status;
+    if (status) |st| return types.decodeWaitStatus(gc, st) catch PrimitiveError.OutOfMemory;
+    return types.FALSE;
+}
+
+fn processWait(args: []const Value) PrimitiveError!Value {
+    const proc = try expectProcess("process-wait", args[0]);
+    if (args.len > 1) {
+        // 'timeout: parks a fiber against the reactor — Phase 2 (KEP-0022
+        // implementation plan). Reject it loudly here so nobody ships a
+        // busy-wait by accident.
+        if (types.isSymbol(args[1]) and std.mem.eql(u8, types.symbolName(args[1]), "timeout:")) {
+            return primitives.argError("process-wait", "timeout: arrives with the reactor-based wait (KEP-0022 Phase 2)", .{});
+        }
+        return primitives.argError("process-wait", "unknown option", .{});
+    }
+
+    // Already reaped (possibly by an earlier wait, a sweep, or both): the
+    // stored status is the answer.
+    if (proc.status) |st| {
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+        return types.decodeWaitStatus(gc, st) catch PrimitiveError.OutOfMemory;
+    }
+
+    // Sweep first: a prior spawn/wait sweep may already hold our exit, and
+    // this is the KEP's zombie-discipline hook on the blocking wait path.
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    sweepUnreaped(gc);
+    if (proc.status) |st| {
+        return types.decodeWaitStatus(gc, st) catch PrimitiveError.OutOfMemory;
+    }
+
+    // Blocking reap. Phase 1 semantics: no scheduler-awareness — a fiber
+    // that waits parks the whole OS thread (Phase 2 makes this park only the
+    // fiber via reactor child-exit readiness). EINTR retries; any other
+    // failure is a real waitpid error (an ECHILD here would mean something
+    // outside Kaappi reaped our specific child).
+    var st: c_int = 0;
+    var wait_errno: c_int = 0;
+    var reaped = false;
+    {
+        // A child-thread VM blocking in waitpid never reaches the dispatch-
+        // loop safepoint, so a concurrent parent collection would spin in
+        // markLiveChildRoots for the child's whole wait (#1933 shape;
+        // kaappi#2414 review). The frames/registers are stable for the
+        // duration of the syscall, so publish the VM as markable-in-native —
+        // and restore .running before anything below can allocate (the
+        // collector must never mark concurrently with a mutating VM).
+        const wait_vm: ?*vm_mod.VM = if (vm_mod.vm_instance) |vm|
+            (if (!vm.owns_globals) vm else null)
+        else
+            null;
+        if (wait_vm) |vm| vm.setCollectionInNative();
+        defer if (wait_vm) |vm| vm.setCollectionRunning();
+        while (true) {
+            const r = platform.waitPid(proc.pid, &st, 0);
+            if (r == proc.pid) {
+                reaped = true;
+                break;
+            }
+            if (r < 0) {
+                wait_errno = std.c._errno().*;
+                const eintr: c_int = @intFromEnum(std.c.E.INTR);
+                if (wait_errno == eintr) continue;
+                break;
+            }
+        }
+    }
+    if (!reaped)
+        return raiseProcessError(gc, "cannot wait for process", types.FALSE, wait_errno);
+    const raw: u32 = @bitCast(st);
+    proc.status = raw;
+    removeFromUnreaped(gc, proc);
+    return types.decodeWaitStatus(gc, raw) catch PrimitiveError.OutOfMemory;
+}
+
+fn processKill(args: []const Value) PrimitiveError!Value {
+    const proc = try expectProcess("process-kill", args[0]);
+    var sig: c_int = SIGTERM;
+    var group = false;
+    var i: usize = 1;
+    while (i < args.len) : (i += 2) {
+        if (!types.isSymbol(args[i]))
+            return primitives.argError("process-kill", "expected an option symbol like 'signal:", .{});
+        if (i + 1 >= args.len)
+            return primitives.argError("process-kill", "option '{s}' has no value", .{types.symbolName(args[i])});
+        const opt = types.symbolName(args[i]);
+        const val = args[i + 1];
+        if (std.mem.eql(u8, opt, "signal:")) {
+            if (!types.isFixnum(val))
+                return primitives.typeError("process-kill", "integer (signal number)", val);
+            const n = types.toFixnum(val);
+            if (n < 0 or n > 64)
+                return primitives.argError("process-kill", "signal number {d} outside the valid range", .{n});
+            sig = @intCast(n);
+        } else if (std.mem.eql(u8, opt, "group:")) {
+            group = types.isTruthy(val);
+        } else {
+            return primitives.argError("process-kill", "unknown option '{s}'", .{opt});
+        }
+    }
+
+    // Never re-signal a reaped pid (Python's Popen.kill contract): the
+    // number may have been reused by an unrelated process. A kill after
+    // reap is a quiet no-op, not an error.
+    if (proc.status != null) return types.VOID;
+
+    if (group and proc.pgid == 0) {
+        return primitives.argError("process-kill", "process was not spawned with 'new-group: #t; group: would signal the parent's own process group", .{});
+    }
+    if (group) {
+        // ESRCH right after spawn is almost always the SETPGROUP race, not
+        // "already dead": POSIX_SPAWN_SETPGROUP's setpgid runs in the child
+        // just before its exec, and the parent's posix_spawn return does
+        // not synchronize with it — a group kill issued microseconds after
+        // spawn can precede the group's creation. Retry briefly; the group
+        // appears once the child execs. (A pid kill has no such race: the
+        // pid exists from spawn on.) Bounded at ~100 ms — 200 × 500 µs — so
+        // a genuinely dead group surfaces as an error, just a moment later.
+        const esrch: c_int = @intFromEnum(std.c.E.SRCH);
+        var attempts: u32 = 0;
+        while (true) {
+            const rc = platform.procKill(-proc.pgid, sig);
+            if (rc == 0) break;
+            const errno_val = std.c._errno().*;
+            if (errno_val == esrch and attempts < 200) {
+                attempts += 1;
+                platform.sleepNs(500 * std.time.ns_per_us);
+                continue;
+            }
+            const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+            return raiseProcessError(gc, "cannot signal process group", types.FALSE, errno_val);
+        }
+        return types.VOID;
+    }
+    const target: i32 = proc.pid;
+    if (platform.procKill(target, sig) != 0) {
+        const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+        return raiseProcessError(gc, "cannot signal process", args[0], std.c._errno().*);
+    }
+    return types.VOID;
+}
+
+fn processEnvironment(_: []const Value) PrimitiveError!Value {
+    // Same alist shape as (get-environment-variables) — (name . value)
+    // string pairs — so `env:` replace-wholesale composes with copy-and-
+    // extend: (append (process-environment) (list (cons "FOO" "bar"))).
+    return primitives_r7rs.getEnvironmentAlist();
+}
+
+// ---------------------------------------------------------------------------
+// Specs
+// ---------------------------------------------------------------------------
+
+pub const specs = [_]primitives.PrimSpec{
+    .{ .name = "spawn-process", .func = &spawnProcessFn, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.kaappi_process), .sandbox = false, .wasm = false },
+    .{ .name = "%process-spawn", .func = &processSpawnRawFn, .arity = .{ .exact = 7 }, .libs = primitives.INTERNAL, .sandbox = false, .wasm = false },
+    .{ .name = "process?", .func = &processP, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_process), .sandbox = false, .wasm = false },
+    .{ .name = "process-pid", .func = &processPid, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_process), .sandbox = false, .wasm = false },
+    .{ .name = "process-group", .func = &processGroup, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_process), .sandbox = false, .wasm = false },
+    .{ .name = "process-stdin", .func = &processStdin, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_process), .sandbox = false, .wasm = false },
+    .{ .name = "process-stdout", .func = &processStdout, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_process), .sandbox = false, .wasm = false },
+    .{ .name = "process-stderr", .func = &processStderr, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_process), .sandbox = false, .wasm = false },
+    .{ .name = "process-status", .func = &processStatus, .arity = .{ .exact = 1 }, .libs = LS.initOne(.kaappi_process), .sandbox = false, .wasm = false },
+    .{ .name = "process-wait", .func = &processWait, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.kaappi_process), .sandbox = false, .wasm = false },
+    .{ .name = "process-kill", .func = &processKill, .arity = .{ .variadic = 1 }, .libs = LS.initOne(.kaappi_process), .sandbox = false, .wasm = false },
+    .{ .name = "process-environment", .func = &processEnvironment, .arity = .{ .exact = 0 }, .libs = LS.initOne(.kaappi_process), .sandbox = false, .wasm = false },
+};

--- a/src/primitives_process.zig
+++ b/src/primitives_process.zig
@@ -53,6 +53,15 @@ const spawn_c = struct {
         argv: [*:null]const ?[*:0]const u8,
         envp: [*:null]const ?[*:0]const u8,
     ) c_int;
+    /// OpenBSD only (see the pre-flight in spawnImpl): its userland,
+    /// vfork-based posix_spawn has no channel to report the child's exec
+    /// failure, so spawning a missing program "succeeds" and the child
+    /// exits 127 — POSIX permits that, but every other target reports
+    /// ENOENT synchronously and the catchable-file-error contract should
+    /// not be platform lottery for the common case.
+    pub const spawn_cannot_report_exec_failure = builtin.os.tag == .openbsd;
+    pub extern "c" fn access(path: [*:0]const u8, mode: c_int) c_int;
+
     pub extern "c" fn posix_spawnattr_init(attr: *AttrPtr) c_int;
     pub extern "c" fn posix_spawnattr_destroy(attr: *AttrPtr) c_int;
     pub extern "c" fn posix_spawnattr_setflags(attr: *AttrPtr, flags: c_short) c_int;
@@ -117,6 +126,39 @@ const spawn_c = struct {
         else => false,
     };
     pub extern "c" fn posix_spawn_file_actions_addchdir_np(actions: *FileActionsPtr, path: [*:0]const u8) c_int;
+
+    /// NetBSD only: its posix_spawn is an in-kernel syscall whose *child*
+    /// completes the exec after the parent's call has already returned — and
+    /// a signal posted to the child before that exec has fully finished is
+    /// dropped outright (measured on NetBSD 10.1: 5 of 40 immediate SIGTERMs
+    /// to a spawned `sleep` were lost and the children ran to completion —
+    /// kaappi#2414, the process-kill breakage both prior attempts hit).
+    /// Every other target has no window by construction: FreeBSD/OpenBSD/
+    /// glibc/musl spawn with vfork semantics (the parent resumes only after
+    /// the exec), and macOS's spawn is atomic in-kernel.
+    ///
+    /// The barrier is kqueue's NOTE_EXEC — the kernel's own "exec completed"
+    /// notification, raised at the end of execve_runproc. A CLOEXEC-pipe
+    /// EOF barrier was tried first and measured *insufficient* (8/40 kills
+    /// still lost): the kernel closes close-on-exec descriptors partway
+    /// through the exec, before the child's signal state is finalized, so
+    /// EOF arrives inside the loss window. A kill delayed past the window
+    /// (50 ms) was 0/15 lost, pinning the mechanism to exec-completion
+    /// timing.
+    pub const needs_exec_barrier = builtin.os.tag == .netbsd;
+
+    /// NetBSD versions every libc symbol whose signature contains `time_t`;
+    /// the modern kevent is `__kevent50` (see the same binding in
+    /// reactor.zig). Declared here unconditionally but referenced only under
+    /// `needs_exec_barrier`, so no other target links it.
+    pub extern "c" fn __kevent50(
+        kq: c_int,
+        changelist: [*]const std.c.Kevent,
+        nchanges: c_int,
+        eventlist: [*]std.c.Kevent,
+        nevents: c_int,
+        timeout: ?*const std.c.timespec,
+    ) c_int;
 };
 
 const SIGTERM: c_int = 15;
@@ -454,6 +496,22 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
     if (flags != 0 and spawn_c.posix_spawnattr_setflags(attr, @bitCast(flags)) != 0)
         return spawnFileActionError(gc);
 
+    // OpenBSD pre-flight (see spawn_cannot_report_exec_failure): for a
+    // slash-containing program path — the case with exactly one candidate
+    // file — probe it with access(X_OK) so "no such program" raises the
+    // same errno-carrying file-error as on every other platform. A bare
+    // name goes through posix_spawnp's PATH search and keeps the
+    // POSIX-sanctioned exit-127 fallback; the probe is advisory (TOCTOU
+    // races simply fall back to that same behavior).
+    if (comptime spawn_c.spawn_cannot_report_exec_failure) {
+        const prog = argv[0].?;
+        if (std.mem.indexOfScalar(u8, std.mem.span(prog), '/') != null) {
+            const X_OK: c_int = 1;
+            if (spawn_c.access(prog, X_OK) != 0)
+                return raiseProcessError(gc, "cannot spawn process", cfg.argv[0], std.c._errno().*);
+        }
+    }
+
     // -- spawn
     var pid: c_int = -1;
     const envp: [*:null]const ?[*:0]const u8 = env_block orelse @ptrCast(std.c.environ);
@@ -471,6 +529,14 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
     if (stdin_pipe[0] >= 0) _ = platform.close(stdin_pipe[0]);
     if (stdout_pipe[1] >= 0) _ = platform.close(stdout_pipe[1]);
     if (stderr_pipe[1] >= 0) _ = platform.close(stderr_pipe[1]);
+
+    // Exec barrier (NetBSD; see needs_exec_barrier): block until the kernel
+    // reports the child's exec completed (or the child died), so the child
+    // is signalable from the moment spawn-process returns. Without this, a
+    // process-kill issued promptly after spawn is silently dropped.
+    if (comptime spawn_c.needs_exec_barrier) {
+        execBarrierWait(pid);
+    }
 
     // -- Process object + parent-end ports. `proc_val` stays rooted across
     // the three port allocations; each port is stored into the Process as
@@ -562,6 +628,33 @@ fn addInheritedFdCloses(gc: *GC, actions: *spawn_c.FileActionsPtr) PrimitiveErro
             _ = try spawnFileActionError(gc);
         }
     }
+}
+
+/// NetBSD's exec barrier (see spawn_c.needs_exec_barrier): register a
+/// oneshot EVFILT_PROC knote for NOTE_EXEC|NOTE_EXIT on the fresh child and
+/// wait for it. NOTE_EXEC is raised at the very end of the kernel's exec
+/// path, strictly after the child's signal state is final — the property the
+/// CLOEXEC-pipe EOF measurably lacked. The 20 ms timeout covers the one
+/// blind spot: a child that completed its exec in the microseconds before
+/// the knote was registered raises no event (rare — the child needs a
+/// scheduling slot first — and the fallback only ever *delays*, never
+/// breaks). Registration failure (ESRCH: child already exited and reaped by
+/// a concurrent sweep) just returns. Best-effort by design: no error path.
+fn execBarrierWait(pid: c_int) void {
+    const kq = std.c.kqueue();
+    if (kq < 0) return;
+    defer _ = platform.close(kq);
+    var change = [1]std.c.Kevent{.{
+        .ident = @intCast(pid),
+        .filter = std.c.EVFILT.PROC,
+        .flags = std.c.EV.ADD | std.c.EV.ONESHOT,
+        .fflags = std.c.NOTE.EXEC | std.c.NOTE.EXIT,
+        .data = 0,
+        .udata = 0,
+    }};
+    var out: [1]std.c.Kevent = undefined;
+    const ts: std.c.timespec = .{ .sec = 0, .nsec = 20 * std.time.ns_per_ms };
+    _ = spawn_c.__kevent50(kq, &change, 1, &out, 1, &ts);
 }
 
 fn closePipePair(fds: *[2]platform.fd_t) void {

--- a/src/primitives_process.zig
+++ b/src/primitives_process.zig
@@ -640,7 +640,10 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
     // between any two steps leaves the remaining ends to the cleanup defer.
     const pgid: i32 = if (cfg.new_group) pid else 0;
     const proc = gc.allocProcess(pid, pgid) catch {
-        killAndReapFresh(pid);
+        // Nothing tracks this child (enrolment happens inside allocProcess),
+        // so an unreaped survivor here is lost for good — but that needs
+        // the kill itself to fail, which has no realistic path.
+        _ = killAndReapFresh(pid);
         return PrimitiveError.OutOfMemory;
     };
     var proc_val = types.makePointer(&proc.header);
@@ -655,9 +658,12 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
     // child, and record the status so freeObject does not reap a reused
     // pid later.
     errdefer {
-        killAndReapFresh(pid);
-        proc.status = 9; // (signaled . 9): the raw wait status of SIGKILL
-        removeFromUnreaped(gc, proc);
+        if (killAndReapFresh(pid)) {
+            proc.status = 9; // (signaled . 9): the raw wait status of SIGKILL
+            removeFromUnreaped(gc, proc);
+        }
+        // else: keep the registry entry — the WNOHANG sweeps reap it when
+        // the child does die, instead of the pid being forgotten.
     }
 
     if (stdin_pipe[1] >= 0) {
@@ -682,15 +688,37 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
 }
 
 /// Terminate and reap a child spawned moments ago that no caller will ever
-/// be able to wait on (a post-spawn allocation failed). SIGKILL cannot be
-/// caught, so the blocking reap is bounded by the process teardown itself;
-/// EINTR retries, any other waitpid failure gives up (nothing more can be
-/// done on an OOM path).
-fn killAndReapFresh(pid: c_int) void {
-    _ = platform.procKill(pid, 9);
+/// be able to wait on (a post-spawn allocation failed). Returns true when
+/// the child was actually reaped — the caller keeps its registry entry
+/// otherwise, so the ordinary WNOHANG sweeps can finish the job later
+/// rather than a pid being forgotten (kaappi#2442 review). The blocking
+/// reap runs only after the SIGKILL demonstrably went out (an unchecked
+/// kill followed by an unconditional wait could block on a child that was
+/// never signaled), under the same markable-in-native protocol as
+/// process-wait, since a child-thread VM blocking here would otherwise
+/// starve a concurrent parent collection (#1933 shape). SIGKILL cannot be
+/// caught, so the wait is bounded by the child's own teardown (an
+/// uninterruptible-sleep child can stretch that, but never indefinitely).
+fn killAndReapFresh(pid: c_int) bool {
+    if (platform.procKill(pid, 9) != 0) {
+        // Could not signal (already reaped elsewhere would be a bug; a
+        // bizarre EPERM leaves the child running): one non-blocking probe,
+        // then let the registry sweeps take over.
+        var st0: c_int = 0;
+        return platform.waitPid(pid, &st0, platform.WNOHANG) == pid;
+    }
+    const wait_vm: ?*vm_mod.VM = if (vm_mod.vm_instance) |vm|
+        (if (!vm.owns_globals) vm else null)
+    else
+        null;
+    if (wait_vm) |vm| vm.setCollectionInNative();
+    defer if (wait_vm) |vm| vm.setCollectionRunning();
     var st: c_int = 0;
-    while (platform.waitPid(pid, &st, 0) < 0) {
-        if (std.c._errno().* != @intFromEnum(std.c.E.INTR)) break;
+    while (true) {
+        const r = platform.waitPid(pid, &st, 0);
+        if (r == pid) return true;
+        if (r < 0 and std.c._errno().* == @intFromEnum(std.c.E.INTR)) continue;
+        return false;
     }
 }
 

--- a/src/primitives_process.zig
+++ b/src/primitives_process.zig
@@ -127,6 +127,21 @@ const spawn_c = struct {
     };
     pub extern "c" fn posix_spawn_file_actions_addchdir_np(actions: *FileActionsPtr, path: [*:0]const u8) c_int;
 
+    /// Darwin only: under POSIX_SPAWN_CLOEXEC_DEFAULT even the stdio slots
+    /// are closed unless a file action names them; addinherit_np is the
+    /// action the man page prescribes for a descriptor that must survive
+    /// as-is (kaappi#2442 review).
+    pub extern "c" fn posix_spawn_file_actions_addinherit_np(actions: *FileActionsPtr, filedes: c_int) c_int;
+
+    /// FreeBSD >= 13.1: close every child fd >= `from` in one action —
+    /// the kernel-side equivalent of the per-fd scan, with no upper bound,
+    /// so a 100k+ RLIMIT_NOFILE costs nothing (kaappi#2442 review: the
+    /// scan's old 65536 cap silently exempted valid high descriptors).
+    /// glibc >= 2.34 has it too, but Linux keeps the /proc-driven scan,
+    /// which works on every libc and glibc floor.
+    pub const has_addclosefrom = builtin.os.tag == .freebsd;
+    pub extern "c" fn posix_spawn_file_actions_addclosefrom_np(actions: *FileActionsPtr, from: c_int) c_int;
+
     /// NetBSD only: its posix_spawn is an in-kernel syscall whose *child*
     /// completes the exec after the parent's call has already returned — and
     /// a signal posted to the child before that exec has fully finished is
@@ -269,6 +284,16 @@ fn parseRedir(comptime proc: []const u8, val: Value) PrimitiveError!Redir {
         // own writes; the drain can park a fiber, and a re-executed spawn
         // re-parses the options idempotently.
         if (port.is_output) try primitives_io.drainPortWriteBufferForSpawn(port);
+        // The input mirror: software read-ahead makes the kernel offset run
+        // ahead of the port's logical position, so a child handed the raw
+        // fd would silently skip the buffered bytes. Seekable fds are
+        // rewound; an unseekable fd with pending read-ahead is rejected
+        // (kaappi#2442 review).
+        if (port.is_input) {
+            const unsynced = primitives_io.rewindPortReadAheadForSpawn(port);
+            if (unsynced != 0)
+                return primitives.argError(proc, "redirection port has {d} buffered byte(s) of read-ahead that its unseekable descriptor cannot give back to the child", .{unsynced});
+        }
         return .{ .fd = port.fd };
     }
     return primitives.typeError(proc, "redirection spec (inherit, pipe, null, stdout, or an fd-backed port)", val);
@@ -349,18 +374,28 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
         directory_z = try dupeZChecked("spawn-process", arena_al, dir.data[0..dir.len], "directory: path");
     }
 
-    // -- pipes. Cleanup discipline: every path before a successful spawn
-    // closes everything through the `spawned` defer; after it, the ports own
-    // the parent ends and the child ends were closed by hand.
+    // -- pipes. Cleanup discipline: every fd this function creates lives in
+    // one of the slots below, and the single defer closes whatever is still
+    // >= 0 on ANY exit path — success included. Ownership transfer is
+    // recorded by writing -1 into the slot: the child ends after their
+    // explicit post-spawn close, each parent end once a Port owns it, the
+    // staged redirect duplicates never (the parent must always release
+    // them). Nothing is disarmed wholesale, so an OOM between the spawn and
+    // the last port allocation cannot leak a descriptor (kaappi#2442
+    // review).
     var stdin_pipe: [2]platform.fd_t = .{ -1, -1 }; // [0] child read end, [1] parent write end
     var stdout_pipe: [2]platform.fd_t = .{ -1, -1 };
     var stderr_pipe: [2]platform.fd_t = .{ -1, -1 };
-    var spawned = false;
-    defer if (!spawned) {
+    var staged_fds: [3]platform.fd_t = .{ -1, -1, -1 }; // parent-side dups of low redirect sources
+    defer {
         closePipePair(&stdin_pipe);
         closePipePair(&stdout_pipe);
         closePipePair(&stderr_pipe);
-    };
+        for (&staged_fds) |*sfd| {
+            if (sfd.* >= 0) _ = platform.close(sfd.*);
+            sfd.* = -1;
+        }
+    }
     if (cfg.stdin == .pipe and pipeWithFdRetry(gc, &stdin_pipe) != 0)
         return raiseProcessError(gc, "cannot create stdin pipe", types.FALSE, std.c._errno().*);
     if (cfg.stdout == .pipe and pipeWithFdRetry(gc, &stdout_pipe) != 0)
@@ -368,84 +403,102 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
     if (cfg.stderr == .pipe and pipeWithFdRetry(gc, &stderr_pipe) != 0)
         return raiseProcessError(gc, "cannot create stderr pipe", types.FALSE, std.c._errno().*);
 
-    // -- file actions + attrs
+    // A launcher that closed a standard descriptor makes pipe(2) hand back
+    // 0, 1, or 2 — and a pipe end living IN a stdio slot corrupts the file
+    // actions (dup2(0,0) then close(0) destroys the stream it just
+    // installed; a parent end in 0..2 collides with the port close
+    // discipline). Lift every pipe end above the stdio range before any
+    // action names it (kaappi#2442 review).
+    try normalizePipeAboveStdio(gc, &stdin_pipe);
+    try normalizePipeAboveStdio(gc, &stdout_pipe);
+    try normalizePipeAboveStdio(gc, &stderr_pipe);
+
+    // Caller-port redirect sources in 0..2 must be staged into fds >= 3:
+    // the file actions run sequentially in the child, so a later action
+    // naming a low source reads whatever an earlier dup2 just installed
+    // there — `stdout: (current-error-port) stderr: (current-output-port)`
+    // queued dup2(2,1); dup2(1,2) and sent BOTH streams to the original
+    // stderr instead of swapping (kaappi#2442 review). The staged copies
+    // are parent-side CLOEXEC dups: actions reference them, exec drops
+    // them in the child, and the defer above releases the parent's copies.
+    var redirs = [3]Redir{ cfg.stdin, cfg.stdout, cfg.stderr };
+    for (&redirs, 0..) |*r, slot| {
+        if (r.* != .fd) continue;
+        if (r.*.fd > 2) continue;
+        const staged = platform.dupCloexecAtLeast(r.*.fd, 3);
+        if (staged < 0)
+            return raiseProcessError(gc, "cannot stage redirection descriptor", types.FALSE, std.c._errno().*);
+        staged_fds[slot] = staged;
+        r.* = .{ .fd = staged };
+    }
+
+    // -- file actions + attrs. Both initializers can fail (ENOMEM on the
+    // pointer-backed libcs), and their destroy must run only on a
+    // successfully initialized object (kaappi#2442 review).
     var actions_storage = spawn_c.zeroStorage();
     const actions: *spawn_c.FileActionsPtr = @ptrCast(&actions_storage);
-    _ = spawn_c.posix_spawn_file_actions_init(actions);
-    // Destroyed on every exit path below (arm the defer immediately; a
-    // mid-setup failure must not leak the malloc'd internals on the
-    // pointer-flavor platforms).
+    {
+        const rc = spawn_c.posix_spawn_file_actions_init(actions);
+        if (rc != 0) return spawnSetupError(gc, rc);
+    }
     defer _ = spawn_c.posix_spawn_file_actions_destroy(actions);
 
     const O_RDONLY: c_int = 0;
     const O_WRONLY: c_int = 1;
     const null_z: [*:0]const u8 = "/dev/null";
+    const child_pipe_ends = [3]platform.fd_t{ stdin_pipe[0], stdout_pipe[1], stderr_pipe[1] };
+    const slot_oflag = [3]c_int{ O_RDONLY, O_WRONLY, O_WRONLY };
 
-    // stdin (slot 0)
-    switch (cfg.stdin) {
-        .inherit => {},
-        .pipe => {
-            if (spawn_c.posix_spawn_file_actions_adddup2(actions, stdin_pipe[0], 0) != 0 or
-                spawn_c.posix_spawn_file_actions_addclose(actions, stdin_pipe[0]) != 0)
-                return spawnFileActionError(gc);
-        },
-        .null_sink => {
-            if (spawn_c.posix_spawn_file_actions_addopen(actions, 0, null_z, O_RDONLY, 0o666) != 0)
-                return spawnFileActionError(gc);
-        },
-        .fd => |fd| {
-            if (spawn_c.posix_spawn_file_actions_adddup2(actions, fd, 0) != 0)
-                return spawnFileActionError(gc);
-        },
-        .merge_stdout => return primitives.argError("spawn-process", "'stdout is a stderr-only redirection spec", .{}),
-    }
-    // stdout (slot 1)
-    switch (cfg.stdout) {
-        .inherit => {},
-        .pipe => {
-            if (spawn_c.posix_spawn_file_actions_adddup2(actions, stdout_pipe[1], 1) != 0 or
-                spawn_c.posix_spawn_file_actions_addclose(actions, stdout_pipe[1]) != 0)
-                return spawnFileActionError(gc);
-        },
-        .null_sink => {
-            if (spawn_c.posix_spawn_file_actions_addopen(actions, 1, null_z, O_WRONLY, 0o666) != 0)
-                return spawnFileActionError(gc);
-        },
-        .fd => |fd| {
-            if (spawn_c.posix_spawn_file_actions_adddup2(actions, fd, 1) != 0)
-                return spawnFileActionError(gc);
-        },
-        .merge_stdout => return primitives.argError("spawn-process", "'stdout is a stderr-only redirection spec", .{}),
-    }
-    // stderr (slot 2) — after stdout, so 'stdout merging duplicates the
-    // child's final slot-1 descriptor, whatever installed it.
-    switch (cfg.stderr) {
-        .inherit => {},
-        .pipe => {
-            if (spawn_c.posix_spawn_file_actions_adddup2(actions, stderr_pipe[1], 2) != 0 or
-                spawn_c.posix_spawn_file_actions_addclose(actions, stderr_pipe[1]) != 0)
-                return spawnFileActionError(gc);
-        },
-        .null_sink => {
-            if (spawn_c.posix_spawn_file_actions_addopen(actions, 2, null_z, O_WRONLY, 0o666) != 0)
-                return spawnFileActionError(gc);
-        },
-        .fd => |fd| {
-            if (spawn_c.posix_spawn_file_actions_adddup2(actions, fd, 2) != 0)
-                return spawnFileActionError(gc);
-        },
-        .merge_stdout => {
-            if (spawn_c.posix_spawn_file_actions_adddup2(actions, 1, 2) != 0)
-                return spawnFileActionError(gc);
-        },
+    // Slot actions, stdin/stdout/stderr in order — stderr last, so the
+    // 'stdout merge duplicates the child's final slot-1 descriptor,
+    // whatever installed it. `redirs` (not cfg) carries the staged sources.
+    for (redirs, 0..) |redir, slot_usize| {
+        const slot: c_int = @intCast(slot_usize);
+        switch (redir) {
+            .inherit => {
+                // Darwin's CLOEXEC_DEFAULT closes even the stdio slots
+                // unless a file action names them — a plain 'inherit spawn
+                // lost all three streams (kaappi#2442 review; the man page
+                // prescribes addinherit_np for exactly this). A slot the
+                // parent itself has closed is skipped: the child correctly
+                // sees it closed, and an addinherit on a bad fd would fail
+                // the whole spawn.
+                if (comptime spawn_c.apple_cloexec_default) {
+                    if (platform.getFdFlags(slot) >= 0) {
+                        const rc = spawn_c.posix_spawn_file_actions_addinherit_np(actions, slot);
+                        if (rc != 0) return spawnSetupError(gc, rc);
+                    }
+                }
+            },
+            .pipe => {
+                const child_end = child_pipe_ends[slot_usize];
+                var rc = spawn_c.posix_spawn_file_actions_adddup2(actions, child_end, slot);
+                if (rc == 0) rc = spawn_c.posix_spawn_file_actions_addclose(actions, child_end);
+                if (rc != 0) return spawnSetupError(gc, rc);
+            },
+            .null_sink => {
+                const rc = spawn_c.posix_spawn_file_actions_addopen(actions, slot, null_z, slot_oflag[slot_usize], 0o666);
+                if (rc != 0) return spawnSetupError(gc, rc);
+            },
+            .fd => |fd| {
+                const rc = spawn_c.posix_spawn_file_actions_adddup2(actions, fd, slot);
+                if (rc != 0) return spawnSetupError(gc, rc);
+            },
+            .merge_stdout => {
+                if (slot != 2)
+                    return primitives.argError("spawn-process", "'stdout is a stderr-only redirection spec", .{});
+                const rc = spawn_c.posix_spawn_file_actions_adddup2(actions, 1, 2);
+                if (rc != 0) return spawnSetupError(gc, rc);
+            },
+        }
     }
     // Comptime gate, not just the run-time one above: the extern is absent
     // from NetBSD/OpenBSD libc, so the call itself must not be analyzed
     // there (Zig only links referenced externs).
     if (comptime spawn_c.has_addchdir) {
         if (directory_z) |dir| {
-            if (spawn_c.posix_spawn_file_actions_addchdir_np(actions, dir) != 0)
-                return spawnFileActionError(gc);
+            const rc = spawn_c.posix_spawn_file_actions_addchdir_np(actions, dir);
+            if (rc != 0) return spawnSetupError(gc, rc);
         }
     }
 
@@ -466,15 +519,18 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
 
     var attr_storage = spawn_c.zeroStorage();
     const attr: *spawn_c.AttrPtr = @ptrCast(&attr_storage);
-    _ = spawn_c.posix_spawnattr_init(attr);
+    {
+        const rc = spawn_c.posix_spawnattr_init(attr);
+        if (rc != 0) return spawnSetupError(gc, rc);
+    }
     defer _ = spawn_c.posix_spawnattr_destroy(attr);
 
     var flags: u16 = 0;
     if (cfg.new_group) {
         // pgroup 0 = the child becomes its own group leader
         // (setpgid(child, 0) semantics), so pgid == pid after spawn.
-        if (spawn_c.posix_spawnattr_setpgroup(attr, 0) != 0)
-            return spawnFileActionError(gc);
+        const rc = spawn_c.posix_spawnattr_setpgroup(attr, 0);
+        if (rc != 0) return spawnSetupError(gc, rc);
         flags |= spawn_c.SPAWN_SETPGROUP;
     }
     {
@@ -488,13 +544,15 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
         // renamed ABI, so the plain symbols are not portably linkable.
         var sigset = std.posix.sigemptyset();
         std.posix.sigaddset(&sigset, std.posix.SIG.PIPE);
-        if (spawn_c.posix_spawnattr_setsigdefault(attr, &sigset) != 0)
-            return spawnFileActionError(gc);
+        const rc = spawn_c.posix_spawnattr_setsigdefault(attr, &sigset);
+        if (rc != 0) return spawnSetupError(gc, rc);
         flags |= spawn_c.SPAWN_SETSIGDEF;
     }
     if (spawn_c.apple_cloexec_default) flags |= spawn_c.SPAWN_CLOEXEC_DEFAULT;
-    if (flags != 0 and spawn_c.posix_spawnattr_setflags(attr, @bitCast(flags)) != 0)
-        return spawnFileActionError(gc);
+    if (flags != 0) {
+        const rc = spawn_c.posix_spawnattr_setflags(attr, @bitCast(flags));
+        if (rc != 0) return spawnSetupError(gc, rc);
+    }
 
     // OpenBSD pre-flight (see spawn_cannot_report_exec_failure): for a
     // slash-containing program path — the case with exactly one candidate
@@ -515,59 +573,112 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
     // -- spawn
     var pid: c_int = -1;
     const envp: [*:null]const ?[*:0]const u8 = env_block orelse @ptrCast(std.c.environ);
-    const spawn_rc = spawn_c.posix_spawnp(&pid, argv[0].?, actions, attr, argv, envp);
+    var spawn_rc: c_int = 0;
+    {
+        // A child-thread VM blocking in the vfork-style spawn (which waits
+        // through the exec and its filesystem lookups) — or in the NetBSD
+        // exec barrier — never reaches the dispatch-loop safepoint, so a
+        // concurrent parent collection would spin in markLiveChildRoots
+        // (the same #1933 shape process-wait already handles; kaappi#2442
+        // review). Publish the VM as markable-in-native for the syscall
+        // stretch, restoring .running before anything below allocates.
+        const spawn_vm: ?*vm_mod.VM = if (vm_mod.vm_instance) |vm|
+            (if (!vm.owns_globals) vm else null)
+        else
+            null;
+        if (spawn_vm) |vm| vm.setCollectionInNative();
+        defer if (spawn_vm) |vm| vm.setCollectionRunning();
+        spawn_rc = spawn_c.posix_spawnp(&pid, argv[0].?, actions, attr, argv, envp);
+        // Exec barrier (NetBSD; see needs_exec_barrier): block until the
+        // kernel reports the child's exec completed (or the child died), so
+        // the child is signalable from the moment spawn-process returns.
+        // Without this, a process-kill issued promptly after spawn is
+        // silently dropped.
+        if (comptime spawn_c.needs_exec_barrier) {
+            if (spawn_rc == 0) execBarrierWait(pid);
+        }
+    }
     if (spawn_rc != 0) {
         // posix_spawn returns the errno itself, not -1. ENOENT is the common
         // case (program not on PATH); the errno rides the condition so
-        // posix-error-name reports it precisely. The `spawned` defer closes
-        // the pipes; the destroy defers release actions/attr.
+        // posix-error-name reports it precisely. The function-wide defer
+        // closes the pipes and staged fds; the destroy defers release
+        // actions/attr.
         return raiseProcessError(gc, "cannot spawn process", cfg.argv[0], spawn_rc);
     }
-    spawned = true;
 
-    // The child owns the child ends now; the parent's copies must go.
+    // The child owns the child ends now; the parent's copies must go
+    // (recorded as -1 so the cleanup defer never double-closes them).
     if (stdin_pipe[0] >= 0) _ = platform.close(stdin_pipe[0]);
+    stdin_pipe[0] = -1;
     if (stdout_pipe[1] >= 0) _ = platform.close(stdout_pipe[1]);
+    stdout_pipe[1] = -1;
     if (stderr_pipe[1] >= 0) _ = platform.close(stderr_pipe[1]);
-
-    // Exec barrier (NetBSD; see needs_exec_barrier): block until the kernel
-    // reports the child's exec completed (or the child died), so the child
-    // is signalable from the moment spawn-process returns. Without this, a
-    // process-kill issued promptly after spawn is silently dropped.
-    if (comptime spawn_c.needs_exec_barrier) {
-        execBarrierWait(pid);
-    }
+    stderr_pipe[1] = -1;
 
     // -- Process object + parent-end ports. `proc_val` stays rooted across
     // the three port allocations; each port is stored into the Process as
-    // soon as it exists so the next allocation sees it reachable.
+    // soon as it exists so the next allocation sees it reachable. Each
+    // parent end's slot is blanked as its Port takes ownership; an OOM
+    // between any two steps leaves the remaining ends to the cleanup defer.
     const pgid: i32 = if (cfg.new_group) pid else 0;
-    const proc = gc.allocProcess(pid, pgid) catch return PrimitiveError.OutOfMemory;
+    const proc = gc.allocProcess(pid, pgid) catch {
+        // The child is alive but nothing tracks it (enrolment happens
+        // inside allocProcess): a Process the caller never sees cannot be
+        // waited, and the unreaped registry never learned the pid. On this
+        // one OOM path, terminate and reap the fresh child rather than
+        // leak a zombie (kaappi#2442 review).
+        _ = platform.procKill(pid, 9);
+        var st: c_int = 0;
+        while (platform.waitPid(pid, &st, 0) < 0) {
+            if (std.c._errno().* != @intFromEnum(std.c.E.INTR)) break;
+        }
+        return PrimitiveError.OutOfMemory;
+    };
     var proc_val = types.makePointer(&proc.header);
     gc.pushRoot(&proc_val);
     defer gc.popRoot();
 
     if (stdin_pipe[1] >= 0) {
         const port_val = try primitives_io.makeFdPort(gc, stdin_pipe[1], false, true, "process-stdin");
+        stdin_pipe[1] = -1;
         proc.stdin_port = port_val;
         gc.writeBarrier(&proc.header, port_val);
     }
     if (stdout_pipe[0] >= 0) {
         const port_val = try primitives_io.makeFdPort(gc, stdout_pipe[0], true, false, "process-stdout");
+        stdout_pipe[0] = -1;
         proc.stdout_port = port_val;
         gc.writeBarrier(&proc.header, port_val);
     }
     if (stderr_pipe[0] >= 0) {
         const port_val = try primitives_io.makeFdPort(gc, stderr_pipe[0], true, false, "process-stderr");
+        stderr_pipe[0] = -1;
         proc.stderr_port = port_val;
         gc.writeBarrier(&proc.header, port_val);
     }
     return proc_val;
 }
 
-fn spawnFileActionError(gc: *GC) PrimitiveError!Value {
-    const errno_val = std.c._errno().*;
-    return raiseProcessError(gc, "cannot set up process redirection", types.FALSE, errno_val);
+/// Raise the errno-carrying redirection-setup error. All posix_spawn
+/// file-action and attr functions RETURN the error number rather than
+/// setting errno (kaappi#2442 review) — callers pass that return code here.
+fn spawnSetupError(gc: *GC, rc: c_int) PrimitiveError!Value {
+    return raiseProcessError(gc, "cannot set up process redirection", types.FALSE, rc);
+}
+
+/// Lift both ends of a created pipe above the stdio range (fd >= 3) via
+/// F_DUPFD_CLOEXEC, closing the low originals. See the call site for why a
+/// pipe end in 0..2 is unusable in the file actions.
+fn normalizePipeAboveStdio(gc: *GC, fds: *[2]platform.fd_t) PrimitiveError!void {
+    for (fds) |*fd| {
+        if (fd.* < 0 or fd.* > 2) continue;
+        const high = platform.dupCloexecAtLeast(fd.*, 3);
+        if (high < 0)
+            _ = try raiseProcessError(gc, "cannot relocate pipe descriptor above the stdio range", types.FALSE, std.c._errno().*);
+        _ = platform.close(fd.*);
+        fd.* = high;
+    }
 }
 
 /// Add a close file-action for every open fd > 2 that is not close-on-exec
@@ -585,6 +696,16 @@ fn spawnFileActionError(gc: *GC) PrimitiveError!Value {
 /// slip through — the same race every enumerate-then-spawn implementation
 /// (CPython's subprocess on platforms without close_range) accepts.
 fn addInheritedFdCloses(gc: *GC, actions: *spawn_c.FileActionsPtr) PrimitiveError!void {
+    if (comptime spawn_c.has_addclosefrom) {
+        // One kernel-side action replaces the whole scan, with no upper
+        // bound to silently exempt high descriptors. It runs after the slot
+        // dup2s, so redirect sources have already been copied into 0..2;
+        // closing them (and everything else >= 3) is exactly
+        // close-by-default.
+        const rc = spawn_c.posix_spawn_file_actions_addclosefrom_np(actions, 3);
+        if (rc != 0) _ = try spawnSetupError(gc, rc);
+        return;
+    }
     if (comptime builtin.os.tag == .linux) {
         if (platform.DirIter.open("/proc/self/fd")) |it_state| {
             // The genuinely sparse enumeration must be collected before
@@ -606,17 +727,20 @@ fn addInheritedFdCloses(gc: *GC, actions: *spawn_c.FileActionsPtr) PrimitiveErro
             return;
         }
     }
-    // BSD fallback (and Linux without /proc): probe the descriptor range
-    // inline — materializing up to 65k entries per spawn would cost real
-    // allocation on the hot path for nothing, since the range is dense by
-    // construction (kaappi#2442 review).
-    const cap: u64 = 65536;
+    // NetBSD/OpenBSD fallback (and Linux without /proc): probe the
+    // descriptor range inline — no ArrayList (materializing the dense range
+    // costs allocation for nothing) and no arbitrary cap: a valid high
+    // descriptor silently exempted is a broken close-by-default guarantee
+    // (kaappi#2442 review), so the scan runs to the full soft limit. The
+    // targets that commonly raise RLIMIT_NOFILE into six figures (FreeBSD,
+    // Linux) never reach this loop — they use addclosefrom_np and /proc
+    // respectively.
+    const fallback: u64 = 65536;
     const limit: u64 = blk: {
-        const rl = std.posix.getrlimit(.NOFILE) catch break :blk cap;
+        const rl = std.posix.getrlimit(.NOFILE) catch break :blk fallback;
         // rlim_t is signed on some libcs (FreeBSD's i64); a negative
         // cur (RLIM_INFINITY representations aside) means "no info".
-        const cur = std.math.cast(u64, rl.cur) orelse break :blk cap;
-        break :blk @min(cur, cap);
+        break :blk std.math.cast(u64, rl.cur) orelse fallback;
     };
     var fd: platform.fd_t = 3;
     while (fd < limit) : (fd += 1) {
@@ -630,9 +754,8 @@ fn closeFdIfInheritable(gc: *GC, actions: *spawn_c.FileActionsPtr, fd: platform.
     const flags = platform.getFdFlags(fd);
     if (flags < 0) return; // closed (or the enumeration dir's own fd)
     if ((flags & FD_CLOEXEC) != 0) return; // exec closes it anyway
-    if (spawn_c.posix_spawn_file_actions_addclose(actions, fd) != 0) {
-        _ = try spawnFileActionError(gc);
-    }
+    const rc = spawn_c.posix_spawn_file_actions_addclose(actions, fd);
+    if (rc != 0) _ = try spawnSetupError(gc, rc);
 }
 
 /// NetBSD's exec barrier (see spawn_c.needs_exec_barrier): register a

--- a/src/primitives_process.zig
+++ b/src/primitives_process.zig
@@ -361,11 +361,11 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
         closePipePair(&stdout_pipe);
         closePipePair(&stderr_pipe);
     };
-    if (cfg.stdin == .pipe and platform.pipe(&stdin_pipe) != 0)
+    if (cfg.stdin == .pipe and pipeWithFdRetry(gc, &stdin_pipe) != 0)
         return raiseProcessError(gc, "cannot create stdin pipe", types.FALSE, std.c._errno().*);
-    if (cfg.stdout == .pipe and platform.pipe(&stdout_pipe) != 0)
+    if (cfg.stdout == .pipe and pipeWithFdRetry(gc, &stdout_pipe) != 0)
         return raiseProcessError(gc, "cannot create stdout pipe", types.FALSE, std.c._errno().*);
-    if (cfg.stderr == .pipe and platform.pipe(&stderr_pipe) != 0)
+    if (cfg.stderr == .pipe and pipeWithFdRetry(gc, &stderr_pipe) != 0)
         return raiseProcessError(gc, "cannot create stderr pipe", types.FALSE, std.c._errno().*);
 
     // -- file actions + attrs
@@ -655,6 +655,22 @@ fn execBarrierWait(pid: c_int) void {
     var out: [1]std.c.Kevent = undefined;
     const ts: std.c.timespec = .{ .sec = 0, .nsec = 20 * std.time.ns_per_ms };
     _ = spawn_c.__kevent50(kq, &change, 1, &out, 1, &ts);
+}
+
+/// pipe(2) with the kaappi#1993 descriptor-exhaustion recovery `open` has
+/// had since #2324: on EMFILE/ENFILE, force a full collection — closing the
+/// descriptors held by unreachable process pipe ports — and retry once. A
+/// legal program that abandons process handles faster than the GC's
+/// allocation-count threshold trips must not spuriously fail at a normal
+/// `ulimit -n`; the OpenBSD CI leg's low limit caught exactly that in the
+/// spawn-loop rooting test. GC-safe at both call sites: everything held at
+/// pipe-creation time is either arena memory or a register-rooted argument
+/// Value, so a collection here frees only garbage.
+fn pipeWithFdRetry(gc: *GC, fds: *[2]platform.fd_t) c_int {
+    const rc = platform.pipe(fds);
+    if (rc == 0 or !platform.errnoIsFdExhausted()) return rc;
+    gc.collectFull();
+    return platform.pipe(fds);
 }
 
 fn closePipePair(fds: *[2]platform.fd_t) void {

--- a/src/primitives_process.zig
+++ b/src/primitives_process.zig
@@ -280,20 +280,24 @@ fn parseRedir(comptime proc: []const u8, val: Value) PrimitiveError!Redir {
         // rather than corrupt (kaappi#2414 review).
         if (port.nonblocking)
             return primitives.argError(proc, "redirection port is in non-blocking use by the fiber scheduler; pass a port not yet driven by fibers", .{});
-        // Buffered parent output must land in the file before the child's
-        // own writes; the drain can park a fiber, and a re-executed spawn
-        // re-parses the options idempotently.
-        if (port.is_output) try primitives_io.drainPortWriteBufferForSpawn(port);
-        // The input mirror: software read-ahead makes the kernel offset run
-        // ahead of the port's logical position, so a child handed the raw
-        // fd would silently skip the buffered bytes. Seekable fds are
-        // rewound; an unseekable fd with pending read-ahead is rejected
-        // (kaappi#2442 review).
+        // Input read-ahead FIRST: software read-ahead makes the kernel
+        // offset run ahead of the port's logical position, so a child
+        // handed the raw fd would silently skip the buffered bytes.
+        // Seekable fds are rewound; an unseekable fd with pending
+        // read-ahead is rejected. Order matters on a bidirectional port:
+        // draining output before the rewind would land the parent's
+        // buffered writes at the stale read-ahead offset instead of the
+        // logical position (kaappi#2442 review).
         if (port.is_input) {
             const unsynced = primitives_io.rewindPortReadAheadForSpawn(port);
             if (unsynced != 0)
                 return primitives.argError(proc, "redirection port has {d} buffered byte(s) of read-ahead that its unseekable descriptor cannot give back to the child", .{unsynced});
         }
+        // Then buffered parent output, so it lands in the file at the
+        // logical position, before the child's own writes; the drain can
+        // park a fiber, and a re-executed spawn re-parses the options
+        // idempotently.
+        if (port.is_output) try primitives_io.drainPortWriteBufferForSpawn(port);
         return .{ .fd = port.fd };
     }
     return primitives.typeError(proc, "redirection spec (inherit, pipe, null, stdout, or an fd-backed port)", val);
@@ -425,6 +429,12 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
     for (&redirs, 0..) |*r, slot| {
         if (r.* != .fd) continue;
         if (r.*.fd > 2) continue;
+        // A source already sitting in its own destination slot needs no
+        // stage: dup2(slot, slot) cannot collide with any earlier action,
+        // and it still names the descriptor for Darwin's CLOEXEC_DEFAULT —
+        // so `stdout: (current-output-port)` (explicit inheritance) must
+        // not fail just because the fd table is full (kaappi#2442 review).
+        if (r.*.fd == @as(platform.fd_t, @intCast(slot))) continue;
         const staged = platform.dupCloexecAtLeast(r.*.fd, 3);
         if (staged < 0)
             return raiseProcessError(gc, "cannot stage redirection descriptor", types.FALSE, std.c._errno().*);
@@ -438,7 +448,12 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
     var actions_storage = spawn_c.zeroStorage();
     const actions: *spawn_c.FileActionsPtr = @ptrCast(&actions_storage);
     {
-        const rc = spawn_c.posix_spawn_file_actions_init(actions);
+        // FreeBSD's initializers return -1 with the error in errno (unlike
+        // the errno-returning convention everywhere else in this API), so a
+        // negative result is normalized before it can masquerade as a bogus
+        // error number (kaappi#2442 review).
+        var rc = spawn_c.posix_spawn_file_actions_init(actions);
+        if (rc < 0) rc = std.c._errno().*;
         if (rc != 0) return spawnSetupError(gc, rc);
     }
     defer _ = spawn_c.posix_spawn_file_actions_destroy(actions);
@@ -520,7 +535,9 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
     var attr_storage = spawn_c.zeroStorage();
     const attr: *spawn_c.AttrPtr = @ptrCast(&attr_storage);
     {
-        const rc = spawn_c.posix_spawnattr_init(attr);
+        // Same FreeBSD -1/errno normalization as the file-actions init.
+        var rc = spawn_c.posix_spawnattr_init(attr);
+        if (rc < 0) rc = std.c._errno().*;
         if (rc != 0) return spawnSetupError(gc, rc);
     }
     defer _ = spawn_c.posix_spawnattr_destroy(attr);
@@ -623,21 +640,25 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
     // between any two steps leaves the remaining ends to the cleanup defer.
     const pgid: i32 = if (cfg.new_group) pid else 0;
     const proc = gc.allocProcess(pid, pgid) catch {
-        // The child is alive but nothing tracks it (enrolment happens
-        // inside allocProcess): a Process the caller never sees cannot be
-        // waited, and the unreaped registry never learned the pid. On this
-        // one OOM path, terminate and reap the fresh child rather than
-        // leak a zombie (kaappi#2442 review).
-        _ = platform.procKill(pid, 9);
-        var st: c_int = 0;
-        while (platform.waitPid(pid, &st, 0) < 0) {
-            if (std.c._errno().* != @intFromEnum(std.c.E.INTR)) break;
-        }
+        killAndReapFresh(pid);
         return PrimitiveError.OutOfMemory;
     };
     var proc_val = types.makePointer(&proc.header);
     gc.pushRoot(&proc_val);
     defer gc.popRoot();
+
+    // Any failure between here and the return leaves a Process the caller
+    // will never see: it would be collected, dropped from the unreaped
+    // registry, and its still-running child would be permanently untracked
+    // (kaappi#2442 review — the kill/reap must cover the port
+    // constructions, not just allocProcess). Terminate and reap the fresh
+    // child, and record the status so freeObject does not reap a reused
+    // pid later.
+    errdefer {
+        killAndReapFresh(pid);
+        proc.status = 9; // (signaled . 9): the raw wait status of SIGKILL
+        removeFromUnreaped(gc, proc);
+    }
 
     if (stdin_pipe[1] >= 0) {
         const port_val = try primitives_io.makeFdPort(gc, stdin_pipe[1], false, true, "process-stdin");
@@ -658,6 +679,19 @@ fn spawnImpl(cfg: SpawnConfig) PrimitiveError!Value {
         gc.writeBarrier(&proc.header, port_val);
     }
     return proc_val;
+}
+
+/// Terminate and reap a child spawned moments ago that no caller will ever
+/// be able to wait on (a post-spawn allocation failed). SIGKILL cannot be
+/// caught, so the blocking reap is bounded by the process teardown itself;
+/// EINTR retries, any other waitpid failure gives up (nothing more can be
+/// done on an OOM path).
+fn killAndReapFresh(pid: c_int) void {
+    _ = platform.procKill(pid, 9);
+    var st: c_int = 0;
+    while (platform.waitPid(pid, &st, 0) < 0) {
+        if (std.c._errno().* != @intFromEnum(std.c.E.INTR)) break;
+    }
 }
 
 /// Raise the errno-carrying redirection-setup error. All posix_spawn
@@ -736,12 +770,16 @@ fn addInheritedFdCloses(gc: *GC, actions: *spawn_c.FileActionsPtr) PrimitiveErro
     // Linux) never reach this loop — they use addclosefrom_np and /proc
     // respectively.
     const fallback: u64 = 65536;
-    const limit: u64 = blk: {
+    const raw_limit: u64 = blk: {
         const rl = std.posix.getrlimit(.NOFILE) catch break :blk fallback;
         // rlim_t is signed on some libcs (FreeBSD's i64); a negative
         // cur (RLIM_INFINITY representations aside) means "no info".
         break :blk std.math.cast(u64, rl.cur) orelse fallback;
     };
+    // Clamp to what an fd can actually number — an RLIM_INFINITY-shaped
+    // soft limit must not overflow the counter (kaappi#2442 review). This
+    // is not a coverage cap: no descriptor can exceed maxInt(fd_t).
+    const limit: platform.fd_t = @intCast(@min(raw_limit, std.math.maxInt(platform.fd_t)));
     var fd: platform.fd_t = 3;
     while (fd < limit) : (fd += 1) {
         try closeFdIfInheritable(gc, actions, fd);

--- a/src/primitives_process.zig
+++ b/src/primitives_process.zig
@@ -585,14 +585,15 @@ fn spawnFileActionError(gc: *GC) PrimitiveError!Value {
 /// slip through — the same race every enumerate-then-spawn implementation
 /// (CPython's subprocess on platforms without close_range) accepts.
 fn addInheritedFdCloses(gc: *GC, actions: *spawn_c.FileActionsPtr) PrimitiveError!void {
-    var fds: std.ArrayList(platform.fd_t) = .empty;
-    defer fds.deinit(gc.allocator);
-
-    var listed = false;
     if (comptime builtin.os.tag == .linux) {
         if (platform.DirIter.open("/proc/self/fd")) |it_state| {
+            // The genuinely sparse enumeration must be collected before
+            // probing: the directory's own fd is part of the listing, and
+            // only closing the iterator first lets the F_GETFD re-probe in
+            // closeFdIfInheritable see it as already gone.
+            var fds: std.ArrayList(platform.fd_t) = .empty;
+            defer fds.deinit(gc.allocator);
             var it = it_state;
-            listed = true;
             while (it.next()) |name| {
                 const n = std.fmt.parseInt(platform.fd_t, name, 10) catch continue;
                 fds.append(gc.allocator, n) catch {
@@ -601,32 +602,36 @@ fn addInheritedFdCloses(gc: *GC, actions: *spawn_c.FileActionsPtr) PrimitiveErro
                 };
             }
             it.close();
+            for (fds.items) |fd| try closeFdIfInheritable(gc, actions, fd);
+            return;
         }
     }
-    if (!listed) {
-        const cap: u64 = 65536;
-        const limit: u64 = blk: {
-            const rl = std.posix.getrlimit(.NOFILE) catch break :blk cap;
-            // rlim_t is signed on some libcs (FreeBSD's i64); a negative
-            // cur (RLIM_INFINITY representations aside) means "no info".
-            const cur = std.math.cast(u64, rl.cur) orelse break :blk cap;
-            break :blk @min(cur, cap);
-        };
-        var fd: platform.fd_t = 3;
-        while (fd < limit) : (fd += 1) {
-            fds.append(gc.allocator, fd) catch return PrimitiveError.OutOfMemory;
-        }
+    // BSD fallback (and Linux without /proc): probe the descriptor range
+    // inline — materializing up to 65k entries per spawn would cost real
+    // allocation on the hot path for nothing, since the range is dense by
+    // construction (kaappi#2442 review).
+    const cap: u64 = 65536;
+    const limit: u64 = blk: {
+        const rl = std.posix.getrlimit(.NOFILE) catch break :blk cap;
+        // rlim_t is signed on some libcs (FreeBSD's i64); a negative
+        // cur (RLIM_INFINITY representations aside) means "no info".
+        const cur = std.math.cast(u64, rl.cur) orelse break :blk cap;
+        break :blk @min(cur, cap);
+    };
+    var fd: platform.fd_t = 3;
+    while (fd < limit) : (fd += 1) {
+        try closeFdIfInheritable(gc, actions, fd);
     }
+}
 
+fn closeFdIfInheritable(gc: *GC, actions: *spawn_c.FileActionsPtr, fd: platform.fd_t) PrimitiveError!void {
     const FD_CLOEXEC: c_int = 1;
-    for (fds.items) |fd| {
-        if (fd < 3) continue;
-        const flags = platform.getFdFlags(fd);
-        if (flags < 0) continue; // closed (or the enumeration dir's own fd)
-        if ((flags & FD_CLOEXEC) != 0) continue; // exec closes it anyway
-        if (spawn_c.posix_spawn_file_actions_addclose(actions, fd) != 0) {
-            _ = try spawnFileActionError(gc);
-        }
+    if (fd < 3) return;
+    const flags = platform.getFdFlags(fd);
+    if (flags < 0) return; // closed (or the enumeration dir's own fd)
+    if ((flags & FD_CLOEXEC) != 0) return; // exec closes it anyway
+    if (spawn_c.posix_spawn_file_actions_addclose(actions, fd) != 0) {
+        _ = try spawnFileActionError(gc);
     }
 }
 

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -173,6 +173,14 @@ fn getEnvVar(args: []const Value) PrimitiveError!Value {
 
 fn getEnvVars(args: []const Value) PrimitiveError!Value {
     _ = args;
+    return getEnvironmentAlist();
+}
+
+/// The current environment as an alist of `(name . value)` string pairs.
+/// Split out of `getEnvVars` (same body) so `(kaappi process)`'s
+/// `process-environment` returns the identical shape its `env:` option
+/// consumes — the copy-and-extend idiom composes exactly (KEP-0022).
+pub fn getEnvironmentAlist() PrimitiveError!Value {
     const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
 
     var result: Value = types.NIL;

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -723,6 +723,24 @@ fn printValueOnce(
             .channel => {
                 try writer.writeAll("#<channel>");
             },
+            // Atom-style, like fiber/channel: the three port fields are
+            // Values but are NOT printed here, so the printer never recurses
+            // into a Process and it needs no isTraversable/childAt entry
+            // (that list exists so cycle detection sees every *printed* edge
+            // -- kaappi#1954).
+            .process => {
+                const proc = obj.as(types.Process);
+                try writer.print("#<process {d} ", .{proc.pid});
+                if (proc.status) |st| {
+                    if (types.ifWaitSignaled(st)) {
+                        try writer.print("signaled {d}>", .{types.waitTermSig(st)});
+                    } else {
+                        try writer.print("exited {d}>", .{types.waitExitStatus(st)});
+                    }
+                } else {
+                    try writer.writeAll("running>");
+                }
+            },
             .mutex => {
                 const m = obj.as(types.Mutex);
                 try writer.writeAll("#<mutex");

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -616,6 +616,12 @@ const KqueueBackend = struct {
     fn init(_: std.mem.Allocator) !KqueueBackend {
         const kq = std.c.kqueue();
         if (kq < 0) return error.Unexpected;
+        // CLOEXEC: kqueue(2) takes no flags, and a kqueue fd IS a normal fd —
+        // inherited across fork and kept open across exec unless FD_CLOEXEC
+        // says otherwise (the comment on EpollBackend.init below long claimed
+        // the opposite). Without this, the reactor's kq leaks into every
+        // child the core spawns (KEP-0022 CLOEXEC audit).
+        _ = platform.setFdCloexec(kq);
         var self: KqueueBackend = .{ .kq = kq };
         var reg = std.c.Kevent{
             .ident = 0,
@@ -760,8 +766,9 @@ const EpollBackend = struct {
     fn init(_: std.mem.Allocator) !EpollBackend {
         // CLOEXEC: without it the epoll fd leaks into every child the core
         // spawns (thottam_proc.zig, native_compiler.zig via
-        // std.process.Child). kqueue needs no equivalent — kqueue(2) fds
-        // are never inherited across fork by design.
+        // std.process.Child). The kqueue backend sets FD_CLOEXEC after
+        // kqueue() in KqueueBackend.init -- same discipline, different
+        // mechanism, since kqueue(2) takes no flags argument.
         const rc = linux.epoll_create1(linux.EPOLL.CLOEXEC);
         if (linux.errno(rc) != .SUCCESS) return error.Unexpected;
         const epfd: i32 = @intCast(rc);

--- a/src/test_selection.zig
+++ b/src/test_selection.zig
@@ -478,7 +478,10 @@ fn runCapture(arena: std.mem.Allocator, argv: []const []const u8) ?CaptureResult
     if (pid == 0) {
         _ = std.c.close(pipe[0]);
         _ = std.c.dup2(pipe[1], 1);
-        const devnull = std.c.open("/dev/null", .{ .ACCMODE = .WRONLY });
+        // CLOEXEC on the null sink: the dup2 onto 2 clears it on the target
+        // only, so unlike before, the original slot cannot leak into the
+        // exec'd child (KEP-0022 Phase 1 audit).
+        const devnull = std.c.open("/dev/null", .{ .ACCMODE = .WRONLY, .CLOEXEC = true });
         if (devnull >= 0) _ = std.c.dup2(devnull, 2);
         _ = std.c.close(pipe[1]);
         _ = std.posix.system.execve(

--- a/src/tests_deepcopy.zig
+++ b/src/tests_deepcopy.zig
@@ -638,6 +638,20 @@ test "deepCopy rejects continuation" {
     try std.testing.expectError(error.UncopyableType, gc2.deepCopy(cont));
 }
 
+test "deepCopy rejects process" {
+    // A Process is thread-affine (KEP-0022, kaappi#2414): it must never
+    // cross a channel or a thread-start!/join copy boundary. The pid is
+    // bogus and never signaled or waited on blockingly; freeObject's
+    // last-resort WNOHANG reap tolerates it (ECHILD).
+    var gc1 = memory.GC.init(std.testing.allocator);
+    defer gc1.deinit();
+    var gc2 = memory.GC.init(std.testing.allocator);
+    defer gc2.deinit();
+
+    const proc = try gc1.allocProcess(1234, 0);
+    try std.testing.expectError(error.UncopyableType, gc2.deepCopy(types.makePointer(&proc.header)));
+}
+
 // #1978: file-info / user-info / group-info are pure value records and now
 // cross the thread boundary by value, like SchemeString. Each test copies
 // into a *fresh* GC (the thread-join!/channel shape) and checks every field.

--- a/src/tests_gc_tracing.zig
+++ b/src/tests_gc_tracing.zig
@@ -480,6 +480,28 @@ test "gc tracing: channel traces head and tail" {
     try expectTraced(&gc, ch_val, &.{ ref(head, 1), ref(tail, 2) });
 }
 
+test "gc tracing: process traces its three pipe ports" {
+    var gc = newGc();
+    defer gc.deinit();
+    const stdin_port = try young(&gc, 1);
+    const stdout_port = try young(&gc, 2);
+    const stderr_port = try young(&gc, 3);
+    const proc = try gc.allocProcess(123, 0);
+    proc.stdin_port = stdin_port;
+    proc.stdout_port = stdout_port;
+    proc.stderr_port = stderr_port;
+    try expectTraced(&gc, types.makePointer(&proc.header), &.{
+        ref(stdin_port, 1),
+        ref(stdout_port, 2),
+        ref(stderr_port, 3),
+    });
+    // Reaped in teardown: allocProcess enrolled it in unreaped_processes,
+    // and freeObject (via the sweep the next collection runs) removes it —
+    // the pid is bogus, but it is never waited on: the sweep and
+    // freeObject's last-resort reap tolerate a dead pid (ECHILD).
+    gc.collectFull();
+}
+
 test "gc tracing: mutex traces name, owner and specific" {
     var gc = newGc();
     defer gc.deinit();
@@ -1798,6 +1820,14 @@ test "gc tracing: heap-struct field inventory is unchanged" {
     expectFields(types.Guardian, &.{ "header", "is_transport", "registered", "ready" });
     expectFields(types.TransportCell, &.{ "header", "key", "value", "broken" });
     expectFields(types.NumericVector, &.{ "header", "kind", "data" });
+    // Only the three port fields are Value-bearing; pid/wait_handle/status/
+    // pgid are scalars and `waiters` is an opaque Phase-2 placeholder
+    // (KEP-0022) -- marking/sweeping obligations stop at the ports.
+    expectFields(types.Process, &.{
+        "header",     "pid",         "wait_handle", "status",
+        "stdin_port", "stdout_port", "stderr_port", "pgid",
+        "waiters",
+    });
 
     // Satellites the switches reach *through* — the highest-risk group,
     // because a new field here is invisible at the ObjectTag level entirely.
@@ -1835,7 +1865,7 @@ test "gc tracing: every ObjectTag has a case in this file" {
     // returns a NaN-boxed immediate, so no heap Flonum is ever created (the
     // tag, its struct and its five arms are vestigial). Keep this count in
     // step with ObjectTag so a new tag cannot be added without landing here.
-    try std.testing.expectEqual(@as(usize, 41), @typeInfo(types.ObjectTag).@"enum".fields.len);
+    try std.testing.expectEqual(@as(usize, 42), @typeInfo(types.ObjectTag).@"enum".fields.len);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests_process.zig
+++ b/src/tests_process.zig
@@ -529,6 +529,57 @@ test "process: the child's SIGPIPE disposition is reset to default" {
     );
 }
 
+test "process: pipe creation reclaims descriptors via GC on exhaustion (#1993)" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // A legal program may abandon process handles faster than the GC's
+    // allocation-count threshold trips; their parent-end pipe fds are then
+    // only released at a collection. spawn's pipe(2) must therefore mirror
+    // open(2)'s EMFILE recovery (kaappi#1993/#2324): collect and retry once.
+    // Deterministic version of what the OpenBSD CI leg's low `ulimit -n`
+    // caught in the spawn-loop rooting test: lower the soft NOFILE limit to
+    // a small headroom above the fds already open, then run more pipe
+    // spawns than the headroom allows — without the retry, spawn raises
+    // "cannot create stdout pipe" partway through.
+    const platform = @import("platform.zig");
+    var highest: std.posix.rlim_t = 0;
+    var fd: platform.fd_t = 0;
+    while (fd < 1024) : (fd += 1) {
+        if (platform.getFdFlags(fd) >= 0) highest = @intCast(fd);
+    }
+    const old = std.posix.getrlimit(.NOFILE) catch return error.SkipZigTest;
+    const lowered: std.posix.rlim_t = highest + 32;
+    if (lowered >= old.cur) return error.SkipZigTest; // already that low; nothing to prove
+    std.posix.setrlimit(.NOFILE, .{ .cur = lowered, .max = old.max }) catch return error.SkipZigTest;
+    defer std.posix.setrlimit(.NOFILE, old) catch {};
+
+    // Three pipes per spawn and no reads keep the fd burn rate (3/iteration)
+    // far ahead of the allocation rate, so the soft limit is reached well
+    // before the GC's own allocation-count threshold could trip a natural
+    // collection — without the retry this loop deterministically raises
+    // "cannot create ... pipe" partway through (verified by mutation:
+    // disabling the retry fails it).
+    const n: usize = 20;
+    const source = try std.fmt.allocPrint(std.testing.allocator,
+        \\(let loop ((i {d}) (acc 0))
+        \\  (if (= i 0)
+        \\      acc
+        \\      (let* ((p (spawn-process '("true") 'stdin: 'pipe 'stdout: 'pipe 'stderr: 'pipe))
+        \\             (st (process-wait p)))
+        \\        (loop (- i 1) (+ acc (if (= st 0) 1 0))))))
+    , .{n});
+    defer std.testing.allocator.free(source);
+    const result = vm.eval(source) catch |e| {
+        std.debug.print("spawn under lowered RLIMIT_NOFILE failed: {s}\n", .{vm.last_error_detail[0..vm.last_error_detail_len]});
+        return e;
+    };
+    try std.testing.expectEqual(@as(i64, @intCast(n)), types.toFixnum(result));
+}
+
 test "process: the sweep stores status without an explicit wait" {
     if (comptime !is_posix) return error.SkipZigTest;
     var ctx: th.TestContext = undefined;

--- a/src/tests_process.zig
+++ b/src/tests_process.zig
@@ -194,9 +194,9 @@ test "process: redirection matrix" {
     const vm = ctx.vm;
     _ = try vm.eval("(import (scheme file))");
 
-    // 'null: the child's stdout goes to the null device — the pipe
-    // accessor still exists (stdout was 'pipe), and reads EOF.
-    // (Two 'stdout: options: last wins — the null one.)
+    // 'null: the child's stdout goes to the null device. Two 'stdout:
+    // options are given and the last one wins, so the earlier 'pipe is
+    // discarded, no pipe is created, and the accessor is #f.
     try expectTrue(vm,
         \\(let* ((p (spawn-process '("/bin/echo" "discarded") 'stdout: 'pipe 'stdout: 'null)))
         \\  (and (eq? (process-stdout p) #f)

--- a/src/tests_process.zig
+++ b/src/tests_process.zig
@@ -672,18 +672,39 @@ test "process: spawn failure paths leak no descriptors (OOM sweep)" {
         }
     }.count;
 
-    const src =
-        \\(let ((p (spawn-process '("true") 'stdin: 'pipe 'stdout: 'pipe 'stderr: 'pipe)))
-        \\  (process-wait p) #t)
-    ;
+    // Compile the spawn once; the sweep then re-evals only a tiny call, so
+    // nearly all of each iteration's countdown budget lands inside the
+    // spawn path itself — denser failure-point coverage AND an order of
+    // magnitude less work per iteration, which is what keeps the emulated
+    // QEMU CI legs (riscv64/s390x/ppc64le) inside their job budget.
+    _ = try vm.eval(
+        \\(define (kaappi-oom-spawn-2442)
+        \\  (let ((p (spawn-process '("true") 'stdin: 'pipe 'stdout: 'pipe 'stderr: 'pipe)))
+        \\    (process-wait p) #t))
+    );
+    const src = "(kaappi-oom-spawn-2442)";
     // Baseline: one full run so lazily-created infrastructure (reactor fds,
-    // caches) exists before the count is taken.
+    // caches) exists before the count is taken — armed with a huge countdown
+    // whose remainder measures the call's TOTAL GC-allocation count, so the
+    // sweep below covers exactly the failure window and not one iteration
+    // more (every iteration past it is a full successful spawn that asserts
+    // nothing and, under the QEMU CI legs, costs real wall clock).
+    gc.oom_countdown = 100_000;
     _ = try vm.eval(src);
+    const total: u32 = @intCast(100_000 - (gc.oom_countdown orelse 0));
+    gc.oom_countdown = null;
+    // Sanity: a collapsed measurement (counting broken, or the call never
+    // reaching the spawn) would silently shrink the sweep to nothing. The
+    // real window is small by design — the compiled call's GC allocations
+    // are essentially just the Process, its ports, and the status decode —
+    // so the floor only guards against zero-shaped breakage.
+    try std.testing.expect(total >= 4);
     gc.collectFull();
     const before = countFds();
 
+    const upper = @min(total + 8, 250);
     var n: u32 = 0;
-    while (n < 400) : (n += 1) {
+    while (n < upper) : (n += 1) {
         gc.oom_countdown = n;
         _ = vm.eval(src) catch {};
         gc.oom_countdown = null;

--- a/src/tests_process.zig
+++ b/src/tests_process.zig
@@ -627,17 +627,18 @@ test "process: collecting an abandoned pipe port never blocks the sweep" {
     // wedged the collector. Fill the pipe near capacity (flushed), buffer
     // more below the high-water mark (unflushed), abandon everything, and
     // require the full collection to come back promptly.
-    // 12000 flushed fits even the smallest fixed pipe (OpenBSD's 16 KiB),
-    // so the flush itself can never block; the 60000-byte unflushed tail
-    // then exceeds the REMAINING capacity on every platform (16 KiB fixed
-    // and 64 KiB big-pipe alike), so the sweep's drain always meets a full
-    // pipe partway through.
+    // A 4096-byte flushed prefill is at or below one pipe page everywhere
+    // (Linux under the per-user pipe-page soft limit may hand out 2-page,
+    // 8 KiB pipes — kaappi#2442 review), so the explicit flush can never
+    // block; the 68000-byte unflushed tail then exceeds even a 64 KiB
+    // pipe's remaining capacity, so the abandoned buffer is guaranteed
+    // larger than what any drain could sink.
     try expectTrue(vm,
         \\(let* ((p (spawn-process '("/bin/sleep" "3") 'stdin: 'pipe))
         \\       (in (process-stdin p)))
-        \\  (write-string (make-string 12000 #\x) in)
+        \\  (write-string (make-string 4096 #\x) in)
         \\  (flush-output-port in)
-        \\  (write-string (make-string 60000 #\y) in)
+        \\  (write-string (make-string 68000 #\y) in)
         \\  #t)
     );
     const platform = @import("platform.zig");
@@ -719,23 +720,39 @@ test "process: spawn failure paths leak no descriptors (OOM sweep)" {
         _ = vm.eval(src) catch {};
         gc.oom_countdown = null;
     }
-    gc.collectFull();
+    // Registry check BEFORE collectFull (kaappi#2442 review: a collection
+    // would drop an unreachable Process entry even with its child still
+    // live, hiding exactly the leak this guards). At this point every
+    // legitimate flow has emptied it — successful iterations reaped via
+    // process-wait, spawnImpl-internal failures via the errdefer's blocking
+    // kill+reap, caller-path SIGKILLed stragglers via the WNOHANG sweep —
+    // so a survivor is an abandoned child.
     sweepUnreapedForTest(gc);
+    try std.testing.expectEqual(@as(usize, 0), gc.unreaped_processes.items.len);
+
+    gc.collectFull();
     const after = countFds();
     try std.testing.expectEqual(before, after);
 
-    // No abandoned children either: every spawnImpl-internal failure must
-    // have killed AND reaped its fresh child (kaappi#2442 review) — the
-    // reap in killAndReapFresh is a BLOCKING waitpid, so those paths
-    // structurally cannot leave a zombie — and the registry must be empty.
-    // A countdown that fires in the *caller's* kill/wait after a
-    // successful spawn abandons the Process by the caller's own hand (the
-    // documented GC.unreaped_processes window, not spawnImpl's contract);
-    // its SIGKILLed child may still be mid-death on a slow box, so such
-    // stragglers are drained rather than asserted against.
-    try std.testing.expectEqual(@as(usize, 0), gc.unreaped_processes.items.len);
-    var zst: c_int = 0;
-    while (platform.waitPid(-1, &zst, platform.WNOHANG) > 0) {}
+    // And the OS agrees: within a bounded window, waitpid(-1) must reach
+    // -1/ECHILD — no child of ours left, living or zombie. A persistent 0
+    // is a LIVE abandoned child (the mutation shape: spawnImpl failing
+    // without killing) and fails the test; positive returns are killed
+    // stragglers mid-death on a slow box, reaped and retried. The caller's
+    // own kill runs before its first post-spawn allocation, so a countdown
+    // cannot abandon an un-killed child by the caller's hand here.
+    var reached_echild = false;
+    var tries: u32 = 0;
+    while (tries < 500) : (tries += 1) {
+        var zst: c_int = 0;
+        const r = platform.waitPid(-1, &zst, platform.WNOHANG);
+        if (r < 0) {
+            reached_echild = true;
+            break;
+        }
+        if (r == 0) platform.sleepNs(10 * std.time.ns_per_ms);
+    }
+    try std.testing.expect(reached_echild);
 }
 
 /// Reap any stragglers the OOM sweep left (children whose Process was
@@ -941,8 +958,19 @@ test "process: explicit stdio self-redirect needs no spare descriptor" {
     }
     if (!filled_up) return error.SkipZigTest; // could not exhaust the table
 
-    // Control: a staged duplicate is impossible right now.
+    // Control 1: a staged duplicate is impossible right now.
     try std.testing.expect(platform.dupCloexecAtLeast(1, 3) < 0);
+
+    // Control 2: a PLAIN spawn must work under the full table, or the
+    // premise doesn't hold in this environment and the redirect assertion
+    // below would blame the wrong thing. Concretely: under QEMU
+    // user-emulation (the ppc64le/s390x CI legs), binfmt needs a spare
+    // descriptor to load the interpreter before the child ever reaches its
+    // exec-time CLOEXEC cleanup, so no spawn at all survives a zero-free
+    // table there (kaappi#2442 review; CI jobs 99546383549/99546383648).
+    _ = vm.eval(
+        \\(let ((p (spawn-process '("true")))) (process-wait p) #t)
+    ) catch return error.SkipZigTest;
 
     try expectTrue(vm,
         \\(let ((p (spawn-process '("true") 'stdout: (current-output-port))))

--- a/src/tests_process.zig
+++ b/src/tests_process.zig
@@ -1,0 +1,549 @@
+//! Unit tests for `(kaappi process)` — KEP-0022 Phase 1 (POSIX).
+//!
+//! Every test spawns real children through /bin/sh (present on every hosted
+//! POSIX CI target: macOS, Linux, the three BSDs), so these cover the actual
+//! posix_spawnp path, not a mock. The suite skips on WASM and Windows, where
+//! the library itself is unregistered.
+//!
+//! GC discipline inside the tests: any Value held in a Zig local across an
+//! allocating call is rooted (pushRoot/popRoot), and loops that would be
+//! quadratic under `-Dgc-stress` scale their iteration counts down via
+//! build_options.gc_stress.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const th = @import("testing_helpers.zig");
+const types = @import("types.zig");
+const vm_mod = @import("vm.zig");
+const build_options = @import("build_options");
+
+const is_posix = switch (builtin.os.tag) {
+    .windows, .wasi => false,
+    else => true,
+};
+
+const shell = "/bin/sh";
+
+/// expectEvalTrue, but on a caller-owned VM — for the tests that need
+/// several evals to share one interaction environment (imports, defines).
+fn expectTrue(vm: *vm_mod.VM, source: []const u8) !void {
+    const result = vm.eval(source) catch |e| {
+        std.debug.print("eval error from: {s}\n  detail: {s}\n", .{ source, vm.last_error_detail[0..vm.last_error_detail_len] });
+        return e;
+    };
+    if (result != types.TRUE) {
+        std.debug.print("expected #t from: {s}\n", .{source});
+        return error.TestExpectedTrue;
+    }
+}
+
+fn evalTo(vm: *vm_mod.VM, source: []const u8) ![]u8 {
+    const printer = @import("printer.zig");
+    const result = try vm.eval(source);
+    return printer.valueToString(std.testing.allocator, result, .write);
+}
+
+test "process: cond-expand library gate is present on POSIX" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const s = try evalTo(ctx.vm, "(cond-expand ((library (kaappi process)) 'present) (else 'absent))");
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("present", s);
+}
+
+test "process: spawn, wait, status matrix" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // Normal exit 0 and a propagated nonzero code
+    try expectTrue(vm, "(= 0 (process-wait (spawn-process '(\"true\"))))");
+    try expectTrue(vm, "(= 7 (process-wait (spawn-process '(\"/bin/sh\" \"-c\" \"exit 7\"))))");
+
+    // status is #f while running (a sleeper pinned open by its own stdin
+    // pipe, so there is no exit race with the poll), the code after; waiting
+    // a reaped process returns the stored status immediately. process-status
+    // itself reaps non-blockingly, so it must never return #f for an
+    // already-exited child — the sleeper is the only way to see #f.
+    try expectTrue(vm,
+        \\(let* ((p (spawn-process '("/bin/sh" "-c" "read x; exit 3") 'stdin: 'pipe))
+        \\       (s1 (process-status p)))
+        \\  (write-string "go\n" (process-stdin p))
+        \\  (close-output-port (process-stdin p))
+        \\  (let* ((w1 (process-wait p))
+        \\         (s2 (process-status p))
+        \\         (w2 (process-wait p)))
+        \\    (and (eq? s1 #f) (= w1 3) (= s2 3) (= w2 3))))
+    );
+
+    // process-status reaps on its own: after the child is certainly gone,
+    // polling (with no intervening process-wait) reports the code.
+    try expectTrue(vm,
+        \\(let ((p (spawn-process '("/bin/sh" "-c" "exit 4"))))
+        \\  (let loop ((n 0))
+        \\    (let ((st (process-status p)))
+        \\      (cond ((and (integer? st) (= st 4)) #t)
+        \\            ((> n 5000000) 'timeout)
+        \\            (else (loop (+ n 1)))))))
+    );
+
+    // Signaled death: (signaled . n). $$ is sh's own pid.
+    try expectTrue(vm,
+        \\(let* ((p (spawn-process '("/bin/sh" "-c" "kill -9 $$")))
+        \\       (st (process-wait p)))
+        \\  (and (pair? st) (eq? (car st) 'signaled) (= (cdr st) 9)))
+    );
+
+    // process-kill default is SIGTERM (15)
+    try expectTrue(vm,
+        \\(let* ((p (spawn-process '("/bin/sleep" "30")))
+        \\       (st (and (process-kill p) (process-wait p))))
+        \\  (and (pair? st) (eq? (car st) 'signaled) (= (cdr st) 15)))
+    );
+}
+
+test "process: kill after reap is a no-op, never re-signals the pid" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // A second kill after reap must quietly do nothing — the pid may be
+    // reused, so signaling it again could hit an unrelated process.
+    try expectTrue(vm,
+        \\(let* ((p (spawn-process '("true")))
+        \\       (st (process-wait p)))
+        \\  (and (= st 0) (process-kill p) (process-kill p 'signal: 9) #t))
+    );
+}
+
+test "process: predicates and accessors" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    try expectTrue(vm, "(process? (spawn-process '(\"true\")))");
+    try expectTrue(vm, "(not (process? 42))");
+    try expectTrue(vm, "(not (process? (open-input-string \"x\")))");
+
+    // pid is a positive integer; group is #f without new-group:
+    try expectTrue(vm,
+        \\(let ((p (spawn-process '("true"))))
+        \\  (and (integer? (process-pid p)) (> (process-pid p) 0)
+        \\       (eq? (process-group p) #f)
+        \\       (= (process-wait p) 0)))
+    );
+
+    // new-group: makes the child its own leader: pgid == pid
+    try expectTrue(vm,
+        \\(let ((p (spawn-process '("true") 'new-group: #t)))
+        \\  (and (= (process-group p) (process-pid p))
+        \\       (= (process-wait p) 0)))
+    );
+
+    // Accessors: a port for the 'pipe spec, #f for every other spec
+    try expectTrue(vm,
+        \\(let ((p (spawn-process '("true") 'stdout: 'pipe)))
+        \\  (and (port? (process-stdout p))
+        \\       (eq? (process-stdin p) #f)
+        \\       (eq? (process-stderr p) #f)
+        \\       (= (process-wait p) 0)))
+    );
+
+    // Type errors on non-process arguments
+    try std.testing.expectError(vm_mod.VMError.TypeError, vm.eval("(process-pid 3)"));
+    try std.testing.expectError(vm_mod.VMError.TypeError, vm.eval("(process-stdout 'sym)"));
+    try std.testing.expectError(vm_mod.VMError.TypeError, vm.eval("(process-wait #f)"));
+    try std.testing.expectError(vm_mod.VMError.TypeError, vm.eval("(process-kill \"x\")"));
+}
+
+test "process: stdin/stdout pipe round trip" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // cat echoes stdin back: write, half-close (EOF for cat), read, wait.
+    const s = try evalTo(vm,
+        \\(let* ((p (spawn-process '("/bin/cat") 'stdin: 'pipe 'stdout: 'pipe))
+        \\       (in (process-stdin p))
+        \\       (out (process-stdout p)))
+        \\  (write-string "round-trip" in)
+        \\  (flush-output-port in)
+        \\  (close-output-port in)
+        \\  (let ((line (read-line out)))
+        \\    (list line (process-wait p))))
+    );
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("(\"round-trip\" 0)", s);
+}
+
+test "process: redirection matrix" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+    _ = try vm.eval("(import (scheme file))");
+
+    // 'null: the child's stdout goes to the null device — the pipe
+    // accessor still exists (stdout was 'pipe), and reads EOF.
+    // (Two 'stdout: options: last wins — the null one.)
+    try expectTrue(vm,
+        \\(let* ((p (spawn-process '("/bin/echo" "discarded") 'stdout: 'pipe 'stdout: 'null)))
+        \\  (and (eq? (process-stdout p) #f)
+        \\       (= (process-wait p) 0)))
+    );
+
+    // A caller-supplied fd port as stdout: the child writes INTO the port's
+    // descriptor; the accessor is #f and no pipe was created.
+    try expectTrue(vm,
+        \\(let* ((path "/tmp/kaappi-process-test.out")
+        \\       (sink (open-output-file path))
+        \\       (p (spawn-process '("/bin/echo" "to-file") 'stdout: sink)))
+        \\  (and (eq? (process-stdout p) #f)
+        \\       (= (process-wait p) 0)
+        \\       (begin (close-port sink) #t)))
+    );
+    const content = try evalTo(vm,
+        \\(call-with-input-file "/tmp/kaappi-process-test.out" read-line)
+    );
+    defer std.testing.allocator.free(content);
+    try std.testing.expectEqualStrings("\"to-file\"", content);
+
+    // An fd port as stdin: the child reads FROM the file descriptor
+    try expectTrue(vm,
+        \\(let* ((sink (open-output-file "/tmp/kaappi-process-test.in")))
+        \\  (write-string "from-file" sink)
+        \\  (close-port sink)
+        \\  (let* ((src (open-input-file "/tmp/kaappi-process-test.in"))
+        \\         (p (spawn-process '("/bin/cat") 'stdin: src 'stdout: 'pipe))
+        \\         (line (read-line (process-stdout p))))
+        \\    (and (string? line) (= (process-wait p) 0))))
+    );
+
+    // stderr 'stdout merges the streams: both lines land on the stdout
+    // pipe, and the stderr accessor is #f. sh sequences the two echoes.
+    const merged = try evalTo(vm,
+        \\(let* ((p (spawn-process '("/bin/sh" "-c" "echo out; echo err 1>&2")
+        \\                            'stdout: 'pipe 'stderr: 'stdout))
+        \\       (l1 (read-line (process-stdout p)))
+        \\       (l2 (read-line (process-stdout p))))
+        \\  (list l1 l2 (eq? (process-stderr p) #f) (process-wait p)))
+    );
+    defer std.testing.allocator.free(merged);
+    try std.testing.expectEqualStrings("(\"out\" \"err\" #t 0)", merged);
+
+    // 'inherit (the default) keeps the parent's own stdio: #f everywhere
+    try expectTrue(vm,
+        \\(let ((p (spawn-process '("true"))))
+        \\  (and (eq? (process-stdin p) #f)
+        \\       (eq? (process-stdout p) #f)
+        \\       (eq? (process-stderr p) #f)
+        \\       (= (process-wait p) 0)))
+    );
+}
+
+test "process: env replaces wholesale" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    const s = try evalTo(vm,
+        \\(let* ((p (spawn-process '("/bin/sh" "-c" "echo $KAPVAR1:$KAPVAR2")
+        \\                         'stdout: 'pipe
+        \\                         'env: '(("KAPVAR1" . "one") ("KAPVAR2" . "two")))))
+        \\  (read-line (process-stdout p)))
+    );
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("\"one:two\"", s);
+
+    // The empty list means an EMPTY environment (not "inherit"): HOME is
+    // gone, so the default expansion prints "unset" rather than the
+    // inherited home directory.
+    const empty_env = try evalTo(vm,
+        \\(let* ((p (spawn-process '("/bin/sh" "-c" "echo ${HOME:-unset}")
+        \\                         'stdout: 'pipe 'env: '())))
+        \\  (read-line (process-stdout p)))
+    );
+    defer std.testing.allocator.free(empty_env);
+    try std.testing.expectEqualStrings("\"unset\"", empty_env);
+
+    // Malformed entries are type errors
+    try std.testing.expectError(vm_mod.VMError.TypeError, vm.eval(
+        "(spawn-process '(\"true\") 'env: '((\"OK\" . 1)))",
+    ));
+}
+
+test "process: process-environment returns a (name . value) alist" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // Every entry is a pair of strings, PATH is present, and the shape
+    // feeds straight back into env: (the copy-and-extend idiom).
+    try expectTrue(vm,
+        \\(let* ((env (process-environment))
+        \\       (all-pairs (let loop ((rest env) (ok #t))
+        \\                    (cond ((null? rest) ok)
+        \\                          ((and (pair? (car rest))
+        \\                                (string? (car (car rest)))
+        \\                                (string? (cdr (car rest))))
+        \\                           (loop (cdr rest) ok))
+        \\                          (else #f)))))
+        \\  (and all-pairs (pair? (assoc "PATH" env))))
+    );
+}
+
+test "process: fd hygiene — the child inherits only the three stdio slots" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // Close-by-default means the strong assertion holds even inside the
+    // unit-test binary, whatever descriptors the harness (or kcov) holds:
+    // CLOEXEC fds die at exec, non-CLOEXEC strays are closed by the
+    // spawner's explicit close actions (macOS: CLOEXEC_DEFAULT). The child
+    // probes openness by DUPLICATING each fd (`: <&N` in a subshell) — a
+    // stat of /dev/fd/N would false-positive on the BSDs, where those
+    // entries are static device nodes that exist whether or not the fd is
+    // open.
+    try expectTrue(vm,
+        \\(let* ((p (spawn-process '("/bin/sh" "-c" "i=3; while [ $i -le 32 ]; do if (eval \": <&$i\") 2>/dev/null; then echo $i; fi; i=$((i+1)); done")
+        \\                            'stdout: 'pipe))
+        \\       (out (process-stdout p)))
+        \\  (let loop ((acc '()))
+        \\    (let ((line (read-line out)))
+        \\      (if (eof-object? line)
+        \\          (begin (process-wait p) (null? acc))
+        \\          (loop (cons line acc))))))
+    );
+}
+
+test "process: fd hygiene — a deliberately inheritable fd is closed for the child" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // The kaappi#2414 review repro: an fd Kaappi *inherited* (here: opened
+    // via raw libc with no O_CLOEXEC, standing in for `kaappi 9</dev/null`)
+    // has no CLOEXEC flag, so only the spawner's close-by-default pass can
+    // keep it out of the child. First prove the probe discriminates — the
+    // fd IS open and non-CLOEXEC in the parent — then spawn a child that
+    // must find it closed (dup of it fails -> exit 1).
+    const platform = @import("platform.zig");
+    const fd = std.c.open("/dev/null", .{ .ACCMODE = .RDONLY }, @as(c_uint, 0));
+    try std.testing.expect(fd >= 3);
+    defer _ = platform.close(fd);
+    const flags = platform.getFdFlags(fd);
+    try std.testing.expect(flags >= 0);
+    try std.testing.expect((flags & 1) == 0); // no FD_CLOEXEC: genuinely inheritable
+
+    const source = try std.fmt.allocPrint(std.testing.allocator,
+        \\(let ((p (spawn-process '("/bin/sh" "-c" "if (eval \": <&{d}\") 2>/dev/null; then exit 1; else exit 0; fi"))))
+        \\  (= (process-wait p) 0))
+    , .{fd});
+    defer std.testing.allocator.free(source);
+    try expectTrue(vm, source);
+}
+
+test "process: gc-stress rooting of Process and its ports" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // Under -Dgc-stress every allocation collects, so a spawn loop stresses
+    // the Process/port rooting discipline hard. Iterations scale down; the
+    // assertion is behavioral (exit status + output), so a mis-rooted port
+    // would surface as a wrong read or a crash.
+    const n: usize = if (build_options.gc_stress) 20 else 200;
+    const source = try std.fmt.allocPrint(std.testing.allocator,
+        \\(let loop ((i {d}) (acc 0))
+        \\  (if (= i 0)
+        \\      acc
+        \\      (let* ((p (spawn-process '("{s}" "-c" "echo x") 'stdout: 'pipe))
+        \\             (line (read-line (process-stdout p)))
+        \\             (st (process-wait p)))
+        \\        (loop (- i 1) (+ acc (if (and (string? line) (= st 0)) 1 0))))))
+    , .{ n, shell });
+    defer std.testing.allocator.free(source);
+    const result = try vm.eval(source);
+    try std.testing.expectEqual(@as(i64, @intCast(n)), types.toFixnum(result));
+}
+
+test "process: spawn failure raises a catchable file error" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // ENOENT rides the condition; file-error? sees it.
+    try expectTrue(vm,
+        \\(guard (e ((file-error? e) #t) (else 'wrong-kind))
+        \\  (spawn-process '("/nonexistent/kaappi-test-program")))
+    );
+
+    // argv must be a non-empty list of strings: '() fails the pair check
+    // (TypeError), a non-string element the element check.
+    try std.testing.expectError(vm_mod.VMError.TypeError, vm.eval("(spawn-process '())"));
+    try std.testing.expectError(vm_mod.VMError.TypeError, vm.eval("(spawn-process '(\"/bin/echo\" 42))"));
+
+    // 'stdout is a stderr-only spec
+    try std.testing.expectError(vm_mod.VMError.InvalidArgument, vm.eval("(spawn-process '(\"true\") 'stdout: 'stdout)"));
+}
+
+test "process: printer shows pid and state without erroring" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // #<process PID running> while live, #<process PID exited N> reaped:
+    // assert the shape via string prefixes/suffixes, not the pid itself.
+    const s = try evalTo(vm,
+        \\(let* ((p (spawn-process '("true")))
+        \\       (sp1 (open-output-string)))
+        \\  (write p sp1)
+        \\  (let ((running (get-output-string sp1)))
+        \\    (process-wait p)
+        \\    (let ((sp2 (open-output-string)))
+        \\      (write p sp2)
+        \\      (list (string-prefix? "#<process " running)
+        \\            (string-suffix? "running>" running)
+        \\            (string-prefix? "#<process " (get-output-string sp2))
+        \\            (string-suffix? "exited 0>" (get-output-string sp2))))))
+    );
+    defer std.testing.allocator.free(s);
+    try std.testing.expectEqualStrings("(#t #t #t #t)", s);
+}
+
+test "process: cyclic argv and env lists are errors, not hangs" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // kaappi#2414 review: types.listLength-style walks spin forever on a
+    // legal cyclic pair, uninterruptibly, inside the native primitive. Both
+    // list surfaces must reject the cycle instead.
+    try std.testing.expectError(vm_mod.VMError.InvalidArgument, vm.eval(
+        \\(let ((x (list "true"))) (set-cdr! x x) (spawn-process x))
+    ));
+    try std.testing.expectError(vm_mod.VMError.InvalidArgument, vm.eval(
+        \\(let ((e (list (cons "A" "b")))) (set-cdr! e e)
+        \\  (spawn-process '("true") 'env: e))
+    ));
+}
+
+test "process: embedded NUL bytes are rejected on every C-string surface" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // kaappi#2414 review: dupeZ would silently truncate at the interior NUL
+    // — the child would receive (or exec!) something other than what the
+    // program supplied. \x0; is R7RS string-escape syntax for U+0000.
+    try std.testing.expectError(vm_mod.VMError.InvalidArgument, vm.eval(
+        "(spawn-process '(\"/bin/echo\" \"a\\x0;b\"))",
+    ));
+    try std.testing.expectError(vm_mod.VMError.InvalidArgument, vm.eval(
+        "(spawn-process '(\"true\") 'env: '((\"A\\x0;B\" . \"v\")))",
+    ));
+    try std.testing.expectError(vm_mod.VMError.InvalidArgument, vm.eval(
+        "(spawn-process '(\"true\") 'env: '((\"A\" . \"v\\x0;w\")))",
+    ));
+    try std.testing.expectError(vm_mod.VMError.InvalidArgument, vm.eval(
+        "(spawn-process '(\"true\") 'directory: \"/tm\\x0;p\")",
+    ));
+    // Environment-name shape: empty and '='-carrying names could
+    // reinterpret the entry.
+    try std.testing.expectError(vm_mod.VMError.InvalidArgument, vm.eval(
+        "(spawn-process '(\"true\") 'env: '((\"\" . \"v\")))",
+    ));
+    try std.testing.expectError(vm_mod.VMError.InvalidArgument, vm.eval(
+        "(spawn-process '(\"true\") 'env: '((\"A=B\" . \"v\")))",
+    ));
+}
+
+test "process: writing to a dead child's stdin raises a catchable EPIPE error" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // kaappi#2414 review: with SIGPIPE ignored process-wide, the KEP-0005
+    // contract is that the EPIPE surfaces as an ordinary catchable
+    // file-error on the explicit write/flush — not a silently dropped
+    // buffer reporting success.
+    try expectTrue(vm,
+        \\(let ((p (spawn-process '("true") 'stdin: 'pipe)))
+        \\  (process-wait p)
+        \\  (guard (e ((file-error? e) #t) (else 'wrong-kind))
+        \\    (write-string "into the void" (process-stdin p))
+        \\    (flush-output-port (process-stdin p))
+        \\    'not-raised))
+    );
+}
+
+test "process: the child's SIGPIPE disposition is reset to default" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // kaappi#2414 review: the parent runs with SIGPIPE ignored (VM.init) and
+    // ignored dispositions survive exec, so without POSIX_SPAWN_SETSIGDEF a
+    // child would silently inherit the runtime's policy. A self-SIGPIPE must
+    // therefore kill it: (signaled . 13). This also pins the SETSIGDEF flag
+    // *value*, which differs between the BSDs (0x10) and everyone else
+    // (0x04) — the wrong constant makes this test report a normal exit.
+    try expectTrue(vm,
+        \\(let* ((p (spawn-process '("/bin/sh" "-c" "kill -PIPE $$; exit 42")))
+        \\       (st (process-wait p)))
+        \\  (and (pair? st) (eq? (car st) 'signaled) (= (cdr st) 13)))
+    );
+}
+
+test "process: the sweep stores status without an explicit wait" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // p1 exits on its own; p2's spawn runs the WNOHANG sweep first, which
+    // may already reap p1 and store its status. Waiting p1 afterwards must
+    // return 5 without blocking, whichever way it went.
+    try expectTrue(vm,
+        \\(begin
+        \\  (define p1 (spawn-process '("/bin/sh" "-c" "exit 5")))
+        \\  (define p2 (spawn-process '("/bin/sh" "-c" "exit 0")))
+        \\  (= (process-wait p2) 0))
+    );
+    try expectTrue(vm, "(= (process-wait p1) 5)");
+}

--- a/src/tests_process.zig
+++ b/src/tests_process.zig
@@ -627,12 +627,17 @@ test "process: collecting an abandoned pipe port never blocks the sweep" {
     // wedged the collector. Fill the pipe near capacity (flushed), buffer
     // more below the high-water mark (unflushed), abandon everything, and
     // require the full collection to come back promptly.
+    // 12000 flushed fits even the smallest fixed pipe (OpenBSD's 16 KiB),
+    // so the flush itself can never block; the 60000-byte unflushed tail
+    // then exceeds the REMAINING capacity on every platform (16 KiB fixed
+    // and 64 KiB big-pipe alike), so the sweep's drain always meets a full
+    // pipe partway through.
     try expectTrue(vm,
         \\(let* ((p (spawn-process '("/bin/sleep" "3") 'stdin: 'pipe))
         \\       (in (process-stdin p)))
-        \\  (write-string (make-string 60000 #\x) in)
+        \\  (write-string (make-string 12000 #\x) in)
         \\  (flush-output-port in)
-        \\  (write-string (make-string 8100 #\y) in)
+        \\  (write-string (make-string 60000 #\y) in)
         \\  #t)
     );
     const platform = @import("platform.zig");
@@ -677,10 +682,15 @@ test "process: spawn failure paths leak no descriptors (OOM sweep)" {
     // spawn path itself — denser failure-point coverage AND an order of
     // magnitude less work per iteration, which is what keeps the emulated
     // QEMU CI legs (riscv64/s390x/ppc64le) inside their job budget.
+    // A LONG-LIVED child (self-killed on the success path), not `true`:
+    // with a child that exits instantly, a failure path that abandons a
+    // still-running child is invisible — the child is gone before any
+    // assertion looks (kaappi#2442 review). With `sleep`, an abandoned
+    // child survives to the post-sweep checks below.
     _ = try vm.eval(
         \\(define (kaappi-oom-spawn-2442)
-        \\  (let ((p (spawn-process '("true") 'stdin: 'pipe 'stdout: 'pipe 'stderr: 'pipe)))
-        \\    (process-wait p) #t))
+        \\  (let ((p (spawn-process '("/bin/sleep" "30") 'stdin: 'pipe 'stdout: 'pipe 'stderr: 'pipe)))
+        \\    (process-kill p 'signal: 9) (process-wait p) #t))
     );
     const src = "(kaappi-oom-spawn-2442)";
     // Baseline: one full run so lazily-created infrastructure (reactor fds,
@@ -713,6 +723,19 @@ test "process: spawn failure paths leak no descriptors (OOM sweep)" {
     sweepUnreapedForTest(gc);
     const after = countFds();
     try std.testing.expectEqual(before, after);
+
+    // No abandoned children either: every spawnImpl-internal failure must
+    // have killed AND reaped its fresh child (kaappi#2442 review) — the
+    // reap in killAndReapFresh is a BLOCKING waitpid, so those paths
+    // structurally cannot leave a zombie — and the registry must be empty.
+    // A countdown that fires in the *caller's* kill/wait after a
+    // successful spawn abandons the Process by the caller's own hand (the
+    // documented GC.unreaped_processes window, not spawnImpl's contract);
+    // its SIGKILLed child may still be mid-death on a slow box, so such
+    // stragglers are drained rather than asserted against.
+    try std.testing.expectEqual(@as(usize, 0), gc.unreaped_processes.items.len);
+    var zst: c_int = 0;
+    while (platform.waitPid(-1, &zst, platform.WNOHANG) > 0) {}
 }
 
 /// Reap any stragglers the OOM sweep left (children whose Process was
@@ -755,15 +778,174 @@ test "process: close-by-default reaches descriptors above 65536" {
     try std.testing.expect(flags >= 0);
     try std.testing.expect((flags & 1) == 0); // inheritable
 
-    // Control: the probe must DETECT an open fd, or "closed" verdicts below
-    // are vacuous (a shell that rejects multi-digit redirection fds would
-    // report every fd closed). fd 2 is inherited and certainly open.
+    // The probe cannot be a shell `<&70000` dup: FreeBSD's /bin/sh rejects
+    // the multi-digit operand outright, so it reports every high fd closed
+    // and the test would stay green with addclosefrom_np removed
+    // (kaappi#2442 review). Instead, ask the OS's own fd inventory — the
+    // per-OS spelling below is exact on the platforms this test can run on
+    // (the BSDs without such an inventory have default limits far below
+    // 70000 and skip at the dup2 above). Each probe is validated by an
+    // fd-2 control that must report OPEN before the 70000 verdict counts.
+    const probe = struct {
+        fn cmd(comptime fd_str: []const u8, comptime open_exit: []const u8, comptime closed_exit: []const u8) []const u8 {
+            const check = switch (builtin.os.tag) {
+                .macos, .ios => "[ -e /dev/fd/" ++ fd_str ++ " ]",
+                .linux => "[ -e /proc/self/fd/" ++ fd_str ++ " ]",
+                .freebsd => "procstat -f $$ 2>/dev/null | awk '$3 == " ++ fd_str ++ "' | grep -q .",
+                else => "",
+            };
+            return "(let ((p (spawn-process (list \"/bin/sh\" \"-c\" \"if " ++ check ++
+                "; then exit " ++ open_exit ++ "; else exit " ++ closed_exit ++
+                "; fi\")))) (= (process-wait p) 0))";
+        }
+    };
+    if (comptime (builtin.os.tag != .macos and builtin.os.tag != .ios and
+        builtin.os.tag != .linux and builtin.os.tag != .freebsd)) return error.SkipZigTest;
+    try expectTrue(vm, comptime probe.cmd("2", "0", "1")); // control: OPEN detected
+    try expectTrue(vm, comptime probe.cmd("70000", "1", "0")); // must be CLOSED
+}
+
+test "process: a bidirectional redirect port reconciles read-ahead before its output" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+    const platform = @import("platform.zig");
+
+    // kaappi#2442 review: draining buffered output BEFORE rewinding the
+    // input read-ahead lands the parent's writes at the stale kernel offset
+    // (end of the read-ahead chunk) instead of the logical position. With
+    // an O_RDWR file holding ABCDEF: read A (pulling BCDEF into
+    // read-ahead), buffer X, hand the port to a child — the file must
+    // become AXCDEF (X at the logical position) and the child must read
+    // from position 2 (C), not from wherever the raw offset drifted.
+    const path = "/tmp/kaappi-bidi-2442.txt";
+    {
+        const f = std.c.open(path, .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true }, @as(c_uint, 0o644));
+        try std.testing.expect(f >= 0);
+        _ = platform.write(f, "ABCDEF", 6);
+        _ = platform.close(f);
+    }
+    // No defer close: fd->port takes ownership of `rw`, and the collected
+    // port's sweep closes it — a second close here could hit a reused fd.
+    const rw = std.c.open(path, .{ .ACCMODE = .RDWR }, @as(c_uint, 0));
+    try std.testing.expect(rw >= 0);
+
+    const source = try std.fmt.allocPrint(std.testing.allocator,
+        \\(let* ((bp (fd->port {d}))
+        \\       (first (read-char bp)))
+        \\  (write-string "X" bp)
+        \\  (let* ((p (spawn-process '("/bin/sh" "-c" "dd bs=1 count=1 2>/dev/null")
+        \\                           'stdin: bp 'stdout: 'pipe))
+        \\         (child-first (read-line (process-stdout p)))
+        \\         (st (process-wait p)))
+        \\    (and (char=? first #\A) (equal? child-first "C") (= st 0))))
+    , .{rw});
+    defer std.testing.allocator.free(source);
+    _ = try vm.eval("(import (kaappi ffi))");
+    try expectTrue(vm, source);
+
+    var buf: [8]u8 = undefined;
+    const chk = std.c.open(path, .{ .ACCMODE = .RDONLY }, @as(c_uint, 0));
+    try std.testing.expect(chk >= 0);
+    defer _ = platform.close(chk);
+    const nread = platform.read(chk, &buf, 8);
+    try std.testing.expectEqual(@as(isize, 6), nread);
+    try std.testing.expectEqualStrings("AXCDEF", buf[0..6]);
+}
+
+test "process: the sweep's teardown drain leaves dup aliases blocking" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+    const platform = @import("platform.zig");
+
+    // kaappi#2442 review: O_NONBLOCK lives on the shared open-file
+    // description, so the sweep's teardown flip must be undone before the
+    // close or every dup/dup2 alias of the descriptor comes out of a
+    // collection permanently non-blocking.
+    var fds: [2]platform.fd_t = .{ -1, -1 };
+    try std.testing.expectEqual(@as(c_int, 0), platform.pipe(&fds));
+    defer {
+        if (fds[0] >= 0) _ = platform.close(fds[0]);
+    }
+    const alias = platform.fcntlDupCloexec(fds[1]);
+    try std.testing.expect(alias >= 0);
+    defer _ = platform.close(alias);
+
+    const nonblock: c_int = @intCast(@as(u32, @bitCast(std.posix.O{ .NONBLOCK = true })));
+    const flags_before = std.c.fcntl(alias, std.posix.F.GETFL, @as(c_int, 0));
+    try std.testing.expect(flags_before >= 0);
+    try std.testing.expect((flags_before & nonblock) == 0);
+
+    // Wrap the write end in a port, buffer output without flushing, drop
+    // the port, and collect: the sweep drains (flipping the description
+    // non-blocking for the drain) and closes the port's fd.
+    const source = try std.fmt.allocPrint(std.testing.allocator,
+        \\(let ((p (fd->port {d}))) (write-string "x" p) #t)
+    , .{fds[1]});
+    defer std.testing.allocator.free(source);
+    _ = try vm.eval("(import (kaappi ffi))");
+    try expectTrue(vm, source);
+    fds[1] = -1; // the collected port owns and closes it
+    ctx.gc.collectFull();
+
+    const flags_after = std.c.fcntl(alias, std.posix.F.GETFL, @as(c_int, 0));
+    try std.testing.expect(flags_after >= 0);
+    try std.testing.expect((flags_after & nonblock) == 0);
+}
+
+test "process: explicit stdio self-redirect needs no spare descriptor" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    if (build_options.gc_stress) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+    const platform = @import("platform.zig");
+
+    // kaappi#2442 review: `stdout: (current-output-port)` is explicit
+    // inheritance — source fd == destination slot — and must not require a
+    // staging duplicate, or it fails under a full fd table where the plain
+    // default succeeds. Starve the PARENT's table by lowering the soft
+    // limit to a still-comfortable 256 and filling it with CLOEXEC
+    // /dev/null descriptors until EMFILE. Lowering alone to "zero free"
+    // would also starve the CHILD's exec — dyld aborts when it cannot open
+    // the image, measured as (signaled . 6) — but at 256 the child is
+    // unaffected: its exec closes every CLOEXEC fill fd first, and its own
+    // opens land at small numbers far below the limit.
+    const old = std.posix.getrlimit(.NOFILE) catch return error.SkipZigTest;
+    if (old.cur > 256) {
+        std.posix.setrlimit(.NOFILE, .{ .cur = 256, .max = old.max }) catch return error.SkipZigTest;
+    }
+    defer std.posix.setrlimit(.NOFILE, old) catch {};
+    var fill: std.ArrayList(platform.fd_t) = .empty;
+    defer {
+        for (fill.items) |f| _ = platform.close(f);
+        fill.deinit(std.testing.allocator);
+    }
+    var filled_up = false;
+    while (fill.items.len < 65536) {
+        const f = std.c.open("/dev/null", .{ .ACCMODE = .RDONLY, .CLOEXEC = true }, @as(c_uint, 0));
+        if (f < 0) {
+            filled_up = true;
+            break;
+        }
+        fill.append(std.testing.allocator, f) catch {
+            _ = platform.close(f);
+            break;
+        };
+    }
+    if (!filled_up) return error.SkipZigTest; // could not exhaust the table
+
+    // Control: a staged duplicate is impossible right now.
+    try std.testing.expect(platform.dupCloexecAtLeast(1, 3) < 0);
+
     try expectTrue(vm,
-        \\(let ((p (spawn-process '("/bin/sh" "-c" "if (eval \": <&2\") 2>/dev/null; then exit 0; else exit 1; fi"))))
-        \\  (= (process-wait p) 0))
-    );
-    try expectTrue(vm,
-        \\(let ((p (spawn-process '("/bin/sh" "-c" "if (eval \": <&70000\") 2>/dev/null; then exit 1; else exit 0; fi"))))
+        \\(let ((p (spawn-process '("true") 'stdout: (current-output-port))))
         \\  (= (process-wait p) 0))
     );
 }

--- a/src/tests_process.zig
+++ b/src/tests_process.zig
@@ -321,10 +321,14 @@ test "process: fd hygiene — the child inherits only the three stdio slots" {
     // probes openness by DUPLICATING each fd (`: <&N` in a subshell) — a
     // stat of /dev/fd/N would false-positive on the BSDs, where those
     // entries are static device nodes that exist whether or not the fd is
-    // open.
+    // open. Two probe-artifact guards: stderr is 'null rather than a
+    // per-command `2>/dev/null`, and stdin is closed up front (`exec
+    // 0<&-`) — bash implements a per-command redirection by parking the
+    // real descriptor at fd 10+ for the command's duration, so probing
+    // `<&10` while stdin is open would detect the shell's own save of it.
     try expectTrue(vm,
-        \\(let* ((p (spawn-process '("/bin/sh" "-c" "i=3; while [ $i -le 32 ]; do if (eval \": <&$i\") 2>/dev/null; then echo $i; fi; i=$((i+1)); done")
-        \\                            'stdout: 'pipe))
+        \\(let* ((p (spawn-process '("/bin/sh" "-c" "exec 0<&-; i=3; while [ $i -le 32 ]; do if (eval \": <&$i\"); then echo $i; fi; i=$((i+1)); done")
+        \\                            'stdout: 'pipe 'stderr: 'null))
         \\       (out (process-stdout p)))
         \\  (let loop ((acc '()))
         \\    (let ((line (read-line out)))
@@ -578,6 +582,169 @@ test "process: pipe creation reclaims descriptors via GC on exhaustion (#1993)" 
         return e;
     };
     try std.testing.expectEqual(@as(i64, @intCast(n)), types.toFixnum(result));
+}
+
+test "process: an input redirect port's read-ahead is given back to the child" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // Reading one character pulls a whole chunk into the port's software
+    // read-ahead, leaving the kernel offset far past the logical position.
+    // A child handed the raw fd then starts at the kernel offset, silently
+    // skipping everything buffered-but-unconsumed (kaappi#2442 review).
+    // The fd is seekable, so the spawner must rewind it: after the parent
+    // reads "A", the child must see "B" first.
+    _ = try vm.eval("(import (scheme file))");
+    try expectTrue(vm,
+        \\(let ((sink (open-output-file "/tmp/kaappi-readahead-2442.txt")))
+        \\  (write-string "AB" sink)
+        \\  (write-string (make-string 5000 #\x) sink)
+        \\  (close-port sink)
+        \\  (let* ((src (open-input-file "/tmp/kaappi-readahead-2442.txt"))
+        \\         (first (read-char src))
+        \\         (p (spawn-process '("/bin/sh" "-c" "dd bs=1 count=1 2>/dev/null")
+        \\                           'stdin: src 'stdout: 'pipe))
+        \\         (child-first (read-line (process-stdout p)))
+        \\         (st (process-wait p)))
+        \\    (close-port src)
+        \\    (and (char=? first #\A) (equal? child-first "B") (= st 0))))
+    );
+}
+
+test "process: collecting an abandoned pipe port never blocks the sweep" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    // kaappi#2442 review: the sweep's best-effort flush used a BLOCKING
+    // write, and a fresh process pipe stays in blocking mode — so dropping
+    // a port with pending buffered output against a child that never reads
+    // wedged the collector. Fill the pipe near capacity (flushed), buffer
+    // more below the high-water mark (unflushed), abandon everything, and
+    // require the full collection to come back promptly.
+    try expectTrue(vm,
+        \\(let* ((p (spawn-process '("/bin/sleep" "3") 'stdin: 'pipe))
+        \\       (in (process-stdin p)))
+        \\  (write-string (make-string 60000 #\x) in)
+        \\  (flush-output-port in)
+        \\  (write-string (make-string 8100 #\y) in)
+        \\  #t)
+    );
+    const platform = @import("platform.zig");
+    const start_ns = platform.monotonicNs();
+    ctx.gc.collectFull();
+    const elapsed_ns = platform.monotonicNs() - start_ns;
+    // The child sleeps 3 s and never reads; a blocking flush would sit the
+    // whole 3 s (or forever against a longer-lived child). Generous bound
+    // for slow CI, still far under the sleep.
+    try std.testing.expect(elapsed_ns < 2 * std.time.ns_per_s);
+}
+
+test "process: spawn failure paths leak no descriptors (OOM sweep)" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    if (build_options.gc_stress) return error.SkipZigTest; // countdown + stress interact combinatorially
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+    const platform = @import("platform.zig");
+    const memory = @import("memory.zig");
+    const gc = memory.gc_instance.?;
+
+    // Drive an allocation failure at every GC-allocation point of a
+    // pipe-heavy spawn (kaappi#2442 review: an OOM between the spawn and
+    // the last port allocation used to leak the parent pipe ends). The
+    // invariant: however the spawn dies, no descriptor survives once the
+    // garbage ports are collected.
+    const countFds = struct {
+        fn count() usize {
+            var n: usize = 0;
+            var fd: platform.fd_t = 0;
+            while (fd < 256) : (fd += 1) {
+                if (platform.getFdFlags(fd) >= 0) n += 1;
+            }
+            return n;
+        }
+    }.count;
+
+    const src =
+        \\(let ((p (spawn-process '("true") 'stdin: 'pipe 'stdout: 'pipe 'stderr: 'pipe)))
+        \\  (process-wait p) #t)
+    ;
+    // Baseline: one full run so lazily-created infrastructure (reactor fds,
+    // caches) exists before the count is taken.
+    _ = try vm.eval(src);
+    gc.collectFull();
+    const before = countFds();
+
+    var n: u32 = 0;
+    while (n < 400) : (n += 1) {
+        gc.oom_countdown = n;
+        _ = vm.eval(src) catch {};
+        gc.oom_countdown = null;
+    }
+    gc.collectFull();
+    sweepUnreapedForTest(gc);
+    const after = countFds();
+    try std.testing.expectEqual(before, after);
+}
+
+/// Reap any stragglers the OOM sweep left (children whose Process was
+/// collected mid-construction are reaped by freeObject; ones that survived
+/// as unreaped registry entries get the ordinary sweep).
+fn sweepUnreapedForTest(gc: *@import("memory.zig").GC) void {
+    const platform = @import("platform.zig");
+    var i: usize = 0;
+    while (i < gc.unreaped_processes.items.len) {
+        const proc = gc.unreaped_processes.items[i];
+        var st: c_int = 0;
+        if (platform.waitPid(proc.pid, &st, platform.WNOHANG) == proc.pid) {
+            proc.status = @bitCast(st);
+            _ = gc.unreaped_processes.swapRemove(i);
+        } else {
+            i += 1;
+        }
+    }
+}
+
+test "process: close-by-default reaches descriptors above 65536" {
+    if (comptime !is_posix) return error.SkipZigTest;
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+    const platform = @import("platform.zig");
+
+    // kaappi#2442 review: the scan's old 65536 cap silently exempted valid
+    // high descriptors on systems with a six-figure RLIMIT_NOFILE (FreeBSD's
+    // reference VM runs at 117153). Park an inheritable fd at 70000 and
+    // require the child to find it closed. Skipped where the limit forbids
+    // an fd that high.
+    const low = std.c.open("/dev/null", .{ .ACCMODE = .RDONLY }, @as(c_uint, 0));
+    if (low < 0) return error.SkipZigTest;
+    defer _ = platform.close(low);
+    if (platform.dup2(low, 70000) < 0) return error.SkipZigTest;
+    defer _ = platform.close(70000);
+    const flags = platform.getFdFlags(70000);
+    try std.testing.expect(flags >= 0);
+    try std.testing.expect((flags & 1) == 0); // inheritable
+
+    // Control: the probe must DETECT an open fd, or "closed" verdicts below
+    // are vacuous (a shell that rejects multi-digit redirection fds would
+    // report every fd closed). fd 2 is inherited and certainly open.
+    try expectTrue(vm,
+        \\(let ((p (spawn-process '("/bin/sh" "-c" "if (eval \": <&2\") 2>/dev/null; then exit 0; else exit 1; fi"))))
+        \\  (= (process-wait p) 0))
+    );
+    try expectTrue(vm,
+        \\(let ((p (spawn-process '("/bin/sh" "-c" "if (eval \": <&70000\") 2>/dev/null; then exit 1; else exit 0; fi"))))
+        \\  (= (process-wait p) 0))
+    );
 }
 
 test "process: the sweep stores status without an explicit wait" {

--- a/src/thottam_proc.zig
+++ b/src/thottam_proc.zig
@@ -64,6 +64,13 @@ pub fn runCapture(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?
 
     var pipe: [2]c_int = undefined;
     if (std.c.pipe(&pipe) != 0) return error.PipeFailed;
+    // CLOEXEC audit (KEP-0022 Phase 1): both pipe ends and the stderr-save
+    // dup below are close-on-exec. The child's dup2s onto 0/1/2 clear it on
+    // exactly the slots the exec'd child needs, and the saved stderr now
+    // survives only a FAILED execve (its whole purpose) instead of leaking
+    // into every successfully spawned git.
+    _ = platform.setFdCloexec(pipe[0]);
+    _ = platform.setFdCloexec(pipe[1]);
 
     const pid = std.posix.system.fork();
     if (pid < 0) return error.ForkFailed;
@@ -75,9 +82,10 @@ pub fn runCapture(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?
         _ = std.c.close(pipe[1]);
         // Save the real stderr so an execve failure stays audible; the
         // /dev/null dup2 silences only git's own stderr, which is the point
-        // of capture (#2152).
-        const real_stderr = std.c.dup(2);
-        const devnull = std.c.open("/dev/null", .{ .ACCMODE = .WRONLY }, @as(c_uint, 0));
+        // of capture (#2152). F_DUPFD_CLOEXEC (fcntl with cmd 6 / arg 0):
+        // like dup(2) but close-on-exec.
+        const real_stderr = platform.fcntlDupCloexec(2);
+        const devnull = std.c.open("/dev/null", .{ .ACCMODE = .WRONLY, .CLOEXEC = true }, @as(c_uint, 0));
         if (devnull >= 0) {
             _ = std.c.dup2(devnull, 2);
             _ = std.c.close(devnull);

--- a/src/types.zig
+++ b/src/types.zig
@@ -154,6 +154,7 @@ pub fn typeName(val: Value) []const u8 {
         .guardian => "guardian",
         .transport_cell => "transport-cell",
         .numeric_vector => "numeric-vector",
+        .process => "process",
     };
 }
 
@@ -208,6 +209,10 @@ pub const ObjectTag = enum(u6) {
     // SRFI 160: homogeneous numeric vectors other than u8 (which stays a
     // plain bytevector alias, per SRFI 160's own recommended identity).
     numeric_vector = 40,
+    // KEP-0022 (kaappi process): a spawned subprocess handle. Thread-affine
+    // like .channel/.fiber; refused by gc_deep_copy and owner-checked in
+    // every primitive (see types_process.zig).
+    process = 41,
 };
 
 pub const Object = struct {
@@ -287,6 +292,7 @@ pub const Object = struct {
             Guardian => .guardian,
             TransportCell => .transport_cell,
             NumericVector => .numeric_vector,
+            Process => .process,
             else => null,
         };
     }
@@ -626,6 +632,14 @@ pub const GuardEntry = types_weakrefs.GuardEntry;
 pub const Guardian = types_weakrefs.Guardian;
 pub const TransportCell = types_weakrefs.TransportCell;
 
+const types_process = @import("types_process.zig");
+pub const Process = types_process.Process;
+pub const ifWaitExited = types_process.ifExited;
+pub const waitExitStatus = types_process.exitStatus;
+pub const ifWaitSignaled = types_process.ifSignaled;
+pub const waitTermSig = types_process.termSig;
+pub const decodeWaitStatus = types_process.decodeStatus;
+
 // ---------------------------------------------------------------------------
 // Type predicates on Value
 // ---------------------------------------------------------------------------
@@ -897,6 +911,14 @@ pub fn isSrfi18Time(v: Value) bool {
 
 pub fn toSrfi18Time(v: Value) *Srfi18Time {
     return toObject(v).as(Srfi18Time);
+}
+
+pub fn isProcess(v: Value) bool {
+    return isPointer(v) and toObject(v).tag == .process;
+}
+
+pub fn toProcess(v: Value) *Process {
+    return toObject(v).as(Process);
 }
 
 pub fn isHashTable(v: Value) bool {

--- a/src/types_process.zig
+++ b/src/types_process.zig
@@ -1,0 +1,89 @@
+//! The `(kaappi process)` heap type (KEP-0022 Phase 1).
+//!
+//! A `Process` is a spawned child: its pid, its reaped exit status, and the
+//! Kaappi-side ends of any pipes requested at spawn. The child-side pipe ends
+//! live only inside the posix_spawn file actions; nothing here refers to them.
+
+const types = @import("types.zig");
+const platform = @import("platform.zig");
+const Value = types.Value;
+const Object = types.Object;
+
+pub const Process = struct {
+    header: Object,
+    /// The child's pid. Valid for signaling only while `status == null`
+    /// (process-kill refuses to re-signal a reaped pid -- the number may have
+    /// been reused by an unrelated process).
+    pid: i32,
+    /// Linux: pidfd from pidfd_open(); Windows: the process HANDLE. kqueue
+    /// platforms: always -1 (EVFILT_PROC is registered by pid, not fd).
+    /// Phase 1 leaves it -1 everywhere; Phase 2 (reactor reaping) fills it.
+    wait_handle: platform.fd_t = -1,
+    /// The raw waitpid(2) status word once reaped; null while running. Use
+    /// the decoders below to turn it into the Scheme-facing representation
+    /// (see `decodeStatus`).
+    status: ?u32 = null,
+    /// Kaappi-side pipe ports, one per 'pipe redirection spec. FALSE for
+    /// every other spec ('inherit, 'null, a caller-supplied port, and stderr
+    /// under the 'stdout merge) -- exactly what the process-stdin/stdout/
+    /// stderr accessors return. Stored once, at spawn, while the Process is
+    /// young; the write barrier is applied at that store anyway per the
+    /// gc-safety rule ("when in doubt").
+    stdin_port: Value = types.FALSE,
+    stdout_port: Value = types.FALSE,
+    stderr_port: Value = types.FALSE,
+    /// Process-group id when spawned with new-group:, else 0. Group kills
+    /// signal -pgid; a lone-child kill signals pid.
+    pgid: i32 = 0,
+    /// Fibers parked in process-wait (Phase 2, reactor reaping). Opaque
+    /// placeholder until then, matching the Channel.shared / FfiLibrary.handle
+    /// precedent for fields the types layer must not reach into.
+    waiters: ?*anyopaque = null,
+};
+
+// ---------------------------------------------------------------------------
+// waitpid(2) status decoding
+// ---------------------------------------------------------------------------
+//
+// The POSIX macros as functions over the raw status word. Platform-independent
+// by construction (every POSIX kernel encodes wait status this way), so the
+// BSDs' nonstandard bits (core dump, stop) are simply ignored.
+
+pub fn ifExited(status: u32) bool {
+    return (status & 0x7f) == 0;
+}
+
+pub fn exitStatus(status: u32) u32 {
+    return (status >> 8) & 0xff;
+}
+
+pub fn ifSignaled(status: u32) bool {
+    const sig = status & 0x7f;
+    return sig != 0 and sig != 0x7f;
+}
+
+pub fn termSig(status: u32) u32 {
+    return status & 0x7f;
+}
+
+/// The user-facing encoding of a reaped status (KEP-0022 unresolved question
+/// 4, settled Phase 1): the integer exit code for a normal exit, and the pair
+/// `(signaled . n)` for abnormal death. This matches the KEP's guide-level
+/// examples and the Guile/Python convention (Popen.returncode's negative
+/// signaling), needs no decoder procedures, and leaves room for decoders to
+/// layer on top later if a SRFI-170-style surface is ever wanted.
+///
+/// GC-safe as written: the fixnum is immediate, and the signaled pair's
+/// symbol is interned (root-marked via the symbol table) while allocPair
+/// roots its own arguments.
+pub fn decodeStatus(gc: anytype, status: u32) !Value {
+    if (ifExited(status)) return types.makeFixnum(@intCast(exitStatus(status)));
+    if (ifSignaled(status)) {
+        const sym = try gc.allocSymbol("signaled");
+        return gc.allocPair(sym, types.makeFixnum(@intCast(termSig(status))));
+    }
+    // WIFSTOPPED/WIFCONTINUED (0x7f with stopsig): only reachable via
+    // WUNTRACED waits, which Kaappi never issues. Report it as a signal
+    // death of 0 rather than inventing a third encoding.
+    return types.makeFixnum(0);
+}

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -721,6 +721,7 @@ pub const VM = struct {
     collection_state: std.atomic.Value(CollectionState) = .init(.running),
 
     pub fn init(gc: *memory.GC) !VM {
+        ignoreSigpipe();
         const frames = try gc.allocator.alloc(CallFrame, INITIAL_FRAME_CAPACITY);
         errdefer gc.allocator.free(frames);
         const registers = try gc.allocator.alloc(Value, INITIAL_REGISTER_CAPACITY);
@@ -762,6 +763,28 @@ pub const VM = struct {
         vm.stderr_port = gc.allocPort(2, false, true, "stderr", false) catch types.VOID;
         if (vm.stderr_port != types.VOID) try gc.extra_roots.append(gc.allocator, vm.stderr_port);
         return vm;
+    }
+
+    /// KEP-0022 Phase 1: SIGPIPE must be ignored process-wide, explicitly.
+    /// The canonical subprocess failure -- writing to the stdin of a child
+    /// that has already exited -- must surface as an ordinary catchable I/O
+    /// error carrying EPIPE, never as process death by signal. Kaappi's own
+    /// binary already gets this from Zig's std.start (keep_sigpipe == false
+    /// defaults to SIG_IGN), but an embedder linking the runtime as a
+    /// library gets no std.start: their first write to a dead child's pipe
+    /// would kill the host. Idempotent, cheap, and safe to call per VM (the
+    /// signal disposition is process-wide; child-thread VMs re-run it
+    /// harmlessly). Not applicable on Windows (no SIGPIPE) or WASI (no
+    /// signals).
+    fn ignoreSigpipe() void {
+        const builtin = @import("builtin");
+        if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
+        var act: std.posix.Sigaction = .{
+            .handler = .{ .handler = std.posix.SIG.IGN },
+            .mask = std.posix.sigemptyset(),
+            .flags = 0,
+        };
+        std.posix.sigaction(std.posix.SIG.PIPE, &act, null);
     }
 
     pub fn initForThread(gc: *memory.GC, parent: *VM) !VM {

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -779,6 +779,13 @@ pub const VM = struct {
     fn ignoreSigpipe() void {
         const builtin = @import("builtin");
         if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
+        // Only upgrade the DEFAULT disposition (die by signal) to SIG_IGN.
+        // An embedder that deliberately installed its own SIGPIPE handler
+        // keeps it — their handler runs and the write still returns EPIPE,
+        // which is all the KEP-0022 contract needs (kaappi#2442 review).
+        var old: std.posix.Sigaction = undefined;
+        std.posix.sigaction(std.posix.SIG.PIPE, null, &old);
+        if (old.handler.handler != std.posix.SIG.DFL) return;
         var act: std.posix.Sigaction = .{
             .handler = .{ .handler = std.posix.SIG.IGN },
             .mask = std.posix.sigemptyset(),

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -63,6 +63,10 @@ test {
     _ = @import("tests_diagnostics.zig");
     _ = @import("tests_spans.zig");
     _ = @import("tests_platform.zig");
+    // (kaappi process), KEP-0022 Phase 1. POSIX-only: the specs (and the
+    // whole primitives module) are gated out of the WASM and Windows builds,
+    // so the suite skips there too.
+    _ = @import("tests_process.zig");
     // Byte-order pins. The unit suite is one of only three things that runs
     // on the big-endian s390x leg, so this is where an endian assertion
     // actually reaches the canary (src/tests_endian.zig explains the rest).

--- a/tests/scheme/compile/process-spawn-2414.sh
+++ b/tests/scheme/compile/process-spawn-2414.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Native-tier regression for (kaappi process) — KEP-0022 Phase 1, kaappi#2414.
+#
+# spawn-process and its accessors are ordinary primitives (no LLVM emitter
+# work), but a .scm test only ever exercises the interpreter tier, and three
+# regressions once passed for years that way while the native tier failed them.
+# So a compiled program that spawns a child, reads its stdout through a pipe
+# port, and reaps it must be checked through `kaappi compile` too.
+#
+# Usage: bash tests/scheme/compile/process-spawn-2414.sh [path-to-kaappi]
+
+set -euo pipefail
+
+# (kaappi process) is POSIX-only until Phase 3, and native-compile tests need a
+# native Zig toolchain on this machine (kaappi#1613).
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "(kaappi process) is POSIX-only until Phase 3; compile suite needs a native Zig toolchain (kaappi#1613)"
+
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+KAAPPI="${1:-$REPO_DIR/zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+ensure_runtime_lib "$REPO_DIR"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+FAILED=0
+
+# Run a program both ways and require identical output; the interpreter is the
+# oracle (tests/scheme/CLAUDE.md).
+check_both() {
+    local label="$1" expected="$2"
+    local src="$DIR/${label}.scm" bin="$DIR/${label}.bin"
+
+    local interp_out interp_status=0
+    interp_out="$(cd "$REPO_DIR" && "$KAAPPI_ABS" "$src" 2>&1)" || interp_status=$?
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        FAILED=1
+        return
+    fi
+    if [[ "$interp_out" != "$expected" ]]; then
+        echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        FAILED=1
+        return
+    fi
+
+    local compile_out compile_status=0
+    compile_out="$(cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" 2>&1)" || compile_status=$?
+    if [[ $compile_status -ne 0 ]]; then
+        echo "FAIL: $label — kaappi compile exited $compile_status: $compile_out" >&2
+        FAILED=1
+        return
+    fi
+    if [[ ! -x "$bin" ]]; then
+        echo "FAIL: $label — kaappi compile produced no binary" >&2
+        FAILED=1
+        return
+    fi
+
+    local native_out native_status=0
+    native_out="$("$bin" 2>&1)" || native_status=$?
+    if [[ $native_status -ne 0 ]]; then
+        echo "FAIL: $label — compiled binary exited $native_status (output: '$native_out')" >&2
+        FAILED=1
+        return
+    fi
+    if [[ "$native_out" != "$interp_out" ]]; then
+        echo "FAIL: $label — native '$native_out' != interpreted '$interp_out'" >&2
+        FAILED=1
+    fi
+}
+
+# Spawn a child, capture its stdout through a pipe port, and reap it — the
+# whole Phase 1 surface exercised from compiled code.
+cat > "$DIR/spawn.scm" << 'SCHEME'
+(import (scheme base) (scheme write) (kaappi process))
+(define (drain port)
+  (let loop ((acc '()))
+    (let ((b (read-u8 port)))
+      (if (eof-object? b)
+          (list->string (map integer->char (reverse acc)))
+          (loop (cons b acc))))))
+(define p (spawn-process '("sh" "-c" "printf native-ok") 'stdout: 'pipe))
+(display (drain (process-stdout p)))
+(display " ")
+(display (process-wait p))
+(newline)
+SCHEME
+check_both "spawn" "native-ok 0"
+
+if [[ $FAILED -ne 0 ]]; then
+    exit 1
+fi
+echo "PASS"

--- a/tests/scheme/errors/process-stdio-2442.sh
+++ b/tests/scheme/errors/process-stdio-2442.sh
@@ -35,11 +35,19 @@ FAIL=0
 ok()   { echo "PASS: $1"; PASS=$((PASS + 1)); }
 bad()  { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
 
-# The library gate: exit 77 (suite SKIP) on targets without (kaappi process).
-printf '(cond-expand ((library (kaappi process)) (exit 0)) (else (exit 1)))\n' > "$DIR/gate.scm"
-if ! "$KAAPPI" "$DIR/gate.scm" >/dev/null 2>&1; then
+# The library gate: exit 77 (suite SKIP) only on the DISTINCT status the
+# gate program reserves for "library absent" — any other failure (a broken
+# binary, a startup error) must fail the suite, not silently skip all three
+# regressions (kaappi#2442 review).
+printf '(import (scheme base) (scheme process-context))\n(cond-expand ((library (kaappi process)) (exit 0)) (else (exit 9)))\n' > "$DIR/gate.scm"
+gate_status=0
+"$KAAPPI" "$DIR/gate.scm" >/dev/null 2>&1 || gate_status=$?
+if [[ "$gate_status" -eq 9 ]]; then
     echo "SKIP: (kaappi process) not available on this target"
     exit 77
+elif [[ "$gate_status" -ne 0 ]]; then
+    echo "FAIL: gate program exited $gate_status (neither available nor the absent marker)"
+    exit 1
 fi
 
 # --- 1. 'inherit passes the parent's stdio through, with real content -------

--- a/tests/scheme/errors/process-stdio-2442.sh
+++ b/tests/scheme/errors/process-stdio-2442.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Regression tests for the (kaappi process) stdio-plumbing findings of the
+# kaappi#2442 review — behaviors only visible when the PARENT's own standard
+# descriptors are arranged by the harness, which a .scm-only suite cannot do:
+#
+#   1. 'inherit must actually pass the parent's stdio through. Darwin's
+#      POSIX_SPAWN_CLOEXEC_DEFAULT closes even fds 0..2 unless a file action
+#      names them, so before the addinherit_np actions a plain spawn lost
+#      all three streams.
+#   2. A stdout/stderr SWAP via caller ports must swap. The file actions run
+#      sequentially in the child, so un-staged low-fd sources read whatever
+#      an earlier dup2 just installed — both streams landed on the original
+#      stderr.
+#   3. Spawning with a standard descriptor CLOSED in the parent must still
+#      work. pipe(2) then hands back fd 0/1/2, and an un-normalized pipe end
+#      in a stdio slot corrupts the dup2/close action pair for that slot.
+#
+# The whole file is POSIX-only, like the library it tests.
+
+set -euo pipefail
+
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "(kaappi process) is POSIX-only until KEP-0022 Phase 3"
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+case "$KAAPPI" in
+    /*) ;;
+    *) KAAPPI="$PWD/$KAAPPI" ;;
+esac
+DIR="$(mktemp -d)"
+trap 'rm -rf "$DIR"' EXIT
+PASS=0
+FAIL=0
+
+ok()   { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad()  { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# The library gate: exit 77 (suite SKIP) on targets without (kaappi process).
+printf '(cond-expand ((library (kaappi process)) (exit 0)) (else (exit 1)))\n' > "$DIR/gate.scm"
+if ! "$KAAPPI" "$DIR/gate.scm" >/dev/null 2>&1; then
+    echo "SKIP: (kaappi process) not available on this target"
+    exit 77
+fi
+
+# --- 1. 'inherit passes the parent's stdio through, with real content -------
+cat > "$DIR/inherit.scm" <<'SCM'
+(import (scheme base) (kaappi process))
+(let ((p (spawn-process '("/bin/sh" "-c" "echo CHILD-OUT; echo CHILD-ERR 1>&2"))))
+  (exit (if (equal? 0 (process-wait p)) 0 1)))
+SCM
+if "$KAAPPI" "$DIR/inherit.scm" > "$DIR/inherit.out" 2> "$DIR/inherit.err" \
+    && grep -q '^CHILD-OUT$' "$DIR/inherit.out" \
+    && grep -q '^CHILD-ERR$' "$DIR/inherit.err"; then
+    ok "'inherit delivers the child's stdout and stderr to the parent's streams"
+else
+    bad "'inherit lost child output (stdout: '$(cat "$DIR/inherit.out")', stderr: '$(cat "$DIR/inherit.err")')"
+fi
+
+# --- 2. stdout/stderr swap through the parent's own stdio ports -------------
+cat > "$DIR/swap.scm" <<'SCM'
+(import (scheme base) (kaappi process))
+(let ((p (spawn-process '("/bin/sh" "-c" "echo OUT; echo ERR 1>&2")
+                        'stdout: (current-error-port)
+                        'stderr: (current-output-port))))
+  (exit (if (equal? 0 (process-wait p)) 0 1)))
+SCM
+if "$KAAPPI" "$DIR/swap.scm" > "$DIR/swap.out" 2> "$DIR/swap.err" \
+    && grep -q '^ERR$' "$DIR/swap.out" && ! grep -q '^OUT$' "$DIR/swap.out" \
+    && grep -q '^OUT$' "$DIR/swap.err" && ! grep -q '^ERR$' "$DIR/swap.err"; then
+    ok "stdout:/stderr: swap through low-fd caller ports actually swaps"
+else
+    bad "swap did not swap (stdout: '$(cat "$DIR/swap.out")', stderr: '$(cat "$DIR/swap.err")')"
+fi
+
+# --- 3. spawn works with the parent's stdin closed (pipe lands on fd 0) -----
+cat > "$DIR/closed0.scm" <<'SCM'
+(import (scheme base) (kaappi process))
+(let* ((p (spawn-process '("/bin/cat") 'stdin: 'pipe 'stdout: 'pipe))
+       (in (process-stdin p)))
+  (write-string "ping" in)
+  (close-output-port in)
+  (let ((line (read-line (process-stdout p))))
+    (exit (if (and (equal? "ping" line) (equal? 0 (process-wait p))) 0 1))))
+SCM
+if "$KAAPPI" "$DIR/closed0.scm" 0<&- > "$DIR/closed0.out" 2>&1; then
+    ok "pipe round trip survives the parent launching with fd 0 closed"
+else
+    bad "closed-stdin spawn failed: $(cat "$DIR/closed0.out")"
+fi
+
+echo "process-stdio-2442: $PASS pass, $FAIL fail"
+[[ $FAIL -eq 0 ]]

--- a/tests/scheme/process/process-child-script.scm
+++ b/tests/scheme/process/process-child-script.scm
@@ -1,0 +1,79 @@
+;; A Kaappi child under (kaappi process): bidirectional stdio round trips.
+;;
+;; Spawns a *kaappi* child (the same binary, via the KAAPPI environment
+;; variable run-all.sh exports) running a reader-loop script, and exchanges
+;; lines with it in both directions — the streaming shape of the KEP's
+;; driving workload (a long-lived tool speaking line protocol over pipes).
+;; Skips cleanly when KAAPPI is not in the environment (ad-hoc runs).
+
+(import (scheme base) (scheme write) (srfi 64))
+
+;; Gate before the import (see process-test.scm for why the exit-0 guard
+;; must precede the first spawn-process reference).
+(cond-expand
+  ((library (kaappi process))
+   (import (kaappi process)))
+  (else (display "no (kaappi process) on this platform\n") (exit 0)))
+
+(define kaappi-binary (get-environment-variable "KAAPPI"))
+
+;; The child script: read a line, echo it wrapped in angle brackets, stop at
+;; EOF. Written to a temp file because argv-only spawn takes no -c strings
+;; from us — the file IS the portable way to hand a program its code.
+(define child-source
+  "(import (scheme base) (scheme read) (scheme write))
+(let loop ()
+  (let ((line (read-line)))
+    (unless (eof-object? line)
+      (write-string \"<\") (write-string line) (write-string \">\") (newline)
+      (flush-output-port (current-output-port))
+      (loop))))")
+
+;; Written under KAAPPI_HOME when the runner provides it (a fresh mktemp
+;; dir per run-all.sh invocation — unique against parallel runs), TMPDIR
+;; otherwise. No other test file uses this name either way.
+(define script-path
+  (string-append (or (get-environment-variable "KAAPPI_HOME")
+                     (get-environment-variable "TMPDIR")
+                     "/tmp")
+                 "/kaappi-process-child.scm"))
+
+(if (not kaappi-binary)
+    (begin
+      (display "KAAPPI not set; skipping child-script round trip\n")
+      (exit 0))
+    (begin
+      (test-begin "kaappi-process-child")
+
+      (call-with-output-file script-path
+        (lambda (port) (write-string child-source port)))
+
+      (define p (spawn-process (list kaappi-binary script-path)
+                               'stdin: 'pipe 'stdout: 'pipe 'stderr: 'inherit))
+
+      (test-assert "the child is a kaappi process with live pipes"
+        (and (process? p) (port? (process-stdin p)) (port? (process-stdout p))))
+
+      (test-equal "bidirectional line exchange with a kaappi child"
+        '("<one>" "<two>" "<three>")
+        (begin
+          (write-string "one" (process-stdin p)) (newline (process-stdin p))
+          (write-string "two" (process-stdin p)) (newline (process-stdin p))
+          (write-string "three" (process-stdin p)) (newline (process-stdin p))
+          (flush-output-port (process-stdin p))
+          ;; Exactly three reads: the child echoes one line per input line
+          ;; and then blocks on its own read, so a fourth read here would
+          ;; deadlock the pair (the lesson this test exists to teach).
+          (let ((out (process-stdout p)))
+            (let loop ((acc '()) (n 0))
+              (if (= n 3)
+                  (reverse acc)
+                  (loop (cons (read-line out) acc) (+ n 1)))))))
+
+      ;; Half-close: the child sees EOF on stdin and exits cleanly.
+      (close-output-port (process-stdin p))
+      (test-equal "child exits 0 after stdin EOF" 0 (process-wait p))
+
+      (let ((runner (test-runner-current)))
+        (test-end "kaappi-process-child")
+        (when (> (test-runner-fail-count runner) 0) (exit 1)))))

--- a/tests/scheme/process/process-test.scm
+++ b/tests/scheme/process/process-test.scm
@@ -1,0 +1,186 @@
+;; End-to-end tests for (kaappi process) — KEP-0022 Phase 1 (POSIX).
+;;
+;; Children are spawned through the portable POSIX helpers (/bin/sh, cat,
+;; echo); the kaappi-as-a-child round trip lives in process-child-script.scm.
+;; The whole file skips on platforms without the library (WASM, Windows
+;; until Phase 3) via the cond-expand gate the KEP made the feature's
+;; presence check.
+
+(import (scheme base) (scheme write) (srfi 64))
+
+;; Gate before the import: on platforms without subprocess support (WASM;
+;; Windows until KEP-0022 Phase 3) this exits 0 before `spawn-process` is
+;; ever referenced, and kaappi compiles forms one at a time so the later
+;; unbound references never compile either.
+(cond-expand
+  ((library (kaappi process))
+   (import (kaappi process)))
+  (else (display "no (kaappi process) on this platform\n") (exit 0)))
+
+(test-begin "kaappi-process")
+
+;; ---------------------------------------------------------------- helpers
+
+(define (drain port)
+  ;; Read every line of an output pipe into a list of strings.
+  (let loop ((acc '()))
+    (let ((line (read-line port)))
+      (if (eof-object? line)
+          (reverse acc)
+          (loop (cons line acc))))))
+
+;; ------------------------------------------------- spawn/wait/status matrix
+
+(test-equal "exit 0"
+  0 (process-wait (spawn-process '("true"))))
+
+(test-equal "nonzero exit code propagates"
+  7 (process-wait (spawn-process '("/bin/sh" "-c" "exit 7"))))
+
+(test-assert "status is #f while running, code after; re-wait returns stored"
+  ;; The child blocks on its stdin pipe, so the pre-exit poll cannot race
+  ;; its exit (process-status reaps on its own, so an exited child would
+  ;; report a code, not #f).
+  (let* ((p (spawn-process '("/bin/sh" "-c" "read x; exit 3") 'stdin: 'pipe))
+         (s1 (process-status p)))
+    (write-string "go\n" (process-stdin p))
+    (close-output-port (process-stdin p))
+    (let* ((w1 (process-wait p))
+           (s2 (process-status p))
+           (w2 (process-wait p)))
+      (and (eq? s1 #f) (= w1 3) (= s2 3) (= w2 3)))))
+
+(test-assert "abnormal death is (signaled . n)"
+  (let* ((p (spawn-process '("/bin/sh" "-c" "kill -9 $$")))
+         (st (process-wait p)))
+    (and (pair? st) (eq? (car st) 'signaled) (= (cdr st) 9))))
+
+(test-assert "process-kill defaults to SIGTERM"
+  (let* ((p (spawn-process '("/bin/sleep" "30")))
+         (st (and (process-kill p) (process-wait p))))
+    (and (pair? st) (= (cdr st) 15))))
+
+(test-assert "kill after reap is a quiet no-op"
+  (let* ((p (spawn-process '("true")))
+         (st (process-wait p)))
+    (and (= st 0) (process-kill p) (process-kill p 'signal: 9) #t)))
+
+;; --------------------------------------------------------- pipes and specs
+
+(test-equal "stdin/stdout pipe round trip via cat"
+  '("round-trip")
+  (let* ((p (spawn-process '("/bin/cat") 'stdin: 'pipe 'stdout: 'pipe))
+         (in (process-stdin p))
+         (out (process-stdout p)))
+    (write-string "round-trip" in)
+    (flush-output-port in)
+    (close-output-port in)             ; EOF so cat can finish
+    (let ((lines (drain out)))
+      (process-wait p)
+      lines)))
+
+(test-equal "stderr 'stdout merges both streams onto the stdout pipe"
+  '("out" "err")
+  (let* ((p (spawn-process '("/bin/sh" "-c" "echo out; echo err 1>&2")
+                           'stdout: 'pipe 'stderr: 'stdout)))
+    (let ((lines (drain (process-stdout p))))
+      (process-wait p)
+      lines)))
+
+(test-assert "non-pipe specs leave #f accessors"
+  (let ((p (spawn-process '("true") 'stdout: 'null)))
+    (and (eq? (process-stdin p) #f)
+         (eq? (process-stdout p) #f)
+         (eq? (process-stderr p) #f)
+         (= (process-wait p) 0))))
+
+;; ---------------------------------------------------------- env and groups
+
+(test-equal "env: replaces the environment wholesale"
+  '("one:two")
+  (let* ((p (spawn-process '("/bin/sh" "-c" "echo $KAPVAR1:$KAPVAR2")
+                           'stdout: 'pipe
+                           'env: '(("KAPVAR1" . "one") ("KAPVAR2" . "two")))))
+    (let ((lines (drain (process-stdout p))))
+      (process-wait p)
+      lines)))
+
+(test-equal "env: '() is an empty environment, not inheritance"
+  '("unset")
+  (let* ((p (spawn-process '("/bin/sh" "-c" "echo ${HOME:-unset}")
+                           'stdout: 'pipe 'env: '())))
+    (let ((lines (drain (process-stdout p))))
+      (process-wait p)
+      lines)))
+
+(test-assert "process-environment feeds copy-and-extend"
+  (let* ((env (process-environment))
+         (p (spawn-process '("/bin/sh" "-c" "echo $KAPNEW")
+                           'stdout: 'pipe
+                           'env: (append env '(("KAPNEW" . "extended"))))))
+    (let ((lines (drain (process-stdout p))))
+      (process-wait p)
+      (equal? lines '("extended")))))
+
+(test-assert "new-group: makes the child its own group leader"
+  (let ((p (spawn-process '("true") 'new-group: #t)))
+    (and (= (process-group p) (process-pid p))
+         (= (process-wait p) 0))))
+
+(test-assert "group kill reaches the whole group"
+  ;; The child sh starts a sleeper grandchild in ITS group (setsid-free:
+  ;; the child sh shares the new group), the group kill must terminate both.
+  (let ((p (spawn-process '("/bin/sh" "-c" "sleep 30 & wait")
+                          'new-group: #t)))
+    (process-kill p 'group: #t)
+    (let ((st (process-wait p)))
+      (and (pair? st) (eq? (car st) 'signaled) (= (cdr st) 15)))))
+
+;; ------------------------------------------------------------- predicates
+
+(test-assert "process? is a total predicate"
+  (and (process? (spawn-process '("true")))
+       (not (process? 42))
+       (not (process? "process"))
+       (not (process? (open-input-string "s")))))
+
+(test-assert "the printed form carries pid and state"
+  (let* ((p (spawn-process '("true")))
+         (sp1 (open-output-string)))
+    (write p sp1)
+    (let ((running (get-output-string sp1)))
+      (process-wait p)
+      (let* ((sp2 (open-output-string))
+             (dead (begin (write p sp2) (get-output-string sp2))))
+        (and (string-prefix? "#<process " running)
+             (string-suffix? "running>" running)
+             (string-suffix? "exited 0>" dead))))))
+
+;; ------------------------------------------------------------- fd hygiene
+
+(test-equal
+  "a spawned child inherits only the three stdio slots"
+  '()
+  ;; Fresh kaappi process: every descriptor it holds is CLOEXEC (and the
+  ;; spawner closes inherited strays), so the child must see nothing open at
+  ;; 3..24. Openness is probed by duplicating the fd (`: <&N` in a subshell)
+  ;; — a stat of /dev/fd/N would false-positive on the BSDs, where those
+  ;; entries are static device nodes that exist whether or not the fd does.
+  (let* ((p (spawn-process
+             '("/bin/sh" "-c"
+               "i=3; while [ $i -le 24 ]; do if (eval \": <&$i\") 2>/dev/null; then echo $i; fi; i=$((i+1)); done")
+             'stdout: 'pipe)))
+    (let ((lines (drain (process-stdout p))))
+      (process-wait p)
+      lines)))
+
+;; ----------------------------------------------------------- error report
+
+(test-assert "spawning a missing program raises a catchable file error"
+  (guard (e ((file-error? e) #t)
+            (else 'wrong-kind))
+    (spawn-process '("/nonexistent/kaappi-process-test"))))
+
+(let ((runner (test-runner-current)))
+  (test-end "kaappi-process")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/process/process-test.scm
+++ b/tests/scheme/process/process-test.scm
@@ -166,10 +166,15 @@
   ;; 3..24. Openness is probed by duplicating the fd (`: <&N` in a subshell)
   ;; — a stat of /dev/fd/N would false-positive on the BSDs, where those
   ;; entries are static device nodes that exist whether or not the fd does.
+  ;; Two probe-artifact guards: stderr goes to 'null rather than a
+  ;; per-command `2>/dev/null`, and stdin is closed up front (`exec 0<&-`)
+  ;; — bash implements a per-command redirection by parking the real
+  ;; descriptor at fd 10+ for the command's duration, so probing `<&10`
+  ;; while stdin is open would detect the shell's own save of it.
   (let* ((p (spawn-process
              '("/bin/sh" "-c"
-               "i=3; while [ $i -le 24 ]; do if (eval \": <&$i\") 2>/dev/null; then echo $i; fi; i=$((i+1)); done")
-             'stdout: 'pipe)))
+               "exec 0<&-; i=3; while [ $i -le 24 ]; do if (eval \": <&$i\"); then echo $i; fi; i=$((i+1)); done")
+             'stdout: 'pipe 'stderr: 'null)))
     (let ((lines (drain (process-stdout p))))
       (process-wait p)
       lines)))

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -497,7 +497,7 @@ run_shell_suite() {
 # included fragment and never opens a SRFI-64 suite, while every real suite
 # file does. Verified against the whole tree — 11 fixture .scm files under
 # suite subdirectories, none containing `test-begin`, and no false positives.
-SCM_SUITE_DIRS="smoke compliance continuations hygiene srfi ffi audit"
+SCM_SUITE_DIRS="smoke compliance continuations hygiene srfi ffi process audit"
 
 check_unreachable_tests() {
     echo "=== Reachability check ==="

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -12,6 +12,9 @@
 set -euo pipefail
 
 KAAPPI=zig-out/bin/kaappi
+# Exported so .scm files can spawn kaappi as a child (tests/scheme/process/
+# round-trips a reader-loop script through the real binary, KEP-0022).
+export KAAPPI
 
 # This script used to run a bare `zig build` when the binary was missing. That
 # convenience dates from when it was the only runner, and it silently
@@ -657,6 +660,7 @@ if command -v zig >/dev/null 2>&1; then
     fi
 fi
 run_suite "FFI tests" tests/scheme/ffi/*.scm
+run_suite "Process tests" tests/scheme/process/*.scm
 run_suite "Audit tests" tests/scheme/audit/*.scm
 run_shell_suite "Error tests" tests/scheme/errors
 run_shell_suite "Compile tests" tests/scheme/compile

--- a/tools/run-gc-stress-suite.sh
+++ b/tools/run-gc-stress-suite.sh
@@ -39,6 +39,10 @@ case "$KAAPPI" in
     /*) ;;
     *) KAAPPI="$PWD/$KAAPPI" ;;
 esac
+# Exported so .scm files can spawn kaappi as a child (tests/scheme/process/
+# round-trips a reader-loop script through the real binary, KEP-0022) —
+# without it, process-child-script.scm silently skips its round trip.
+export KAAPPI
 
 # Then run from the repo root regardless of where we were invoked: every path
 # below is repo-relative, and so is the --lib-path passed to each run.
@@ -95,7 +99,7 @@ fi
 # existing, with no second place to update -- but see the floor check below,
 # because a glob that silently matches nothing is the failure mode a curated
 # list does not have.
-SCM_SUITE_DIRS="smoke compliance continuations hygiene srfi ffi audit"
+SCM_SUITE_DIRS="smoke compliance continuations hygiene srfi ffi process audit"
 
 # A file that legitimately takes minutes under stress collection is fine; a
 # file that HANGS must not silently consume the whole CI job's budget with no


### PR DESCRIPTION
Implements **Phase 1 of KEP-0022** (#2414): spawn-based (never fork-based) subprocess support in the core, with child stdin/stdout/stderr exposed as ordinary reactor-integrated pipe ports. **POSIX only; blocking `process-wait`; reactor reaping is Phase 2, Windows is Phase 3.**

This is a fresh PR drawing on both prior attempts (#2441 and a second local iteration), and it addresses all nine blocking findings from the #2441 review — each with a regression test.

## The feature

### New heap type — `Process`
- `src/types_process.zig` (ObjectTag `.process`, 41 → 42), re-exported from `types.zig`. Full five-switch checklist (`markObjectContents` / `markValueInner` worklist / `referencesYoung`; `objectSize` / `freeObject`; `typeName`; printer) plus the `expectFields` inventory pin and a `tests_gc_tracing` trace case. The three pipe-port `Value` fields are GC-traced; the printer arm is atomic (`#<process PID running|exited N|signaled N>`), so `isTraversable`/`childAt` are untouched.
- Thread-affine: every accessor owner-checks against the current GC (the channel precedent), and `gc_deep_copy.zig` refuses to copy a `Process` across a channel/thread boundary (refusal test in `tests_deepcopy.zig`).

### Library `(kaappi process)`
New `.kaappi_process` Lib enum entry; exports derived from the specs table (`.sandbox = false, .wasm = false`, with a comptime check enforcing the wasm gate on every spec). Registered on POSIX only — absent on WASM and (via the new `Lib.windowsAvailable`) on Windows, so `(cond-expand ((library (kaappi process)) …))` gates correctly everywhere.

`spawn-process` (options `stdin:`/`stdout:`/`stderr:` with `inherit`/`pipe`/`null`/a caller fd-port/`'stdout` merge, `directory:`, `env:` wholesale replacement, `new-group:`), `process?`, `process-pid`, `process-group`, `process-stdin`/`stdout`/`stderr` (`#f` for every non-`'pipe` spec), `process-status` (now reaps non-blockingly itself), blocking `process-wait`, `process-kill` (`signal:`/`group:`, no-op after reap), `process-environment`, plus the internal positional `%process-spawn`.

### Settled Phase-1 decisions (KEP unresolved questions)
- **Status encoding:** a fixnum exit code, or `(signaled . signo)`; `#f` while running.
- **Zombie discipline:** a bounded `waitpid(WNOHANG)` sweep of the per-heap unreaped list runs on the blocking spawn/wait paths; `process-status` reaps its own target; `freeObject` makes a last-resort non-blocking reap when a Process is collected. The only remaining window (a Process collected while its child still runs) is documented on `GC.unreaped_processes` and closes fully with Phase 2's reactor reaping.

## The nine review blockers, each fixed + tested

1. **glibc 2.28 link failure** — `posix_spawn_file_actions_addchdir_np` is glibc ≥ 2.29; `has_addchdir` now gates comptime on the target glibc version, so `zig build -Dtarget=x86_64-linux-gnu.2.28` (the release floor) links again. `directory:` raises a clean catchable error where the symbol is absent (gnu < 2.29, NetBSD, OpenBSD).
2. **Inherited descriptors leaked into children** — close-by-default is now real: macOS uses `POSIX_SPAWN_CLOEXEC_DEFAULT`; everywhere else the spawner enumerates open fds (`/proc/self/fd` on Linux; an `fcntl(F_GETFD)` probe on the BSDs, whose `/dev/fd` entries are static nodes) and adds a close action for every non-CLOEXEC fd > 2. Regression: a deliberately inheritable fd (no `O_CLOEXEC`, standing in for `kaappi 9</dev/null`) is first proven open+inheritable in the parent, then proven closed in the child.
3. **Children inherited SIGPIPE=SIG_IGN** — spawn attrs now set `POSIX_SPAWN_SETSIGDEF` with SIGPIPE in the default set. Fixing this exposed that **the `POSIX_SPAWN_SETSIGDEF` flag value is not portable**: it is 0x04 on macOS/glibc/musl but 0x10 on FreeBSD/NetBSD/OpenBSD (0x04 there is `SETSCHEDPARAM`). The constant is now per-OS, and the regression (`sh -c "kill -PIPE $$; exit 42"` must die `(signaled . 13)`) pins the value on every platform. The sigset is built with Zig's own `std.posix` helpers — NetBSD's libc sigset accessors are not portably linkable symbols.
4. **Zombies from abandoned Process objects** — the sweep/registry described above; `gc_sweep.freeObject` reaps a collected unreaped Process non-blockingly instead of forgetting the pid.
5. **Cyclic argv/env hung the VM** — both list walks are now Floyd-cycle-guarded and raise a catchable error; the second env pass is additionally bounded by the first pass's count.
6. **Embedded NUL truncation** — argv elements, env names/values, and `directory:` all reject interior NULs; env names additionally reject empty and `'='`-carrying names.
7. **Blocking `process-wait` starved parent GC** — a child-thread VM (`!owns_globals`) publishes itself via `setCollectionInNative`/`setCollectionRunning` around the blocking `waitpid` (the #1933 pattern), with the error path restructured so nothing allocates while the VM is marked in-native.
8. **EPIPE was swallowed** — `drainWriteBuffer` now raises a KEP-0005 `file-error` carrying the errno on the explicit write/flush paths (`write-*`, `flush-output-port`, `set-port-position!`), while close-port and the flush-before-read stay non-raising cleanup. Regression: write+flush to a dead child's stdin under `guard` must be caught by `file-error?`.
9. **NetBSD kill breakage** — diagnosed live on the NetBSD 10.1 reference VM. NetBSD's `posix_spawn` is an in-kernel syscall whose *child* completes its exec after the parent's call has returned, and a signal posted before that exec fully finishes is **dropped outright**: 5/40 immediate SIGTERMs to a spawned `sleep` were lost (children ran to completion), a shell-issued `kill` of the same children never failed, and a 50 ms-delayed native kill was 0/15 — pinning the mechanism to exec-completion timing. A CLOEXEC-pipe EOF barrier measured *insufficient* (8/40 still lost: the kernel closes close-on-exec fds partway through exec, before the child's signal state is final). The fix is kqueue's **`NOTE_EXEC`** — the kernel's own exec-completed notification (the reactor already speaks NetBSD kqueue) — with `NOTE_EXIT` and a 20 ms timeout as fallbacks: spawn returns only once the child is signalable. Re-measured: **40/40 immediate kills deliver, 0.77 s total** (vs. 253 s of lost-kill sleeps before). Every other target has no window by construction (vfork-semantics libcs resume the parent post-exec; macOS spawns atomically in-kernel).

A tenth platform gap the VM matrix surfaced: OpenBSD's userland `posix_spawn` cannot report the child's exec failure, so spawning a missing program "succeeded" with exit 127 (POSIX-sanctioned, but it broke the catchable-file-error contract every other platform honors). A pre-flight `access(X_OK)` on slash-containing program paths raises the same errno-carrying file-error there; PATH-searched bare names keep the POSIX fallback.

An eleventh find, courtesy of the first CI round: the `openbsd-test` leg's low `ulimit -n` exposed that spawn's pipe creation lacked the EMFILE/ENFILE recovery `open(2)` has had since #2324 — a program abandoning process handles faster than the GC threshold trips spuriously failed. `pipe(2)` in the spawner now collects and retries once, with a mutation-verified regression that lowers `RLIMIT_NOFILE` deterministically.

Review fixes beyond the nine: caller-port redirects flush their pending buffered output before the spawn and reject ports the fiber scheduler has flipped non-blocking (dup2 shares the O_NONBLOCK file-description flag); the group-kill ESRCH retry now sleeps 500 µs per attempt (~100 ms total) instead of the 500 ms that contradicted its own comment; `platform.pipe` marks both ends CLOEXEC; the kqueue reactor fd, `mkstemp` fds, opendir fds, and every `platform.open*` are CLOEXEC; `thottam_proc`/`test_selection` child helpers audited.

## Tests

- `src/tests_process.zig` (~20 tests): spawn/wait/status matrix, signaled death, kill + kill-after-reap no-op, redirection matrix, env wholesale/empty, pipe round trip, both fd-hygiene tests (strong empty assertion via dup-probe — `/dev/fd` stat lies on the BSDs — plus the deliberate-inheritable-fd regression), gc-stress-scaled spawn loop, cyclic argv/env, NUL surfaces, dead-child EPIPE, child SIGPIPE disposition, printer shape, sweep semantics. Green under `-Dgc-stress=true`.
- `src/tests_gc_tracing.zig`: Process trace case + `expectFields` pin + ObjectTag count; `src/tests_deepcopy.zig`: refusal case.
- `tests/scheme/process/process-test.scm` + `process-child-script.scm` (bidirectional line protocol with a Kaappi child), wired into `run-all.sh`.
- `tests/scheme/compile/process-spawn-2414.sh`: native-tier evidence (`kaappi compile` of a spawn/pipe/wait program, interpreter as oracle).

## Verified — on the real reference machines, not just CI

| Where | What | Result |
|-------|------|--------|
| macOS ARM (host) | `zig build test`; `run-all.sh`; process suite under `-Dgc-stress=true` | 1858 pass / 0 fail (×4 runs); **2130 pass / 0 fail**; 28/28 |
| FreeBSD 15.1 aarch64 (UTM VM) | unit + thottam + run-all | **1858/0** + 88/0; run-all 2122 pass / 1 fail — the one fail is a pre-existing filesystem-audit issue (FreeBSD rejects `chmod 7777` on a regular file with EFTYPE for non-root; even system chmod fails), flagged separately |
| OpenBSD 7.9 aarch64 (UTM VM) | unit + thottam + run-all | **1858/0** + 88/0; run-all 2105 pass / 13 fail, every residual environmental: the native-`compile/` suite (compile-on-box needs the BTCFI/toolchain setup this VM lacks), the same sticky-bit audit (OpenBSD's chmod rejects it too — noted on the tracking issue), and two load timeouts (`callcc-bench` passes standalone). Process + R7RS suites fully pass |
| NetBSD 10.1 aarch64 (UTM VM) | unit + thottam + run-all; 40× immediate-kill race loop | **1858/0** + 87/0; race loop **0/40 lost** (was 5–8/40); run-all 2095 pass / 27 fail, every residual environmental and accounted: 25× native-`compile/` (base GCC cannot consume `.ll`; box lacks pkgsrc clang), 1× the same sticky-bit audit, 1× `--changed` (no git on box). Process suites pass |
| Alpine s390x (big-endian, musl, QEMU VM) | unit + thottam + run-all | **1853 pass / 0 fail** (12 platform skips) + 88/0; both process Scheme suites pass. run-all's residual failures are that tier's known scope limits (static musl has no dlopen for the FFI suites; no native backend on s390x) — CI runs units + R7RS there by design |
| Windows 11 aarch64 (UTM VM) | library-absence gate on the real box | `(cond-expand ((library (kaappi process)) …))` prints `process-absent` |
| Alpine ppc64le (musl, QEMU VM) | unit + thottam | **1853 pass / 0 fail** (12 platform skips) + 88/0 — same shape as the s390x leg (the VM needed two restarts to come back on SSH, hence this row landing after the others) |
| Cross-compile | x86_64-linux-gnu.2.28 / gnu / musl, aarch64-linux-gnu, riscv64, s390x-musl, ppc64le, x86_64-{freebsd,netbsd,openbsd}, {x86_64,aarch64}-windows, wasm32-wasi | all build; the process library is registered on none of windows/wasi |

Docs (`docs/dev` + guide page) and the high-level `run-process`/timeouts are Phase 4 per the KEP; `docs/dev/architecture.md` file tables updated.

Closes #2414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
