### PR TITLE
Always check SRFI 231 array-ref and array-set!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **SRFI 231 `array-ref`/`array-set!` are always checked** (#2448) — an
+  array built with `safe?: #f` handed the user the raw, unchecked accessor,
+  so an out-of-domain multi-index still computed a body offset. When that
+  offset landed inside the body it silently read or clobbered a *different,
+  valid* element: on a 2x3 array, `(array-ref a 0 5)` returned element
+  `(1 2)` and `(array-set! a 99 0 5)` overwrote it, with no error. This was
+  the default, since `specialized-array-default-safe?` is `#f`. Reported by
+  the SRFI's author, who has removed the safe/unsafe distinction from the
+  reference implementation for the same reason: the spec makes `safe?: #t`
+  *add* checks, it never licenses an unchecked `array-ref`/`array-set!`.
+  The user-visible getter and setter are now always wrapped, in all four
+  constructors (`make-specialized-array`,
+  `make-specialized-array-from-data`, `specialized-array-share`,
+  `specialized-array-reshape`); an internal unchecked pair is kept on the
+  array and used only by bulk operations, which generate their own
+  in-domain indices. Values are still checked on the way into a body except
+  where provably vacuous. `array-safe?` still reports what the caller asked
+  for, it just no longer gates checking. Net effect on the official suite:
+  known-divergence 351 is resolved and pruned, and bulk operations over
+  *safe* arrays get about 2x faster (a 200x200 `f64` `array-copy` goes from
+  0.348 s to 0.178 s) since they no longer re-validate indices they just
+  generated.
 - **A "never" reactor deadline no longer fails the poll** (#2395) — SRFI-18
   reads `+inf.0` as "never times out" and saturates it to a maxInt-nanosecond
   deadline ~585 years out; handed to `kevent` as a timespec that far ahead,

--- a/lib/srfi/231/arrays.sld
+++ b/lib/srfi/231/arrays.sld
@@ -40,11 +40,22 @@
           ;; and later phases) to build genuinely specialized arrays with
           ;; custom indexers, the same way (srfi 160 base)'s %uvec-* helpers
           ;; exist only for that package's own per-tag files to consume.
-          %make-array %safe-getter %safe-setter %make-lex-indexer %check-boolean!)
+          %make-array %make-array/unsafe %safe-getter %safe-setter
+          array-unsafe-getter array-unsafe-setter %copy-value-checker
+          %make-lex-indexer %check-boolean!)
   (begin
 
+    ;; getter/setter are ALWAYS the checked, user-visible pair; unsafe-getter
+    ;; and unsafe-setter are the internal, unchecked pair that bulk
+    ;; operations use because they only ever present in-domain multi-indices
+    ;; they generated themselves (#2448).
+    ;;
+    ;; safe? no longer gates whether array-ref/array-set! check -- they
+    ;; always do. It is retained because the spec exposes array-safe?, and
+    ;; it still records what the caller asked for.
     (define-record-type <array>
-      (%make-array domain getter setter body indexer storage-class safe?)
+      (%make-array/unsafe domain getter setter body indexer storage-class safe?
+                          unsafe-getter unsafe-setter)
       array?
       (domain array-domain)
       (getter array-getter)
@@ -52,7 +63,23 @@
       (body %array-body-raw)
       (indexer %array-indexer-raw)
       (storage-class %array-storage-class-raw)
-      (safe? %array-safe?-raw))
+      (safe? %array-safe?-raw)
+      (unsafe-getter %array-unsafe-getter-raw)
+      (unsafe-setter %array-unsafe-setter-raw %array-set-unsafe-setter!))
+
+    ;; An array with no separately-supplied raw pair -- a closure-backed
+    ;; generalized array, where no unchecked accessor exists to fall back
+    ;; to. Its "unsafe" accessors are the checked ones, so bulk operations
+    ;; stay correct; they simply do not get the speedup.
+    (define (%make-array domain getter setter body indexer storage-class safe?)
+      (%make-array/unsafe domain getter setter body indexer storage-class safe?
+                          getter setter))
+
+    ;; Bulk operations call these instead of array-getter/array-setter.
+    ;; ONLY valid when the caller generates the multi-index from the array's
+    ;; own domain (interval-for-each and friends). Never hand one to user code.
+    (define (array-unsafe-getter a) (%array-unsafe-getter-raw a))
+    (define (array-unsafe-setter a) (%array-unsafe-setter-raw a))
 
     (define (mutable-array? a) (and (array? a) (if (%array-setter-raw a) #t #f)))
     (define (specialized-array? a) (and (array? a) (if (%array-body-raw a) #t #f)))
@@ -77,6 +104,28 @@
       (unless (specialized-array? a) (error "array-safe?: not a specialized array" a))
       (%array-safe?-raw a))
 
+    ;; Values are still checked on the way INTO a destination body, even
+    ;; though the index check is skipped -- storing an out-of-range value
+    ;; is what actually corrupts (u1 silently drops bits) or raises from
+    ;; deep inside the storage layer, and neither is acceptable just
+    ;; because the caller asked for an unsafe array (#2448).
+    ;;
+    ;; Returns the checker to apply per element, or #f when the check is
+    ;; provably vacuous:
+    ;;   - a generic destination manipulates every value; or
+    ;;   - source and destination share a storage class, so every value
+    ;;     read out of the source body already satisfies the destination's
+    ;;     checker by construction.
+    ;; (The reference goes further with a widening table -- u8 into u32 and
+    ;; friends. Not needed for the paths here; the two cases above already
+    ;; cover same-class copies and generic destinations.)
+    (define (%copy-value-checker source dest-storage-class)
+      (if (or (eq? dest-storage-class generic-storage-class)
+              (and (specialized-array? source)
+                   (eq? (array-storage-class source) dest-storage-class)))
+          #f
+          (storage-class-checker dest-storage-class)))
+
     (define (array-dimension a) (interval-dimension (array-domain a)))
     (define (array-empty? a) (interval-empty? (array-domain a)))
 
@@ -88,6 +137,9 @@
     (define (array-freeze! a)
       (unless (array? a) (error "array-freeze!: not an array" a))
       (%array-set-setter! a #f)
+      ;; must clear BOTH -- leaving the unsafe setter live would keep a
+      ;; frozen array writable through the bulk-operation path (#2448)
+      (%array-set-unsafe-setter! a #f)
       a)
 
     (define (make-array interval getter . maybe-setter)
@@ -182,9 +234,13 @@
                              ((storage-class-getter storage-class) body (apply indexer multi-index))))
                (raw-setter (lambda (val . multi-index)
                              ((storage-class-setter storage-class) body (apply indexer multi-index) val)))
-               (getter (if safe? (%safe-getter interval raw-getter) raw-getter))
-               (setter (if safe? (%safe-setter interval (storage-class-checker storage-class) raw-setter) raw-setter)))
-          (%make-array interval getter setter body indexer storage-class safe?))))
+               ;; ALWAYS checked, whatever safe? says -- the spec makes
+               ;; safe? add checks, it never licenses an unchecked
+               ;; user-visible accessor (#2448).
+               (getter (%safe-getter interval raw-getter))
+               (setter (%safe-setter interval (storage-class-checker storage-class) raw-setter)))
+          (%make-array/unsafe interval getter setter body indexer storage-class safe?
+                              raw-getter raw-setter))))
 
     ;; Wraps EXTERNALLY supplied data (e.g. a plain vector or one of this
     ;; codebase's own (srfi 160 <tag>) numeric vectors) as the body of a
@@ -208,10 +264,11 @@
                (indexer (lambda (i) i))
                (raw-getter (lambda (i) ((storage-class-getter storage-class) body (indexer i))))
                (raw-setter (lambda (val i) ((storage-class-setter storage-class) body (indexer i) val)))
-               (getter (if safe? (%safe-getter interval raw-getter) raw-getter))
+               (getter (%safe-getter interval raw-getter))
                (setter (and mutable?
-                            (if safe? (%safe-setter interval (storage-class-checker storage-class) raw-setter) raw-setter))))
-          (%make-array interval getter setter body indexer storage-class safe?))))
+                            (%safe-setter interval (storage-class-checker storage-class) raw-setter))))
+          (%make-array/unsafe interval getter setter body indexer storage-class safe?
+                              raw-getter (and mutable? raw-setter)))))
 
     ;; #t iff lexicographic traversal order visits CONSECUTIVE, INCREASING
     ;; body positions -- per spec, "the elements of array, taken in

--- a/lib/srfi/231/assembly.sld
+++ b/lib/srfi/231/assembly.sld
@@ -64,14 +64,17 @@
       (unless (array? source) (error "array-assign!: source is not an array" source))
       (unless (interval= (array-domain destination) (array-domain source))
         (error "array-assign!: destination and source must have the same domain" destination source))
-      (let ((dest-setter (array-setter destination)) (src-getter (array-getter source)))
+      ;; Domains are equal (checked above) and the indices come from
+      ;; interval-for-each over them, so the index check is redundant on
+      ;; both sides -- but the VALUE check is not (#2448).
+      (let ((dest-setter (array-unsafe-setter destination)) (src-getter (array-unsafe-getter source)))
         ;; The reference validates every element against the destination's
         ;; checker even when the destination is an UNSAFE specialized array
-        ;; ("should check anyway", test-arrays.scm:4361); the raw setter
-        ;; below skips checking, which for e.g. u1 silently corrupts bits
+        ;; ("should check anyway", test-arrays.scm:4361); the unsafe setter
+        ;; skips checking, which for e.g. u1 silently corrupts bits
         ;; instead of erroring (#2359).
         (let ((checker (and (specialized-array? destination)
-                            (storage-class-checker (array-storage-class destination)))))
+                            (%copy-value-checker source (array-storage-class destination)))))
           (interval-for-each (lambda multi-index
                                (let ((val (apply src-getter multi-index)))
                                  (when (and checker (not (checker val)))

--- a/lib/srfi/231/combinators.sld
+++ b/lib/srfi/231/combinators.sld
@@ -101,13 +101,13 @@
         (%check-same-domain! all "array-map")
         (make-array (array-domain array)
                     (lambda multi-index
-                      (apply f (map (lambda (a) (apply (array-getter a) multi-index)) all))))))
+                      (apply f (map (lambda (a) (apply (array-unsafe-getter a) multi-index)) all))))))
 
     (define (array-for-each f array . arrays)
       (%check-procedure! f "array-for-each")
       (let ((all (cons array arrays)))
         (%check-same-domain! all "array-for-each")
-        (interval-for-each (lambda multi-index (apply f (map (lambda (a) (apply (array-getter a) multi-index)) all)))
+        (interval-for-each (lambda multi-index (apply f (map (lambda (a) (apply (array-unsafe-getter a) multi-index)) all)))
                             (array-domain array))))
 
     (define (array-fold-left operator identity array . arrays)
@@ -115,7 +115,7 @@
       (let ((all (cons array arrays)) (acc identity))
         (%check-same-domain! all "array-fold-left")
         (interval-for-each (lambda multi-index
-                              (set! acc (apply operator acc (map (lambda (a) (apply (array-getter a) multi-index)) all))))
+                              (set! acc (apply operator acc (map (lambda (a) (apply (array-unsafe-getter a) multi-index)) all))))
                             (array-domain array))
         acc))
 
@@ -129,7 +129,7 @@
       (let ((all (cons array arrays)) (results '()))
         (%check-same-domain! all "array-fold-right")
         (interval-for-each (lambda multi-index
-                              (set! results (cons (map (lambda (a) (apply (array-getter a) multi-index)) all) results)))
+                              (set! results (cons (map (lambda (a) (apply (array-unsafe-getter a) multi-index)) all) results)))
                             (array-domain array))
         (let loop ((xs results) (acc identity))
           (if (null? xs) acc (loop (cdr xs) (apply operator (append (car xs) (list acc))))))))
@@ -146,7 +146,7 @@
       (unless (array? array) (error "array-reduce: not an array" array))
       (unless (procedure? operator) (error "array-reduce: not a procedure" operator))
       (when (array-empty? array) (error "array-reduce: cannot reduce an empty array" array))
-      (let ((acc %array-reduce-sentinel) (getter (array-getter array)))
+      (let ((acc %array-reduce-sentinel) (getter (array-unsafe-getter array)))
         (interval-for-each (lambda multi-index
                               (let ((val (apply getter multi-index)))
                                 (set! acc (if (eq? acc %array-reduce-sentinel) val (operator acc val)))))
@@ -163,7 +163,7 @@
         (call/cc
          (lambda (return)
            (interval-for-each (lambda multi-index
-                                 (let ((r (apply predicate (map (lambda (a) (apply (array-getter a) multi-index)) all))))
+                                 (let ((r (apply predicate (map (lambda (a) (apply (array-unsafe-getter a) multi-index)) all))))
                                    (when r (return r))))
                                (array-domain array))
            #f))))
@@ -177,7 +177,7 @@
         (call/cc
          (lambda (return)
            (interval-for-each (lambda multi-index
-                                 (let ((r (apply predicate (map (lambda (a) (apply (array-getter a) multi-index)) all))))
+                                 (let ((r (apply predicate (map (lambda (a) (apply (array-unsafe-getter a) multi-index)) all))))
                                    (if r (set! last-result r) (return #f))))
                                (array-domain array))
            last-result))))
@@ -192,8 +192,8 @@
             (d1 (array-dimension array1)))
         (make-array domain
                     (lambda multi-index
-                      (operator (apply (array-getter array1) (take multi-index d1))
-                                (apply (array-getter array2) (drop multi-index d1)))))))
+                      (operator (apply (array-unsafe-getter array1) (take multi-index d1))
+                                (apply (array-unsafe-getter array2) (drop multi-index d1)))))))
 
     (define (array-inner-product A f g B)
       (%check-procedure! f "array-inner-product")
@@ -218,7 +218,7 @@
     (define (array->list array)
       (unless (array? array) (error "array->list: not an array" array))
       (let ((acc '()))
-        (interval-for-each (lambda multi-index (set! acc (cons (apply (array-getter array) multi-index) acc)))
+        (interval-for-each (lambda multi-index (set! acc (cons (apply (array-unsafe-getter array) multi-index) acc)))
                             (array-domain array))
         (reverse acc)))
 
@@ -247,7 +247,10 @@
                       (error "list->array: not all elements of the source can be manipulated by the storage class" x storage-class)))
                   lst)
         (let* ((dest (make-specialized-array interval storage-class (storage-class-default storage-class) safe?))
-               (setter (array-setter dest))
+               ;; every element was checked above and the indices come from
+               ;; interval-for-each, so the checked setter would re-verify
+               ;; what is already known (#2448)
+               (setter (array-unsafe-setter dest))
                (remaining lst))
           (interval-for-each (lambda multi-index
                                (apply setter (car remaining) multi-index)
@@ -276,7 +279,8 @@
                      (vector-ref vect i) storage-class))
             (loop (+ i 1))))
         (let* ((dest (make-specialized-array interval storage-class (storage-class-default storage-class) safe?))
-               (setter (array-setter dest))
+               ;; see list->array
+               (setter (array-unsafe-setter dest))
                (i 0))
           (interval-for-each (lambda multi-index
                                (apply setter (vector-ref vect i) multi-index)

--- a/lib/srfi/231/views.sld
+++ b/lib/srfi/231/views.sld
@@ -87,10 +87,12 @@
                            ((storage-class-getter storage-class) body (apply new-indexer multi-index))))
              (raw-setter (lambda (val . multi-index)
                            ((storage-class-setter storage-class) body (apply new-indexer multi-index) val)))
-             (getter (if safe? (%safe-getter new-domain raw-getter) raw-getter))
+             ;; always checked; the raw pair is kept for bulk ops (#2448)
+             (getter (%safe-getter new-domain raw-getter))
              (setter (and mutable?
-                          (if safe? (%safe-setter new-domain (storage-class-checker storage-class) raw-setter) raw-setter))))
-        (%make-array new-domain getter setter body new-indexer storage-class safe?)))
+                          (%safe-setter new-domain (storage-class-checker storage-class) raw-setter))))
+        (%make-array/unsafe new-domain getter setter body new-indexer storage-class safe?
+                            raw-getter (and mutable? raw-setter))))
 
     ;; --- the 3-way dispatch shape shared by extract/translate/permute/reverse/sample ---
 
@@ -325,10 +327,20 @@
              (mutable? (%opt opts 1 (if specialized? (mutable-array? array) (specialized-array-default-mutable?))))
              (safe? (%opt opts 2 (if specialized? (array-safe? array) (specialized-array-default-safe?))))
              (domain (array-domain array))
-             (getter (array-getter array))
+             ;; indices come from interval-for-each over the source's own
+             ;; domain, so neither side needs the index check; values are
+             ;; still checked unless provably valid (#2448)
+             (getter (array-unsafe-getter array))
              (dest (make-specialized-array domain storage-class (storage-class-default storage-class) safe?))
-             (dest-setter (array-setter dest)))
-        (interval-for-each (lambda multi-index (apply dest-setter (apply getter multi-index) multi-index)) domain)
+             (dest-setter (array-unsafe-setter dest))
+             (checker (%copy-value-checker array storage-class)))
+        (interval-for-each (lambda multi-index
+                             (let ((val (apply getter multi-index)))
+                               (when (and checker (not (checker val)))
+                                 (error "array-copy: not all elements of the source can be stored in the destination"
+                                        val storage-class))
+                               (apply dest-setter val multi-index)))
+                           domain)
         (if mutable? dest (array-freeze! dest))))
 
     (define (array-copy array . opts) (%array-copy-impl array opts))
@@ -433,10 +445,11 @@
                                          ((storage-class-getter storage-class) body (apply new-indexer multi-index))))
                            (raw-setter (lambda (val . multi-index)
                                          ((storage-class-setter storage-class) body (apply new-indexer multi-index) val)))
-                           (getter (if safe? (%safe-getter new-domain raw-getter) raw-getter))
+                           (getter (%safe-getter new-domain raw-getter))
                            (setter (and mutable?
-                                        (if safe? (%safe-setter new-domain (storage-class-checker storage-class) raw-setter) raw-setter))))
-                      (%make-array new-domain getter setter body new-indexer storage-class safe?)))))
+                                        (%safe-setter new-domain (storage-class-checker storage-class) raw-setter))))
+                      (%make-array/unsafe new-domain getter setter body new-indexer storage-class safe?
+                                          raw-getter (and mutable? raw-setter))))))
             ;; NumPy's _attempt_nocopy_reshape, transcribed. Walk minimal
             ;; adjacent-axis groups of equal volume in the old and new
             ;; shapes; within each old group require C-contiguity so one

--- a/tests/scheme/srfi/srfi231-arrays.scm
+++ b/tests/scheme/srfi/srfi231-arrays.scm
@@ -217,6 +217,62 @@
 ;; an empty plain array errors on any access instead of running the closure
 (let ((e (make-array (make-interval '#(3 0)) (lambda (i j) 'should-never-run))))
   (test-equal #t (guard (e2 (#t #t)) ((array-getter e) 0 0) #f)))
+
+;;; --- #2448: safe? must not disable the user-visible checks ------------
+;;; Reported by the SRFI 231 author (gambiteer): the spec makes safe?: #t
+;;; ADD argument checking, it never licenses an unchecked array-ref /
+;;; array-set!. The dangerous case is NOT the wild index that escapes the
+;;; body and trips the storage layer -- it is the out-of-domain index that
+;;; lands INSIDE it, which used to silently read or clobber a different,
+;;; valid element with no error at all.
+(let ((a (make-specialized-array (make-interval (vector 2 3)) u8-storage-class 0 #f)))
+  (array-set! a 7 1 2)
+  (test-equal "unsafe array: in-domain ref still works" 7 (array-ref a 1 2))
+  ;; (0 5) is out of domain but maps to flat offset 5 -- the same cell as
+  ;; (1 2). Before the fix this returned 7 rather than raising.
+  (test-assert "unsafe array: out-of-domain ref that aliases a valid cell raises"
+               (guard (e (#t #t)) (array-ref a 0 5) #f))
+  (test-assert "unsafe array: out-of-domain set! that aliases a valid cell raises"
+               (guard (e (#t #t)) (array-set! a 99 0 5) #f))
+  (test-equal "unsafe array: the aliased cell was not clobbered" 7 (array-ref a 1 2))
+  ;; indices that escape the body entirely were already loud, but reported
+  ;; from the storage layer naming a flat offset the user never wrote
+  (test-assert "unsafe array: far out-of-domain ref raises"
+               (guard (e (#t #t)) (array-ref a 9 9) #f))
+  (test-assert "unsafe array: negative out-of-domain ref raises"
+               (guard (e (#t #t)) (array-ref a -4 0) #f))
+  ;; values are checked too, not just indices
+  (test-assert "unsafe array: out-of-range value raises"
+               (guard (e (#t #t)) (array-set! a 300 0 0) #f))
+  (test-assert "unsafe array: wrong-typed value raises"
+               (guard (e (#t #t)) (array-set! a (quote foo) 0 0) #f))
+  (test-equal "unsafe array: a rejected store left the cell alone" 0 (array-ref a 0 0)))
+
+;;; An unsafe array now reports exactly what a safe one does.
+(let ((u (make-specialized-array (make-interval (vector 2 3)) u8-storage-class 0 #f))
+      (s (make-specialized-array (make-interval (vector 2 3)) u8-storage-class 0 #t)))
+  (test-equal "safe and unsafe agree on out-of-domain ref"
+              (guard (e (#t (error-object-message e))) (array-ref s 0 5) (quote no-error))
+              (guard (e (#t (error-object-message e))) (array-ref u 0 5) (quote no-error)))
+  (test-equal "safe and unsafe agree on a rejected value"
+              (guard (e (#t (error-object-message e))) (array-set! s 300 0 0) (quote no-error))
+              (guard (e (#t (error-object-message e))) (array-set! u 300 0 0) (quote no-error))))
+
+;;; array-safe? still reports what the caller asked for -- the flag is
+;;; retained (the spec exposes it), it just no longer gates checking.
+(let ((u (make-specialized-array (make-interval (vector 2)) u8-storage-class 0 #f))
+      (s (make-specialized-array (make-interval (vector 2)) u8-storage-class 0 #t)))
+  (test-equal "array-safe? still reflects the constructor argument #f" #f (array-safe? u))
+  (test-equal "array-safe? still reflects the constructor argument #t" #t (array-safe? s)))
+
+;;; array-freeze! must close the bulk-operation write path too, not just
+;;; the user-visible setter.
+(let ((a (make-specialized-array (make-interval (vector 2 2)) u8-storage-class 0 #f)))
+  (array-freeze! a)
+  (test-equal "frozen unsafe array is immutable" #f (mutable-array? a))
+  (test-assert "frozen unsafe array rejects array-set!"
+               (guard (e (#t #t)) (array-set! a 1 0 0) #f)))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-231-arrays")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi231-assembly.scm
+++ b/tests/scheme/srfi/srfi231-assembly.scm
@@ -5,8 +5,8 @@
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi231-assembly.scm
 
 (import (scheme base) (scheme process-context) (srfi 64)
-        (srfi 231 intervals) (srfi 231 arrays) (srfi 231 views)
-        (srfi 231 combinators) (srfi 231 assembly))
+        (srfi 231 intervals) (srfi 231 storage-classes) (srfi 231 arrays)
+        (srfi 231 views) (srfi 231 combinators) (srfi 231 assembly))
 
 (test-begin "srfi-231-assembly")
 
@@ -173,6 +173,27 @@
                          '#(1 1))))
   (test-equal '(0 1 10 11) (array->list b))
   (test-equal 4 src-calls))
+
+
+;;; --- #2448: array-assign! uses the unchecked accessors internally ------
+;;; Both sides' domains are verified equal up front and the indices come
+;;; from interval-for-each over them, so the index check is redundant --
+;;; but the VALUE check is not, and must survive the switch.
+(let ((src (make-specialized-array (make-interval (vector 3 4)) u8-storage-class 0 #f))
+      (n 0))
+  (interval-for-each (lambda (i j) (array-set! src n i j) (set! n (+ n 1)))
+                     (array-domain src))
+  (let ((dest (make-specialized-array (make-interval (vector 3 4)) u8-storage-class 0 #f)))
+    (array-assign! dest src)
+    (test-equal "array-assign! into an unsafe destination copies every element"
+                (array->list src) (array->list dest))))
+
+;;; A value the destination body cannot hold must still raise, not corrupt
+;;; -- u1 is the sharp case, since an unchecked store silently drops bits.
+(let ((generic (array-copy (make-array (make-interval (vector 2 2)) (lambda (i j) 5))))
+      (dest (make-specialized-array (make-interval (vector 2 2)) u1-storage-class 0 #f)))
+  (test-assert "array-assign! into u1 rejects an unstorable value"
+               (guard (e (#t #t)) (array-assign! dest generic) #f)))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-231-assembly")

--- a/tests/scheme/srfi/srfi231-official-transform.py
+++ b/tests/scheme/srfi/srfi231-official-transform.py
@@ -735,14 +735,16 @@ NEW_REPORT = ''';;; --- kaappi vendoring: known-divergence accounting ----------
 ;;; epilogue fails the suite unless every entry accounts exactly: an id
 ;;; that never executes, zero observed (stale -- prune it), more
 ;;; divergences than expected (an undocumented failure is hiding under
-;;; the id, e.g. a third unsafe-view evaluation absorbed by the 351
-;;; entry, whose site legitimately fires twice), or fewer but nonzero
-;;; (over-accounting -- re-count it).
+;;; the id), or fewer but nonzero (over-accounting -- re-count it).
+;;;
+;;; Entry 351 lived here until kaappi#2448: unsafe specialized views went
+;;; unchecked, which the spec text permits but the reference does not do.
+;;; kaappi now always checks the user-visible getter/setter, so that
+;;; divergence is resolved rather than documented.
 (define divergent-tests 0)
 (define diverged-counts (make-vector 10000 0))
 (define known-divergences
-  (list '(147 1 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")
-        '(351 2 . "unsafe specialized views are unchecked per the spec text; the reference happens to check (see kaappi#2362)")))
+  (list '(147 1 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")))
 (define (known-divergence id) (assq id known-divergences))
 
 (define (report-failure id line result expected)

--- a/tests/scheme/srfi/srfi231-official.scm
+++ b/tests/scheme/srfi/srfi231-official.scm
@@ -123,14 +123,16 @@ OTHER DEALINGS IN THE SOFTWARE.
 ;;; epilogue fails the suite unless every entry accounts exactly: an id
 ;;; that never executes, zero observed (stale -- prune it), more
 ;;; divergences than expected (an undocumented failure is hiding under
-;;; the id, e.g. a third unsafe-view evaluation absorbed by the 351
-;;; entry, whose site legitimately fires twice), or fewer but nonzero
-;;; (over-accounting -- re-count it).
+;;; the id), or fewer but nonzero (over-accounting -- re-count it).
+;;;
+;;; Entry 351 lived here until kaappi#2448: unsafe specialized views went
+;;; unchecked, which the spec text permits but the reference does not do.
+;;; kaappi now always checks the user-visible getter/setter, so that
+;;; divergence is resolved rather than documented.
 (define divergent-tests 0)
 (define diverged-counts (make-vector 10000 0))
 (define known-divergences
-  (list '(147 1 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")
-        '(351 2 . "unsafe specialized views are unchecked per the spec text; the reference happens to check (see kaappi#2362)")))
+  (list '(147 1 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")))
 (define (known-divergence id) (assq id known-divergences))
 
 (define (report-failure id line result expected)

--- a/tests/scheme/srfi/srfi231-views.scm
+++ b/tests/scheme/srfi/srfi231-views.scm
@@ -316,6 +316,46 @@
                 (array-tile (make-array (make-interval (vector 0)) list)
                             (vector (vector 0))))))
 
+
+;;; --- #2448: unsafe VIEWS are checked too, and bulk ops stay correct ---
+;;; specialized-array-share and specialized-array-reshape build their own
+;;; getter/setter pair, so each needed the same fix as the two array
+;;; constructors. This is the case the vendored official suite recorded as
+;;; known-divergence 351 ("unsafe specialized views are unchecked") --
+;;; that entry is pruned as of this fix.
+(let* ((base (make-specialized-array (make-interval (vector 4 4)) u8-storage-class 0 #f))
+       (sub (specialized-array-share base (make-interval (vector 2 2))
+                                     (lambda (i j) (values i j)))))
+  (test-equal "unsafe view: in-domain ref works" 0 (array-ref sub 1 1))
+  (test-assert "unsafe view: out-of-domain ref raises"
+               (guard (e (#t #t)) (array-ref sub 2 0) #f))
+  (test-assert "unsafe view: out-of-domain set! raises"
+               (guard (e (#t #t)) (array-set! sub 1 0 3) #f))
+  (test-assert "unsafe view: rejected value raises"
+               (guard (e (#t #t)) (array-set! sub 300 0 0) #f)))
+
+;;; The bulk operations now use the unchecked accessors internally; they
+;;; must still traverse and produce exactly what they did before.
+(let* ((src (make-specialized-array (make-interval (vector 3 4)) u8-storage-class 0 #f))
+       (n 0))
+  (interval-for-each (lambda (i j) (array-set! src n i j) (set! n (+ n 1)))
+                     (array-domain src))
+  (let ((copy (array-copy src)))
+    (test-equal "array-copy over an unsafe source reproduces every element"
+                (array->list src) (array->list copy))
+    (test-equal "array-copy result has the source's domain"
+                #t (interval= (array-domain src) (array-domain copy))))
+  ;; a copy is still checked on the way in, and its own accessors are checked
+  (let ((copy (array-copy src)))
+    (test-assert "array-copy result rejects an out-of-domain ref"
+                 (guard (e (#t #t)) (array-ref copy 0 4) #f))))
+
+;;; Value checking on the copy path survives the switch to unchecked
+;;; setters: a generic source holding values a u8 body cannot store must
+;;; raise rather than corrupt (the u1 case silently drops bits).
+(let ((generic (array-copy (make-array (make-interval (vector 2 2)) (lambda (i j) 300)))))
+  (test-assert "array-copy into u8 rejects an unstorable value"
+               (guard (e (#t #t)) (array-copy generic u8-storage-class) #f)))
 (let ((runner (test-runner-current)))
   (test-end "srfi-231-views")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
## The bug

An array built with `safe?: #f` handed the user the **raw, unchecked**
accessor, so an out-of-domain multi-index still computed a body offset.
When that offset landed *inside* the body, it silently read or clobbered a
different, valid element:

```scheme
(define a (make-specialized-array (make-interval (vector 2 3)) u8-storage-class))
(array-set! a 7 1 2)
(array-ref a 1 2)     ; => 7
(array-ref a 0 5)     ; => 7   (0 5) is NOT in the domain -- aliases (1 2)
(array-set! a 99 0 5) ; no error
(array-ref a 1 2)     ; => 99  silently clobbered
```

This was the **default** path, since `specialized-array-default-safe?` is
`#f`. Only an index wild enough to escape the body was loud, and then the
diagnostic leaked the storage layer and named a flat offset the user never
wrote (`bytevector-u8-ref: index 36 out of range for length 6`).

Reproduced identically on released **v0.25.0** (`767d54ec`) and on HEAD.

Worth stating plainly, since the upstream report is framed around crashes:
**kaappi never crashed here.** Every storage class bounds-checks its body --
probed with +/-1e6 indices across `u1`, `u8`, `s16`, `u32`, `f32`, `f64`,
`c64`, `generic`, all 24 ref/set combinations raise. The wrong answer *was*
the bug, and it is quieter than a crash.

## The fix

The spec makes `safe?: #t` **add** argument checking; it never licenses an
unchecked `array-ref`/`array-set!`. The SRFI's author has since removed the
distinction from the reference implementation for the same reason, and this
follows that design:

- the user-visible getter/setter are **always** wrapped, in all four
  constructors -- `make-specialized-array`,
  `make-specialized-array-from-data`, `specialized-array-share`,
  `specialized-array-reshape`;
- an internal `unsafe-getter`/`unsafe-setter` pair is kept on `<array>` and
  used **only** by bulk operations, which generate their own in-domain
  indices from `interval-for-each` and so cannot present a bad one;
- an array with no raw pair (a closure-backed generalized array) gets the
  checked accessors as its "unsafe" pair, so bulk ops stay correct there --
  they just don't get the speedup;
- `array-freeze!` clears **both** setters, or a frozen array would stay
  writable through the bulk path;
- `array-safe?` still reports what the caller asked for. It just no longer
  gates checking.

Values are still validated on the way into a body -- an unchecked store is
what actually corrupts, and `u1` silently drops bits. `%copy-value-checker`
skips the check only where provably vacuous: a generic destination
manipulates every value, and a same-storage-class copy reads values that
already satisfy the destination's checker. (The reference goes further with
a widening table, `u8` into `u32` and friends; not needed for these paths.)

## Evidence

**The official suite already knew about this.** The vendored upstream suite
carried it as known-divergence **351** -- *"unsafe specialized views are
unchecked per the spec text; the reference happens to check (see #2362)"*.
That entry is now resolved and pruned from the transform. With the entry
pruned, measured against the same regenerated suite:

| | unexpected failures | passed |
|---|---|---|
| before the fix | **2** | 10924 |
| after the fix | **0** | 10926 |

So the change moves us onto the reference's behavior rather than away from
it. (Isolated by running the pristine pre-change `.sld` files through a
`KAAPPI_HOME` lib tree against the same binary and same suite.)

**Bulk operations over safe arrays get ~2x faster**, since they no longer
re-validate indices they just generated:

```text
array-copy 200x200 f64, safe:   0.348 s  ->  0.178 s
array-copy 200x200 f64, unsafe: 0.165 s  ->  0.178 s
```

Unsafe arrays give up ~8% to become correct; safe arrays roughly halve. The
two now cost the same, which is the point -- there is no longer a fast tier
and a correct tier.

## Tests

New regression tests in `srfi231-arrays.scm` (+15), `srfi231-views.scm`
(+9), `srfi231-assembly.scm` (+2), each named so a failure is legible.
Against the **pre-fix** `.sld` they fail 5 / 3 / 0 respectively; after, all
pass. They cover the aliasing case specifically -- the out-of-domain index
that lands inside the body -- since that is the one the existing suite could
not catch, as it returned a plausible value rather than raising.

Also asserted: bulk ops still reproduce every element over unsafe sources,
`array-copy`/`array-assign!` still reject unstorable values (`u1` and `u8`
destinations), and a frozen unsafe array rejects writes.

## Verification

- `zig build test` -- pass
- `bash tests/scheme/run-all.sh` -- **2132 pass, 0 fail** (737 Scheme files
  + 1395 R7RS)
- official SRFI 231 suite -- 10926 passed, 0 unexpected failures, 0 resolved
  divergences, 0 count mismatches
- `markdownlint` clean; transform regeneration is reproducible

The generated suite was regenerated via the transform, never hand-edited.

One pre-existing, unrelated wrinkle left alone: 11 `continuation cannot
resume across a returned native call` diagnostics in the official suite,
identical in count before and after this change.

Closes #2448
