### PR TITLE
Give apply and call-with-values a non-tail resumable path (#2451)

### DIFF
--- a/.claude/skills/bytecode-isa/SKILL.md
+++ b/.claude/skills/bytecode-isa/SKILL.md
@@ -5,7 +5,7 @@ description: Reference for the Kaappi bytecode instruction set
 # Bytecode ISA
 
 The instruction set reference lives in `docs/dev/bytecode.md` — read that
-file for the full 31-opcode table, operand encodings, closure capture
+file for the full 32-opcode table, operand encodings, closure capture
 encoding, and disassembler output format. Do not duplicate the table here;
 that doc is the single source of truth.
 
@@ -20,9 +20,23 @@ Quick orientation:
 ## Adding a new opcode
 
 1. Add to the `OpCode` enum in `src/types.zig` (append at the end — `.sbc`
-   bytecode files encode opcodes by integer value)
-2. Add a case to the `runUntil` dispatch switch in `src/vm_dispatch.zig`
+   bytecode files encode opcodes by integer value, so inserting one renumbers
+   every opcode after it. The cache load path rejects a foreign build by
+   compiler hash, but `src/testdata/fuzz-seed.sbc` patches that hash in at
+   comptime and has no such guard: it decodes as garbage, and the `fuzz seed
+   .sbc fixture stays loadable` test is what tells you). Bump the count in the
+   comptime doc-sync gate below the enum and follow the files it names.
+2. Add its width to the `fixed_operand_bytes` switch in `src/vm_dispatch.zig`
+   — the authoritative operand-width table — and a case to the `runUntil`
+   dispatch switch
 3. Emit it in the compiler (`src/compiler.zig` or the relevant
    `compiler_*.zig` module)
-4. Handle it in `src/disassembler.zig`
-5. Update the table in `docs/dev/bytecode.md`
+4. Handle it in `src/disassembler.zig` (both its `fixed_operand_bytes` switch
+   and its printer)
+5. Add it to `validateFunctionBytecode` in `src/bytecode_file_read.zig`, or a
+   `.sbc` carrying it is rejected as corrupt
+6. Widen the three `raw_op > @intFromEnum(OpCode.<last>)` range checks that
+   guard the decoders (`vm_dispatch.zig`, `bytecode_file_read.zig`,
+   `disassembler.zig`) — they name the last enum member, so appending moves
+   them
+7. Update the table in `docs/dev/bytecode.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Continuations captured under a non-tail `apply` or `call-with-values`
+  (#2451)** — resuming one raised `KP3000: continuation cannot resume across a
+  returned native call`. Both reached their callee through a native
+  primitive's `vm.callWithArgs`, a fresh VM session under a Zig frame that is
+  gone by the time the continuation is reinstated. Tail position was already
+  exempt (the `tail_apply` opcode), which is what made the restriction
+  impossible to predict from the outside — `map`, `for-each`, `vector-map`,
+  `vector-for-each` and `string-for-each` were fine either way, these two only
+  in tail position, and R7RS requires all of them to be fully re-entrant. A new
+  non-tail `apply` opcode calls the flattened callee with an ordinary VM frame,
+  and `call-with-values` now applies its consumer through it in both positions,
+  so the consumer's frame lives in the continuation snapshot like any other.
+  An `apply` flattening more than 255 arguments still takes the native route
+  (#649 requires it to work at all, and the call opcode's argument count is one
+  byte), as does `call-with-values`' producer. Diagnostics are unchanged in
+  both wording and order, including the parity with the LLVM backend that
+  `tests/scheme/compile/native-apply-lowering-1803.sh` pins.
 - **SRFI 231 `array-ref`/`array-set!` are always checked** (#2448) — an
   array built with `safe?: #f` handed the user the raw, unchecked accessor,
   so an out-of-domain multi-index still computed a body offset. When that

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ mapped or walked freely.
 `append-map`, `pair-for-each`, `pair-fold`, the `lset-*` family, and
 `assoc`/`member` with a custom predicate, among others — plus two corners of
 the exempt pair: `call-with-values`' **producer** (the consumer is what runs in
-the dispatch loop; the producer still runs under the native call), and an
+the dispatch loop; the producer still runs under the native call — #2453), and an
 `apply` whose flattened argument list exceeds 255 arguments, which falls back to
 the native route because the call opcode's argument count is a single byte.
 

--- a/README.md
+++ b/README.md
@@ -391,15 +391,25 @@ element — cannot be resumed once that driver's call has returned, because the
 driver's state lives on the Zig stack, not in the copied VM state. This is the
 restriction [CONFORMANCE.md](CONFORMANCE.md) refers to. It is why a
 continuation-backed value (e.g. a SRFI 158 coroutine generator, which captures
-a continuation on every `yield`) breaks when consumed inside such a driver. As
-of #2060 the SRFI-1 `fold`, `filter`, `any`, `every`, `unfold` and SRFI-69
-`hash-table-walk` run in the bytecode dispatch loop and are exempt — a coroutine
-generator can be folded, filtered, or walked freely. The remaining native
-SRFI-1 drivers still carry the restriction: `fold-right`, `reduce`,
-`reduce-right`, `find`, `find-tail`, `count`, `partition`, `remove`,
+a continuation on every `yield`) breaks when consumed inside such a driver.
+
+Which procedures are exempt is not guessable from the outside, so here is the
+list. **Exempt** — a continuation captured in the callback resumes freely:
+`apply` and `call-with-values` (both positions, #2451 for the non-tail half),
+`map`, `for-each`, `vector-map`, `vector-for-each`, `string-for-each`, and — as
+of #2060 — the SRFI-1 `fold`, `filter`, `any`, `every`, `unfold` and SRFI-69
+`hash-table-walk`. A coroutine generator can be applied, folded, filtered,
+mapped or walked freely.
+
+**Still restricted**: the remaining native SRFI-1 drivers — `fold-right`,
+`reduce`, `reduce-right`, `find`, `find-tail`, `count`, `partition`, `remove`,
 `take-while`, `drop-while`, `delete`, `delete-duplicates`, `filter-map`,
 `append-map`, `pair-for-each`, `pair-fold`, the `lset-*` family, and
-`assoc`/`member` with a custom predicate, among others.
+`assoc`/`member` with a custom predicate, among others — plus two corners of
+the exempt pair: `call-with-values`' **producer** (the consumer is what runs in
+the dispatch loop; the producer still runs under the native call), and an
+`apply` whose flattened argument list exceeds 255 arguments, which falls back to
+the native route because the call opcode's argument count is a single byte.
 
 SRFI 248's delimited continuations (`with-unwind-handler`, and the extended
 `guard`) are built on this `call/cc` via a sticky exception handler, with three

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -79,7 +79,7 @@ investigations.
 
 | Document | Contents |
 |----------|----------|
-| [bytecode.md](bytecode.md) | Bytecode instruction set (31 opcodes), encoding, disassembler |
+| [bytecode.md](bytecode.md) | Bytecode instruction set (32 opcodes), encoding, disassembler |
 | [repl.md](repl.md) | REPL reference: line editing, comma commands, completion |
 | [unicode-case-mapping.md](unicode-case-mapping.md) | Case-conversion coverage by script |
 | [fuzzing-feasibility.md](fuzzing-feasibility.md) | Why neither Fuzzilli nor AFL++ is the tool, the existing `std.testing.fuzz` targets, and where fuzzing can improve |

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -330,7 +330,7 @@ enum value followed by operands.
 
 ### Opcodes
 
-31 opcodes, defined by the `OpCode` enum in `src/types.zig`. Register, slot,
+32 opcodes, defined by the `OpCode` enum in `src/types.zig`. Register, slot,
 constant-index and symbol-index operands are u16 (big-endian); only `nargs` and
 a closure capture descriptor's `is_local` flag are u8.
 

--- a/docs/dev/bytecode.md
+++ b/docs/dev/bytecode.md
@@ -62,6 +62,13 @@ compiler hash in at comptime, so it has none of the cross-build rejection that
 protects a real cache entry — it simply decoded as garbage. **New opcodes go on
 the end of the enum.**
 
+The `apply` handler's body is `dispatchApply` in `vm_dispatch_helpers.zig`,
+not the dispatch arm: `vm_dispatch.zig` sits at the 1500-line file-size
+ceiling, and operand validation plus argument staging are what that file
+already holds for every other opcode. The arm keeps only what a helper cannot
+express — the `continue` that resumes a restored continuation in *that*
+dispatch loop, and the ip rewind for a parked fiber's retry.
+
 `apply` and `tail_apply` differ in more than tail position. `tail_apply`
 rejects a flattened argument list longer than 255 (`tooManyApplyArgs`, KP3007)
 because it has nowhere to put the overflow; `apply` falls back to the native

--- a/docs/dev/bytecode.md
+++ b/docs/dev/bytecode.md
@@ -5,7 +5,7 @@ the ISA — the `/bytecode-isa` skill points here.
 
 ## Instruction set
 
-31 opcodes, register-based, variable-length encoding. Register/slot,
+32 opcodes, register-based, variable-length encoding. Register/slot,
 constant-index and symbol-index operands are all u16 (big-endian); jump
 offsets are i16 (signed, relative to the instruction after the jump). The
 only u8 operands are `nargs` and the `is_local` flag in a closure capture
@@ -49,10 +49,29 @@ operand-width table — it is what `ensureOperands` validates against, so the
 | 28 | `self_tail_call` | base:u16, nargs:u8 | 4 | Self-recursive tail call: copy args to frame base, reset IP |
 | 29 | `tail_call_cc` | base:u16, dst:u16 | 5 | `call/cc` in tail position: captures the continuation into dst, then tail-calls the receiver at base+0 |
 | 30 | `tail_eval` | base:u16, nargs:u8 | 4 | `eval` in tail position: compiles the expression at base+0 (optional environment at base+1) and tail-calls it |
+| 31 | `apply` | base:u16, nargs:u8 | 4 | Non-tail apply with list unpacking: flattens the final operand list into base+1… and calls the procedure at base+0 with an ordinary frame, result → base |
 
 `self_tail_call` skips the global lookup, type check, and arity check for
 direct self-recursion and named `let` loops — see
 [decisions/self-tail-call-optimization.md](decisions/self-tail-call-optimization.md).
+
+`apply` is numbered 31 rather than sitting next to `tail_apply` at 9 because
+an opcode's *number* is part of the `.sbc` encoding: inserting one renumbers
+every opcode after it, and `src/testdata/fuzz-seed.sbc` patches the header's
+compiler hash in at comptime, so it has none of the cross-build rejection that
+protects a real cache entry — it simply decoded as garbage. **New opcodes go on
+the end of the enum.**
+
+`apply` and `tail_apply` differ in more than tail position. `tail_apply`
+rejects a flattened argument list longer than 255 (`tooManyApplyArgs`, KP3007)
+because it has nowhere to put the overflow; `apply` falls back to the native
+`applyFn`'s heap-staged `callWithArgs` route, since #649 established that
+non-tail `apply` has no such ceiling. That fallback is also the one route
+through `apply` that keeps the returned-native-call restriction (kaappi#2451).
+Their diagnostics differ too: `apply` reproduces `applyFn`'s `typeError` texts,
+which `tests/scheme/compile/native-apply-lowering-1803.sh` pins against the
+LLVM backend's; `tail_apply` keeps its own terser in-loop wording, which that
+suite deliberately exempts.
 
 ### Encoding details
 

--- a/docs/dev/claude-code-harness.md
+++ b/docs/dev/claude-code-harness.md
@@ -258,7 +258,7 @@ missing type dispatch).
 ### `/bytecode-isa`
 
 Reference for the bytecode instruction set. Points at
-[bytecode.md](bytecode.md) (the single source of truth for the 31-opcode
+[bytecode.md](bytecode.md) (the single source of truth for the 32-opcode
 table and encodings) and carries the adding-a-new-opcode checklist. Used
 when working on the compiler or VM.
 

--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -658,6 +658,16 @@ expression in the body (~19x on kaappi#1803's arithmetic-loop reproducer). So
   ordinary indirect call through whatever `apply` resolves to in scope,
   matching the interpreter's plain `call_global`/local call.
 
+Since kaappi#2451 the interpreter has a **non-tail** `apply` opcode as well,
+which calls the flattened callee with an ordinary VM frame so a continuation
+captured in it survives the call's return. The native backend keeps routing
+both positions through `@kaappi_apply`, i.e. `applyFn`'s re-entrant
+`callWithArgs`, so that one guarantee is interpreter-only. Everything the
+`check_both*` cases in `tests/scheme/compile/native-apply-lowering-1803.sh`
+compare — results, and the non-tail `typeError` texts — is unaffected, because
+the opcode reproduces `applyFn`'s diagnostics verbatim for exactly that
+reason.
+
 Two consequences worth knowing. First, the free-variable analyses
 (`nodeHasFreeVars`/`collectNodeFreeVars` in `llvm_emit_freevars.zig`) walk an
 apply `passthrough`'s raw operands — a capture inside one must become a closure

--- a/src/bytecode_file_read.zig
+++ b/src/bytecode_file_read.zig
@@ -342,7 +342,7 @@ fn validateFunctionBytecode(func: *Function) BytecodeError!void {
     var ip: usize = 0;
     while (ip < code.len) {
         const raw = code[ip];
-        if (raw > @intFromEnum(OpCode.tail_eval)) return BytecodeError.CorruptedFile;
+        if (raw > @intFromEnum(OpCode.apply)) return BytecodeError.CorruptedFile;
         const op: OpCode = @enumFromInt(raw);
         ip += 1;
 
@@ -361,7 +361,7 @@ fn validateFunctionBytecode(func: *Function) BytecodeError!void {
                 if (ip + 4 > code.len) return BytecodeError.CorruptedFile;
                 ip += 4;
             },
-            .call, .tail_call, .tail_apply, .self_tail_call, .tail_eval => {
+            .call, .apply, .tail_call, .tail_apply, .self_tail_call, .tail_eval => {
                 if (ip + 3 > code.len) return BytecodeError.CorruptedFile;
                 ip += 3;
             },

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -477,8 +477,9 @@ pub const Compiler = struct {
     /// Answers whether a free global reference spelled `sym_name` (a bare
     /// name like `apply`, or a hygiene-renamed `__hyg_N_apply`) would still
     /// resolve to the genuine `(scheme base)` primitive `base_name` at run
-    /// time — the gate the tail-position superinstructions
-    /// (apply/eval/call/cc/call-with-values) need so a top-level
+    /// time — the gate the builtin superinstructions
+    /// (apply/call-with-values in any position, eval/call/cc in tail
+    /// position) need so a top-level
     /// redefinition of one of those names routes to the user's procedure
     /// instead of the baked-in builtin (kaappi#2033). Mirrors
     /// IR.isRedefined's fold gate and the resolution order of
@@ -1028,7 +1029,7 @@ pub const Compiler = struct {
             } // end if (!is_local)
         }
 
-        if (is_tail and types.isSymbol(head)) {
+        if (types.isSymbol(head)) {
             const sym_name = types.symbolName(head);
             // A compiler-synthesized reference carries base_binding_prefix
             // (#1715) — the let-values/let*-values/define-values/case-lambda
@@ -1037,7 +1038,7 @@ pub const Compiler = struct {
             // through the (scheme base) registry at run time, so the fast
             // path is always sound for it and the gate below does not apply.
             const is_synth = globals_mod.stripBaseBindingPrefix(sym_name) != null;
-            // The five tail fast paths (apply / call-with-values / call/cc /
+            // The five fast paths (apply / call-with-values / call/cc /
             // eval) recognize their operator by spelling. Since #2003 a
             // macro template's free reference to one of these globals is
             // hygiene-renamed (__hyg_N_<name>), so compare the stripped name
@@ -1053,11 +1054,20 @@ pub const Compiler = struct {
             else
                 types.stripHygienicPrefix(sym_name);
 
-            if (std.mem.eql(u8, eff_name, "apply") or
-                std.mem.eql(u8, eff_name, "call-with-values") or
-                std.mem.eql(u8, eff_name, "call-with-current-continuation") or
-                std.mem.eql(u8, eff_name, "call/cc") or
-                std.mem.eql(u8, eff_name, "eval"))
+            // apply and call-with-values have a non-tail superinstruction
+            // too (kaappi#2451): `apply`, which calls the flattened callee
+            // with an ordinary VM frame instead of routing it through the
+            // native applyFn's `vm.callWithArgs` re-entry, so a continuation
+            // captured under a non-tail `(apply f ...)` can be resumed after
+            // the call returns. call/cc and eval have tail-only opcodes
+            // (tail_call_cc, tail_eval) and keep the ordinary call path
+            // elsewhere.
+            const has_nontail_form = std.mem.eql(u8, eff_name, "apply") or
+                std.mem.eql(u8, eff_name, "call-with-values");
+            if (has_nontail_form or
+                (is_tail and (std.mem.eql(u8, eff_name, "call-with-current-continuation") or
+                    std.mem.eql(u8, eff_name, "call/cc") or
+                    std.mem.eql(u8, eff_name, "eval"))))
             {
                 // #2033: a *user-text* reference must resolve like any other
                 // global — R7RS 5.3.1 makes a top-level redefinition
@@ -1071,8 +1081,8 @@ pub const Compiler = struct {
                         (try self.resolveUpvalue(sym_name)) == null and
                         self.globalBindingStillGenuine(sym_name, eff_name));
                 if (fast_ok) {
-                    if (std.mem.eql(u8, eff_name, "apply")) return passthrough.compileApplyTail(self, expr, dst);
-                    if (std.mem.eql(u8, eff_name, "call-with-values")) return passthrough.compileCallWithValuesTail(self, expr, dst);
+                    if (std.mem.eql(u8, eff_name, "apply")) return passthrough.compileApplyForm(self, expr, dst, is_tail);
+                    if (std.mem.eql(u8, eff_name, "call-with-values")) return passthrough.compileCallWithValuesForm(self, expr, dst, is_tail);
                     if (std.mem.eql(u8, eff_name, "call-with-current-continuation") or
                         std.mem.eql(u8, eff_name, "call/cc"))
                     {

--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -269,7 +269,11 @@ fn compileSelfTailCall(self: *Compiler, expr: Value, dst: u16, nargs: u8) Compil
     }
 }
 
-pub fn compileApplyTail(self: *Compiler, expr: Value, dst: u16) CompileError!void {
+/// `(apply f a ... lst)` in either position (kaappi#2451). Tail position emits
+/// `tail_apply`; non-tail emits the `apply` opcode, which — unlike the native
+/// `applyFn` it replaces there — calls the flattened callee with an ordinary VM
+/// frame, so a continuation captured inside it survives the call's return.
+pub fn compileApplyForm(self: *Compiler, expr: Value, dst: u16, is_tail: bool) CompileError!void {
     var arg_list = types.cdr(expr);
     // A *proper* operand list of the wrong length (< 2) is an arity question,
     // not a syntax question: route the form through the ordinary call path so
@@ -284,7 +288,7 @@ pub fn compileApplyTail(self: *Compiler, expr: Value, dst: u16) CompileError!voi
             count += 1;
         }
         if (walk.cur != types.NIL) return CompileError.InvalidSyntax;
-        if (count < 2) return compileCall(self, expr, dst, true);
+        if (count < 2) return compileCall(self, expr, dst, is_tail);
     }
 
     const needs_rebase = (dst + 1 != self.next_register);
@@ -307,7 +311,7 @@ pub fn compileApplyTail(self: *Compiler, expr: Value, dst: u16) CompileError!voi
     if (nargs_count > 255) return CompileError.InternalLimit;
     const nargs: u8 = @intCast(nargs_count);
 
-    try self.emitOp(.tail_apply);
+    try self.emitOp(if (is_tail) .tail_apply else .apply);
     try self.emitU16(base);
     try self.emit(nargs);
 
@@ -316,21 +320,41 @@ pub fn compileApplyTail(self: *Compiler, expr: Value, dst: u16) CompileError!voi
         self.freeReg();
     }
     if (needs_rebase) {
+        // The non-tail opcode leaves its result in `base`, exactly as `call`
+        // does; `tail_apply` never returns here at all.
+        if (!is_tail) {
+            try self.emitOp(.move);
+            try self.emitU16(dst);
+            try self.emitU16(base);
+        }
         self.freeReg();
     }
 }
 
-pub fn compileCallWithValuesTail(self: *Compiler, expr: Value, dst: u16) CompileError!void {
-    // (call-with-values producer consumer) in tail position.
-    // Emits bytecode directly: load `list`/`call-with-values`, call the
-    // latter with (producer, list) -> values, then tail_apply(consumer,
-    // values). `list`/`call-with-values` are loaded via
-    // self.emitTrueBuiltinLoad, which marks the reference to resolve
-    // through the true (scheme base) binding at run time rather than
-    // by ordinary name lookup, so neither a lexical shadow NOR a later
-    // top-level redefinition of either name can affect this call (#1715;
-    // the previous plain get_global/call_global-by-name approach only
-    // ever protected against the former).
+pub fn compileCallWithValuesForm(self: *Compiler, expr: Value, dst: u16, is_tail: bool) CompileError!void {
+    // (call-with-values producer consumer), either position.
+    // Emits bytecode directly: call `%call-with-values->list` with (producer,
+    // consumer) -> the list of produced values, then apply/tail_apply the
+    // consumer over that list. Applying the consumer from the dispatch loop
+    // rather than from inside the native `call-with-values` is what lets a
+    // continuation captured in the consumer be resumed after the form
+    // returns: in non-tail position that used to be the native's own
+    // `vm.callWithArgs` re-entry, whose Zig frame is gone by the time the
+    // continuation is reinstated (kaappi#2451). The *producer* still runs
+    // under `%call-with-values->list`'s own native frame in both positions,
+    // so a continuation captured there keeps the restriction.
+    //
+    // `%call-with-values->list` takes the consumer only to type-check it —
+    // before running the producer, exactly where `callWithValuesFn` checked
+    // it — so a bad consumer is still reported as `call-with-values` rather
+    // than as the `apply` this compiles into.
+    //
+    // The callee is loaded via self.emitTrueBuiltinLoad, which marks the
+    // reference to resolve through the pristine registry at run time rather
+    // than by ordinary name lookup, so neither a lexical shadow NOR a later
+    // top-level redefinition can affect this call (#1715; the previous plain
+    // get_global/call_global-by-name approach only ever protected against the
+    // former).
     // A *proper* argument list of the wrong length is an arity question, not a
     // syntax question: route the form through the ordinary call path so the
     // runtime arity check reports KP3003 exactly as the same form one position
@@ -344,7 +368,7 @@ pub fn compileCallWithValuesTail(self: *Compiler, expr: Value, dst: u16) Compile
             count += 1;
         }
         if (walk.cur != types.NIL) return CompileError.InvalidSyntax;
-        if (count != 2) return compileCall(self, expr, dst, true);
+        if (count != 2) return compileCall(self, expr, dst, is_tail);
     }
     const args = types.cdr(expr);
     const producer = types.car(args);
@@ -358,25 +382,36 @@ pub fn compileCallWithValuesTail(self: *Compiler, expr: Value, dst: u16) Compile
 
     const cwv_base = try self.allocReg();
     const producer_reg = try self.allocReg();
-    const list_reg = try self.allocReg();
+    const consumer_reg = try self.allocReg();
 
     try self.compileExprViaIR(producer, producer_reg, false);
 
-    try self.emitTrueBuiltinLoad("list", list_reg);
-    try self.emitTrueBuiltinLoad("call-with-values", cwv_base);
+    // The consumer is already evaluated (in `base`); pass a copy for the
+    // type check.
+    try self.emitOp(.move);
+    try self.emitU16(consumer_reg);
+    try self.emitU16(base);
+    try self.emitTrueBuiltinLoad("%call-with-values->list", cwv_base);
     try self.emitOp(.call);
     try self.emitU16(cwv_base);
     try self.emit(2);
 
-    self.freeReg(); // list_reg
+    self.freeReg(); // consumer_reg
     self.freeReg(); // producer_reg
 
-    try self.emitOp(.tail_apply);
+    try self.emitOp(if (is_tail) .tail_apply else .apply);
     try self.emitU16(base);
     try self.emit(1);
 
     self.freeReg(); // cwv_base
-    if (needs_rebase) self.freeReg();
+    if (needs_rebase) {
+        if (!is_tail) {
+            try self.emitOp(.move);
+            try self.emitU16(dst);
+            try self.emitU16(base);
+        }
+        self.freeReg();
+    }
 }
 
 pub fn compileCallCCTail(self: *Compiler, expr: Value, dst: u16) CompileError!void {

--- a/src/disassembler.zig
+++ b/src/disassembler.zig
@@ -62,7 +62,7 @@ fn disassembleInstruction(func: *types.Function, code: []const u8, offset: usize
     const off_str = std.fmt.bufPrint(&buf, "  {d:0>4}  ", .{offset}) catch "  ????  ";
     writeStderr(off_str);
 
-    if (raw_op > @intFromEnum(OpCode.tail_eval)) {
+    if (raw_op > @intFromEnum(OpCode.apply)) {
         const s = std.fmt.bufPrint(&buf, "<invalid opcode 0x{x:0>2}>\n", .{raw_op}) catch "<invalid opcode>\n";
         writeStderr(s);
         return ip;
@@ -75,7 +75,7 @@ fn disassembleInstruction(func: *types.Function, code: []const u8, offset: usize
         .move => 4,
         .get_global => 4,
         .set_global, .define_global => 4,
-        .tail_apply => 3,
+        .apply, .tail_apply => 3,
         .get_upvalue, .set_upvalue => 4,
         .call, .tail_call => 3,
         .@"return" => 2,
@@ -154,6 +154,13 @@ fn disassembleInstruction(func: *types.Function, code: []const u8, offset: usize
             const name = constName(func, idx, allocator);
             defer if (name.len > 0) allocator.free(name);
             const s = std.fmt.bufPrint(&buf, "define_global   {s}, r{d}\n", .{ name, src }) catch "define_global\n";
+            writeStderr(s);
+        },
+        .apply => {
+            const base = readU16(code, &ip);
+            const nargs = code[ip];
+            ip += 1;
+            const s = std.fmt.bufPrint(&buf, "apply           r{d}, {d}\n", .{ base, nargs }) catch "apply\n";
             writeStderr(s);
         },
         .tail_apply => {

--- a/src/primitives_control.zig
+++ b/src/primitives_control.zig
@@ -34,6 +34,13 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "dynamic-wind", .func = primitives.bootstrapStub("dynamic-wind"), .arity = .{ .exact = 3 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
     .{ .name = "values", .func = &valuesFn, .arity = .{ .variadic = 0 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
     .{ .name = "call-with-values", .func = &callWithValuesFn, .arity = .{ .exact = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
+    // The producer half of `call-with-values`, for the compiler's
+    // apply/tail_apply lowering of the form (kaappi#1715, kaappi#2451): checks
+    // both operands the way callWithValuesFn does, runs the producer, and
+    // hands back the produced values as a list for the consumer to be applied
+    // to. Keeping the checks here is what lets the lowering report a bad
+    // consumer as `call-with-values`, not as the `apply` it compiles into.
+    .{ .name = "%call-with-values->list", .func = &callWithValuesToListFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.internal) },
     .{ .name = "%push-wind", .func = &pushWindFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.internal) },
     .{ .name = "%pop-wind", .func = &popWindFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.internal) },
     .{ .name = "%unwind-to-escape", .func = &unwindToEscapeFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.internal) },
@@ -545,6 +552,34 @@ fn callWithValuesFn(args: []const Value) PrimitiveError!Value {
         };
         return result;
     }
+}
+
+/// (%call-with-values->list producer consumer) → the list of values `producer`
+/// produced, after rejecting either operand that is not a procedure exactly as
+/// `callWithValuesFn` does.
+///
+/// The compiler lowers `(call-with-values p c)` to this followed by
+/// `apply`/`tail_apply` of `c` over the returned list, so the consumer runs in
+/// an ordinary VM frame and a continuation captured inside it can be resumed
+/// after the form returns (kaappi#2451). The producer still runs under this
+/// native frame — the restriction moved, it did not disappear.
+fn callWithValuesToListFn(args: []const Value) PrimitiveError!Value {
+    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
+    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
+    const producer = args[0];
+    const consumer = args[1];
+
+    if (!types.isProcedure(producer)) return primitives.typeError("call-with-values", "procedure", producer);
+    if (!types.isProcedure(consumer)) return primitives.typeError("call-with-values", "procedure", consumer);
+
+    var produced = try vm.callThunk(producer);
+    gc.pushRoot(&produced);
+    defer gc.popRoot();
+    if (types.isMultipleValues(produced)) {
+        const mv = types.toObject(produced).as(types.MultipleValues);
+        return gc.makeList(mv.values) catch return PrimitiveError.OutOfMemory;
+    }
+    return gc.allocPair(produced, types.NIL) catch return PrimitiveError.OutOfMemory;
 }
 
 fn pushWindFn(args: []const Value) PrimitiveError!Value {

--- a/src/tests_continuations.zig
+++ b/src/tests_continuations.zig
@@ -568,77 +568,64 @@ test "call/cc does not capture stale gap registers (#1464)" {
 // frame returned: "continuation cannot resume across a returned native call".
 // Tail position was already exempt (`tail_apply`), which is what made the
 // restriction unpredictable from the outside. These pin both positions.
+//
+// Each source is ONE top-level form on purpose: a continuation cannot be
+// resumed across the boundary between two of them, so the capture and the
+// re-invocation have to live in the same `let`.
 
 test "continuation captured under a non-tail apply resumes (#2451)" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
-
-    // One top-level form: a continuation cannot be resumed across the
-    // boundary between two of them, so the capture and the re-invocation
-    // have to live in the same `let`.
-    const result = try vm.eval(
+    try th.expectEval(
         \\(let ((saved #f) (n 0))
         \\  (define (f x) (call/cc (lambda (k) (set! saved k))) (set! n (+ n 1)) x)
         \\  (apply f (list 1))
         \\  (if (< n 3) (saved 'again) n))
-    );
-    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
+    , 3);
 }
 
 test "continuation captured under a non-tail call-with-values resumes (#2451)" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
-
-    const result = try vm.eval(
+    try th.expectEval(
         \\(let ((saved #f) (n 0))
         \\  (define (f x) (call/cc (lambda (k) (set! saved k))) (set! n (+ n 1)) x)
         \\  (call-with-values (lambda () 1) f)
         \\  (if (< n 3) (saved 'again) n))
-    );
-    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
+    , 3);
 }
 
 // The opcode only fires for a reference that still means the builtin (#2033).
-// A rebound `apply` must reach the user's procedure, not the superinstruction.
+// A rebound or shadowed `apply` must reach the user's procedure, not the
+// superinstruction — including when the rebinding is an earlier child of the
+// same top-level `begin` (the gate reads the live global environment, and a
+// top-level `begin`'s children are compiled and run one at a time).
 test "a top-level redefinition of apply wins over the non-tail opcode (#2451)" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
-
-    const result = try vm.eval(
-        \\(define (apply f xs) 'mine)
-        \\(let ((v (apply + (list 1 2)))) v)
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define (apply f xs) 'mine)
+        \\  (eq? (let ((v (apply + (list 1 2)))) v) 'mine))
     );
-    try std.testing.expectEqualStrings("mine", types.symbolName(result));
+}
+
+test "a top-level redefinition of call-with-values wins over the non-tail opcode (#2451)" {
+    try th.expectEvalTrue(
+        \\(begin
+        \\  (define (call-with-values p c) 'mine)
+        \\  (eq? (let ((v (call-with-values (lambda () 1) (lambda (x) x)))) v) 'mine))
+    );
 }
 
 test "a lexically shadowed apply wins over the non-tail opcode (#2451)" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
-
-    const result = try vm.eval("(let ((apply (lambda (f xs) 'shadow))) (+ 0 0) (apply + (list 1 2)))");
-    try std.testing.expectEqualStrings("shadow", types.symbolName(result));
+    try th.expectEvalTrue(
+        \\(let ((apply (lambda (f xs) 'shadow)))
+        \\  (eq? (let ((v (apply + (list 1 2)))) v) 'shadow))
+    );
 }
 
 // #649: non-tail apply has no 255-argument ceiling (tail position does, since
 // tail_apply has nowhere to put the overflow). The opcode keeps the overflow
 // on applyFn's heap-staged route rather than rejecting the call.
 test "non-tail apply still accepts more than 255 arguments (#649, #2451)" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
-
-    const result = try vm.eval(
-        \\(define (mk n) (if (= n 0) '() (cons n (mk (- n 1)))))
-        \\(let ((v (apply + (mk 500)))) v)
-    );
-    try std.testing.expectEqual(@as(i64, 125250), types.toFixnum(result));
+    try th.expectEval(
+        \\(let ()
+        \\  (define (mk n) (if (= n 0) '() (cons n (mk (- n 1)))))
+        \\  (let ((v (apply + (mk 500)))) v))
+    , 125250);
 }

--- a/src/tests_continuations.zig
+++ b/src/tests_continuations.zig
@@ -559,3 +559,86 @@ test "call/cc does not capture stale gap registers (#1464)" {
     );
     try std.testing.expectEqual(@as(i64, 1), types.toFixnum(result));
 }
+
+// --- kaappi#2451: non-tail apply / call-with-values are re-enterable -------
+//
+// Before the `apply` opcode, a non-tail `(apply f ...)` reached `f` through
+// the native applyFn's `vm.callWithArgs` — a fresh `runUntil` under a Zig
+// frame — so a continuation captured in `f` could not be reinstated once that
+// frame returned: "continuation cannot resume across a returned native call".
+// Tail position was already exempt (`tail_apply`), which is what made the
+// restriction unpredictable from the outside. These pin both positions.
+
+test "continuation captured under a non-tail apply resumes (#2451)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // One top-level form: a continuation cannot be resumed across the
+    // boundary between two of them, so the capture and the re-invocation
+    // have to live in the same `let`.
+    const result = try vm.eval(
+        \\(let ((saved #f) (n 0))
+        \\  (define (f x) (call/cc (lambda (k) (set! saved k))) (set! n (+ n 1)) x)
+        \\  (apply f (list 1))
+        \\  (if (< n 3) (saved 'again) n))
+    );
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
+}
+
+test "continuation captured under a non-tail call-with-values resumes (#2451)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(let ((saved #f) (n 0))
+        \\  (define (f x) (call/cc (lambda (k) (set! saved k))) (set! n (+ n 1)) x)
+        \\  (call-with-values (lambda () 1) f)
+        \\  (if (< n 3) (saved 'again) n))
+    );
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
+}
+
+// The opcode only fires for a reference that still means the builtin (#2033).
+// A rebound `apply` must reach the user's procedure, not the superinstruction.
+test "a top-level redefinition of apply wins over the non-tail opcode (#2451)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(define (apply f xs) 'mine)
+        \\(let ((v (apply + (list 1 2)))) v)
+    );
+    try std.testing.expectEqualStrings("mine", types.symbolName(result));
+}
+
+test "a lexically shadowed apply wins over the non-tail opcode (#2451)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval("(let ((apply (lambda (f xs) 'shadow))) (+ 0 0) (apply + (list 1 2)))");
+    try std.testing.expectEqualStrings("shadow", types.symbolName(result));
+}
+
+// #649: non-tail apply has no 255-argument ceiling (tail position does, since
+// tail_apply has nowhere to put the overflow). The opcode keeps the overflow
+// on applyFn's heap-staged route rather than rejecting the call.
+test "non-tail apply still accepts more than 255 arguments (#649, #2451)" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const result = try vm.eval(
+        \\(define (mk n) (if (= n 0) '() (cons n (mk (- n 1)))))
+        \\(let ((v (apply + (mk 500)))) v)
+    );
+    try std.testing.expectEqual(@as(i64, 125250), types.toFixnum(result));
+}

--- a/src/types.zig
+++ b/src/types.zig
@@ -1462,6 +1462,14 @@ pub const OpCode = enum(u8) {
     self_tail_call, // base:u16, nargs:u8
     tail_call_cc, // base:u16, dst:u16 (receiver at base+0; captures continuation at dst, tail-calls receiver)
     tail_eval, // base:u16, nargs:u8 (expr at base+0, optional env at base+1; compiles and tail-calls)
+    // Non-tail `apply` (kaappi#2451) — the sibling of `tail_apply` above, but
+    // appended here rather than placed beside it: an opcode's *number* is part
+    // of the on-disk `.sbc` encoding, and inserting one renumbers every opcode
+    // after it. `readFileWithTopLevel` rejects a cache entry from another build
+    // by compiler hash, but `src/testdata/fuzz-seed.sbc` patches that hash in at
+    // comptime and so has no such guard — it decoded as garbage the moment the
+    // numbering shifted. New opcodes go on the end.
+    apply, // base:u16, nargs:u8
 };
 
 // -- Doc sync gate ----------------------------------------------------------
@@ -1478,7 +1486,7 @@ pub const OpCode = enum(u8) {
 // than trusting the list — grep the *noun*, since the count is written at least
 // four ways ("31 opcodes", "31-opcode", "(31 opcodes)", and number-after-noun).
 comptime {
-    if (@typeInfo(OpCode).@"enum".fields.len != 31)
+    if (@typeInfo(OpCode).@"enum".fields.len != 32)
         @compileError("OpCode count changed. Update the table in docs/dev/bytecode.md, then every " ++
             "file quoting the count — known: docs/dev/architecture.md, docs/dev/README.md, " ++
             "docs/dev/claude-code-harness.md, .claude/skills/bytecode-isa/SKILL.md. Find any others " ++

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -36,6 +36,7 @@ const rejectImmutableEnv = vm_dispatch_helpers.rejectImmutableEnv;
 const raiseUndefinedVariable = vm_dispatch_helpers.raiseUndefinedVariable;
 const lookupGlobalLocked = vm_dispatch_helpers.lookupGlobalLocked;
 const raiseDeadNativeReturn = vm_dispatch_helpers.raiseDeadNativeReturn;
+const raiseApplyTypeError = vm_dispatch_helpers.raiseApplyTypeError;
 const raiseCrossHeapStoreVM = vm_dispatch_helpers.raiseCrossHeapStoreVM;
 
 /// True when a just-restored (or escape-unwound) frame stack should resume in
@@ -151,7 +152,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
         if (frame.ip >= frame.code.len) return VMError.InvalidBytecode;
 
         const raw_op = frame.code[frame.ip];
-        if (raw_op > @intFromEnum(OpCode.tail_eval)) return VMError.InvalidBytecode;
+        if (raw_op > @intFromEnum(OpCode.apply)) return VMError.InvalidBytecode;
         const op: OpCode = @enumFromInt(raw_op);
         frame.ip += 1;
 
@@ -162,7 +163,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
             .get_global => 4,
             .set_global => 4,
             .define_global => 4,
-            .tail_apply => 3,
+            .apply, .tail_apply => 3,
             .get_upvalue, .set_upvalue => 4,
             .call, .tail_call => 3,
             .@"return" => 2,
@@ -698,6 +699,123 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     self.setErrorDetail("not a procedure", .{});
                     return VMError.NotAProcedure;
                 }
+            },
+            .apply => {
+                // Non-tail `(apply f a ... lst)` (kaappi#2451). The point of
+                // the opcode is what it does NOT do: the native `applyFn`
+                // reached the callee through `vm.callWithArgs`, i.e. a fresh
+                // `runUntil` under a Zig frame, so a continuation captured in
+                // the callee could not be resumed once that frame returned
+                // ("continuation cannot resume across a returned native
+                // call"). Here the callee's frame is an ordinary VM frame in
+                // the same dispatch loop, so it lives in a continuation
+                // snapshot like any other — matching what tail_apply already
+                // gave tail position, and what map/for-each give their
+                // callbacks.
+                const base_reg = readU16(self, frame);
+                const nargs = readU8(self, frame);
+                if (nargs == 0) return VMError.InvalidBytecode;
+                const abs_base_wide = @as(usize, frame.base) + @as(usize, base_reg);
+                try ensureCallWindow(self, abs_base_wide, nargs);
+                const abs_base: u32 = try toBase(abs_base_wide);
+                const proc = self.registers[abs_base];
+
+                // applyFn's order and wording, both deliberate: the callee is
+                // rejected before the operand list is walked, and the texts
+                // are the native ones (see raiseApplyTypeError).
+                if (!types.isProcedure(proc) and !types.isNativeFn(proc))
+                    return raiseApplyTypeError(self, "procedure", proc);
+
+                // Validate and measure the operand list before touching any
+                // register, so the two argument-staging paths below both start
+                // from a known count. The tortoise-and-hare is applyFn's: a
+                // circular final list must be named as an improper list, not
+                // walked forever.
+                const operand_list = self.registers[abs_base + nargs];
+                var list_len: usize = 0;
+                var rest = operand_list;
+                var slow = rest;
+                var step: bool = false;
+                while (rest != types.NIL) {
+                    if (!types.isPair(rest)) return raiseApplyTypeError(self, "proper list", rest);
+                    list_len += 1;
+                    rest = types.cdr(rest);
+                    if (step) {
+                        slow = types.cdr(slow);
+                        if (slow == rest) return raiseApplyTypeError(self, "proper list", rest);
+                    }
+                    step = !step;
+                }
+                const count = @as(usize, nargs - 1) + list_len;
+
+                if (count > std.math.maxInt(u8)) {
+                    // More arguments than a call frame's u8 `nargs` can
+                    // encode. #649 settled that non-tail `apply` has no such
+                    // ceiling — `(apply + (mk 500))` is a supported program —
+                    // so this stays on applyFn's own route: stage the
+                    // arguments on the heap and re-enter through
+                    // `callWithArgs`. That route is exactly the one whose Zig
+                    // frame makes a captured continuation unresumable, so a
+                    // >255-argument apply keeps the restriction this opcode
+                    // lifts for every other call. Tail position instead
+                    // *rejects* the call (tooManyApplyArgs), because
+                    // `tail_apply` has nowhere to put the overflow.
+                    var big: std.ArrayList(Value) = .empty;
+                    defer big.deinit(self.gc.allocator);
+                    big.ensureTotalCapacity(self.gc.allocator, count) catch return VMError.OutOfMemory;
+                    var fi: u8 = 0;
+                    while (fi + 1 < nargs) : (fi += 1) big.appendAssumeCapacity(self.registers[abs_base + 1 + fi]);
+                    // Every staged Value is still reachable from a register
+                    // (the fixed operands) or from the operand list (itself in
+                    // a register), so the slice needs no rooting of its own.
+                    var walk = operand_list;
+                    while (walk != types.NIL) : (walk = types.cdr(walk)) big.appendAssumeCapacity(types.car(walk));
+
+                    const result = self.callWithArgs(proc, big.items) catch |err| {
+                        if (err == VMError.ContinuationInvoked) {
+                            if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
+                            return VMError.ContinuationInvoked;
+                        }
+                        if (err == VMError.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
+                        return err;
+                    };
+                    self.registers[abs_base] = result;
+                    continue;
+                }
+
+                var flat_args: [256]Value = undefined;
+                {
+                    var fi: u8 = 0;
+                    while (fi + 1 < nargs) : (fi += 1) flat_args[fi] = self.registers[abs_base + 1 + fi];
+                    var i: usize = nargs - 1;
+                    var walk = operand_list;
+                    while (walk != types.NIL) : (walk = types.cdr(walk)) {
+                        flat_args[i] = types.car(walk);
+                        i += 1;
+                    }
+                }
+
+                const total: u8 = @intCast(count);
+                try ensureCallWindow(self, abs_base_wide, total);
+                // This overwrites abs_base + nargs (the operand list's own
+                // register) as soon as the list is non-empty, so the
+                // Yielded-retry path below — which rewinds ip and re-executes
+                // this whole instruction — has to put the list back first.
+                for (0..count) |i| self.registers[abs_base + 1 + i] = flat_args[i];
+
+                vm_calls.callValue(self, proc, abs_base, total) catch |err| {
+                    if (err == VMError.ContinuationInvoked) {
+                        if (resumesHere(self, target_frame_count, scope_root_seq)) {
+                            continue;
+                        }
+                        return VMError.ContinuationInvoked;
+                    }
+                    if (err == VMError.Yielded) {
+                        if (self.yield_retry) self.registers[abs_base + nargs] = operand_list;
+                        maybeRewindRetry(self, 1 + fixed_operand_bytes);
+                    }
+                    return err;
+                };
             },
             .tail_apply => {
                 const base_reg = readU16(self, frame);

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -36,7 +36,7 @@ const rejectImmutableEnv = vm_dispatch_helpers.rejectImmutableEnv;
 const raiseUndefinedVariable = vm_dispatch_helpers.raiseUndefinedVariable;
 const lookupGlobalLocked = vm_dispatch_helpers.lookupGlobalLocked;
 const raiseDeadNativeReturn = vm_dispatch_helpers.raiseDeadNativeReturn;
-const raiseApplyTypeError = vm_dispatch_helpers.raiseApplyTypeError;
+const dispatchApply = vm_dispatch_helpers.dispatchApply;
 const raiseCrossHeapStoreVM = vm_dispatch_helpers.raiseCrossHeapStoreVM;
 
 /// True when a just-restored (or escape-unwound) frame stack should resume in
@@ -701,119 +701,19 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 }
             },
             .apply => {
-                // Non-tail `(apply f a ... lst)` (kaappi#2451). The point of
-                // the opcode is what it does NOT do: the native `applyFn`
-                // reached the callee through `vm.callWithArgs`, i.e. a fresh
-                // `runUntil` under a Zig frame, so a continuation captured in
-                // the callee could not be resumed once that frame returned
-                // ("continuation cannot resume across a returned native
-                // call"). Here the callee's frame is an ordinary VM frame in
-                // the same dispatch loop, so it lives in a continuation
-                // snapshot like any other — matching what tail_apply already
-                // gave tail position, and what map/for-each give their
-                // callbacks.
+                // Non-tail `(apply f a ... lst)` (kaappi#2451). The work is
+                // `vm_dispatch_helpers.dispatchApply`; what stays here is the
+                // control flow only the loop can express.
                 const base_reg = readU16(self, frame);
                 const nargs = readU8(self, frame);
-                if (nargs == 0) return VMError.InvalidBytecode;
-                const abs_base_wide = @as(usize, frame.base) + @as(usize, base_reg);
-                try ensureCallWindow(self, abs_base_wide, nargs);
-                const abs_base: u32 = try toBase(abs_base_wide);
-                const proc = self.registers[abs_base];
-
-                // applyFn's order and wording, both deliberate: the callee is
-                // rejected before the operand list is walked, and the texts
-                // are the native ones (see raiseApplyTypeError).
-                if (!types.isProcedure(proc) and !types.isNativeFn(proc))
-                    return raiseApplyTypeError(self, "procedure", proc);
-
-                // Validate and measure the operand list before touching any
-                // register, so the two argument-staging paths below both start
-                // from a known count. The tortoise-and-hare is applyFn's: a
-                // circular final list must be named as an improper list, not
-                // walked forever.
-                const operand_list = self.registers[abs_base + nargs];
-                var list_len: usize = 0;
-                var rest = operand_list;
-                var slow = rest;
-                var step: bool = false;
-                while (rest != types.NIL) {
-                    if (!types.isPair(rest)) return raiseApplyTypeError(self, "proper list", rest);
-                    list_len += 1;
-                    rest = types.cdr(rest);
-                    if (step) {
-                        slow = types.cdr(slow);
-                        if (slow == rest) return raiseApplyTypeError(self, "proper list", rest);
-                    }
-                    step = !step;
-                }
-                const count = @as(usize, nargs - 1) + list_len;
-
-                if (count > std.math.maxInt(u8)) {
-                    // More arguments than a call frame's u8 `nargs` can
-                    // encode. #649 settled that non-tail `apply` has no such
-                    // ceiling — `(apply + (mk 500))` is a supported program —
-                    // so this stays on applyFn's own route: stage the
-                    // arguments on the heap and re-enter through
-                    // `callWithArgs`. That route is exactly the one whose Zig
-                    // frame makes a captured continuation unresumable, so a
-                    // >255-argument apply keeps the restriction this opcode
-                    // lifts for every other call. Tail position instead
-                    // *rejects* the call (tooManyApplyArgs), because
-                    // `tail_apply` has nowhere to put the overflow.
-                    var big: std.ArrayList(Value) = .empty;
-                    defer big.deinit(self.gc.allocator);
-                    big.ensureTotalCapacity(self.gc.allocator, count) catch return VMError.OutOfMemory;
-                    var fi: u8 = 0;
-                    while (fi + 1 < nargs) : (fi += 1) big.appendAssumeCapacity(self.registers[abs_base + 1 + fi]);
-                    // Every staged Value is still reachable from a register
-                    // (the fixed operands) or from the operand list (itself in
-                    // a register), so the slice needs no rooting of its own.
-                    var walk = operand_list;
-                    while (walk != types.NIL) : (walk = types.cdr(walk)) big.appendAssumeCapacity(types.car(walk));
-
-                    const result = self.callWithArgs(proc, big.items) catch |err| {
-                        if (err == VMError.ContinuationInvoked) {
-                            if (resumesHere(self, target_frame_count, scope_root_seq)) continue;
-                            return VMError.ContinuationInvoked;
-                        }
-                        if (err == VMError.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
-                        return err;
-                    };
-                    self.registers[abs_base] = result;
-                    continue;
-                }
-
-                var flat_args: [256]Value = undefined;
-                {
-                    var fi: u8 = 0;
-                    while (fi + 1 < nargs) : (fi += 1) flat_args[fi] = self.registers[abs_base + 1 + fi];
-                    var i: usize = nargs - 1;
-                    var walk = operand_list;
-                    while (walk != types.NIL) : (walk = types.cdr(walk)) {
-                        flat_args[i] = types.car(walk);
-                        i += 1;
-                    }
-                }
-
-                const total: u8 = @intCast(count);
-                try ensureCallWindow(self, abs_base_wide, total);
-                // This overwrites abs_base + nargs (the operand list's own
-                // register) as soon as the list is non-empty, so the
-                // Yielded-retry path below — which rewinds ip and re-executes
-                // this whole instruction — has to put the list back first.
-                for (0..count) |i| self.registers[abs_base + 1 + i] = flat_args[i];
-
-                vm_calls.callValue(self, proc, abs_base, total) catch |err| {
+                dispatchApply(self, frame.base, base_reg, nargs) catch |err| {
                     if (err == VMError.ContinuationInvoked) {
                         if (resumesHere(self, target_frame_count, scope_root_seq)) {
                             continue;
                         }
                         return VMError.ContinuationInvoked;
                     }
-                    if (err == VMError.Yielded) {
-                        if (self.yield_retry) self.registers[abs_base + nargs] = operand_list;
-                        maybeRewindRetry(self, 1 + fixed_operand_bytes);
-                    }
+                    if (err == VMError.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
                     return err;
                 };
             },

--- a/src/vm_dispatch_helpers.zig
+++ b/src/vm_dispatch_helpers.zig
@@ -140,6 +140,110 @@ pub noinline fn raiseApplyTypeError(vm: *VM, expected: []const u8, got: Value) V
     return VMError.TypeError; // bare-ok: detail set above, matching primitives.typeError
 }
 
+/// The whole body of the non-tail `apply` opcode (kaappi#2451): validate the
+/// operands, stage the flattened arguments, and make the call. Lives here
+/// rather than in the dispatch arm because `vm_dispatch.zig` is at the
+/// 1500-line policy ceiling, and because operand validation and argument
+/// staging are what this file already holds for every other opcode.
+///
+/// The caller keeps exactly what a helper cannot express: the `continue` that
+/// resumes a restored continuation in *that* dispatch loop, and the ip rewind
+/// for a parked fiber's retry.
+///
+/// `registers[abs_base]` receives the result, matching the `call` opcode.
+pub fn dispatchApply(vm: *VM, frame_base: u32, base_reg: u16, nargs: u8) VMError!void {
+    const vm_calls = @import("vm_calls.zig");
+    if (nargs == 0) return VMError.InvalidBytecode;
+    const abs_base_wide = @as(usize, frame_base) + @as(usize, base_reg);
+    try ensureCallWindow(vm, abs_base_wide, nargs);
+    const abs_base: u32 = try toBase(abs_base_wide);
+    const proc = vm.registers[abs_base];
+
+    // applyFn's order and wording, both deliberate: the callee is rejected
+    // before the operand list is walked, and the texts are the native ones
+    // (see raiseApplyTypeError).
+    if (!types.isProcedure(proc) and !types.isNativeFn(proc))
+        return raiseApplyTypeError(vm, "procedure", proc);
+
+    const operand_list = vm.registers[abs_base + nargs];
+    const count = @as(usize, nargs - 1) + try properListLength(vm, operand_list);
+
+    if (count > std.math.maxInt(u8)) {
+        // More arguments than a call frame's u8 `nargs` can encode. #649
+        // settled that non-tail `apply` has no such ceiling — `(apply + (mk
+        // 500))` is a supported program — so this stays on applyFn's own
+        // route: stage the arguments on the heap and re-enter through
+        // `callWithArgs`. That route is exactly the one whose Zig frame makes
+        // a captured continuation unresumable, so a >255-argument apply keeps
+        // the restriction this opcode lifts for every other call. Tail
+        // position instead *rejects* the call (tooManyApplyArgs), because
+        // `tail_apply` has nowhere to put the overflow.
+        var big: std.ArrayList(Value) = .empty;
+        defer big.deinit(vm.gc.allocator);
+        big.ensureTotalCapacity(vm.gc.allocator, count) catch return VMError.OutOfMemory;
+        var fi: u8 = 0;
+        while (fi + 1 < nargs) : (fi += 1) big.appendAssumeCapacity(vm.registers[abs_base + 1 + fi]);
+        // Every staged Value is still reachable from a register (the fixed
+        // operands) or from the operand list (itself in a register), so the
+        // slice needs no rooting of its own. This path never overwrites the
+        // operand list's register, so it needs no repair below.
+        var walk = operand_list;
+        while (walk != types.NIL) : (walk = types.cdr(walk)) big.appendAssumeCapacity(types.car(walk));
+
+        vm.registers[abs_base] = try vm.callWithArgs(proc, big.items);
+        return;
+    }
+
+    var flat: [256]Value = undefined;
+    {
+        var fi: u8 = 0;
+        while (fi + 1 < nargs) : (fi += 1) flat[fi] = vm.registers[abs_base + 1 + fi];
+        var i: usize = nargs - 1;
+        var walk = operand_list;
+        while (walk != types.NIL) : (walk = types.cdr(walk)) {
+            flat[i] = types.car(walk);
+            i += 1;
+        }
+    }
+
+    const total: u8 = @intCast(count);
+    try ensureCallWindow(vm, abs_base_wide, total);
+    // This overwrites abs_base + nargs — the operand list's own register — as
+    // soon as the list is non-empty.
+    for (0..count) |i| vm.registers[abs_base + 1 + i] = flat[i];
+
+    vm_calls.callValue(vm, proc, abs_base, total) catch |err| {
+        // A parked fiber's retry rewinds ip and re-executes the whole
+        // instruction, which re-reads the register just overwritten. Repair it
+        // here, where the invariant was broken, rather than making every
+        // caller remember to.
+        if (err == VMError.Yielded and vm.yield_retry) vm.registers[abs_base + nargs] = operand_list;
+        return err;
+    };
+}
+
+/// The length of `list`, rejecting an improper or circular one with applyFn's
+/// own text. The tortoise-and-hare is applyFn's too: a circular final list
+/// must be named as an improper list, not walked forever (nor counted up to
+/// the 255-argument limit and reported as one).
+fn properListLength(vm: *VM, list: Value) VMError!usize {
+    var len: usize = 0;
+    var rest = list;
+    var slow = rest;
+    var step: bool = false;
+    while (rest != types.NIL) {
+        if (!types.isPair(rest)) return raiseApplyTypeError(vm, "proper list", rest);
+        len += 1;
+        rest = types.cdr(rest);
+        if (step) {
+            slow = types.cdr(slow);
+            if (slow == rest) return raiseApplyTypeError(vm, "proper list", rest);
+        }
+        step = !step;
+    }
+    return len;
+}
+
 pub fn tooManyApplyArgs(vm: *VM) VMError {
     vm.setErrorDetail("apply: too many arguments (limit 255)", .{});
     return VMError.InvalidArgument;

--- a/src/vm_dispatch_helpers.zig
+++ b/src/vm_dispatch_helpers.zig
@@ -123,6 +123,23 @@ pub fn toBase(base_wide: usize) VMError!u32 {
 /// as recoverable. Reporting StackOverflow both sent readers hunting for
 /// runaway recursion and, once limits stopped being catchable, would have
 /// made a bad argument list unrecoverable.
+/// The non-tail `apply` opcode's type errors, worded exactly like the native
+/// `applyFn`'s (`primitives.typeError("apply", ...)`) rather than like
+/// `tail_apply`'s terser in-loop texts (kaappi#2451).
+///
+/// The wording is load-bearing, not cosmetic: non-tail position is where
+/// `tests/scheme/compile/native-apply-lowering-1803.sh` pins the interpreter's
+/// diagnostics against the LLVM backend's, which reaches `applyFn`'s texts
+/// through `@kaappi_apply`. Tail position is deliberately exempt there — its
+/// texts have always differed — so only this opcode has parity to keep.
+pub noinline fn raiseApplyTypeError(vm: *VM, expected: []const u8, got: Value) VMError {
+    var buf: [128]u8 = undefined;
+    const primitives = @import("primitives.zig");
+    const desc = primitives.safeValueDescription(&buf, got);
+    vm.setErrorDetail("type error in 'apply': expected {s}, got {s}", .{ expected, desc });
+    return VMError.TypeError; // bare-ok: detail set above, matching primitives.typeError
+}
+
 pub fn tooManyApplyArgs(vm: *VM) VMError {
     vm.setErrorDetail("apply: too many arguments (limit 255)", .{});
     return VMError.InvalidArgument;

--- a/tests/scheme/compile/native-apply-lowering-1803.sh
+++ b/tests/scheme/compile/native-apply-lowering-1803.sh
@@ -233,10 +233,12 @@ cat > "$DIR/cond-arm.scm" << 'SCHEME'
 SCHEME
 check_both "cond-arm" "$(printf '106\n0')"
 
-# 8. Error shapes, non-tail so both runtimes report through applyFn's
-#    typeError texts. (Tail-position errors go through the interpreter's
-#    tail_apply opcode, whose texts differ — dispatch parity for those is
-#    covered by the rebound case above.)
+# 8. Error shapes, non-tail so both runtimes report applyFn's typeError texts:
+#    the native tier through @kaappi_apply, and — since kaappi#2451 — the
+#    interpreter through its own non-tail `apply` opcode, which reproduces
+#    those texts verbatim precisely so this parity keeps holding. (Tail-position
+#    errors go through the interpreter's tail_apply opcode, whose texts differ —
+#    dispatch parity for those is covered by the rebound case above.)
 cat > "$DIR/err-not-proc.scm" << 'SCHEME'
 (define (s x) (+ 0 (apply x (list 1))))
 (display (s 5))

--- a/tests/scheme/continuations/callcc-native-driver-reentry-2451.scm
+++ b/tests/scheme/continuations/callcc-native-driver-reentry-2451.scm
@@ -1,0 +1,135 @@
+;; kaappi#2451: a continuation captured under a NON-TAIL `apply` or
+;; `call-with-values` must be resumable after that call has returned.
+;;
+;; Until the `apply` opcode landed, both reached their callee through a native
+;; primitive's `vm.callWithArgs` — a fresh VM session under a Zig frame — so
+;; re-invoking the continuation once that frame had returned raised
+;; "continuation cannot resume across a returned native call" (KP3000). Tail
+;; position was exempt, because `tail_apply` had already replaced the frame,
+;; which is exactly what made the restriction impossible to predict from the
+;; outside: `map`/`for-each`/`vector-map`/`vector-for-each`/`string-for-each`
+;; were fine in both positions, `apply`/`call-with-values` only in tail.
+;;
+;; Each case below runs its capture and its re-invocation inside ONE top-level
+;; form: a continuation cannot cross the boundary between two of them (see
+;; callcc-correctness.scm case 4), which is a separate, documented limitation.
+
+(import (scheme base) (scheme process-context) (srfi 64))
+
+(define %test-fail-count 0)
+(test-begin "callcc-native-driver-reentry-2451")
+
+;; Calls `driver` with a callback that captures a continuation, then
+;; re-invokes that continuation until the callback has run three times.
+;; Returns the final count: 3 when the capture is resumable, 1 when the
+;; re-invocation raised instead.
+;;
+;; `driver` is a procedure rather than a macro on purpose — a macro's template
+;; `f` and a use-site `f` are different identifiers under hygiene — and each
+;; driver below decides its own tail position by whether a form follows the
+;; call under test.
+(define (reentry-count driver)
+  (let ((saved #f) (n 0))
+    (define (f x)
+      (call/cc (lambda (k) (set! saved k)))
+      (set! n (+ n 1))
+      x)
+    (driver f)
+    (if (< n 3) (saved 'again) n)))
+
+(test-eqv "non-tail apply" 3
+  (reentry-count (lambda (f) (apply f (list 1)) 'done)))
+
+(test-eqv "non-tail call-with-values" 3
+  (reentry-count (lambda (f) (call-with-values (lambda () 1) f) 'done)))
+
+;; Tail position kept working throughout; pinned so the two positions cannot
+;; drift apart again.
+(test-eqv "tail apply" 3
+  (reentry-count (lambda (f) (apply f (list 1)))))
+
+(test-eqv "tail call-with-values" 3
+  (reentry-count (lambda (f) (call-with-values (lambda () 1) f))))
+
+;; The drivers that were always exempt, kept as the contrast the issue's table
+;; was built from.
+(test-eqv "non-tail map" 3
+  (reentry-count (lambda (f) (map f (list 1)) 'done)))
+
+(test-eqv "non-tail for-each" 3
+  (reentry-count (lambda (f) (for-each f (list 1)) 'done)))
+
+(test-eqv "non-tail direct call" 3
+  (reentry-count (lambda (f) (f 1) 'done)))
+
+;; `apply` with fixed operands ahead of the list, and with an empty list.
+(test-eqv "non-tail apply with fixed operands" 3
+  (reentry-count (lambda (f) (apply (lambda (a b) (f b)) 1 (list 2)) 'done)))
+
+(test-eqv "non-tail apply with an empty final list" 3
+  (reentry-count (lambda (f) (apply (lambda () (f 1)) '()) 'done)))
+
+;; Multiple values reach the consumer, and the consumer is re-enterable.
+(test-eqv "non-tail call-with-values with several values" 3
+  (reentry-count (lambda (f)
+                   (call-with-values (lambda () (values 1 2))
+                     (lambda (a b) (f (+ a b))))
+                   'done)))
+
+(test-eqv "non-tail call-with-values with no values" 3
+  (reentry-count (lambda (f)
+                   (call-with-values (lambda () (values)) (lambda () (f 1)))
+                   'done)))
+
+;; --- the ordinary semantics the opcode must not disturb -------------------
+
+(test-eqv "apply flattens fixed operands and the list" 10
+  (apply + 1 2 (list 3 4)))
+
+(test-eqv "apply with an empty final list" 0 (apply + '()))
+
+(test-eqv "call-with-values passes several values" 6
+  (call-with-values (lambda () (values 1 2 3)) +))
+
+(test-eqv "call-with-values passes a single value" 84
+  (call-with-values (lambda () 42) (lambda (x) (* x 2))))
+
+;; A rebound or shadowed name must reach the user's procedure, never the
+;; superinstruction (kaappi#2033).
+(test-eq "a lexically shadowed apply is an ordinary call" 'shadow
+  (let ((apply (lambda (f xs) 'shadow)))
+    (apply + (list 1 2))))
+
+(test-eq "a lexically shadowed call-with-values is an ordinary call" 'shadow
+  (let ((call-with-values (lambda (p c) 'shadow)))
+    (call-with-values (lambda () 1) (lambda (x) x))))
+
+;; Diagnostics: non-tail apply reports through the native applyFn's texts,
+;; which the LLVM backend also produces (tests/scheme/compile/
+;; native-apply-lowering-1803.sh pins the two against each other).
+(define (message-of thunk)
+  (guard (e ((error-object? e) (error-object-message e)) (#t 'not-an-error-object))
+    (thunk)
+    'no-error))
+
+(test-equal "a non-procedure operand names apply"
+  "type error in 'apply': expected procedure, got 5"
+  (message-of (lambda () (+ 0 (apply 5 (list 1))))))
+
+(test-equal "an improper final list names apply"
+  "type error in 'apply': expected proper list, got 2"
+  (message-of (lambda () (+ 0 (apply + (cons 1 2))))))
+
+;; A bad consumer is still reported as call-with-values, not as the `apply`
+;; the form compiles into.
+(test-equal "a non-procedure consumer names call-with-values"
+  "type error in 'call-with-values': expected procedure, got 5"
+  (message-of (lambda () (+ 0 (call-with-values (lambda () 1) 5)))))
+
+(test-equal "a non-procedure producer names call-with-values"
+  "type error in 'call-with-values': expected procedure, got 5"
+  (message-of (lambda () (+ 0 (call-with-values 5 +)))))
+
+(set! %test-fail-count (test-runner-fail-count (test-runner-current)))
+(test-end "callcc-native-driver-reentry-2451")
+(if (> %test-fail-count 0) (exit 1))

--- a/tests/scheme/continuations/callcc-native-driver-reentry-2451.scm
+++ b/tests/scheme/continuations/callcc-native-driver-reentry-2451.scm
@@ -104,6 +104,23 @@
   (let ((call-with-values (lambda (p c) 'shadow)))
     (call-with-values (lambda () 1) (lambda (x) x))))
 
+;; ...and when the rebinding is an earlier child of the SAME top-level `begin`.
+;; The gate reads the live global environment rather than a set!-target list,
+;; so it needs the definition to have run by the time the use is compiled; a
+;; top-level `begin`'s children are compiled and executed one at a time, which
+;; is what makes that hold. (A body compiled BEFORE a later top-level
+;; redefinition does keep the builtin — the same compile-time property the
+;; constant folder has for `+`, and unchanged by #2451.)
+(test-eq "a define earlier in the same begin beats the apply opcode" 'mine
+  (begin
+    (define (apply f xs) 'mine)
+    (let ((v (apply + (list 1 2)))) v)))
+
+(test-eq "a define earlier in the same begin beats the call-with-values lowering" 'mine
+  (begin
+    (define (call-with-values p c) 'mine)
+    (let ((v (call-with-values (lambda () 1) (lambda (x) x)))) v)))
+
 ;; Diagnostics: non-tail apply reports through the native applyFn's texts,
 ;; which the LLVM backend also produces (tests/scheme/compile/
 ;; native-apply-lowering-1803.sh pins the two against each other).

--- a/tests/scheme/srfi/srfi231-official.scm
+++ b/tests/scheme/srfi/srfi231-official.scm
@@ -129,10 +129,27 @@ OTHER DEALINGS IN THE SOFTWARE.
 ;;; unchecked, which the spec text permits but the reference does not do.
 ;;; kaappi now always checks the user-visible getter/setter, so that
 ;;; divergence is resolved rather than documented.
+;;;
+;;; Entries 737-741 arrived with kaappi#2451. Before it, these five forms
+;;; could not run at all: their getters capture a continuation and re-invoke
+;;; it after the copy has returned, and re-entering a non-tail `apply` raised
+;;; "continuation cannot resume across a returned native call" (11 diagnostics
+;;; per run). The engine limit is gone, so the forms now run and reach the
+;;; library's own documented divergence instead -- %array-copy-impl
+;;; (lib/srfi/231/views.sld) fills the destination directly rather than
+;;; accumulating the source's values first, so the re-entry overwrites the
+;;; array the first copy already returned instead of materializing a fresh
+;;; one. array-append/stack/block/decurry all delegate to array-copy, which
+;;; is why one fill loop accounts for five ids.
 (define divergent-tests 0)
 (define diverged-counts (make-vector 10000 0))
 (define known-divergences
-  (list '(147 1 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")))
+  (list '(147 1 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")
+        '(737 1 . "array-copy fills the destination directly (lib/srfi/231/views.sld); a getter that re-invokes a captured continuation after the copy returns overwrites that array instead of getting a fresh one")
+        '(738 1 . "array-append delegates to array-copy's direct fill -- see 737")
+        '(739 1 . "array-stack delegates to array-copy's direct fill -- see 737")
+        '(740 1 . "array-block delegates to array-copy's direct fill -- see 737")
+        '(741 1 . "array-decurry delegates to array-copy's direct fill -- see 737")))
 (define (known-divergence id) (assq id known-divergences))
 
 (define (report-failure id line result expected)

--- a/tests/scheme/srfi/srfi231-official.scm
+++ b/tests/scheme/srfi/srfi231-official.scm
@@ -140,7 +140,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 ;;; accumulating the source's values first, so the re-entry overwrites the
 ;;; array the first copy already returned instead of materializing a fresh
 ;;; one. array-append/stack/block/decurry all delegate to array-copy, which
-;;; is why one fill loop accounts for five ids.
+;;; is why one fill loop accounts for five ids. Tracked as kaappi#2454; prune
+;;; all five when it lands.
 (define divergent-tests 0)
 (define diverged-counts (make-vector 10000 0))
 (define known-divergences


### PR DESCRIPTION
Closes #2451

## The gap

A continuation captured under a **non-tail** `apply` or `call-with-values` could not be resumed once that call had returned:

```text
error[KP3000]: continuation cannot resume across a returned native call
```

Both reached their callee through a native primitive's `vm.callWithArgs` — a fresh `runUntil` under a Zig frame that is gone by the time the continuation is reinstated. Tail position was already exempt, because `compileApplyTail` / `compileCallWithValuesTail` emit `tail_apply`, which replaces the frame inside the dispatch loop.

That asymmetry is the part that made the restriction unusable in practice: `map`, `for-each`, `vector-map`, `vector-for-each` and `string-for-each` work in both positions; `apply` and `call-with-values` worked only in tail. R7RS-small requires all of them to be fully re-entrant.

## The fix

A non-tail **`apply` opcode**. It flattens the operand list and hands the callee to `callValue`, so the callee gets an ordinary VM frame that a continuation snapshot copies like any other.

`call-with-values` now applies its consumer through `apply`/`tail_apply` in **both** positions, over the value list returned by a new internal `%call-with-values->list`. That primitive keeps the two type checks `callWithValuesFn` did, in the same order and before the producer runs, so a bad consumer is still reported as `call-with-values` rather than as the `apply` the form compiles into. In tail position that is a small improvement of its own — the consumer check used to surface as `tail_apply`'s bare `apply: not a procedure`.

The issue's table, after:

| construct | non-tail | tail |
|---|---|---|
| `apply` | **ok** | ok |
| `call-with-values` | **ok** | ok |
| `map` / `for-each` / `vector-map` / `vector-for-each` / `string-for-each` | ok | ok |

### What deliberately stays on the native route

Both are named in `README.md` "Known limitations → Continuations":

- **`call-with-values`' producer.** The consumer is what moved into the dispatch loop; the producer still runs under `%call-with-values->list`'s own native frame, in both positions. Unchanged from before, in both positions — not a new asymmetry.
- **An `apply` flattening more than 255 arguments.** #649 established that non-tail `apply` has no argument ceiling (`(apply + (mk 500))` is a supported program) and a call frame's argument count is one byte, so the opcode falls back to `callWithArgs` rather than rejecting the call the way `tail_apply` does.

### Diagnostics are unchanged

The opcode reproduces `applyFn`'s `typeError` texts verbatim, including its tortoise-and-hare rejection of a circular final list, because non-tail position is exactly where `tests/scheme/compile/native-apply-lowering-1803.sh` pins the interpreter's diagnostics against the LLVM backend's. The backend still routes both positions through `@kaappi_apply`, so the resumability guarantee is interpreter-only; `docs/dev/llvm-backend.md` now says so.

### Why the opcode is last in the enum, not next to `tail_apply`

An opcode's *number* is part of the `.sbc` encoding. The cache load path rejects a foreign build by compiler hash, but `src/testdata/fuzz-seed.sbc` patches that hash in at comptime and has no such guard — it decoded as garbage the moment the numbering shifted, and the `fuzz seed .sbc fixture stays loadable` test is what said so. The `/bytecode-isa` skill's "Adding a new opcode" checklist gains that reason plus the four steps the compiler did not catch on its own.

## SRFI 231

The vendored official suite's two continuation groups stop emitting the 11 `KP3000` diagnostics per run the issue reported, and now actually execute. They reach the library's own documented divergence instead: `%array-copy-impl` (`lib/srfi/231/views.sld`) fills the destination directly rather than accumulating the source's values first, so a getter that re-invokes a captured continuation after the copy returns overwrites the array the first copy already returned. Recorded as known-divergence ids 737-741 — one fill loop, since `array-append`/`stack`/`block`/`decurry` all delegate to `array-copy`. Lifting that scope reduction is the library half the issue calls out as a separate decision; it is filed as a follow-up, not done here.

## Tests

- `tests/scheme/continuations/callcc-native-driver-reentry-2451.scm` — 21 assertions: re-entry through non-tail and tail `apply`/`call-with-values`, the exempt drivers as contrast, fixed operands, an empty final list, several values and no values, shadowed/rebound names routing to the user's procedure, and the four diagnostic texts. 6 of them fail without the fix.
- 6 new Zig tests in `src/tests_continuations.zig` (2 fail without the fix), including the >255-argument case.

Both suites green: `zig build test` 1881 pass, and `tests/scheme/run-all.sh` 2133 pass / 0 fail — including `native-apply-lowering-1803.sh` and `native-apply-lexical-scope-1799.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)