### PR TITLE
Stop three false reds: grep -q SIGPIPE races, BSD audit mode probe, riscv64 timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,7 +530,10 @@ jobs:
     needs: format
     if: needs.format.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # QEMU user-mode overhead puts this leg at 16-27m on main, close enough
+    # to 30m that ~1 in 15 runs is killed mid-suite on timing alone and reads
+    # as a failure in gh pr checks (kaappi#2458)
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/tests/scheme/audit/primitives_filesystem-audit.scm
+++ b/tests/scheme/audit/primitives_filesystem-audit.scm
@@ -1031,10 +1031,15 @@
  (lambda (dir)
    (write-file (string-append dir "/a") "x")
    (let ((a (string-append dir "/a")))
-     ;; the full 12-bit mode is accepted; the kernel may still refuse to set
-     ;; setgid when the caller is not in the file's group (POSIX permits that
-     ;; silent clear), so only the 9 permission bits are asserted round-trip
-     (set-file-mode a #o7777)
+     ;; the accepted range is probed with setuid + setgid + the 9 permission
+     ;; bits. The sticky bit is deliberately excluded: on FreeBSD and NetBSD a
+     ;; non-root chmod(2) on a regular file rejects it with EFTYPE rather than
+     ;; clearing it silently as Linux and macOS do (kaappi#2443), and the CI
+     ;; legs run as root, where it works — so a #o7777 probe false-fails on
+     ;; exactly the unprivileged BSD runs. The kernel may still silently clear
+     ;; setgid when the caller is not in the file's group (POSIX permits
+     ;; that), so only the 9 permission bits and setuid are asserted round-trip
+     (set-file-mode a #o6777)
      (test-equal "(logand (file-info:mode (file-info a #t)) #o777)" #o777 (logand (file-info:mode (file-info a #t)) #o777))
      (test-equal "(logand (file-info:mode (file-info a #t)) #o4000)" #o4000 (logand (file-info:mode (file-info a #t)) #o4000))
      (set-file-mode a #o000)

--- a/tests/scheme/shell-common.sh
+++ b/tests/scheme/shell-common.sh
@@ -88,7 +88,9 @@ skip_without_zig() {
 # race a timeout.
 skip_on_debug_build() {
     local kaappi="$1" reason="$2"
-    if "$kaappi" features --json 2>/dev/null | grep -q '"build_mode":"Debug"'; then
+    local features_json
+    features_json="$("$kaappi" features --json 2>/dev/null || true)"
+    if grep -q '"build_mode":"Debug"' <<< "$features_json"; then
         echo "SKIP: $reason"
         exit 77
     fi

--- a/tests/scheme/smoke/load-import-2005.sh
+++ b/tests/scheme/smoke/load-import-2005.sh
@@ -51,7 +51,7 @@ out=$(cd "$work" && "$kaappi_abs" loader.scm 2>&1)
 status=$?
 set -e
 
-if [ "$status" -eq 0 ] && printf '%s' "$out" | grep -q 'inner ok'; then
+if [ "$status" -eq 0 ] && grep -q 'inner ok' <<< "$out"; then
     echo "PASS: load of an import-bearing file runs it"
     PASS=$((PASS + 1))
 else
@@ -80,7 +80,7 @@ berr=$(cd "$work" && "$kaappi_abs" driver.scm 2>&1)
 bstatus=$?
 set -e
 
-if [ "$bstatus" -ne 0 ] && printf '%s' "$berr" | grep -q 'bad.scm:2:'; then
+if [ "$bstatus" -ne 0 ] && grep -q 'bad.scm:2:' <<< "$berr"; then
     echo "PASS: a broken loaded file reports its own file:line"
     PASS=$((PASS + 1))
 else

--- a/tests/scheme/timings/timings-1515.sh
+++ b/tests/scheme/timings/timings-1515.sh
@@ -127,7 +127,7 @@ json="$(stderr_of "$KAAPPI" --timings=json "$IMP")"
 check_json_parses "imports json" "$json"
 check "imports json: recorded as a miss" '"status":"miss"' "$json"
 check "imports json: miss writes an entry" '"written":true' "$json"
-if printf '%s' "$json" | grep -q '"reason":"'; then
+if grep -q '"reason":"' <<< "$json"; then
     echo "FAIL: imports json: no decline reason"
     echo "  $json"
     FAIL=$((FAIL + 1))


### PR DESCRIPTION
Three independent sources of the suites and CI reporting failures nobody caused — one PR because all three are test/CI-only edits with zero engine code, so the review question for each is the same: *does this stop a red nobody caused?*

## #2444 — `grep -q` under `pipefail` (SIGPIPE race)

`load-import-2005.sh` asserted with `printf '%s' "$out" | grep -q …` under `set -euo pipefail` — the exact shape `tests/scheme/CLAUDE.md` forbids (the kaappi#1926 class). `openbsd-test` failed on PR #2442 while printing the very text it was looking for. Both sites now use here-strings.

The sweep the issue asked for found the same forbidden shape in two more places, fixed the same way:

- `shell-common.sh` → `skip_on_debug_build` piped kaappi's (large) `features --json` into `grep -q` inside every pipefail consumer; on a Debug build an early match can SIGPIPE kaappi and the skip silently doesn't fire. Capture first, then grep.
- `timings-1515.sh` — `printf | grep -q` under its own `set -euo pipefail`; here-string.

The `errors/reader-*.sh` pipelines look similar but run plain `set -e` without pipefail — no pipeline inversion is possible — and the `completions.sh` / `compile/` hits pass grep a **file** argument, not a pipe. Left alone.

## #2443 — audit I1's `#o7777` is EFTYPE on unprivileged BSD

Section I1's full-range mode probe includes the sticky bit; FreeBSD and NetBSD `chmod(2)` by non-root rejects sticky-on-a-regular-file with `EFTYPE` instead of clearing it silently as Linux and macOS do — so the audit false-failed on every unprivileged BSD run, masked on the root-running CI legs. The probe now uses `#o6777` (setuid + setgid + the 9 permission bits), with a comment recording why sticky is excluded. The round-trip assertions (9 permission bits, setuid) are unchanged.

## #2458 — riscv64-test rides its 30-minute cap

16–27m observed on main; about one run in fifteen is killed mid-suite on timing alone and is indistinguishable from a real failure in `gh pr checks` — the habit that lets a real riscv64 regression through. Timeout raised to 45m with a comment naming the measured distribution. (Splitting the job was the alternative; it buys a shorter feedback loop at the cost of a second boot+QEMU setup and pushes the workflow file's size for no signal gain.)

## Verification

- `tests/scheme/smoke/` — all 20 scripts pass (skips respected)
- filesystem audit — 468/468 on macOS, before and after the mode-probe change
- `timings-1515.sh` — 51/0; `compile/native-loop-alloca-stack-growth-1808.sh` (the other `skip_on_debug_build` consumer) — PASS
- The unprivileged FreeBSD/NetBSD leg of #2443 (the actual repro environment) could not be run from this session — both reference VMs are down (`no route to host`). The fix is safe by construction: `#o6777` does not contain the sticky bit (`01000`), and `EFTYPE` is triggered by exactly sticky-on-non-directory; setuid/setgid on an owned file are permitted unprivileged.
- `zig build test` currently dies in `tests_step` **on clean `main` on this machine** (#2447 — filed as *not* reproducing on macOS natively; it does here, deterministically, in both this branch's worktree and the untouched checkout). This diff touches no Zig code and cannot affect it.

Closes #2444
Closes #2443
Closes #2458
