### PR TITLE
Make SRFI 231 array-copy continuation-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,10 +74,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   spec's whole documented difference between `array-copy` and `array-copy!`
   is that the non-`!` one must be safe under exactly this. `array-copy` (and
   `array-append`, `array-stack`, `array-block`, `array-decurry`, which
-  delegate to it) now collect every source value through a functional
-  accumulator — no `set!`, so a re-entry re-runs the collection and
-  materializes its own destination — before the destination exists.
-  `array-copy!` keeps the direct fill, which the spec explicitly permits.
+  delegate to it) now collect every source value — before the destination
+  exists — into a pre-sized scratch vector indexed by a position threaded
+  functionally through the walk (a cons-list accumulator instead holds N
+  pairs live and allocates 2N more across the reverse: 18.0M total pair
+  allocations for that shape against this one's 16.0M at 1M elements; the
+  churn that remains is the library apply shape every fill loop shares,
+  tracked in kaappi#2464), so a re-entry re-runs the collection from its
+  capture point and materializes its own destination. `array-copy!`
+  keeps the direct fill, which the spec explicitly permits. One residual
+  exposure remains, shared with the reference implementation: a destination
+  storage class from `make-storage-class` contributes user-written setter
+  code to the copy-out, where a capture re-enters with the destination
+  already allocated and hands back the same object (with identical
+  contents).
 - **Continuations captured under a non-tail `apply` or `call-with-values`
   (#2451)** — resuming one raised `KP3000: continuation cannot resume across a
   returned native call`. Both reached their callee through a native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **SRFI 231 `array-copy` is continuation-safe** (#2454) — the fill wrote
+  directly into a destination allocated before the loop started, so a getter
+  that captured a continuation and re-invoked it after `array-copy` returned
+  kept writing into the array the first copy had already handed back: the
+  caller's array silently mutated under it (the official suite's own case —
+  the first copy reading `((4 1) (1 1))` instead of `((1 1) (1 1))`). The
+  spec's whole documented difference between `array-copy` and `array-copy!`
+  is that the non-`!` one must be safe under exactly this. `array-copy` (and
+  `array-append`, `array-stack`, `array-block`, `array-decurry`, which
+  delegate to it) now collect every source value through a functional
+  accumulator — no `set!`, so a re-entry re-runs the collection and
+  materializes its own destination — before the destination exists.
+  `array-copy!` keeps the direct fill, which the spec explicitly permits.
 - **Continuations captured under a non-tail `apply` or `call-with-values`
   (#2451)** — resuming one raised `KP3000: continuation cannot resume across a
   returned native call`. Both reached their callee through a native

--- a/lib/srfi/231/assembly.sld
+++ b/lib/srfi/231/assembly.sld
@@ -37,7 +37,11 @@
 ;;; source's values before the destination exists, so the aliases
 ;;; inherit continuation-re-entry safety -- more than the spec asks of
 ;;; the `!` variants (which may skip exactly that guarantee), never
-;;; less.
+;;; less. The `!` twins do pay the same scratch cost as the non-! ones
+;;; (one pre-sized vector, N words -- the aliasing trades that memory
+;;; for one code path; splitting them apart to reclaim it would
+;;; re-diverge five fill loops for a cost the spec's `!` exemption
+;;; exists precisely to allow skipping).
 (define-library (srfi 231 assembly)
   (import (scheme base) (srfi 1)
           (srfi 231 misc) (srfi 231 intervals) (srfi 231 storage-classes)

--- a/lib/srfi/231/assembly.sld
+++ b/lib/srfi/231/assembly.sld
@@ -28,15 +28,16 @@
 ;;; entirely to array-copy (already handling storage-class/mutable?/
 ;;; safe? option parsing and the materializing fill loop) rather than
 ;;; hand-rolling a separate fill mechanism per procedure. Their `!`
-;;; twins are implemented as pure aliases of the non-! version -- a
-;;; scope reduction already established for array-copy/array-copy! in
-;;; phase 3, now confirmed for these four too by reading the reference
-;;; implementation directly: every one of these four's `!` and non-`!`
-;;; entry points are two one-line wrappers around one shared internal
-;;; helper differing only in whether input arrays are eagerly
-;;; materialized before the fill runs, a distinction that is only
-;;; observable under the exotic multi-shot-continuation-re-entry
-;;; scenario the spec itself declares "an error" to trigger.
+;;; twins are implemented as pure aliases of the non-! version --
+;;; confirmed by reading the reference implementation directly: every
+;;; one of these four's `!` and non-`!` entry points are two one-line
+;;; wrappers around one shared internal helper differing only in
+;;; whether input arrays are eagerly materialized before the fill runs.
+;;; Since #2454 the shared path underneath (array-copy) collects the
+;;; source's values before the destination exists, so the aliases
+;;; inherit continuation-re-entry safety -- more than the spec asks of
+;;; the `!` variants (which may skip exactly that guarantee), never
+;;; less.
 (define-library (srfi 231 assembly)
   (import (scheme base) (srfi 1)
           (srfi 231 misc) (srfi 231 intervals) (srfi 231 storage-classes)

--- a/lib/srfi/231/views.sld
+++ b/lib/srfi/231/views.sld
@@ -314,55 +314,44 @@
     ;; documented difference from array-copy!): the re-entry gets a FRESH
     ;; array, and the array the first call already returned never mutates
     ;; under its holder. That requires collecting every source value
-    ;; BEFORE the destination exists, threading the values through a
-    ;; FUNCTIONAL accumulator -- a set! accumulator (or
-    ;; interval-fold-left/right, which use one) lets the re-entry keep
-    ;; appending to the first run's partial list, and a direct fill into
+    ;; BEFORE the destination exists, into a pre-sized scratch vector
+    ;; indexed by a position threaded FUNCTIONALLY through the walk --
+    ;; the threading is the safety mechanism (a set! position counter, or
+    ;; interval-fold-left/right, which use one, lets the re-entry keep
+    ;; counting on the first run's progress). The scratch itself is
+    ;; shared mutable state, deliberately: a re-entry resumes from the
+    ;; position captured at its capture point, so positions below it
+    ;; retain the first run's values and positions above are re-fetched
+    ;; -- observably identical to a functional cons accumulator, without
+    ;; that shape's cost (at 1M elements: 18.0M total pair allocations
+    ;; for a cons-list collector against 16.0M here, and its N live
+    ;; pairs gone; the churn that remains is the library apply shape
+    ;; every fill loop already shares -- kaappi#2464). A direct fill into
     ;; a pre-allocated destination (the pre-#2454 shape, and what
     ;; array-copy! still is -- the spec explicitly permits the `!`
     ;; variant to skip exactly this guarantee) lets the resumed fill
     ;; overwrite the already-returned array.
-    (define (%array-collect getter checker storage-class lowers uppers)
+    (define (%domain-walk lowers uppers leaf k)
       ;; Walk the domain in lexicographic order (first axis outermost,
-      ;; matching %interval-for-each-indices in intervals.sld), consing
-      ;; each (apply getter index) onto a reversed accumulator threaded
-      ;; functionally through both the axis loops and the recursion, so a
-      ;; re-invoked continuation re-runs the walk from its capture point
-      ;; over the accumulator value captured at that moment.
+      ;; matching %interval-for-each-indices in intervals.sld), calling
+      ;; (leaf index k) per multi-index with the index as a list, and
+      ;; threading the leaf's returned position functionally through the
+      ;; axis loops and the recursion. That threading is what makes a
+      ;; continuation captured inside a leaf re-run the walk from ITS
+      ;; captured position over ITS captured prefix, never the first
+      ;; run's. One helper serves both array-copy passes so they cannot
+      ;; drift out of order-agreement.
       (letrec ((walk
-                (lambda (ls us rev-index acc)
+                (lambda (ls us rev-index k)
                   (if (null? ls)
-                      (let ((val (apply getter (reverse rev-index))))
-                        (when (and checker (not (checker val)))
-                          (error "array-copy: not all elements of the source can be stored in the destination"
-                                 val storage-class))
-                        (cons val acc))
-                      (let loop ((i (car ls)) (acc acc))
+                      (leaf (reverse rev-index) k)
+                      (let loop ((i (car ls)) (k k))
                         (if (>= i (car us))
-                            acc
+                            k
                             (loop (+ i 1)
                                   (walk (cdr ls) (cdr us)
-                                        (cons i rev-index) acc))))))))
-        (reverse (walk lowers uppers '() '()))))
-
-    (define (%array-fill-from-list dest-setter vals lowers uppers)
-      ;; Second pass over the same domain order, consuming the collected
-      ;; values; only library code runs here (the destination's unsafe
-      ;; setter -- the value check already happened at collection), so no
-      ;; continuation can be captured mid-fill.
-      (letrec ((walk
-                (lambda (ls us rev-index vals)
-                  (if (null? ls)
-                      (begin
-                        (apply dest-setter (car vals) (reverse rev-index))
-                        (cdr vals))
-                      (let loop ((i (car ls)) (vals vals))
-                        (if (>= i (car us))
-                            vals
-                            (loop (+ i 1)
-                                  (walk (cdr ls) (cdr us)
-                                        (cons i rev-index) vals))))))))
-        (walk lowers uppers '() vals)))
+                                        (cons i rev-index) k))))))))
+        (walk lowers uppers '() k)))
 
     (define (%array-copy-impl array opts call/cc-safe?)
       (unless (array? array) (error "array-copy: not an array" array))
@@ -380,15 +369,42 @@
              (checker (%copy-value-checker array storage-class))
              (lowers (interval-lower-bounds->list domain))
              (uppers (interval-upper-bounds->list domain))
-             (vals (and call/cc-safe?
-                        (%array-collect getter checker storage-class lowers uppers)))
-             ;; allocated after collection completed (or immediately, for
-             ;; the direct-fill `!` path), so a continuation re-entry
-             ;; re-runs collection and materializes its own destination
+             ;; The whole collection runs here, inside the binding --
+             ;; strictly before the destination below is allocated --
+             ;; calling every getter (and the value checker) into the
+             ;; scratch, so a continuation captured in a getter re-runs
+             ;; collection and materializes its own destination.
+             (scratch (and call/cc-safe?
+                           (let ((buf (make-vector (interval-volume domain))))
+                             (%domain-walk lowers uppers
+                                           (lambda (index k)
+                                             (let ((val (apply getter index)))
+                                               (when (and checker (not (checker val)))
+                                                 (error "array-copy: not all elements of the source can be stored in the destination"
+                                                        val storage-class))
+                                               (vector-set! buf k val)
+                                               (+ k 1)))
+                                           0)
+                             buf)))
              (dest (make-specialized-array domain storage-class (storage-class-default storage-class) safe?))
              (dest-setter (array-unsafe-setter dest)))
         (if call/cc-safe?
-            (%array-fill-from-list dest-setter vals lowers uppers)
+            ;; Copy-out from the scratch: the values are already
+            ;; collected, so a getter re-entry cannot change what lands
+            ;; in dest. The dest-setter is library code for the built-in
+            ;; storage classes but USER code when the destination's
+            ;; storage class came from make-storage-class -- a
+            ;; continuation captured there re-enters this copy-out with
+            ;; dest already allocated, so it does not get a fresh array
+            ;; (the same residual exposure the reference implementation's
+            ;; own accumulate-then-materialize shape has; both runs write
+            ;; identical collected values, so only the identity of the
+            ;; re-entry's result object is affected).
+            (%domain-walk lowers uppers
+                          (lambda (index k)
+                            (apply dest-setter (vector-ref scratch k) index)
+                            (+ k 1))
+                          0)
             (interval-for-each (lambda multi-index
                                  (let ((val (apply getter multi-index)))
                                    (when (and checker (not (checker val)))

--- a/lib/srfi/231/views.sld
+++ b/lib/srfi/231/views.sld
@@ -309,16 +309,62 @@
     ;; call a true copy; otherwise omitted options fall back to
     ;; generic-storage-class/specialized-array-default-mutable?/-safe? --
     ;; confirmed via an explicit spec quote naming this exact asymmetry.
-    ;; array-copy! is documented to differ from array-copy only in
-    ;; call/cc re-entrancy safety during the fill (the spec permits it to
-    ;; be faster/leaner by skipping a safety guarantee, never in the
-    ;; final result for an ordinary, non-continuation-abusing caller);
-    ;; this port implements both identically (a direct fill loop, no
-    ;; accumulate-to-a-list-first indirection) as a deliberate, documented
-    ;; scope reduction -- getters that escape and re-invoke a captured
-    ;; continuation mid-copy are exotic enough that the extra allocation
-    ;; and complexity isn't justified for this phase.
-    (define (%array-copy-impl array opts)
+    ;; array-copy must be safe under a getter that captures a
+    ;; continuation and re-invokes it after the copy returned (the whole
+    ;; documented difference from array-copy!): the re-entry gets a FRESH
+    ;; array, and the array the first call already returned never mutates
+    ;; under its holder. That requires collecting every source value
+    ;; BEFORE the destination exists, threading the values through a
+    ;; FUNCTIONAL accumulator -- a set! accumulator (or
+    ;; interval-fold-left/right, which use one) lets the re-entry keep
+    ;; appending to the first run's partial list, and a direct fill into
+    ;; a pre-allocated destination (the pre-#2454 shape, and what
+    ;; array-copy! still is -- the spec explicitly permits the `!`
+    ;; variant to skip exactly this guarantee) lets the resumed fill
+    ;; overwrite the already-returned array.
+    (define (%array-collect getter checker storage-class lowers uppers)
+      ;; Walk the domain in lexicographic order (first axis outermost,
+      ;; matching %interval-for-each-indices in intervals.sld), consing
+      ;; each (apply getter index) onto a reversed accumulator threaded
+      ;; functionally through both the axis loops and the recursion, so a
+      ;; re-invoked continuation re-runs the walk from its capture point
+      ;; over the accumulator value captured at that moment.
+      (letrec ((walk
+                (lambda (ls us rev-index acc)
+                  (if (null? ls)
+                      (let ((val (apply getter (reverse rev-index))))
+                        (when (and checker (not (checker val)))
+                          (error "array-copy: not all elements of the source can be stored in the destination"
+                                 val storage-class))
+                        (cons val acc))
+                      (let loop ((i (car ls)) (acc acc))
+                        (if (>= i (car us))
+                            acc
+                            (loop (+ i 1)
+                                  (walk (cdr ls) (cdr us)
+                                        (cons i rev-index) acc))))))))
+        (reverse (walk lowers uppers '() '()))))
+
+    (define (%array-fill-from-list dest-setter vals lowers uppers)
+      ;; Second pass over the same domain order, consuming the collected
+      ;; values; only library code runs here (the destination's unsafe
+      ;; setter -- the value check already happened at collection), so no
+      ;; continuation can be captured mid-fill.
+      (letrec ((walk
+                (lambda (ls us rev-index vals)
+                  (if (null? ls)
+                      (begin
+                        (apply dest-setter (car vals) (reverse rev-index))
+                        (cdr vals))
+                      (let loop ((i (car ls)) (vals vals))
+                        (if (>= i (car us))
+                            vals
+                            (loop (+ i 1)
+                                  (walk (cdr ls) (cdr us)
+                                        (cons i rev-index) vals))))))))
+        (walk lowers uppers '() vals)))
+
+    (define (%array-copy-impl array opts call/cc-safe?)
       (unless (array? array) (error "array-copy: not an array" array))
       (%check-boolean! (%opt opts 1 (specialized-array-default-mutable?)) "array-copy: mutable?")
       (%check-boolean! (%opt opts 2 (specialized-array-default-safe?)) "array-copy: safe?")
@@ -327,24 +373,33 @@
              (mutable? (%opt opts 1 (if specialized? (mutable-array? array) (specialized-array-default-mutable?))))
              (safe? (%opt opts 2 (if specialized? (array-safe? array) (specialized-array-default-safe?))))
              (domain (array-domain array))
-             ;; indices come from interval-for-each over the source's own
-             ;; domain, so neither side needs the index check; values are
-             ;; still checked unless provably valid (#2448)
+             ;; indices come from a walk over the source's own domain, so
+             ;; neither side needs the index check; values are still
+             ;; checked unless provably valid (#2448)
              (getter (array-unsafe-getter array))
+             (checker (%copy-value-checker array storage-class))
+             (lowers (interval-lower-bounds->list domain))
+             (uppers (interval-upper-bounds->list domain))
+             (vals (and call/cc-safe?
+                        (%array-collect getter checker storage-class lowers uppers)))
+             ;; allocated after collection completed (or immediately, for
+             ;; the direct-fill `!` path), so a continuation re-entry
+             ;; re-runs collection and materializes its own destination
              (dest (make-specialized-array domain storage-class (storage-class-default storage-class) safe?))
-             (dest-setter (array-unsafe-setter dest))
-             (checker (%copy-value-checker array storage-class)))
-        (interval-for-each (lambda multi-index
-                             (let ((val (apply getter multi-index)))
-                               (when (and checker (not (checker val)))
-                                 (error "array-copy: not all elements of the source can be stored in the destination"
-                                        val storage-class))
-                               (apply dest-setter val multi-index)))
-                           domain)
+             (dest-setter (array-unsafe-setter dest)))
+        (if call/cc-safe?
+            (%array-fill-from-list dest-setter vals lowers uppers)
+            (interval-for-each (lambda multi-index
+                                 (let ((val (apply getter multi-index)))
+                                   (when (and checker (not (checker val)))
+                                     (error "array-copy: not all elements of the source can be stored in the destination"
+                                            val storage-class))
+                                   (apply dest-setter val multi-index)))
+                               domain))
         (if mutable? dest (array-freeze! dest))))
 
-    (define (array-copy array . opts) (%array-copy-impl array opts))
-    (define (array-copy! array . opts) (%array-copy-impl array opts))
+    (define (array-copy array . opts) (%array-copy-impl array opts #t))
+    (define (array-copy! array . opts) (%array-copy-impl array opts #f))
 
     ;; --- specialized-array-reshape: see the file header for the
     ;; algorithm description. ---

--- a/tests/scheme/srfi/srfi231-official.scm
+++ b/tests/scheme/srfi/srfi231-official.scm
@@ -130,27 +130,22 @@ OTHER DEALINGS IN THE SOFTWARE.
 ;;; kaappi now always checks the user-visible getter/setter, so that
 ;;; divergence is resolved rather than documented.
 ;;;
-;;; Entries 737-741 arrived with kaappi#2451. Before it, these five forms
-;;; could not run at all: their getters capture a continuation and re-invoke
-;;; it after the copy has returned, and re-entering a non-tail `apply` raised
-;;; "continuation cannot resume across a returned native call" (11 diagnostics
-;;; per run). The engine limit is gone, so the forms now run and reach the
-;;; library's own documented divergence instead -- %array-copy-impl
-;;; (lib/srfi/231/views.sld) fills the destination directly rather than
-;;; accumulating the source's values first, so the re-entry overwrites the
-;;; array the first copy already returned instead of materializing a fresh
-;;; one. array-append/stack/block/decurry all delegate to array-copy, which
-;;; is why one fill loop accounts for five ids. Tracked as kaappi#2454; prune
-;;; all five when it lands.
+;;; Entries 737-741 lived here until kaappi#2454. They arrived with
+;;; kaappi#2451: these five forms' getters capture a continuation and
+;;; re-invoke it after the copy has returned, which used to raise
+;;; "continuation cannot resume across a returned native call" and,
+;;; once #2452 removed that engine limit, reached a library divergence
+;;; instead -- %array-copy-impl (lib/srfi/231/views.sld) filled the
+;;; destination directly, so the re-entry overwrote the array the first
+;;; copy already returned. array-copy now collects the source's values
+;;; through a functional accumulator before the destination exists, so
+;;; the re-entry materializes its own array; array-append/stack/block/
+;;; decurry delegate to array-copy, which is why one change resolved
+;;; all five. That divergence is resolved rather than documented.
 (define divergent-tests 0)
 (define diverged-counts (make-vector 10000 0))
 (define known-divergences
-  (list '(147 1 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")
-        '(737 1 . "array-copy fills the destination directly (lib/srfi/231/views.sld); a getter that re-invokes a captured continuation after the copy returns overwrites that array instead of getting a fresh one")
-        '(738 1 . "array-append delegates to array-copy's direct fill -- see 737")
-        '(739 1 . "array-stack delegates to array-copy's direct fill -- see 737")
-        '(740 1 . "array-block delegates to array-copy's direct fill -- see 737")
-        '(741 1 . "array-decurry delegates to array-copy's direct fill -- see 737")))
+  (list '(147 1 . "R7RS strings are mutable; the suite encodes Gambit's immutable-string expectation")))
 (define (known-divergence id) (assq id known-divergences))
 
 (define (report-failure id line result expected)


### PR DESCRIPTION
Closes #2454

## What

`%array-copy-impl` filled the destination directly — one `interval-for-each`
pass calling the source's getter and the destination's setter per index, into
a `dest` allocated *before* the loop started. A getter that captured a
continuation and re-invoked it after `array-copy` returned kept writing into
the array the first copy had already handed back, so the caller's array
silently mutated under it and the re-entry produced no fresh array at all.
That is precisely the guarantee the spec gives `array-copy` over `array-copy!`.

`array-copy` now collects every source value through a **functional**
accumulator (threaded through a nested-loop walk, built reversed, `reverse`d
once — no `set!`, and `interval-fold-left`/`right` were unusable here because
both accumulate via `set!`) *before* the destination exists, then fills it in
a second pass. A re-entry re-runs the collection from its capture point and
materializes its own destination. `array-append`, `array-stack`, `array-block`
and `array-decurry` delegate to `array-copy`, so one change resolves all five
known-divergence ids (737–741), pruned from the official suite's ledger here.
`array-copy!` keeps the direct fill, which the spec explicitly permits, and
the `assembly.sld` header note about the four `!` twins is updated (they stay
pure aliases of the non-`!` forms and now inherit the safety — more than the
spec asks of them, never less).

## Evidence

- Repro (the official suite's own case): main returns `(((4 1) (1 1))
  ((4 1) (1 1)))`; this branch returns `(((4 1) (1 1)) ((1 1) (1 1)))` — the
  re-entry gets its fresh array, the first copy stays intact.
- `tests/scheme/srfi/srfi231-official.scm`: **10936 passed, 1 known
  divergence (the unrelated id 147), 0 unexpected failures, 0 count
  mismatches** — on main it was 10931 passed + 6 divergent rows under ids
  737–741.
- All seven SRFI 231 suite files green (views 114, assembly 69, arrays 105,
  combinators 88, intervals 87, storage-classes 249, hub 17).
- Perf, measured as the issue asked: 200×300 copies at 0.327s → 0.327s
  (specialized u8) and 0.403s → 0.395s (generic getter) per copy — the extra
  cons per element is noise against the rest-list each `apply` already
  allocates.

## Note

`zig build test` still stops at the pre-existing `tests_step` crash (#2447,
reproduced on clean main and unchanged by this PR — no Zig source is touched
here). The Scheme suites above were run with isolated `KAAPPI_HOME` homes.