### PR TITLE
Report OpenBSD exec failures at the spawn; close wrapped and test fds by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   code to the copy-out, where a capture re-enters with the destination
   already allocated and hands back the same object (with identical
   contents).
+- **A bare program name that resolves to nothing is a file error on
+  OpenBSD** (#2456) — `(spawn-process '("some-missing-command"))` there
+  "succeeded" and the child exited 127: OpenBSD's vfork-based userland
+  `posix_spawn` has no channel to report the child's exec failure, and
+  POSIX permits exactly that. 127 is also a plausible exit code of a
+  program that really ran, so a mistyped command looked like a completed
+  run. That platform now spawns through `fork` + `execvp` with a CLOEXEC
+  error pipe (CPython `subprocess`'s mechanism): the child writes its
+  exec errno and only then exits, so a miss raises the same
+  errno-carrying file error every other platform's libc reports — and
+  the parent resuming only at the exec restores the signalability
+  property the NetBSD exec barrier exists for. The bare-name assertions
+  in `process-run.scm` and `tests_process_run.zig` are strict again.
+- **`fd->port` leaves the wrapped descriptor inheritable** (#2424) — an
+  FFI descriptor (a kaappi-net socket, a foreign library's pipe) wrapped
+  as a port kept whatever close-on-exec state it arrived with, so on
+  Linux and the BSDs every `spawn-process` child inherited it — a live
+  listening socket could reach the child. The wrap is now the ownership
+  boundary: `makeFdPort` sets `FD_CLOEXEC`, which cannot break a
+  legitimate pass-through (Kaappi execs only through `spawn-process`,
+  whose stdio install clears the flag on exactly the child's slots); a
+  foreign side that wants a child to inherit its descriptor must prepare
+  the fd itself.
+- **Test/dev fd pairs are close-on-exec** (#2422) — the pair constructors
+  in `testing_helpers.zig` and `bench_reactor.zig` called `pipe(2)` and
+  `socketpair(2)` directly, bypassing `platform.pipe`'s CLOEXEC
+  discipline (the hand-rolled fork/exec plumbing in `test_runner.zig`
+  and `test_selection.zig` did the same). These descriptors never
+  intentionally cross an exec, but the fd-hygiene suites had to diff
+  against the parent's own fd set to tolerate them.
 - **Continuations captured under a non-tail `apply` or `call-with-values`
   (#2451)** — resuming one raised `KP3000: continuation cannot resume across a
   returned native call`. Both reached their callee through a native

--- a/src/bench_reactor.zig
+++ b/src/bench_reactor.zig
@@ -33,7 +33,10 @@ fn nowNs() u64 {
 
 fn makePipe() [2]std.c.fd_t {
     var fds: [2]std.c.fd_t = undefined;
-    if (std.c.pipe(&fds) != 0) unreachable;
+    // platform.pipe, not std.c.pipe: same CLOEXEC discipline as every
+    // other test/dev pair constructor (kaappi#2422), and no second call
+    // site to drift if pipe flags ever change.
+    std.debug.assert(platform.pipe(&fds) == 0);
     return fds;
 }
 

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -175,8 +175,14 @@ pub fn pipe(fds: *[2]fd_t) c_int {
 /// Set FD_CLOEXEC on `fd` (the fcntl(2) F_SETFD form; O_CLOEXEC at open is
 /// unavailable for fds other calls hand back -- kqueue(), pipe(2) on
 /// platforms without pipe2). Returns false on failure; callers treat that
-/// as best-effort.
+/// as best-effort. A no-op on Windows: FD_CLOEXEC is a POSIX exec concept
+/// with no analog on CRT fds, and needs none -- process_win confines child
+/// inheritance to an explicit stdio handle list, a stronger guarantee than
+/// any close-by-default scan. No-op, not link-error: makeFdPort calls this
+/// unconditionally at the fd->port wrap (kaappi#2424), and the plain
+/// extern `fcntl` does not exist for Windows targets.
 pub fn setFdCloexec(fd: fd_t) bool {
+    if (comptime is_windows) return false;
     if (comptime is_wasm) return false;
     const F_SETFD: c_int = 2;
     const FD_CLOEXEC: usize = 1;
@@ -186,8 +192,9 @@ pub fn setFdCloexec(fd: fd_t) bool {
 /// fcntl(F_GETFD): the fd-flags word (bit 0 = FD_CLOEXEC), or -1 when `fd`
 /// is not open. The subprocess spawner's close-by-default scan uses it both
 /// as an is-open probe and to skip descriptors exec will close anyway
-/// (KEP-0022).
+/// (KEP-0022). POSIX-only for the same linking reason as setFdCloexec.
 pub fn getFdFlags(fd: fd_t) c_int {
+    if (comptime is_windows) return -1;
     if (comptime is_wasm) return -1;
     const F_GETFD: c_int = 1;
     return fcntlRaw(fd, F_GETFD, 0);

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -946,6 +946,20 @@ fn openBinaryOutputFile(args: []const Value) PrimitiveError!Value {
 /// on it, and unregisters it from the reactor. The caller must not also
 /// close the fd through its own path.
 pub fn makeFdPort(gc: *memory.GC, fd: platform.fd_t, is_input: bool, is_output: bool, name: []const u8) PrimitiveError!Value {
+    // The wrap is the ownership boundary for exec too: a descriptor that
+    // arrives here without FD_CLOEXEC — an FFI socket from kaappi-net, a
+    // foreign library's pipe — would otherwise be inherited by every
+    // spawn-process child on Linux and the BSDs, where close-by-default is
+    // the CLOEXEC audit rather than macOS's wholesale
+    // POSIX_SPAWN_CLOEXEC_DEFAULT (kaappi#2424). Kaappi execs only through
+    // spawn-process, whose stdio install (dup2 into 0..2) clears the flag
+    // on exactly the child's slots, so this cannot break a legitimate
+    // pass-through; a foreign side that genuinely wants a child to inherit
+    // its descriptor must prepare the fd itself. Best-effort on failure: a
+    // descriptor too broken for F_SETFD is the port's problem to report on
+    // first I/O, not a wrap-time error the caller cannot distinguish from
+    // a bad fd number.
+    _ = platform.setFdCloexec(fd);
     const port_val = gc.allocPort(fd, is_input, is_output, name, false) catch return PrimitiveError.OutOfMemory;
     types.toObject(port_val).as(types.Port).is_binary = true;
     return port_val;

--- a/src/process_posix.zig
+++ b/src/process_posix.zig
@@ -53,14 +53,21 @@ const spawn_c = struct {
         argv: [*:null]const ?[*:0]const u8,
         envp: [*:null]const ?[*:0]const u8,
     ) c_int;
-    /// OpenBSD only (see the pre-flight in spawnChild): its userland,
+    /// OpenBSD only (see spawnChild's fork+exec branch): its userland,
     /// vfork-based posix_spawn has no channel to report the child's exec
-    /// failure, so spawning a missing program "succeeds" and the child
-    /// exits 127 — POSIX permits that, but every other target reports
-    /// ENOENT synchronously and the catchable-file-error contract should
-    /// not be platform lottery for the common case.
-    pub const spawn_cannot_report_exec_failure = builtin.os.tag == .openbsd;
-    pub extern "c" fn access(path: [*:0]const u8, mode: c_int) c_int;
+    /// failure — POSIX permits the child to exit 127 instead of the parent
+    /// seeing an error — so a missing program "succeeds" and dies 127,
+    /// indistinguishable from a program that ran and failed. There, spawn
+    /// goes through fork + execvp with a CLOEXEC error pipe (CPython
+    /// subprocess's mechanism), which reports the exec errno synchronously
+    /// like every other libc. file actions cannot express the pipe's
+    /// child-side write, so the redirection setup the actions carry on
+    /// other platforms runs in the forked child directly.
+    pub const spawn_via_fork_exec = builtin.os.tag == .openbsd;
+    pub extern "c" fn fork() c_int;
+    pub extern "c" fn execvp(file: [*:0]const u8, argv: [*:null]const ?[*:0]const u8) c_int;
+    pub extern "c" fn open(path: [*:0]const u8, oflag: c_int, mode: c_uint) c_int;
+    pub extern "c" fn setpgid(pid: c_int, pgid: c_int) c_int;
 
     pub extern "c" fn posix_spawnattr_init(attr: *AttrPtr) c_int;
     pub extern "c" fn posix_spawnattr_destroy(attr: *AttrPtr) c_int;
@@ -284,186 +291,183 @@ pub fn spawnChild(gc: *GC, cfg: SpawnConfig, redirs_in: [3]Redir) PrimitiveError
         r.* = .{ .fd = staged };
     }
 
-    // -- file actions + attrs. Both initializers can fail (ENOMEM on the
-    // pointer-backed libcs), and their destroy must run only on a
-    // successfully initialized object (kaappi#2442 review).
-    var actions_storage = spawn_c.zeroStorage();
-    const actions: *spawn_c.FileActionsPtr = @ptrCast(&actions_storage);
-    {
-        // FreeBSD's initializers return -1 with the error in errno (unlike
-        // the errno-returning convention everywhere else in this API), so a
-        // negative result is normalized before it can masquerade as a bogus
-        // error number (kaappi#2442 review).
-        var rc = spawn_c.posix_spawn_file_actions_init(actions);
-        if (rc < 0) rc = lastError();
-        if (rc != 0) return spawnSetupError(gc, rc);
-    }
-    defer _ = spawn_c.posix_spawn_file_actions_destroy(actions);
-
-    const O_RDONLY: c_int = 0;
-    const O_WRONLY: c_int = 1;
-    const null_z: [*:0]const u8 = "/dev/null";
+    // The child-side ends of any pipes: the posix path's file actions
+    // dup2 them into the stdio slots, the OpenBSD fork path's child does
+    // the same dup2s directly.
     const child_pipe_ends = [3]platform.fd_t{ stdin_pipe[0], stdout_pipe[1], stderr_pipe[1] };
-    const slot_oflag = [3]c_int{ O_RDONLY, O_WRONLY, O_WRONLY };
 
-    // Slot actions, stdin/stdout/stderr in order — stderr last, so the
-    // 'stdout merge duplicates the child's final slot-1 descriptor,
-    // whatever installed it. `redirs` (not cfg) carries the staged sources.
-    for (redirs, 0..) |redir, slot_usize| {
-        const slot: c_int = @intCast(slot_usize);
-        switch (redir) {
-            .inherit => {
-                // Darwin's CLOEXEC_DEFAULT closes even the stdio slots
-                // unless a file action names them — a plain 'inherit spawn
-                // lost all three streams (kaappi#2442 review; the man page
-                // prescribes addinherit_np for exactly this). A slot the
-                // parent itself has closed is skipped: the child correctly
-                // sees it closed, and an addinherit on a bad fd would fail
-                // the whole spawn.
-                if (comptime spawn_c.apple_cloexec_default) {
-                    if (platform.getFdFlags(slot) >= 0) {
-                        const rc = spawn_c.posix_spawn_file_actions_addinherit_np(actions, slot);
-                        if (rc != 0) return spawnSetupError(gc, rc);
-                    }
-                }
-            },
-            .pipe => {
-                const child_end = child_pipe_ends[slot_usize];
-                var rc = spawn_c.posix_spawn_file_actions_adddup2(actions, child_end, slot);
-                if (rc == 0) rc = spawn_c.posix_spawn_file_actions_addclose(actions, child_end);
-                if (rc != 0) return spawnSetupError(gc, rc);
-            },
-            .null_sink => {
-                const rc = spawn_c.posix_spawn_file_actions_addopen(actions, slot, null_z, slot_oflag[slot_usize], 0o666);
-                if (rc != 0) return spawnSetupError(gc, rc);
-            },
-            .fd => |fd| {
-                const rc = spawn_c.posix_spawn_file_actions_adddup2(actions, fd, slot);
-                if (rc != 0) return spawnSetupError(gc, rc);
-            },
-            .merge_stdout => {
-                // Rejected for slots 0 and 1 by the shared caller.
-                const rc = spawn_c.posix_spawn_file_actions_adddup2(actions, 1, 2);
-                if (rc != 0) return spawnSetupError(gc, rc);
-            },
-        }
-    }
-    // Comptime gate, not just the run-time one in the shared caller: the
-    // extern is absent from NetBSD/OpenBSD libc, so the call itself must not
-    // be analyzed there (Zig only links referenced externs).
-    if (comptime spawn_c.has_addchdir) {
-        if (directory_z) |dir| {
-            const rc = spawn_c.posix_spawn_file_actions_addchdir_np(actions, dir);
+    // -- spawn. OpenBSD (spawn_via_fork_exec) forks and execs directly:
+    // reporting the child's exec errno needs a CLOEXEC error pipe written
+    // between fork and exec — child-side code that posix_spawn file
+    // actions cannot express — so the redirection setup the else branch
+    // expresses as actions happens in the forked child instead.
+    var pid: c_int = -1;
+    if (comptime spawn_c.spawn_via_fork_exec) {
+        pid = try spawnChildForkExec(gc, argv, env_block, redirs, child_pipe_ends, cfg);
+    } else {
+        // -- file actions + attrs. Both initializers can fail (ENOMEM on the
+        // pointer-backed libcs), and their destroy must run only on a
+        // successfully initialized object (kaappi#2442 review).
+        var actions_storage = spawn_c.zeroStorage();
+        const actions: *spawn_c.FileActionsPtr = @ptrCast(&actions_storage);
+        {
+            // FreeBSD's initializers return -1 with the error in errno (unlike
+            // the errno-returning convention everywhere else in this API), so a
+            // negative result is normalized before it can masquerade as a bogus
+            // error number (kaappi#2442 review).
+            var rc = spawn_c.posix_spawn_file_actions_init(actions);
+            if (rc < 0) rc = lastError();
             if (rc != 0) return spawnSetupError(gc, rc);
         }
-    }
+        defer _ = spawn_c.posix_spawn_file_actions_destroy(actions);
 
-    // Close-by-default (KEP-0022): the child must inherit only the three
-    // stdio slots. CLOEXEC on every Kaappi-opened fd covers Kaappi's own
-    // descriptors, but a descriptor Kaappi itself INHERITED from its
-    // launcher (`kaappi 9</dev/null prog.scm`) or acquired through FFI has
-    // no such guarantee and would otherwise pass into every child —
-    // leaking sockets and lock files, and holding unrelated pipes open
-    // past EOF (kaappi#2414 review). On macOS POSIX_SPAWN_CLOEXEC_DEFAULT
-    // (below) closes everything wholesale; everywhere else, enumerate the
-    // open non-CLOEXEC fds and add an explicit close action for each.
-    // These actions run AFTER the dup2/open actions above, so a caller
-    // redirect port's own fd is closed only after its slot copy exists.
-    if (comptime !spawn_c.apple_cloexec_default) {
-        try addInheritedFdCloses(gc, actions);
-    }
+        const O_RDONLY: c_int = 0;
+        const O_WRONLY: c_int = 1;
+        const null_z: [*:0]const u8 = "/dev/null";
+        const slot_oflag = [3]c_int{ O_RDONLY, O_WRONLY, O_WRONLY };
 
-    var attr_storage = spawn_c.zeroStorage();
-    const attr: *spawn_c.AttrPtr = @ptrCast(&attr_storage);
-    {
-        // Same FreeBSD -1/errno normalization as the file-actions init.
-        var rc = spawn_c.posix_spawnattr_init(attr);
-        if (rc < 0) rc = lastError();
-        if (rc != 0) return spawnSetupError(gc, rc);
-    }
-    defer _ = spawn_c.posix_spawnattr_destroy(attr);
-
-    var flags: u16 = 0;
-    if (cfg.new_group) {
-        // pgroup 0 = the child becomes its own group leader
-        // (setpgid(child, 0) semantics), so pgid == pid after spawn.
-        const rc = spawn_c.posix_spawnattr_setpgroup(attr, 0);
-        if (rc != 0) return spawnSetupError(gc, rc);
-        flags |= spawn_c.SPAWN_SETPGROUP;
-    }
-    {
-        // Reset SIGPIPE to its default in the child: the parent runs with
-        // SIG_IGN (VM.init, KEP-0022) and ignored dispositions survive exec,
-        // which would silently change the behavior of children that rely on
-        // dying on EPIPE (e.g. `yes | head` inside a shell pipeline). The
-        // same restore Python's subprocess performs by default. The set is
-        // built with Zig's own sigset helpers, not libc's sigemptyset/
-        // sigaddset externs — NetBSD's sigset accessors are macros over a
-        // renamed ABI, so the plain symbols are not portably linkable.
-        var sigset = std.posix.sigemptyset();
-        std.posix.sigaddset(&sigset, std.posix.SIG.PIPE);
-        const rc = spawn_c.posix_spawnattr_setsigdefault(attr, &sigset);
-        if (rc != 0) return spawnSetupError(gc, rc);
-        flags |= spawn_c.SPAWN_SETSIGDEF;
-    }
-    if (spawn_c.apple_cloexec_default) flags |= spawn_c.SPAWN_CLOEXEC_DEFAULT;
-    if (flags != 0) {
-        const rc = spawn_c.posix_spawnattr_setflags(attr, @bitCast(flags));
-        if (rc != 0) return spawnSetupError(gc, rc);
-    }
-
-    // OpenBSD pre-flight (see spawn_cannot_report_exec_failure): for a
-    // slash-containing program path — the case with exactly one candidate
-    // file — probe it with access(X_OK) so "no such program" raises the
-    // same errno-carrying file-error as on every other platform. A bare
-    // name goes through posix_spawnp's PATH search and keeps the
-    // POSIX-sanctioned exit-127 fallback; the probe is advisory (TOCTOU
-    // races simply fall back to that same behavior).
-    if (comptime spawn_c.spawn_cannot_report_exec_failure) {
-        const prog = argv[0].?;
-        if (std.mem.indexOfScalar(u8, std.mem.span(prog), '/') != null) {
-            const X_OK: c_int = 1;
-            if (spawn_c.access(prog, X_OK) != 0)
-                return raiseSpawnError(gc, "cannot spawn process", cfg.argv[0], lastError());
+        // Slot actions, stdin/stdout/stderr in order — stderr last, so the
+        // 'stdout merge duplicates the child's final slot-1 descriptor,
+        // whatever installed it. `redirs` (not cfg) carries the staged sources.
+        for (redirs, 0..) |redir, slot_usize| {
+            const slot: c_int = @intCast(slot_usize);
+            switch (redir) {
+                .inherit => {
+                    // Darwin's CLOEXEC_DEFAULT closes even the stdio slots
+                    // unless a file action names them — a plain 'inherit spawn
+                    // lost all three streams (kaappi#2442 review; the man page
+                    // prescribes addinherit_np for exactly this). A slot the
+                    // parent itself has closed is skipped: the child correctly
+                    // sees it closed, and an addinherit on a bad fd would fail
+                    // the whole spawn.
+                    if (comptime spawn_c.apple_cloexec_default) {
+                        if (platform.getFdFlags(slot) >= 0) {
+                            const rc = spawn_c.posix_spawn_file_actions_addinherit_np(actions, slot);
+                            if (rc != 0) return spawnSetupError(gc, rc);
+                        }
+                    }
+                },
+                .pipe => {
+                    const child_end = child_pipe_ends[slot_usize];
+                    var rc = spawn_c.posix_spawn_file_actions_adddup2(actions, child_end, slot);
+                    if (rc == 0) rc = spawn_c.posix_spawn_file_actions_addclose(actions, child_end);
+                    if (rc != 0) return spawnSetupError(gc, rc);
+                },
+                .null_sink => {
+                    const rc = spawn_c.posix_spawn_file_actions_addopen(actions, slot, null_z, slot_oflag[slot_usize], 0o666);
+                    if (rc != 0) return spawnSetupError(gc, rc);
+                },
+                .fd => |fd| {
+                    const rc = spawn_c.posix_spawn_file_actions_adddup2(actions, fd, slot);
+                    if (rc != 0) return spawnSetupError(gc, rc);
+                },
+                .merge_stdout => {
+                    // Rejected for slots 0 and 1 by the shared caller.
+                    const rc = spawn_c.posix_spawn_file_actions_adddup2(actions, 1, 2);
+                    if (rc != 0) return spawnSetupError(gc, rc);
+                },
+            }
         }
-    }
-
-    // -- spawn
-    var pid: c_int = -1;
-    const envp: [*:null]const ?[*:0]const u8 = env_block orelse @ptrCast(std.c.environ);
-    var spawn_rc: c_int = 0;
-    {
-        // A child-thread VM blocking in the vfork-style spawn (which waits
-        // through the exec and its filesystem lookups) — or in the NetBSD
-        // exec barrier — never reaches the dispatch-loop safepoint, so a
-        // concurrent parent collection would spin in markLiveChildRoots
-        // (the same #1933 shape process-wait already handles; kaappi#2442
-        // review). Publish the VM as markable-in-native for the syscall
-        // stretch, restoring .running before anything below allocates.
-        const spawn_vm: ?*vm_mod.VM = if (vm_mod.vm_instance) |vm|
-            (if (!vm.owns_globals) vm else null)
-        else
-            null;
-        if (spawn_vm) |vm| vm.setCollectionInNative();
-        defer if (spawn_vm) |vm| vm.setCollectionRunning();
-        spawn_rc = spawn_c.posix_spawnp(&pid, argv[0].?, actions, attr, argv, envp);
-        // Exec barrier (NetBSD; see needs_exec_barrier): block until the
-        // kernel reports the child's exec completed (or the child died), so
-        // the child is signalable from the moment spawn-process returns.
-        // Without this, a process-kill issued promptly after spawn is
-        // silently dropped.
-        if (comptime spawn_c.needs_exec_barrier) {
-            if (spawn_rc == 0) execBarrierWait(pid);
+        // Comptime gate, not just the run-time one in the shared caller: the
+        // extern is absent from NetBSD/OpenBSD libc, so the call itself must not
+        // be analyzed there (Zig only links referenced externs).
+        if (comptime spawn_c.has_addchdir) {
+            if (directory_z) |dir| {
+                const rc = spawn_c.posix_spawn_file_actions_addchdir_np(actions, dir);
+                if (rc != 0) return spawnSetupError(gc, rc);
+            }
         }
-    }
-    if (spawn_rc != 0) {
-        // posix_spawn returns the errno itself, not -1. ENOENT is the common
-        // case (program not on PATH); the errno rides the condition so
-        // posix-error-name reports it precisely. The function-wide defer
-        // closes the pipes and staged fds; the destroy defers release
-        // actions/attr.
-        return raiseSpawnError(gc, "cannot spawn process", cfg.argv[0], spawn_rc);
-    }
+
+        // Close-by-default (KEP-0022): the child must inherit only the three
+        // stdio slots. CLOEXEC on every Kaappi-opened fd covers Kaappi's own
+        // descriptors, but a descriptor Kaappi itself INHERITED from its
+        // launcher (`kaappi 9</dev/null prog.scm`) or acquired through FFI has
+        // no such guarantee and would otherwise pass into every child —
+        // leaking sockets and lock files, and holding unrelated pipes open
+        // past EOF (kaappi#2414 review). On macOS POSIX_SPAWN_CLOEXEC_DEFAULT
+        // (below) closes everything wholesale; everywhere else, enumerate the
+        // open non-CLOEXEC fds and add an explicit close action for each.
+        // These actions run AFTER the dup2/open actions above, so a caller
+        // redirect port's own fd is closed only after its slot copy exists.
+        if (comptime !spawn_c.apple_cloexec_default) {
+            try addInheritedFdCloses(gc, actions);
+        }
+
+        var attr_storage = spawn_c.zeroStorage();
+        const attr: *spawn_c.AttrPtr = @ptrCast(&attr_storage);
+        {
+            // Same FreeBSD -1/errno normalization as the file-actions init.
+            var rc = spawn_c.posix_spawnattr_init(attr);
+            if (rc < 0) rc = lastError();
+            if (rc != 0) return spawnSetupError(gc, rc);
+        }
+        defer _ = spawn_c.posix_spawnattr_destroy(attr);
+
+        var flags: u16 = 0;
+        if (cfg.new_group) {
+            // pgroup 0 = the child becomes its own group leader
+            // (setpgid(child, 0) semantics), so pgid == pid after spawn.
+            const rc = spawn_c.posix_spawnattr_setpgroup(attr, 0);
+            if (rc != 0) return spawnSetupError(gc, rc);
+            flags |= spawn_c.SPAWN_SETPGROUP;
+        }
+        {
+            // Reset SIGPIPE to its default in the child: the parent runs with
+            // SIG_IGN (VM.init, KEP-0022) and ignored dispositions survive exec,
+            // which would silently change the behavior of children that rely on
+            // dying on EPIPE (e.g. `yes | head` inside a shell pipeline). The
+            // same restore Python's subprocess performs by default. The set is
+            // built with Zig's own sigset helpers, not libc's sigemptyset/
+            // sigaddset externs — NetBSD's sigset accessors are macros over a
+            // renamed ABI, so the plain symbols are not portably linkable.
+            var sigset = std.posix.sigemptyset();
+            std.posix.sigaddset(&sigset, std.posix.SIG.PIPE);
+            const rc = spawn_c.posix_spawnattr_setsigdefault(attr, &sigset);
+            if (rc != 0) return spawnSetupError(gc, rc);
+            flags |= spawn_c.SPAWN_SETSIGDEF;
+        }
+        if (spawn_c.apple_cloexec_default) flags |= spawn_c.SPAWN_CLOEXEC_DEFAULT;
+        if (flags != 0) {
+            const rc = spawn_c.posix_spawnattr_setflags(attr, @bitCast(flags));
+            if (rc != 0) return spawnSetupError(gc, rc);
+        }
+
+        // -- posix_spawnp
+        const envp: [*:null]const ?[*:0]const u8 = env_block orelse @ptrCast(std.c.environ);
+        var spawn_rc: c_int = 0;
+        {
+            // A child-thread VM blocking in the vfork-style spawn (which waits
+            // through the exec and its filesystem lookups) — or in the NetBSD
+            // exec barrier — never reaches the dispatch-loop safepoint, so a
+            // concurrent parent collection would spin in markLiveChildRoots
+            // (the same #1933 shape process-wait already handles; kaappi#2442
+            // review). Publish the VM as markable-in-native for the syscall
+            // stretch, restoring .running before anything below allocates.
+            const spawn_vm: ?*vm_mod.VM = if (vm_mod.vm_instance) |vm|
+                (if (!vm.owns_globals) vm else null)
+            else
+                null;
+            if (spawn_vm) |vm| vm.setCollectionInNative();
+            defer if (spawn_vm) |vm| vm.setCollectionRunning();
+            spawn_rc = spawn_c.posix_spawnp(&pid, argv[0].?, actions, attr, argv, envp);
+            // Exec barrier (NetBSD; see needs_exec_barrier): block until the
+            // kernel reports the child's exec completed (or the child died), so
+            // the child is signalable from the moment spawn-process returns.
+            // Without this, a process-kill issued promptly after spawn is
+            // silently dropped.
+            if (comptime spawn_c.needs_exec_barrier) {
+                if (spawn_rc == 0) execBarrierWait(pid);
+            }
+        }
+        if (spawn_rc != 0) {
+            // posix_spawn returns the errno itself, not -1. ENOENT is the common
+            // case (program not on PATH); the errno rides the condition so
+            // posix-error-name reports it precisely. The function-wide defer
+            // closes the pipes and staged fds; the destroy defers release
+            // actions/attr.
+            return raiseSpawnError(gc, "cannot spawn process", cfg.argv[0], spawn_rc);
+        }
+    } // !spawn_via_fork_exec
 
     // The child owns the child ends now; the parent's copies must go
     // (recorded as -1 so the cleanup defer never double-closes them).
@@ -482,6 +486,211 @@ pub fn spawnChild(gc: *GC, cfg: SpawnConfig, redirs_in: [3]Redir) PrimitiveError
     stdout_pipe[0] = -1;
     stderr_pipe[0] = -1;
     return out;
+}
+
+/// OpenBSD spawn path (spawn_via_fork_exec): fork + execvp with a CLOEXEC
+/// error pipe, the mechanism CPython's subprocess uses (kaappi#2456). The
+/// child writes its exec's errno into the pipe and only then _exits 127; a
+/// successful exec closes the write end via FD_CLOEXEC, so the parent's
+/// read returns EOF exactly at the exec. That read point also restores the
+/// vfork parity every other platform already has — the parent does not
+/// resume until the exec is done, which is the same signalability-from-
+/// return property the NetBSD exec barrier exists to provide.
+///
+/// Only the fork, the read, and a failure reap run here; everything before
+/// (argv, env block, pipes, redirect staging) is shared with the
+/// posix_spawnp path, and everything the file actions do there happens in
+/// the forked child directly (childExecSide).
+fn spawnChildForkExec(
+    gc: *GC,
+    argv: [*:null]const ?[*:0]const u8,
+    env_block: ?[*:null]const ?[*:0]const u8,
+    redirs: [3]Redir,
+    child_pipe_ends: [3]platform.fd_t,
+    cfg: SpawnConfig,
+) PrimitiveError!c_int {
+    var err_pipe: [2]platform.fd_t = .{ -1, -1 };
+    if (pipeWithFdRetry(gc, &err_pipe) != 0)
+        return raiseSpawnErrorInt(gc, "cannot create exec error pipe", types.FALSE, lastError());
+    defer closePipePair(&err_pipe);
+
+    var forked_pid: c_int = -1;
+    var fork_errno: c_int = 0;
+    var exec_errno: c_int = 0;
+    {
+        // The fork, the read up to the child's exec, and a failure reap
+        // can all block past the dispatch-loop safepoint — the same
+        // markable-in-native protocol as the posix_spawnp stretch (the
+        // #1933 shape), restored before the raises below can allocate.
+        const spawn_vm: ?*vm_mod.VM = if (vm_mod.vm_instance) |vm|
+            (if (!vm.owns_globals) vm else null)
+        else
+            null;
+        if (spawn_vm) |vm| vm.setCollectionInNative();
+        defer if (spawn_vm) |vm| vm.setCollectionRunning();
+
+        forked_pid = spawn_c.fork();
+        if (forked_pid < 0) {
+            fork_errno = lastError();
+        } else if (forked_pid == 0) {
+            childExecSide(argv, env_block, redirs, child_pipe_ends, cfg.new_group, err_pipe[1]);
+        } else {
+            // The child owns its copy of the write end; dropping ours is
+            // what makes the read return at the child's exec rather than
+            // at its death.
+            _ = platform.close(err_pipe[1]);
+            err_pipe[1] = -1;
+            while (true) {
+                var byte: [1]u8 = undefined;
+                const n = platform.read(err_pipe[0], &byte, 1);
+                if (n < 0 and lastError() == @intFromEnum(std.c.E.INTR)) continue;
+                // One byte: the child's exec errno. Zero (EOF): the exec
+                // closed the write end, i.e. it succeeded. A read error
+                // other than EINTR cannot be diagnosed from here; treat
+                // it as success and let the child's own lifetime (or its
+                // first stdio failure) surface the truth.
+                if (n == 1) exec_errno = byte[0];
+                break;
+            }
+            if (exec_errno != 0) {
+                // The child wrote its errno and is in _exit: reap it so
+                // the failure leaves no zombie, then raise the file error
+                // the errno names — synchronously, like every libc that
+                // can report it.
+                var st: c_int = 0;
+                while (true) {
+                    const r = platform.waitPid(forked_pid, &st, 0);
+                    if (r == forked_pid) break;
+                    if (r < 0 and lastError() == @intFromEnum(std.c.E.INTR)) continue;
+                    break; // ECHILD: a concurrent sweep already reaped it
+                }
+            }
+        }
+    }
+    if (fork_errno != 0)
+        return raiseSpawnErrorInt(gc, "cannot spawn process", cfg.argv[0], fork_errno);
+    if (exec_errno != 0)
+        return raiseSpawnErrorInt(gc, "cannot spawn process", cfg.argv[0], exec_errno);
+    return forked_pid;
+}
+
+/// The child side of the OpenBSD fork (spawnChildForkExec): install the
+/// stdio slots, drop every inherited non-CLOEXEC descriptor, become the
+/// optional group leader, restore SIGPIPE's default, and execvp. Between
+/// fork and exec in a forked child of a threaded process only
+/// async-signal-safe calls are allowed — every branch below is raw
+/// syscalls on arena-copied arguments. OpenBSD's execvp builds its PATH
+/// candidates in a stack buffer rather than allocating, which is what
+/// makes it usable here (the same path /bin/sh takes for every external
+/// command). Never returns: a successful execvp replaces the process, and
+/// every failure writes its errno to `err_fd` and _exits 127.
+fn childExecSide(
+    argv: [*:null]const ?[*:0]const u8,
+    env_block: ?[*:null]const ?[*:0]const u8,
+    redirs: [3]Redir,
+    child_pipe_ends: [3]platform.fd_t,
+    new_group: bool,
+    err_fd: platform.fd_t,
+) noreturn {
+    const O_RDONLY: c_int = 0;
+    const O_WRONLY: c_int = 1;
+    const null_z: [*:0]const u8 = "/dev/null";
+    const slot_oflag = [3]c_int{ O_RDONLY, O_WRONLY, O_WRONLY };
+
+    // The direct twin of the file-actions loop: stdin/stdout/stderr in
+    // order, stderr last so 'stdout merge duplicates the child's final
+    // slot-1 descriptor.
+    for (redirs, 0..) |redir, slot_usize| {
+        const slot: platform.fd_t = @intCast(slot_usize);
+        var ok = true;
+        switch (redir) {
+            // 'inherit keeps whatever the parent has in the slot —
+            // including a slot the parent itself closed, which stays
+            // closed in the child (the addinherit arm's getFdFlags guard
+            // exists only because that action FAILS on a bad fd).
+            .inherit => {},
+            .pipe => {
+                const child_end = child_pipe_ends[slot_usize];
+                ok = std.c.dup2(child_end, slot) >= 0;
+                // A close of a just-dup2'd descriptor cannot meaningfully
+                // fail; exec would drop it anyway.
+                _ = platform.close(child_end);
+            },
+            .null_sink => {
+                // addopen's close-then-open-into-the-slot semantics; the
+                // portable form opens to any descriptor (open() picks the
+                // lowest free one, not a named slot) and dup2s it in. The
+                // just-closed slot is usually that lowest free one, in
+                // which case open() returns the slot ITSELF — then dup2
+                // would be a no-op and closing `opened` would undo the
+                // installation (measured as `cat: stdout: Bad file
+                // descriptor` under 'stdout: 'null), so that case is its
+                // own branch.
+                _ = platform.close(slot);
+                const opened = spawn_c.open(null_z, slot_oflag[slot_usize], 0);
+                if (opened >= 0) {
+                    if (opened != slot) {
+                        ok = std.c.dup2(opened, slot) >= 0;
+                        _ = platform.close(opened);
+                    }
+                } else ok = false;
+            },
+            .fd => |fd| ok = std.c.dup2(fd, slot) >= 0,
+            .merge_stdout => ok = std.c.dup2(1, 2) >= 0,
+        }
+        if (!ok) childExecFail(err_fd, lastError());
+    }
+
+    // The fork twin of addInheritedFdCloses: every open non-CLOEXEC fd
+    // >= 3 is closed; the CLOEXEC ones (staged redirect sources, this
+    // path's own error pipe) are left for exec to close. Same inline
+    // fcntl probe as the file-actions fallback — no /proc on OpenBSD, no
+    // allocation, and the same no-arbitrary-cap rationale.
+    const fallback: u64 = 65536;
+    const raw_limit: u64 = blk: {
+        const rl = std.posix.getrlimit(.NOFILE) catch break :blk fallback;
+        break :blk std.math.cast(u64, rl.cur) orelse fallback;
+    };
+    const limit: platform.fd_t = @intCast(@min(raw_limit, std.math.maxInt(platform.fd_t)));
+    const FD_CLOEXEC: c_int = 1;
+    var fd: platform.fd_t = 3;
+    while (fd < limit) : (fd += 1) {
+        const flags = platform.getFdFlags(fd);
+        if (flags < 0) continue; // not open
+        if ((flags & FD_CLOEXEC) == 0) _ = platform.close(fd);
+    }
+
+    if (new_group) _ = spawn_c.setpgid(0, 0);
+
+    // The parent runs SIGPIPE ignored and an ignored disposition survives
+    // fork and exec; restore the default, the same reset SETSIGDEF
+    // performs on the posix_spawnp path.
+    var act = std.posix.Sigaction{
+        .handler = .{ .handler = std.posix.SIG.DFL },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    };
+    std.posix.sigaction(std.posix.SIG.PIPE, &act, null);
+
+    // execvp searches PATH through the global environ; a caller-supplied
+    // env: block is installed by pointer. The child never runs past the
+    // exec, so the mutation is invisible everywhere else — and the const
+    // cast is sound because nothing here writes through environ's
+    // entries; execvp only reads them.
+    if (env_block) |envp| std.c.environ = @ptrCast(@constCast(envp));
+    _ = spawn_c.execvp(argv[0].?, argv);
+    childExecFail(err_fd, lastError());
+}
+
+/// Report a child-side exec failure and die: one errno byte for the parent
+/// (every OpenBSD errno value fits in a byte, and a 1-byte write to a pipe
+/// is atomic), then the conventional exec-failure exit status. Writing
+/// before _exit is what keeps the parent from mistaking this child for a
+/// program that ran and legitimately failed.
+fn childExecFail(err_fd: platform.fd_t, errno_val: c_int) noreturn {
+    const byte: u8 = @truncate(@as(u32, @bitCast(errno_val)));
+    _ = platform.write(err_fd, @ptrCast(&byte), 1);
+    std.c._exit(127);
 }
 
 /// Terminate and reap a child spawned moments ago that no caller will ever
@@ -617,6 +826,13 @@ pub fn signalGroup(proc: *types.Process, sig: c_int) c_int {
 /// A catchable `.file` error carrying errno. Thin forwarder to the shared
 /// raiser so this file needs no import of the primitive layer.
 fn raiseSpawnError(gc: *GC, msg_text: []const u8, irritant: Value, errno_val: c_int) PrimitiveError!Spawned {
+    _ = try @import("primitives_process.zig").raiseProcessError(gc, msg_text, irritant, errno_val);
+    unreachable;
+}
+
+/// The same raise with the fork+exec path's payload type (spawnChildForkExec
+/// returns a bare pid; spawnChild wraps it into `Spawned` afterwards).
+fn raiseSpawnErrorInt(gc: *GC, msg_text: []const u8, irritant: Value, errno_val: c_int) PrimitiveError!c_int {
     _ = try @import("primitives_process.zig").raiseProcessError(gc, msg_text, irritant, errno_val);
     unreachable;
 }

--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -805,7 +805,10 @@ fn spawnWorker(allocator: std.mem.Allocator, exe_path: []const u8, file: []const
     defer freeChildEnv(allocator, envp);
 
     var pipe: [2]c_int = undefined;
-    if (std.c.pipe(&pipe) != 0) return error.PipeFailed;
+    // platform.pipe for the CLOEXEC pair discipline (kaappi#2422): the
+    // child's dup2s onto 1/2 clear it on exactly the installed slots, and
+    // the parent's ends never leak into the exec'd child.
+    if (platform.pipe(&pipe) != 0) return error.PipeFailed;
 
     const pid = std.posix.system.fork();
     if (pid < 0) {

--- a/src/test_selection.zig
+++ b/src/test_selection.zig
@@ -467,7 +467,9 @@ fn runCapture(arena: std.mem.Allocator, argv: []const []const u8) ?CaptureResult
     if (comptime platform.is_wasm) return null;
 
     var pipe: [2]c_int = undefined;
-    if (std.c.pipe(&pipe) != 0) return null;
+    // platform.pipe for the CLOEXEC pair discipline (kaappi#2422); the
+    // child's dup2 onto 1 clears it on the installed slot only.
+    if (platform.pipe(&pipe) != 0) return null;
 
     const pid = std.posix.system.fork();
     if (pid < 0) {

--- a/src/testing_helpers.zig
+++ b/src/testing_helpers.zig
@@ -144,23 +144,32 @@ const winsock_test = if (platform.is_windows) struct {
 /// A connected fd pair, [0] the read end and [1] the write end by the
 /// suites' convention. POSIX: a pipe — the exact object the port layer
 /// wraps for process pipes. Windows: a loopback TCP pair (bidirectional,
-/// which satisfies every unidirectional use).
+/// which satisfies every unidirectional use). Both ends are close-on-exec
+/// (kaappi#2422): these pairs live only for the life of an in-process
+/// test, and a CLOEXEC pair can never surface in a spawned child as a
+/// phantom inherited descriptor.
 pub fn makeFdPair() [2]platform.fd_t {
     if (comptime platform.is_windows) return makeWinLoopbackPair();
     if (comptime platform.is_wasm) wasmNoFdPairs();
     var fds: [2]std.c.fd_t = undefined;
-    if (std.c.pipe(&fds) != 0) unreachable;
+    std.debug.assert(platform.pipe(&fds) == 0);
     return fds;
 }
 
 /// A connected *bidirectional* fd pair backed by sockets on every
 /// platform: AF_UNIX socketpair on POSIX, the loopback TCP pair on
 /// Windows. For tests that need two-way traffic or socket buffer tuning.
+/// Both ends are made close-on-exec (kaappi#2422): SOCK_CLOEXEC is absent
+/// from the macOS SDK, so the flag is set via F_SETFD after the call —
+/// on the BSDs, where it exists, staying with the portable form keeps
+/// one code path.
 pub fn makeBidiFdPair() [2]platform.fd_t {
     if (comptime platform.is_windows) return makeWinLoopbackPair();
     if (comptime platform.is_wasm) wasmNoFdPairs();
     var fds: [2]std.c.fd_t = undefined;
     if (std.c.socketpair(std.c.AF.UNIX, std.c.SOCK.STREAM, 0, &fds) != 0) unreachable;
+    _ = platform.setFdCloexec(fds[0]);
+    _ = platform.setFdCloexec(fds[1]);
     return fds;
 }
 

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -617,6 +617,39 @@ test "#1478: fd->port rejects the standard streams and non-fixnums" {
     try std.testing.expectError(error.TypeError, vm.eval("(fd->port \"nope\")"));
 }
 
+test "#2424: fd->port makes a foreign descriptor close-on-exec at wrap time" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no filesystem on WASI p1 (kaappi#1972)
+    if (comptime platform.is_windows) return error.SkipZigTest; // the FD_CLOEXEC contract is a POSIX exec concern
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // A raw open(2) with no O_CLOEXEC, deliberately: the inheritable shape
+    // an FFI call hands back (a kaappi-net socket arrives the same way).
+    // platform.pipe would already carry FD_CLOEXEC and prove nothing about
+    // the wrap.
+    const fd = std.c.open("/dev/null", .{ .ACCMODE = .RDONLY });
+    try std.testing.expect(fd >= 0);
+
+    var buf: [128]u8 = undefined;
+    const src = try std.fmt.bufPrint(&buf,
+        \\(import (kaappi ffi))
+        \\(fd->port {d})
+    , .{fd});
+    const port_val = try vm.eval(src);
+    _ = port_val; // the port owns fd from here; it stays open until GC
+
+    // The wrap is the ownership boundary: without this, the descriptor is
+    // inherited by every spawn-process child on Linux and the BSDs, where
+    // close-by-default is the CLOEXEC audit rather than macOS's wholesale
+    // POSIX_SPAWN_CLOEXEC_DEFAULT.
+    const FD_CLOEXEC: c_int = 1;
+    const flags = platform.getFdFlags(fd);
+    try std.testing.expect(flags >= 0);
+    try std.testing.expect((flags & FD_CLOEXEC) != 0);
+}
+
 // #1460: readOneByte reads a chunk into read_buf and serves subsequent bytes
 // from memory, so byte-at-a-time consumers (read-u8, read-char,
 // read-bytevector, read-string, read-line) pay one read(2) per burst rather

--- a/src/tests_process.zig
+++ b/src/tests_process.zig
@@ -408,6 +408,18 @@ test "process: spawn failure raises a catchable file error" {
         \\  (spawn-process '("/nonexistent/kaappi-test-program")))
     );
 
+    // The bare-name form must fail the same way rather than "succeed" and
+    // have the child exit 127 — OpenBSD's vfork-based userland
+    // posix_spawn reported a missed PATH search exactly that way, and 127
+    // is indistinguishable from a program that ran and failed
+    // (kaappi#2456; its spawn is fork+exec with a CLOEXEC error pipe now,
+    // and this assertion is what pins the contract there — every other
+    // platform's libc already reports ENOENT synchronously).
+    try expectTrue(vm,
+        \\(guard (e ((file-error? e) #t) (else 'wrong-kind))
+        \\  (spawn-process '("kaappi-no-such-program-2456")))
+    );
+
     // argv must be a non-empty list of strings: '() fails the pair check
     // (TypeError), a non-string element the element check.
     try std.testing.expectError(vm_mod.VMError.TypeError, vm.eval("(spawn-process '())"));

--- a/src/tests_process_run.zig
+++ b/src/tests_process_run.zig
@@ -297,6 +297,16 @@ test "run-process: a spawn failure is a file error, not a timeout condition" {
         \\  (run-process '("/no/such/program/2417"))
         \\  'no-error-raised)
     );
+    // The bare-name form, which POSIX lets libc settle either way and
+    // OpenBSD's settled as an ordinary exit 127 until kaappi#2456 gave its
+    // spawn a CLOEXEC error pipe: the PATH miss must be a file error there
+    // too, never a status a program that ran could also have produced.
+    try th.expectEvalTrue(
+        \\(guard (e (#t (and (file-error? e) (not (process-timeout? e))))
+        \\          (else #f))
+        \\  (run-process '("kaappi-no-such-program-2456"))
+        \\  'no-error-raised)
+    );
 }
 
 test "run-process: runs inside a spawned fiber, and siblings overlap" {

--- a/src/tests_process_run.zig
+++ b/src/tests_process_run.zig
@@ -218,16 +218,19 @@ test "run-process: timeout: raises process-timeout carrying the partial output" 
     if (comptime !is_posix) return error.SkipZigTest;
     // The child prints, then sleeps past the deadline. What it managed to
     // write must survive on the condition — the condition is the only route
-    // to it, since the values return never happens.
+    // to it, since the values return never happens. Generous deadline: the
+    // content assertions need the child to get a scheduling slot before the
+    // kill, which a loaded runner cannot promise inside 250 ms (measured on
+    // the OpenBSD CI VM; twin comment in process-spawn-2414.sh).
     try th.expectEvalTrue(
         \\(guard (e ((process-timeout? e)
         \\           (and (string=? (process-timeout-stdout e) "partial")
         \\                (string=? (process-timeout-stderr e) "half")
         \\                (error-object? e)
         \\                (equal? (error-object-irritants e)
-        \\                        (list '("/bin/sh" "-c" "printf partial; printf half 1>&2; sleep 30") 0.25)))))
+        \\                        (list '("/bin/sh" "-c" "printf partial; printf half 1>&2; sleep 30") 2)))))
         \\  (run-process '("/bin/sh" "-c" "printf partial; printf half 1>&2; sleep 30")
-        \\               'timeout: 0.25)
+        \\               'timeout: 2)
         \\  'no-condition-raised)
     );
 }
@@ -246,10 +249,12 @@ test "run-process: the timeout kill reaches a grandchild holding the same pipe" 
     // `timeout:` implies `new-group: #t`, and the group kill is what lets the
     // drain fibers reach EOF at all: the grandchild inherits stdout, so a
     // child-only kill would leave the pipe open and this call would never
-    // return. Reaching the guard clause *is* the assertion.
+    // return. Reaching the guard clause *is* the assertion — and "up" must
+    // reach the pipe before the kill, so the same loaded-runner headroom
+    // applies as in the partial-output test above.
     try th.expectEvalTrue(
         \\(guard (e ((process-timeout? e) (string=? (process-timeout-stdout e) "up")))
-        \\  (run-process '("/bin/sh" "-c" "sleep 30 & printf up; sleep 30") 'timeout: 0.25)
+        \\  (run-process '("/bin/sh" "-c" "sleep 30 & printf up; sleep 30") 'timeout: 2)
         \\  'no-condition-raised)
     );
 }

--- a/tests/scheme/compile/process-spawn-2414.sh
+++ b/tests/scheme/compile/process-spawn-2414.sh
@@ -112,9 +112,15 @@ cat > "$DIR/run.scm" << 'SCHEME'
   (lambda (status out err)
     (display (list status (string-length out) err))
     (newline)))
-;; A timeout kills the group, drains what exists, and raises.
+;; A timeout kills the group, drains what exists, and raises. The deadline
+;; is deliberately generous: the assertion is about WHAT the drain recovers,
+;; not how fast the kill lands, and on a loaded runner (measured on the
+;; OpenBSD CI VM under full-suite load) a child can lose its first
+;; scheduling slot for well past 250 ms — the kill then lands before the
+;; printf and the honest empty drain fails the test (reproduced 11/50 under
+;; CPU hogs on unmodified main, 4aa2bab1).
 (display (guard (e ((process-timeout? e) (process-timeout-stdout e)))
-           (run-process '("sh" "-c" "printf partial; sleep 30") 'timeout: 0.25)
+           (run-process '("sh" "-c" "printf partial; sleep 30") 'timeout: 2)
            'no-condition))
 (newline)
 SCHEME

--- a/tests/scheme/process/process-run.scm
+++ b/tests/scheme/process/process-run.scm
@@ -200,15 +200,23 @@
              (and (string=? (process-timeout-stdout e) "printed")
                   (string=? (process-timeout-stderr e) "")
                   (error-object? e))))
-    (run-process (run stall-script "printed") 'timeout: 0.25)
+    ;; Generous deadline: on a loaded runner the child can lose its first
+    ;; scheduling slot past a tight one, the kill then lands before the
+    ;; printf, and the honest empty drain fails the content assertion
+    ;; (measured on the OpenBSD CI VM; twin comment in
+    ;; tests/scheme/compile/process-spawn-2414.sh).
+    (run-process (run stall-script "printed") 'timeout: 2)
     #f))
 
 ;; Reaching the guard clause at all is the assertion: the grandchild holds
 ;; the same stdout pipe, so only a group kill lets the drain reach EOF. A
-;; child-only kill hangs here instead of raising.
+;; child-only kill hangs here instead of raising. The grandchild must also
+;; get a slot to print "up" before the kill, so the same generous-deadline
+;; rule applies — with extra headroom for the interpreter grandchild's
+;; startup.
 (test-assert "the timeout kill reaches a grandchild holding the same pipe"
   (guard (e ((process-timeout? e) (string=? (process-timeout-stdout e) "up")))
-    (run-process (run tree-script kaappi-binary stall-script) 'timeout: 0.5)
+    (run-process (run tree-script kaappi-binary stall-script) 'timeout: 3)
     #f))
 
 ;; ------------------------------------------------------------------ errors

--- a/tests/scheme/process/process-run.scm
+++ b/tests/scheme/process/process-run.scm
@@ -213,24 +213,27 @@
 
 ;; ------------------------------------------------------------------ errors
 
-;; An absolute path, deliberately. POSIX leaves it unspecified whether a
-;; *PATH search* that finds nothing fails at posix_spawnp or lets the child
-;; exec fail and exit 127, and OpenBSD takes the second option — so a bare
-;; name would assert a platform's choice rather than this library's
-;; contract. With a path, every supported platform reports the failure at
-;; the spawn (kaappi#2456 tracks closing the bare-name gap).
+;; An absolute path, deliberately kept as its own assertion alongside the
+;; bare-name one below: a path has exactly one candidate file, so the
+;; failure is attributed at the spawn on every platform by construction.
 (test-assert "a program that does not exist is a file error, not a timeout"
   (guard (e (#t (and (file-error? e) (not (process-timeout? e)))))
     (run-process '("/kaappi/no/such/program/2417"))
     #f))
 
-;; The bare-name case, pinned to whichever of the two POSIX permits rather
-;; than left invisible: an error, or a child that never ran. What it must
-;; never be is a normal-looking success.
-(test-assert "a bare name that resolves to nothing never looks like success"
-  (guard (e (#t (file-error? e)))
-    (call-with-values (lambda () (run-process '("kaappi-no-such-program-2417")))
-      (lambda (st out err) (and (not (eqv? st 0)) (string=? out ""))))))
+;; The bare-name case. POSIX leaves it unspecified whether a PATH search
+;; that finds nothing fails at posix_spawnp or lets the child exec fail
+;; and exit 127, and OpenBSD's libc took the second option — so this used
+;; to be pinned leniently (an error, or a non-zero status with no
+;; output). Since kaappi#2456 that platform spawns through fork+exec
+;; with a CLOEXEC error pipe, and the strict contract holds everywhere:
+;; a miss is a file error at the spawn, never an ordinary exit status a
+;; program that really ran could also have produced.
+(test-assert "a bare name that resolves to nothing is a file error"
+  (guard (e (#t (file-error? e))
+            (else #f))
+    (run-process '("kaappi-no-such-program-2417"))
+    #f))
 
 ;; `timeout:` promises a bound, and a child-only kill cannot deliver one: a
 ;; grandchild holding the pipes would keep the drains from ever reaching EOF,

--- a/tests/scheme/process/process-test.scm
+++ b/tests/scheme/process/process-test.scm
@@ -72,6 +72,19 @@
          (st (process-wait p)))
     (and (= st 0) (process-kill p) (process-kill p 'signal: 9) #t)))
 
+(test-assert "spawning a missing program is a file error, by path or by name"
+  ;; The file-error family is what keeps "could not start" distinguishable
+  ;; from "started and failed" — and the bare-name form is the one
+  ;; OpenBSD's vfork-based posix_spawn used to lose, reporting a missed
+  ;; PATH search as an ordinary exit 127 (kaappi#2456; that platform now
+  ;; spawns through fork+exec with a CLOEXEC error pipe).
+  (and (guard (e ((file-error? e) #t) (else #f))
+         (spawn-process '("/nonexistent/kaappi-test-program"))
+         #f)
+       (guard (e ((file-error? e) #t) (else #f))
+         (spawn-process '("kaappi-no-such-program-2456"))
+         #f)))
+
 ;; --------------------------------------------------------- pipes and specs
 
 (test-equal "stdin/stdout pipe round trip via cat"


### PR DESCRIPTION
Closes #2456
Closes #2424
Closes #2422

Three fd-hygiene fixes around exec, one per issue.

## #2456 — bare-name exec failure is a file error on OpenBSD

OpenBSD's vfork-based userland `posix_spawn` has no channel to report the
child's exec failure, so `(spawn-process '("missing-command"))` "succeeded"
and the child exited 127 — indistinguishable from a program that ran and
failed. That platform now spawns through **fork + execvp with a CLOEXEC
error pipe** (CPython `subprocess`'s mechanism, as the issue prescribes):

- the forked child installs the same redirections the file actions carried
  (dup2 per slot, `/dev/null` opens with addopen's close-then-open
  semantics, staged fd sources), closes every open non-CLOEXEC fd ≥ 3 (the
  fork twin of the actions scan), does the optional `setpgid(0,0)`, resets
  SIGPIPE to default, points `environ` at a caller-supplied `env:` block,
  and `execvp`s;
- on any failure it writes the exec errno (one byte — OpenBSD errnos fit)
  to the pipe and only then `_exit`s 127; a successful exec closes the
  pipe via FD_CLOEXEC, so the parent's read returns **exactly at the exec**;
- the parent raises the errno-carrying file error every other libc reports
  synchronously — and resuming only at the exec restores, for free, the
  signalability-from-return property the NetBSD exec barrier exists for.

Only syscalls run between fork and exec (arena-copied args; OpenBSD's
`execvp` builds PATH candidates in a stack buffer — the shell's own
external-command route). The advisory `access()` pre-flight for
slash-paths is superseded and removed. The bare-name assertions in
`process-run.scm` (pinned leniently for this gap by #2455) and
`tests_process_run.zig` are strict again.

Reproduced on the OpenBSD 7.9 aarch64 reference VM — main: `NO-ERROR
status=127`; this branch: `"cannot spawn process"` for both the bare-name
and slash-path forms. Suites there (fresh `KAAPPI_HOME` homes):
process-test 19/19, process-wait-test 10/10, process-run 18/18,
process-portable 18/18, process-child-script 3/3.

Two child-side details worth flagging from that verification: the
`'stdout: 'null` install originally closed the slot it had just opened
(`open()` lands on the just-freed slot number; the follow-up close undid
the install — `cat: stdout: Bad file descriptor`), fixed by recognizing
`opened == slot` as its own branch; and the wait-test failures that
first looked like a regression were bytecode-cache poisoning from a
lib-less first run against a reused `KAAPPI_HOME` — clean homes are
green.

## #2424 — `fd->port` marks the wrapped descriptor close-on-exec

An FFI descriptor (kaappi-net socket, a foreign pipe) wrapped as a port
kept whatever `FD_CLOEXEC` state it arrived with, so on Linux and the
BSDs every `spawn-process` child inherited it. `makeFdPort` now sets the
flag at the wrap — the ownership boundary — which cannot break a
legitimate pass-through: Kaappi execs only through `spawn-process`, whose
stdio install clears the flag on exactly the child's slots. New unit test
wraps a raw `open("/dev/null")` (no O_CLOEXEC) and asserts the flag
lands. The Linux-only acceptance leg (socket inherited into a spawned
child) is covered by the existing fd-hygiene suites on CI; the Linux
containers are not runnable from this dev machine today.

## #2422 — test/dev fd pairs route through `platform.pipe`

`testing_helpers.makeFdPair`/`makeBidiFdPair`, `bench_reactor`'s
`makePipe`, and the hand-rolled fork/exec plumbing in `test_runner.zig`
and `test_selection.zig` called `pipe(2)`/`socketpair(2)` directly,
bypassing `platform.pipe`'s CLOEXEC discipline (the two extra
`std.c.pipe` sites beyond the issue's table are included; `thottam_proc`
was already Phase-1-audited). No direct `std.c.pipe`/`std.c.socketpair`
call remains outside `platform.zig` in test/dev code.

## Verification

- macOS: all five process suites green (19/10/18/18/3), and
  `tests_process`, `tests_process_run`, `tests_port_io`, `tests_reactor`,
  `tests_scheduler`, `tests_waitforfd` all pass.
- Cross-compile clean for `aarch64-openbsd` (where the fork path is
  analyzed) and native.
- `zig build test` stops at the pre-existing `tests_step` crash (#2447 —
  reproduced on clean main, unrelated to this PR); the per-container runs
  above stand in for it.

Sequencing note: also touches `tests/scheme/process/process-run.scm` and
`CHANGELOG.md`; #2461 (SRFI 231) is disjoint.