### PR TITLE
Stop treating a zero Windows pipe write quota as would-block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   and `test_selection.zig` did the same). These descriptors never
   intentionally cross an exec, but the fd-hygiene suites had to diff
   against the parent's own fd set to tolerate them.
+- **Writing more than the pipe buffer to a child's stdin no longer hangs
+  forever on Windows** (#2459) — past 4096 bytes (the pipe size), a feed
+  through `input:` wedged with no error and no CPU whenever a fiber
+  scheduler was running. `pipeWrite` treated
+  `NtQueryInformationFile`'s `WriteQuotaAvailable` as "can I write
+  without blocking" and synthesized `EAGAIN` at zero — but that field
+  tracks whether the peer happens to be parked in a read on the far end,
+  not whether the buffer has room (it reads 0 on a freshly connected,
+  completely empty pipe), so the parked writer waited on a number that
+  never moves. A zero quota now falls through to the plain CRT write,
+  which blocks the OS thread until the reader drains — the graceful
+  degradation the query-failure path already took, and the pre-#1608
+  behavior; a non-zero quota still usefully clamps the request. The
+  collector's abandoned-port flush keeps a never-block flavor
+  (`pipeWriteNoBlock`), since nothing will ever drain an abandoned pipe.
+  Known residual cost, same as before #1608 stage 2: a child that echoes
+  its stdin back while the feed is still blocked can fill its own output
+  pipe and wedge both sides — a parked write with a truthful readiness
+  signal needs overlapped pipe handles, deliberately out of scope. The
+  Windows stdin cap in the concurrent-drain test is gone, and a
+  larger-than-pipe-buffer `input:` feed is asserted on every platform.
 - **Continuations captured under a non-tail `apply` or `call-with-values`
   (#2451)** — resuming one raised `KP3000: continuation cannot resume across a
   returned native call`. Both reached their callee through a native

--- a/src/gc_sweep.zig
+++ b/src/gc_sweep.zig
@@ -456,15 +456,17 @@ pub fn freeObject(gc: *GC, obj: *Object) void {
                         while (start < port.write_buf_len) {
                             // A Windows socket port must send() — CRT _write
                             // cannot operate on a SOCKET handle — and a pipe
-                            // port in emulated non-blocking mode must keep its
-                            // quota gate: plain _write on a full pipe would
-                            // block this sweep forever, exactly the would-block
-                            // this loop promises to drop (#1608).
+                            // port in emulated non-blocking mode needs the
+                            // never-block pipe flavor: pipeWrite's zero-quota
+                            // fall-through is a plain _write that would block
+                            // this sweep forever on a full pipe nobody will
+                            // ever drain, exactly the would-block this loop
+                            // promises to drop (#1608; the split is #2459).
                             const remaining = port.write_buf_len - start;
                             const rc = if (platform.is_windows and port.fd_state.is_socket)
                                 platform.sockSend(port.fd, wb.ptr + start, remaining)
                             else if (platform.is_windows and port.fd_state.is_pipe and port.nonblocking)
-                                platform.pipeWrite(port.fd, wb.ptr + start, remaining)
+                                platform.pipeWriteNoBlock(port.fd, wb.ptr + start, remaining)
                             else
                                 platform.write(port.fd, wb.ptr + start, remaining);
                             if (rc < 0 and platform.errno(rc) == .INTR) continue;

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -15,12 +15,15 @@
 //! event-driven fiber suspension through WSAEventSelect (reactor.zig's
 //! WindowsEventBackend), reading/writing through sockRecv/sockSend.
 //! Pipe ports have no OS-level would-block mode, so they enter *emulated*
-//! non-blocking mode under a scheduler: pipeRead/pipeWrite's
-//! non-destructive pre-checks synthesize EAGAIN and the reactor re-polls
-//! the same checks on a 10 ms quantum (platform_win_pipe.zig). File
-//! ports keep blocking reads — the POSIX baseline too, since no OS has
-//! regular-file readiness. Sequential programs and timer-driven fibers
-//! are unaffected either way. This file is the public facade; the
+//! non-blocking mode under a scheduler: pipeRead's peek pre-check
+//! synthesizes EAGAIN and the reactor re-polls it on a 10 ms quantum
+//! (platform_win_pipe.zig); writes clamp on the pipe's write quota and,
+//! when it reads zero — not a would-block oracle (kaappi#2459) — fall
+//! through to a blocking CRT write bounded by whoever drains the far
+//! end. File ports keep blocking reads — the POSIX baseline too, since
+//! no OS has regular-file readiness. Sequential programs and
+//! timer-driven fibers are unaffected either way. This file is the
+//! public facade; the
 //! Windows ABI declarations and the socket/pipe helpers live in
 //! platform_win.zig, platform_win_sock.zig, and platform_win_pipe.zig.
 
@@ -310,6 +313,7 @@ pub const fdKind = win_pipe.fdKind;
 pub const pipeHandleFromFd = win_pipe.pipeHandleFromFd;
 pub const pipeRead = win_pipe.pipeRead;
 pub const pipeWrite = win_pipe.pipeWrite;
+pub const pipeWriteNoBlock = win_pipe.pipeWriteNoBlock;
 pub const pipePollReady = win_pipe.pipePollReady;
 pub const SockReadiness = win_sock.SockReadiness;
 pub const sockPollReady = win_sock.sockPollReady;

--- a/src/platform_win_pipe.zig
+++ b/src/platform_win_pipe.zig
@@ -11,15 +11,19 @@
 //! buffer space could a write consume right now" (the same query libuv
 //! uses for its non-overlapped pipe writes).
 //!
-//! Those two queries carry the whole design. A pipe port in emulated
-//! non-blocking mode (port.nonblocking set with no OS-level flip —
-//! maybeSetNonblocking) reads/writes through pipeRead/pipeWrite below,
-//! whose pre-checks synthesize the EAGAIN that drives the shared
-//! park-and-retry protocol unchanged; the reactor's WindowsEventBackend
-//! answers "when is it ready again" by re-running the same checks on a
-//! bounded poll cadence (pipePollReady). Sequential programs never set the
-//! flag, so their pipe I/O keeps the plain blocking CRT calls and syscall
-//! profile.
+//! Those two queries carry the whole design — for reads. A pipe port in
+//! emulated non-blocking mode (port.nonblocking set with no OS-level
+//! flip — maybeSetNonblocking) reads through pipeRead, whose peek
+//! pre-check synthesizes the EAGAIN that drives the shared
+//! park-and-retry protocol (PeekNamedPipe answers "are there bytes right
+//! now" exactly); the reactor's WindowsEventBackend answers "when is it
+//! ready again" by re-running the same check on a bounded poll cadence
+//! (pipePollReady). Writes only *clamp* on the quota query: a zero
+//! WriteQuotaAvailable is not a would-block oracle (kaappi#2459 — see
+//! pipeWrite), so there the fall-through is a plain blocking CRT write,
+//! bounded by whatever process or fiber drains the far end. Sequential
+//! programs never set the flag, so their pipe I/O keeps the plain
+//! blocking CRT calls and syscall profile.
 //!
 //! One documented caveat rules the threading story: MSDN warns that
 //! PeekNamedPipe "can block thread execution the same way any I/O function
@@ -126,9 +130,10 @@ fn queryPipeInfo(h: win.HANDLE) ?winp.FilePipeLocalInfo {
 /// data-flow direction is fixed at creation (named_pipe_configuration) and
 /// each handle knows which end it holds (named_pipe_end); CreatePipe's
 /// anonymous pipes are INBOUND with the write handle on the client end.
-/// Load-bearing for pipeWrite: quota == 0 on a writable end means "full,
-/// park until the reader drains", but on a non-writable end it would mean
-/// "park forever" — that case must surface the real write error instead.
+/// Kept as a clamp-only signal: quota > 0 on a writable end bounds the
+/// request that can complete without blocking (pipeWrite's short-write
+/// hint), while a *read-only* end's quota says nothing useful and must not
+/// shape the request — the write itself surfaces the real error.
 fn isWritableEnd(info: winp.FilePipeLocalInfo) bool {
     return switch (info.named_pipe_configuration) {
         winp.FILE_PIPE_FULL_DUPLEX => true,
@@ -159,16 +164,45 @@ pub fn pipeRead(fd: fd_t, buf: [*]u8, len: usize) isize {
     return platform.read(fd, buf, len);
 }
 
-/// write(2)-shaped, quota-gated write on a pipe fd in emulated non-blocking
-/// mode. Byte-mode pipe writes block until *every* requested byte fits, so
-/// the request is clamped to the space known to be free — the caller's
-/// short-write loop (drainWriteBuffer) handles the remainder. Zero free
-/// space on a writable end synthesizes EAGAIN; a failed query or a
-/// non-writable end falls through to the plain CRT write, which surfaces
-/// the real error (or blocks, exactly as before stage 2 — the graceful
-/// degradation, never a wrong result).
+/// write(2)-shaped write on a pipe fd in emulated non-blocking mode —
+/// the port layer's byte sink under a scheduler. Byte-mode pipe writes
+/// block until *every* requested byte fits, so a non-zero
+/// WriteQuotaAvailable usefully bounds the request to what can complete
+/// without blocking — the caller's short-write loop (drainWriteBuffer)
+/// handles the remainder. A zero quota, however, is NOT a would-block
+/// oracle: whether it reads 0 or the buffer size tracks whether the peer
+/// happens to be parked in a read on the far end, not whether the buffer
+/// has room (measured on the Windows 11 ARM64 reference VM: a freshly
+/// connected, completely empty child-stdin pipe reported 0 while
+/// state=CONNECTED and a write would have succeeded immediately —
+/// kaappi#2459). Synthesizing EAGAIN on it wedged the parked writer on a
+/// number that never moves, so zero falls through to the plain CRT
+/// write, which blocks the OS thread until the reader drains — exactly
+/// the graceful degradation the query-failure and non-writable-end paths
+/// already take, and the behavior every pipe write had before the
+/// emulated non-blocking stage. (libuv reads the same field, but only to
+/// size a uv_try_write — never as the sole readiness signal behind a
+/// park.) A readiness signal that would let writes park again needs an
+/// overlapped handle, a larger change than this hang deserves. Callers
+/// that must never block (the collector's abandoned-port flush) use
+/// `pipeWriteNoBlock` instead.
 pub fn pipeWrite(fd: fd_t, buf: [*]const u8, len: usize) isize {
     if (comptime !is_windows) return -1;
+    return pipeWriteImpl(fd, buf, len, false);
+}
+
+/// The never-block flavor the collector's best-effort flush needs: an
+/// abandoned port's pending output must be dropped, not written — there
+/// is by definition no reader left, so the fall-through write of
+/// `pipeWrite` would block the sweep (and the whole OS thread) forever
+/// on a full pipe. Same clamp when the quota is non-zero; EAGAIN when it
+/// is zero.
+pub fn pipeWriteNoBlock(fd: fd_t, buf: [*]const u8, len: usize) isize {
+    if (comptime !is_windows) return -1;
+    return pipeWriteImpl(fd, buf, len, true);
+}
+
+fn pipeWriteImpl(fd: fd_t, buf: [*]const u8, len: usize, no_block: bool) isize {
     const h = pipeHandleFromFd(fd) orelse {
         win._errno().* = @intFromEnum(E.BADF);
         return -1;
@@ -176,8 +210,11 @@ pub fn pipeWrite(fd: fd_t, buf: [*]const u8, len: usize) isize {
     const info = queryPipeInfo(h) orelse return platform.write(fd, buf, len);
     if (!isWritableEnd(info)) return platform.write(fd, buf, len);
     if (info.write_quota_available == 0) {
-        win._errno().* = @intFromEnum(E.AGAIN);
-        return -1;
+        if (no_block) {
+            win._errno().* = @intFromEnum(E.AGAIN);
+            return -1;
+        }
+        return platform.write(fd, buf, len);
     }
     return platform.write(fd, buf, @min(len, info.write_quota_available));
 }
@@ -205,11 +242,11 @@ pub fn pipePollReady(fd: fd_t, want_read: bool, want_write: bool) PipeReadiness 
         }
     }
     if (want_write) {
-        if (queryPipeInfo(h)) |info| {
-            result.writable = !isWritableEnd(info) or info.write_quota_available > 0;
-        } else {
-            result.writable = true;
-        }
+        // Unconditionally writable: WriteQuotaAvailable is not a would-
+        // block oracle (see pipeWrite) — reporting not-ready on it parked
+        // writers forever (kaappi#2459). A spurious wake is always safe
+        // under the park-and-retry protocol; a missed one is not.
+        result.writable = true;
     }
     return result;
 }

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -187,9 +187,11 @@ fn isBufferedFdPort(port: *types.Port) bool {
 /// the wakeup (stage 1). A non-socket pipe fd is marked
 /// `fd_state.is_pipe`; once a scheduler exists the port enters *emulated*
 /// non-blocking mode — `nonblocking` set with no OS-level flip (pipe fds
-/// have no would-block mode) — routing its I/O through pipeRead/pipeWrite,
-/// whose peek/quota pre-checks synthesize the EAGAIN, and the reactor
-/// re-runs those checks on a poll cadence for the wakeup (stage 2). File
+/// have no would-block mode) — routing its I/O through pipeRead/pipeWrite:
+/// reads gate on the peek and park (stage 2), while writes clamp on the
+/// write-quota query and, when it reads zero — not a would-block oracle
+/// (kaappi#2459) — fall through to a blocking CRT write bounded by
+/// whoever drains the far end. File
 /// fds stay fully blocking, which is the POSIX baseline too (O_NONBLOCK
 /// is a no-op on regular files; epoll rejects them). The probe result is
 /// remembered per port (fd_state.probe_done) so file ports don't pay the
@@ -254,8 +256,10 @@ fn portFdRead(port: *types.Port, buf: [*]u8, len: usize) isize {
     return platform.read(port.fd, buf, len);
 }
 
-/// The port's fd byte sink; portFdRead's write-side twin (pipe ports gate
-/// on the write-quota query instead of the peek).
+/// The port's fd byte sink; portFdRead's write-side twin (pipe ports clamp
+/// on the write-quota query instead of gating on the peek — and a zero
+/// quota falls through to the plain write, since it is not a would-block
+/// oracle; kaappi#2459).
 fn portFdWrite(port: *types.Port, buf: [*]const u8, len: usize) isize {
     if (comptime platform.is_windows) {
         if (port.fd_state.is_socket) return platform.sockSend(port.fd, buf, len);

--- a/src/reactor_backends.zig
+++ b/src/reactor_backends.zig
@@ -600,15 +600,18 @@ pub const WasiPollBackend = struct {
 //   waitable readiness objects and carry no would-block mode; completion
 //   I/O is off the table too (CRT/inherited anonymous pipes lack
 //   FILE_FLAG_OVERLAPPED — see platform_win_pipe.zig). What they do
-//   offer is non-destructive state queries, so a pipe port EAGAINs
-//   through pipeRead/pipeWrite's peek/quota pre-checks, and while any
-//   pipe interest is armed wait() bounds its block at
-//   `pipe_poll_quantum_ns` and re-runs the same checks (pipePollReady)
-//   in its sweep — level-triggered by construction, so none of the
-//   edge-record races above apply and no pre-ready snapshot is needed.
-//   The quantum is the same order as the ~15 ms OS timer granularity
-//   that already bounds this backend's timers, and it is paid only
-//   while a fiber is actually parked on a pipe.
+//   offer is non-destructive state queries, so a pipe READ EAGAINs
+//   through pipeRead's peek pre-check, and while any pipe read interest
+//   is armed wait() bounds its block at `pipe_poll_quantum_ns` and
+//   re-runs the same check (pipePollReady) in its sweep —
+//   level-triggered by construction, so none of the edge-record races
+//   above apply and no pre-ready snapshot is needed. The quantum is the
+//   same order as the ~15 ms OS timer granularity that already bounds
+//   this backend's timers, and it is paid only while a fiber is actually
+//   parked on a pipe. Pipe writes never park: WriteQuotaAvailable is not
+//   a would-block oracle (kaappi#2459 — pipeWrite falls through to a
+//   blocking write on a zero quota), so pipePollReady reports them
+//   writable unconditionally.
 //
 // Files stay fully blocking — which is the POSIX baseline as well
 // (O_NONBLOCK is a no-op on regular files; epoll rejects them), so

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -813,10 +813,12 @@ test "a parked mid-read-bytevector retry over a pipe loses no bytes" {
 // #1608 stage 2: OS-pipe pairs (makePipeFdPair). On POSIX these re-cover
 // native pipe readiness with real pipe fds; on Windows they are the
 // end-to-end coverage of the polled pipe backend — fd-kind probe →
-// emulated non-blocking (no OS flip) → pipeRead/pipeWrite EAGAIN →
+// emulated non-blocking (no OS flip) → pipeRead's peek EAGAIN →
 // pipePollReady wakeup. Before stage 2, every parked-fiber test below
 // would deadlock on Windows: the read blocked the OS thread and the
-// writer fiber never ran.
+// writer fiber never ran. (Pipe *writes* stopped parking on Windows with
+// kaappi#2459 — a zero write-quota is not a would-block oracle — so the
+// write-park test below is POSIX-only now.)
 // ---------------------------------------------------------------------------
 
 test "#1608: two fibers reading two OS-pipe ports park and interleave" {
@@ -861,6 +863,7 @@ test "#1608: two fibers reading two OS-pipe ports park and interleave" {
 
 test "#1608: OS-pipe write beyond the pipe buffer parks the writer; a reader fiber drains it" {
     if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
+    if (comptime platform.is_windows) return error.SkipZigTest; // pipe writes no longer park on Windows (kaappi#2459): a zero write-quota falls through to a blocking CRT write, which with a same-thread fiber reader deadlocks — the reader never gets a slot while the writer holds the thread. The same feed with a process on the far end (the run-process shape) is covered end-to-end by the larger-than-pipe-buffer input: test in tests/scheme/process/process-run.scm.
     var gc = memory.GC.init(std.testing.allocator);
     defer gc.deinit();
     var vm = try th.makeTestVM(&gc);
@@ -873,10 +876,9 @@ test "#1608: OS-pipe write beyond the pipe buffer parks the writer; a reader fib
     _ = try vm.eval("(import (kaappi fibers))");
     // 100000 bytes exceeds every platform's pipe capacity (16-64 KiB, and
     // the 64 KiB CRT _pipe buffer on Windows), so the flush hits
-    // would-block mid-buffer — on Windows that is pipeWrite's quota gate,
-    // whose clamp must also keep each retry's blocking CRT write inside
-    // the known-free space. The final count and content check prove no
-    // byte was lost or duplicated across the park/retry cycles.
+    // would-block mid-buffer — real O_NONBLOCK on the POSIX tiers this
+    // test now runs on. The final count and content check prove no byte
+    // was lost or duplicated across the park/retry cycles.
     _ = try vm.eval("(define n 100000)");
     _ = try vm.eval(
         \\(define writer (spawn (lambda ()
@@ -973,10 +975,12 @@ test "#1608: GC finalization of an abandoned pipe port with a full pipe drops th
     const pipe = th.makePipeFdPair();
     defer platform.close(pipe[0]);
 
-    // Fill the pipe to exactly-full without ever blocking: quota-gated
-    // raw writes on Windows, O_NONBLOCK raw writes on POSIX. Reaching
-    // EAGAIN is the test's precondition — a plain blocking write in the
-    // sweep below would then hang forever.
+    // Fill the pipe to exactly-full without ever blocking: the never-block
+    // pipe flavor on Windows (its zero-quota EAGAIN — pipeWrite proper
+    // falls through to a blocking write there since kaappi#2459),
+    // O_NONBLOCK raw writes on POSIX. Reaching EAGAIN is the test's
+    // precondition — a plain blocking write in the sweep below would then
+    // hang forever.
     if (comptime !platform.is_windows) th.setFdNonblocking(pipe[1]);
     var chunk: [4096]u8 = undefined;
     @memset(&chunk, 'f');
@@ -984,7 +988,7 @@ test "#1608: GC finalization of an abandoned pipe port with a full pipe drops th
     var guard: usize = 0;
     while (guard < 10_000) : (guard += 1) {
         const rc = if (comptime platform.is_windows)
-            platform.pipeWrite(pipe[1], &chunk, chunk.len)
+            platform.pipeWriteNoBlock(pipe[1], &chunk, chunk.len)
         else
             platform.write(pipe[1], &chunk, chunk.len);
         if (rc < 0) {
@@ -1015,9 +1019,10 @@ test "#1608: GC finalization of an abandoned pipe port with a full pipe drops th
     }
     gc.popRoot();
 
-    // freeObject's best-effort flush hits the full pipe. The quota gate
-    // (Windows) / O_NONBLOCK (POSIX) turns that into an EAGAIN that drops
-    // the remainder, per the flush's own contract; a blocking write here
-    // would hang this collection — and the whole OS thread — forever.
+    // freeObject's best-effort flush hits the full pipe. The never-block
+    // pipe flavor (Windows) / O_NONBLOCK (POSIX) turns that into an EAGAIN
+    // that drops the remainder, per the flush's own contract; a blocking
+    // write here would hang this collection — and the whole OS thread —
+    // forever.
     gc.collect();
 }

--- a/src/types_port.zig
+++ b/src/types_port.zig
@@ -77,11 +77,14 @@ pub const Port = struct {
         is_socket: bool = false,
         /// `fd` wraps a non-socket pipe end (#1608 stage 2). Under a
         /// scheduler the port enters *emulated* non-blocking mode
-        /// (`nonblocking` set with no OS-level flip): reads/writes route
-        /// through platform.pipeRead/pipeWrite, whose peek/write-quota
-        /// pre-checks synthesize the EAGAIN that parks the fiber, and the
-        /// reactor re-runs the same checks on a poll cadence for the
-        /// wakeup.
+        /// (`nonblocking` set with no OS-level flip): reads route through
+        /// platform.pipeRead, whose peek pre-check synthesizes the EAGAIN
+        /// that parks the fiber, and the reactor re-runs the same check
+        /// on a poll cadence for the wakeup. Writes route through
+        /// platform.pipeWrite, which clamps on the write-quota query and —
+        /// a zero quota not being a would-block oracle (kaappi#2459) —
+        /// falls through to a blocking write bounded by whoever drains
+        /// the far end.
         is_pipe: bool = false,
         _pad: u5 = 0,
     } = .{},

--- a/tests/scheme/process/process-run.scm
+++ b/tests/scheme/process/process-run.scm
@@ -130,6 +130,24 @@
       (lambda () (run-process (run cat-script) 'input: (string->utf8 "bytes")))
     (lambda (st out err) out)))
 
+(test-equal "input: larger than the pipe buffer still completes"
+  '(0 0)
+  ;; Past every platform's pipe buffer (64 KiB on POSIX tiers; Windows
+  ;; pipes are 4 KiB, and a feed even one byte past that hung forever
+  ;; before kaappi#2459 — the parent's write parked on
+  ;; WriteQuotaAvailable, which reads 0 whenever the child is parked in
+  ;; its own read, empty buffer or not, so the number never moves). The
+  ;; child drains without echoing: an interleaved echoer whose own
+  ;; output outgrows its pipe would need the parent's drain fibers to
+  ;; run mid-feed, which a blocking write cannot allow — the
+  ;; overlapped-handle route #2459 deliberately defers. 'timeout: makes
+  ;; the pre-fix wedge fail loudly as a raised process-timeout instead
+  ;; of hanging the suite.
+  (call-with-values
+      (lambda ()
+        (run-process (run flood-script "0") 'input: (make-string 16384 #\i) 'timeout: 30))
+    (lambda (st out err) (list st (string-length out)))))
+
 (test-equal "stdin is empty, not inherited, when input: is omitted"
   '(0 "")
   (call-with-values (lambda () (run-process (run cat-script)))
@@ -151,15 +169,12 @@
 
 ;; The deadlock this whole API exists to avoid: stdin, stdout and stderr all
 ;; past the pipe buffer at the same time. Feed-then-read, or read-stdout-
-;; then-stderr, hangs forever here.
-;;
-;; The stdin leg is capped at the pipe buffer on Windows: a write past it
-;; from a fiber-scheduled program hangs there outright (kaappi#2459 — the
-;; `WriteQuotaAvailable` readiness query reads 0 both when the pipe is full
-;; and when a reader is waiting, and the writer parks on a number that never
-;; moves). Both *output* legs stay at full size on every platform, so what
-;; is lost on Windows is the stdin half of the assertion, not the test.
-(define feed-size (cond-expand (windows 4096) (else 40000)))
+;; then-stderr, hangs forever here. All three legs run at full size on
+;; every platform — the Windows stdin cap this test used to carry is gone
+;; with kaappi#2459 (a zero WriteQuotaAvailable no longer parks the
+;; writer), which is also what lets the dedicated larger-than-buffer
+;; input: test above assert a full round trip.
+(define feed-size 40000)
 
 (test-equal "stdin, stdout and stderr all move at once"
   (list 0 40000 40000)


### PR DESCRIPTION
Closes #2459

## What

Writing more than 4096 bytes (the pipe size) through a pipe port hung the
program forever on Windows whenever a fiber scheduler was running.
`pipeWrite` treated `WriteQuotaAvailable` — from
`NtQueryInformationFile(FilePipeLocalInformation)` — as "can I write without
blocking" and synthesized `EAGAIN` at zero; `pipePollReady` keyed its wakeup
on the same field. As the issue measured, that field is not a would-block
oracle on these handles: whether it reads 0 or the buffer size tracks whether
the peer happens to be parked in a read on the far end, not whether the
buffer has room (0 on a freshly connected, *empty* child-stdin pipe,
`state=CONNECTED`). The parked writer waited on a number that never moves.

- A zero quota now **falls through to the plain CRT write**, which blocks the
  OS thread until the reader drains — the graceful degradation the
  query-failure path already took, and the pre-#1608-stage-2 behavior. A
  non-zero quota still usefully clamps the request (short-write hint).
- `pipePollReady` reports pipe writability **unconditionally** — a spurious
  wake is safe under park-and-retry, a missed one is not.
- The collector's abandoned-port flush must never block (nothing will ever
  drain an abandoned pipe — the GC would hang), so it gets
  **`pipeWriteNoBlock`**, the old clamp-and-EAGAIN flavor; the fill-to-full
  fd test uses it too, and the write-park fiber test is POSIX-only now.
- The Windows stdin cap in the concurrent-drain test is gone, and a new
  larger-than-pipe-buffer `input:` feed is asserted on every platform
  (with `timeout:` so the pre-fix wedge fails loudly instead of hanging a
  CI leg).

## Evidence (Windows 11 ARM64 reference VM, cross-built aarch64-windows)

- Main: the issue's 4097-byte `input:` feed hangs — killed at 15 s with no
  output. This branch: `status=0`, feed completes.
- `process-run.scm` is **19/19** there, including the uncapped
  concurrent-drain test and the new large-feed test.
- Shape boundary mapped on the VM while designing the test: a **drain-only**
  child fed 16384 bytes completes (`ok 0 0 0`); a small interleaved echoer
  (4000 bytes) round-trips (`ok 0 4000 0`); an interleaved **echoer whose
  echo outgrows its own 4 KiB output pipe while the feed is blocked**
  deadlocks — the documented cost of the blocking fallback, called out in
  the CHANGELOG and the test comment. A parked write with a *truthful*
  readiness signal needs overlapped pipe handles (libuv's route), the
  change #2459 explicitly defers.

## Verification

- macOS: all five process suites green (18/18/10/18/3 — process-test has 18
  here because #2462 adds a 19th on its own branch), `tests_port_io` green,
  native + `aarch64-windows` cross-builds clean.
- `zig build test` stops at the pre-existing `tests_step` crash (#2447,
  reproduced on clean main, unrelated).

Sequencing note: touches `tests/scheme/process/process-run.scm` and
`CHANGELOG.md` in different hunks than #2462; if both land close together
the second needs only a trivial CHANGELOG rebase.