### PR TITLE
Discard expected-error stderr in the stepper tests (#2447)

### DIFF
--- a/src/testing_helpers.zig
+++ b/src/testing_helpers.zig
@@ -330,7 +330,13 @@ pub const QuietStderr = struct {
     }
 
     /// Point fd 2 back at the original stderr. A no-op on an inert receiver.
+    ///
+    /// On WASI the comptime guard must be the first statement of EVERY
+    /// method that names `dup`/`dup2`: semantic analysis of even an
+    /// unreachable-at-runtime call generates the `env::dup2` import, which
+    /// wasmtime then refuses (the wasm-job failure of kaappi#2447).
     pub fn deinit(self: *QuietStderr) void {
+        if (comptime platform.is_wasm) return;
         if (!self.active) return;
         _ = platform.dup2(self.saved, 2);
         _ = platform.close(self.saved);

--- a/src/testing_helpers.zig
+++ b/src/testing_helpers.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const testing = std.testing;
 const types = @import("types.zig");
 const platform = @import("platform.zig");
 pub const memory = @import("memory.zig");
@@ -277,6 +278,95 @@ pub fn setFdNonblocking(fd: platform.fd_t) void {
     std.debug.assert(flags >= 0);
     const nonblock: c_int = @intCast(@as(u32, @bitCast(std.posix.O{ .NONBLOCK = true })));
     std.debug.assert(std.c.fcntl(fd, std.posix.F.SETFL, flags | nonblock) >= 0);
+}
+
+/// Redirect the process's real stderr (fd 2) away for the receiver's
+/// lifetime, restoring it on `deinit` — for tests whose expected outcome
+/// includes `runFile`-style diagnostics on fd 2 (kaappi#2447).
+///
+/// Why that matters under `zig build test`: the build runner captures the
+/// test binary's stderr, and a step whose captured stderr is non-empty —
+/// even a fully green one — is rendered with a red ` w` warning marker, the
+/// stderr itself, and a red `failed command: <argv>` provenance line, while
+/// the default summary mode prints no pass/fail line for a successful run.
+/// Expected-error output therefore reads exactly like a crash ("the binary
+/// died with no summary"), which is how kaappi#2447 was filed. Discarding
+/// the expected diagnostics keeps a green run silent.
+///
+/// The same fd juggling the fuzz harness uses for stdout (tests_fuzz's
+/// evalNormalized). WASI has neither dup nor a null device (kaappi#2153),
+/// so the comptime bails leave the receiver inert there and the expected
+/// output stays on the runner's stderr.
+pub const QuietStderr = struct {
+    /// The saved original stderr, valid while `active`.
+    saved: platform.fd_t = -1,
+    /// Whether fd 2 was actually redirected; inert until it is.
+    active: bool = false,
+
+    /// Redirect fd 2 onto the null sink. Inert (not an error) when the swap
+    /// cannot be made: the caller's diagnostics then simply stay on the real
+    /// stderr, the pre-helper behavior.
+    pub fn init(self: *QuietStderr) void {
+        if (comptime platform.is_wasm) return;
+        const devnull = platform.openNullSink() catch return;
+        defer _ = platform.close(devnull);
+        _ = self.initOnto(devnull);
+    }
+
+    /// Redirect fd 2 onto `sink`, which the caller keeps open for the
+    /// receiver's lifetime. Returns false — leaving the receiver inert —
+    /// when the swap cannot be made.
+    pub fn initOnto(self: *QuietStderr, sink: platform.fd_t) bool {
+        if (comptime platform.is_wasm) return false;
+        const saved = platform.dup(2);
+        if (saved < 0) return false;
+        if (platform.dup2(sink, 2) < 0) {
+            _ = platform.close(saved);
+            return false;
+        }
+        self.saved = saved;
+        self.active = true;
+        return true;
+    }
+
+    /// Point fd 2 back at the original stderr. A no-op on an inert receiver.
+    pub fn deinit(self: *QuietStderr) void {
+        if (!self.active) return;
+        _ = platform.dup2(self.saved, 2);
+        _ = platform.close(self.saved);
+        self.saved = -1;
+        self.active = false;
+    }
+};
+
+test "QuietStderr routes fd 2 onto the sink and restores it" {
+    if (comptime platform.is_wasm) return error.SkipZigTest;
+    const pair = makePipeFdPair();
+    defer closeFd(pair[0]);
+    defer closeFd(pair[1]);
+
+    // Asserted, not skipped: a false here means the dup/dup2 juggling is
+    // broken, and every expected-error test relying on the helper would be
+    // silently leaking diagnostics again.
+    var quiet: QuietStderr = .{};
+    try testing.expect(quiet.initOnto(pair[1]));
+    // While active, the process's own stderr writes land in the pipe —
+    // exactly the route the runFile-style diagnostics take — and stay there
+    // across writes (no intervening restore).
+    _ = platform.write(2, "sink", 4);
+    _ = platform.write(2, "!", 1);
+    quiet.deinit();
+    try testing.expect(!quiet.active);
+
+    var buf: [8]u8 = undefined;
+    const n = platform.read(pair[0], &buf, buf.len);
+    try testing.expectEqual(@as(isize, 5), n);
+    try testing.expectEqualStrings("sink!", buf[0..@intCast(n)]);
+
+    // fd 2 is a valid, distinct descriptor again after the restore.
+    const restored = platform.dup(2);
+    try testing.expect(restored >= 0);
+    if (restored >= 0) platform.close(restored);
 }
 
 pub const SockBuf = enum { snd, rcv };

--- a/src/tests_step.zig
+++ b/src/tests_step.zig
@@ -163,6 +163,15 @@ test "stepper: a form error is reported but the program still finishes" {
     stepper.init(vm, src, "<test>");
     defer stepper.deinit();
 
+    // The expected KP3002 diagnostic goes to the process's real stderr.
+    // Discard it: under `zig build test` a green run whose captured stderr
+    // is non-empty is rendered with a red ` w` warning block and a
+    // "failed command:" line and no success summary — indistinguishable
+    // from a crash at a glance, which is how kaappi#2447 was filed.
+    var quiet: th.QuietStderr = .{};
+    quiet.init();
+    defer quiet.deinit();
+
     _ = try runToDone(&stepper, 1_000_000, 8);
     try testing.expect(stepper.had_error);
     // Execution continued past the error to the next form, matching runFile.
@@ -189,6 +198,13 @@ test "stepper: a form that pauses then raises unwinds roots cleanly" {
     var stepper: Stepper = undefined;
     stepper.init(vm, src, "<test>");
     defer stepper.deinit();
+
+    // Same stderr discipline as the form-error test above (kaappi#2447):
+    // the expected KP3002 from the resumed form must not end up in the
+    // build runner's captured stderr.
+    var quiet: th.QuietStderr = .{};
+    quiet.init();
+    defer quiet.deinit();
 
     var steps: usize = 0;
     while (steps < 1_000_000) : (steps += 1) {


### PR DESCRIPTION
Closes #2447

## Root cause: there is no crash

The unit-test binary never dies in the reported environment. What the
issue read as "the runner dies with no pass/fail summary" is Zig 0.16's
build-runner *warning* display for a **successful** step:

1. The two expected-error stepper tests (`a form error is reported but
   the program still finishes`, `a form that pauses then raises unwinds
   roots cleanly`) legitimately drive the `runFile`-style error path, so
   their KP3002 diagnostics are written to the process's real stderr —
   by design, matching batch output.
2. Under `zig build test` the build runner captures that fd as the run
   step's `result_stderr`. A step with non-empty captured stderr — even
   a fully green one — is rendered with a red ` w` warning marker, the
   stderr itself, and a red `failed command: <argv>` provenance line
   (`lib/compiler/build_runner.zig`: the `" w\n"` branch of
   `printStepFailure`, and the `result_failed_command` echo — set for
   every run step, printed as context).
3. The default summary mode prints **no pass/fail summary at all for a
   successful build**.

Expected stderr + red "failed command" + no summary reads exactly like
a segfault. That is the entire symptom.

## Evidence (kaappi-builder-arm64, podman applehv, unmodified main)

| Run | Result |
|---|---|
| Issue's exact repro (`cp` + `rm -rf .zig-cache zig-out` + filtered build), 4 runs | warning block as described — **exit 0** every time |
| Same under a pty (`script -qec`) | reproduces the reporter's display byte-for-byte (progress lines, red ` w` block, `failed command:`) — **exit 0** |
| `--summary all` on the filtered run | `13 pass (13 total)` |
| Test binary run directly (no `--listen`) | `All 13 tests passed.` |
| **Full** `zig build test --summary all`, one-shot container | `13/13 steps succeeded; 1990/2010 tests passed (20 skipped)` — **exit 0**; the rest of the unit suite is not lost |

So both the "crash" and "the podman leg loses the rest of the unit
suite" do not occur: the suite completes green in the exact repro
environment.

## What changed

`th.QuietStderr` (new in `src/testing_helpers.zig`): redirects fd 2 onto
the null sink for its lifetime and restores it — the same
dup/dup2/openNullSink juggling the fuzz harness already uses for stdout
(`tests_fuzz.evalNormalized`), inert on WASI (no dup, no null device,
kaappi#2153). The two expected-error stepper tests now use it, so their
expected diagnostics no longer land in the build runner's captured
stderr. A green `zig build test -Dtest-filter=tests_step` is now
**completely silent**, in every environment — nothing left to misread.

Unit test included (`QuietStderr routes fd 2 onto the sink and restores
it`): asserts fd 2 writes reach the sink while active and that fd 2 is
restored after. Mutation-checked: breaking the dup2 round-trip fails the
test (an earlier draft that *skipped* on redirect failure was rewritten
to assert, exactly so a broken helper cannot hide behind a skip).

## After the fix, in the container

- Issue's exact repro command: **no output, exit 0** (was: warning block
  + `failed command:` line).
- Full `zig build test --summary all` (one-shot container):
  `13/13 steps succeeded; 1991/2011 tests passed (20 skipped)` — exit 0,
  and the `run test unit-tests` line no longer carries the ` w` warning
  marker.
- macOS worktree: full suite green (1990/2011 passed, 21 skipped),
  `-Dgc-stress=true` filtered runs green, `zig fmt --check` clean.

## Side finding (out of scope, filed separately)

While verifying with a *persistent* container I hit the one test that
can genuinely fail in a podman harness: `tests_process` "process-wait
phase2: group kill reaches the child's own child" polls `kill(gpid, 0)`
until ESRCH, but under a PID 1 that never reaps adopted orphans
(`podman run -d ... sleep infinity`) the killed grandchild stays a
zombie and the poll times out — the group kill itself works (state `Z`,
reparented to PID 1). The issue's one-shot `bash -c` PID 1 reaps, so
this does not occur in the reported environment. Follow-up: #2466

Since the diagnosis is "no Kaappi defect, no VM defect — a display
misread", the issue's own downgrade rule applies: priority lowered from
`high` to `low` (only the diagnostic clarity was wrong).
