### PR TITLE
apply/call-with-values: resumable cwv producer (#2453) and unit-wide gate decline for redefined names (#2457)

### DIFF
--- a/.claude/skills/bytecode-isa/SKILL.md
+++ b/.claude/skills/bytecode-isa/SKILL.md
@@ -5,7 +5,7 @@ description: Reference for the Kaappi bytecode instruction set
 # Bytecode ISA
 
 The instruction set reference lives in `docs/dev/bytecode.md` — read that
-file for the full 32-opcode table, operand encodings, closure capture
+file for the full 33-opcode table, operand encodings, closure capture
 encoding, and disassembler output format. Do not duplicate the table here;
 that doc is the single source of truth.
 

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ a continuation on every `yield`) breaks when consumed inside such a driver.
 Which procedures are exempt is not guessable from the outside, so here is the
 list. **Exempt** — a continuation captured in the callback resumes freely:
 `apply` and `call-with-values` (both positions, and both halves of the latter:
-#2451 for its consumer, #2453 for its producer),
+`#2451` for its consumer, `#2453` for its producer),
 `map`, `for-each`, `vector-map`, `vector-for-each`, `string-for-each`, and — as
 of #2060 — the SRFI-1 `fold`, `filter`, `any`, `every`, `unfold` and SRFI-69
 `hash-table-walk`. A coroutine generator can be applied, folded, filtered,

--- a/README.md
+++ b/README.md
@@ -395,7 +395,8 @@ a continuation on every `yield`) breaks when consumed inside such a driver.
 
 Which procedures are exempt is not guessable from the outside, so here is the
 list. **Exempt** — a continuation captured in the callback resumes freely:
-`apply` and `call-with-values` (both positions, #2451 for the non-tail half),
+`apply` and `call-with-values` (both positions, and both halves of the latter:
+#2451 for its consumer, #2453 for its producer),
 `map`, `for-each`, `vector-map`, `vector-for-each`, `string-for-each`, and — as
 of #2060 — the SRFI-1 `fold`, `filter`, `any`, `every`, `unfold` and SRFI-69
 `hash-table-walk`. A coroutine generator can be applied, folded, filtered,
@@ -405,11 +406,10 @@ mapped or walked freely.
 `reduce`, `reduce-right`, `find`, `find-tail`, `count`, `partition`, `remove`,
 `take-while`, `drop-while`, `delete`, `delete-duplicates`, `filter-map`,
 `append-map`, `pair-for-each`, `pair-fold`, the `lset-*` family, and
-`assoc`/`member` with a custom predicate, among others — plus two corners of
-the exempt pair: `call-with-values`' **producer** (the consumer is what runs in
-the dispatch loop; the producer still runs under the native call — #2453), and an
-`apply` whose flattened argument list exceeds 255 arguments, which falls back to
-the native route because the call opcode's argument count is a single byte.
+`assoc`/`member` with a custom predicate, among others — plus one corner of
+the exempt pair: an `apply` whose flattened argument list exceeds 255
+arguments, which falls back to the native route because the call opcode's
+argument count is a single byte.
 
 SRFI 248's delimited continuations (`with-unwind-handler`, and the extended
 `guard`) are built on this `call/cc` via a sticky exception handler, with three

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -80,7 +80,7 @@ investigations.
 
 | Document | Contents |
 |----------|----------|
-| [bytecode.md](bytecode.md) | Bytecode instruction set (32 opcodes), encoding, disassembler |
+| [bytecode.md](bytecode.md) | Bytecode instruction set (33 opcodes), encoding, disassembler |
 | [repl.md](repl.md) | REPL reference: line editing, comma commands, completion |
 | [unicode-case-mapping.md](unicode-case-mapping.md) | Case-conversion coverage by script |
 | [fuzzing-feasibility.md](fuzzing-feasibility.md) | Why neither Fuzzilli nor AFL++ is the tool, the existing `std.testing.fuzz` targets, and where fuzzing can improve |

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -332,7 +332,7 @@ enum value followed by operands.
 
 ### Opcodes
 
-32 opcodes, defined by the `OpCode` enum in `src/types.zig`. Register, slot,
+33 opcodes, defined by the `OpCode` enum in `src/types.zig`. Register, slot,
 constant-index and symbol-index operands are u16 (big-endian); only `nargs` and
 a closure capture descriptor's `is_local` flag are u8.
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -30,7 +30,7 @@ Source code
 | **Reader** | `reader.zig` + `reader_tokens.zig`, `reader_datum.zig` | Tokenizer + recursive descent parser. Handles full R7RS lexical syntax including Unicode identifiers, `#\lambda` character literals, `#(...)` vectors, `#u8(...)` bytevectors, datum labels. |
 | **Expander** | `expander.zig` + `expander_instantiate.zig` | `syntax-rules` pattern matching with ellipsis, literal identifiers, and underscore wildcards. Template instantiation with hygienic renaming (gensym-based). |
 | **IR** | `ir.zig` | Lowers S-expressions to a tree-structured IR (18 node types, one of which — `sexpr_form` — carries 18 `FormKind`s). Runs 1 analysis pass (tail positions) and 5 optimization passes (constant folding, dead branch elimination, boolean simplification, identity elimination, begin simplification). See [ir.md](ir.md) for details. |
-| **Compiler** | `compiler.zig` + 9 sub-modules | Emits register-based bytecode from IR nodes via `compileFromNode()` (in `compiler_ir.zig`). Retains `compileExpr()` for forms delegated via `passthrough`. See the [Compiler & IR](#compiler--ir-11-files) table for the per-file split. |
+| **Compiler** | `compiler.zig` + 10 sub-modules | Emits register-based bytecode from IR nodes via `compileFromNode()` (in `compiler_ir.zig`). Retains `compileExpr()` for forms delegated via `passthrough`. See the [Compiler & IR](#compiler--ir-12-files) table for the per-file split. |
 | **VM** | `vm.zig` + 10 sub-modules | Executes bytecode with a growable register file, call frame stack, exception handler stack, and dynamic-wind stack (all heap-allocated, double-on-overflow; exceeding a hard cap is an uncatchable KP3008). First-class continuations via stack copying, plus a stepping debugger. |
 | **GC** | `memory.zig` | Generational (young/old) mark-and-sweep collector over an intrusive linked list, with a write barrier and remembered set for old→young references. Root tracking via `pushRoot`/`popRoot`. Triggered after N allocations. |
 | **Primitives** | 32 `primitives_*.zig` files | 696 built-in procedures organized by domain. |
@@ -84,7 +84,7 @@ domain-mate (`Pair`, `Symbol`, `SchemeString`, `Closure`, `Function`,
 `Fiber` (`fiber.zig`) predates this split and follows neither convention:
 its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 
-### Compiler & IR (11 files)
+### Compiler & IR (12 files)
 
 | File | Responsibility |
 |------|---------------|
@@ -97,7 +97,8 @@ its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 | `compiler_advanced.zig` | case, case-lambda, guard, quasiquote |
 | `compiler_macro.zig` | Macro-use path: expandAndCompileMacroUse, hygiene injection walks, free-ref collection; re-exports compiler_define_syntax.zig |
 | `compiler_define_syntax.zig` | Macro-defining forms: define-syntax, let-syntax, letrec-syntax, define-property, transformer-spec resolution (SRFI 147), syntax-rules parsing, transformer finalization |
-| `compiler_passthrough.zig` | The `passthrough` path's form compilers: quote, if, call, and the tail-position specializations (`apply`, `call-with-values`, `call/cc`, `eval`) |
+| `compiler_passthrough.zig` | The `passthrough` path's form compilers: quote, if, call, and the tail-position specializations (`apply`, `call-with-values`, `call/cc`, `eval`); owns the whole-unit top-level target set (`unit_top_level_targets`, kaappi#2457) |
+| `compiler_gate.zig` | Redefinition-awareness: the builtin-bypass gate `globalBindingStillGenuine` (superinstruction decisions for redefined built-ins) and the `set!` pre-scan that feeds it (`collectSetTargets`, `scanSetTargetsWithoutMacros`) |
 | `compiler_forms.zig` | Re-export hub (thin file, don't edit directly) |
 
 ### VM (split into 11 files)

--- a/docs/dev/bytecode.md
+++ b/docs/dev/bytecode.md
@@ -5,7 +5,7 @@ the ISA — the `/bytecode-isa` skill points here.
 
 ## Instruction set
 
-32 opcodes, register-based, variable-length encoding. Register/slot,
+33 opcodes, register-based, variable-length encoding. Register/slot,
 constant-index and symbol-index operands are all u16 (big-endian); jump
 offsets are i16 (signed, relative to the instruction after the jump). The
 only u8 operands are `nargs` and the `is_local` flag in a closure capture
@@ -50,6 +50,7 @@ operand-width table — it is what `ensureOperands` validates against, so the
 | 29 | `tail_call_cc` | base:u16, dst:u16 | 5 | `call/cc` in tail position: captures the continuation into dst, then tail-calls the receiver at base+0 |
 | 30 | `tail_eval` | base:u16, nargs:u8 | 4 | `eval` in tail position: compiles the expression at base+0 (optional environment at base+1) and tail-calls it |
 | 31 | `apply` | base:u16, nargs:u8 | 4 | Non-tail apply with list unpacking: flattens the final operand list into base+1… and calls the procedure at base+0 with an ordinary frame, result → base |
+| 32 | `values_list` | dst:u16, src:u16 | 5 | Spread a call-with-values producer's return value (single value or `MultipleValues`) into a fresh argument list → dst, for the apply that follows |
 
 `self_tail_call` skips the global lookup, type check, and arity check for
 direct self-recursion and named `let` loops — see
@@ -79,6 +80,13 @@ Their diagnostics differ too: `apply` reproduces `applyFn`'s `typeError` texts,
 which `tests/scheme/compile/native-apply-lowering-1803.sh` pins against the
 LLVM backend's; `tail_apply` keeps its own terser in-loop wording, which that
 suite deliberately exempts.
+
+`values_list` is the producer half of `call-with-values`' lowering
+(kaappi#2453): the form compiles to a `%call-with-values-check` call, an
+ordinary `call` of the producer, `values_list`, then `apply`/`tail_apply` of
+the consumer. Because the producer runs under an ordinary call opcode, its
+frame is part of the copied VM state and a continuation captured inside it is
+resumable after the form returns — the same property #2451 gave the consumer.
 
 ### Encoding details
 

--- a/docs/dev/claude-code-harness.md
+++ b/docs/dev/claude-code-harness.md
@@ -258,7 +258,7 @@ missing type dispatch).
 ### `/bytecode-isa`
 
 Reference for the bytecode instruction set. Points at
-[bytecode.md](bytecode.md) (the single source of truth for the 32-opcode
+[bytecode.md](bytecode.md) (the single source of truth for the 33-opcode
 table and encodings) and carries the adding-a-new-opcode checklist. Used
 when working on the compiler or VM.
 

--- a/src/bytecode_file_read.zig
+++ b/src/bytecode_file_read.zig
@@ -342,7 +342,7 @@ fn validateFunctionBytecode(func: *Function) BytecodeError!void {
     var ip: usize = 0;
     while (ip < code.len) {
         const raw = code[ip];
-        if (raw > @intFromEnum(OpCode.apply)) return BytecodeError.CorruptedFile;
+        if (raw > @intFromEnum(OpCode.values_list)) return BytecodeError.CorruptedFile;
         const op: OpCode = @enumFromInt(raw);
         ip += 1;
 
@@ -358,6 +358,12 @@ fn validateFunctionBytecode(func: *Function) BytecodeError!void {
                 ip += 2;
             },
             .move, .get_upvalue, .set_upvalue, .get_box_local, .set_box_local => {
+                if (ip + 4 > code.len) return BytecodeError.CorruptedFile;
+                ip += 4;
+            },
+            .values_list => {
+                // dst:u16, src:u16 — the producer-spread half of
+                // call-with-values' lowering (kaappi#2453).
                 if (ip + 4 > code.len) return BytecodeError.CorruptedFile;
                 ip += 4;
             },

--- a/src/check.zig
+++ b/src/check.zig
@@ -83,15 +83,6 @@ pub fn run(vm: *VM, path: []const u8, opts: Options) u8 {
 
     var ctx: check_lint.Context = .{ .arena = arena, .user_defined = &user_defined };
 
-    // The same whole-unit set drives the superinstruction gate during the
-    // compiles analysis performs (kaappi#2457): a top-level define of one of
-    // the five fast-path names anywhere in the file declines the fast path
-    // everywhere in it, matching what a run of the file would compile. Its
-    // define-syntax names are extra but conservative for this purpose.
-    compiler_passthrough.unit_top_level_targets =
-        if (user_defined.count() > 0) &user_defined else null;
-    defer compiler_passthrough.unit_top_level_targets = null;
-
     analyzeSource(vm, &ctx, source, path);
 
     report(arena, ctx.findings.items, opts);
@@ -138,8 +129,37 @@ pub fn analyzeSource(vm: *VM, ctx: *check_lint.Context, source: []const u8, path
         check_lint.active = null;
         ir_mod.optimize_enabled = saved_opt;
     }
+
+    // The exact whole-unit target set a run of this source would install
+    // (kaappi#2457) drives the superinstruction gate during the compiles
+    // below: a top-level define OR set! of one of the five fast-path names
+    // anywhere in the file declines the fast path everywhere in it, so an
+    // analysis compiles exactly what a run compiles. Collected by
+    // unitTargetSet — not the lint's user_defined, which misses top-level
+    // `set!` targets — and installed here, the shared path, so every entry
+    // point (`run`, tests, the LSP) gets it and the three surfaces cannot
+    // drift (kaappi#1981).
+    var unit_targets = unitTargetSet(ctx.arena, vm.gc, source);
+    compiler_passthrough.unit_top_level_targets =
+        if (unit_targets.count() > 0) &unit_targets else null;
+    defer compiler_passthrough.unit_top_level_targets = null;
+
     analyze(vm, ctx, ctx.arena, source, path);
     std.mem.sort(check_lint.Finding, ctx.findings.items, {}, findingLess);
+}
+
+/// The exact whole-unit target set for the superinstruction gate
+/// (kaappi#2457): every name a top-level `define` / `define-values` / `set!`
+/// targets anywhere in `source`, collected by
+/// `compiler_passthrough.collectUnitTopLevelTargets` — the same scan a run of
+/// the file installs. Deliberately NOT the lint's user_defined set, which
+/// additionally gathers define-syntax names and, crucially, misses top-level
+/// `set!` targets. Keys are duped into `arena`; the returned map is valid as
+/// long as the arena is.
+pub fn unitTargetSet(arena: std.mem.Allocator, gc: *@import("memory.zig").GC, source: []const u8) std.StringHashMap(void) {
+    var out = std.StringHashMap(void).init(arena);
+    compiler_passthrough.collectUnitTopLevelTargets(&out, gc, source);
+    return out;
 }
 
 fn analyze(vm: *VM, ctx: *check_lint.Context, arena: std.mem.Allocator, source: []const u8, path: []const u8) void {

--- a/src/check.zig
+++ b/src/check.zig
@@ -28,6 +28,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const reader = @import("reader.zig");
 const compiler = @import("compiler.zig");
+const compiler_passthrough = @import("compiler_passthrough.zig");
 const vm_mod = @import("vm.zig");
 const vm_library = @import("vm_library.zig");
 const ir_mod = @import("ir.zig");
@@ -81,6 +82,15 @@ pub fn run(vm: *VM, path: []const u8, opts: Options) u8 {
     collectTopLevelDefines(&user_defined, arena, vm.gc, source);
 
     var ctx: check_lint.Context = .{ .arena = arena, .user_defined = &user_defined };
+
+    // The same whole-unit set drives the superinstruction gate during the
+    // compiles analysis performs (kaappi#2457): a top-level define of one of
+    // the five fast-path names anywhere in the file declines the fast path
+    // everywhere in it, matching what a run of the file would compile. Its
+    // define-syntax names are extra but conservative for this purpose.
+    compiler_passthrough.unit_top_level_targets =
+        if (user_defined.count() > 0) &user_defined else null;
+    defer compiler_passthrough.unit_top_level_targets = null;
 
     analyzeSource(vm, &ctx, source, path);
 

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -5,6 +5,7 @@ const expander = @import("expander.zig");
 const forms = @import("compiler_forms.zig");
 const advanced = @import("compiler_advanced.zig");
 const passthrough = @import("compiler_passthrough.zig");
+const gate = @import("compiler_gate.zig");
 const macro = @import("compiler_macro.zig");
 const ir_mod = @import("ir.zig");
 const compiler_ir = @import("compiler_ir.zig");
@@ -474,68 +475,6 @@ pub const Compiler = struct {
         return false;
     }
 
-    /// Answers whether a free global reference spelled `sym_name` (a bare
-    /// name like `apply`, or a hygiene-renamed `__hyg_N_apply`) would still
-    /// resolve to the genuine `(scheme base)` primitive `base_name` at run
-    /// time — the gate the builtin superinstructions
-    /// (apply/call-with-values in any position, eval/call/cc in tail
-    /// position) need so a top-level
-    /// redefinition of one of those names routes to the user's procedure
-    /// instead of the baked-in builtin (kaappi#2033). Mirrors
-    /// IR.isRedefined's fold gate and the resolution order of
-    /// vm_dispatch_helpers.lookupGlobalLocked so the compile-time decision
-    /// cannot disagree with what get_global would fetch.
-    fn globalBindingStillGenuine(self: *const Compiler, sym_name: []const u8, base_name: []const u8) bool {
-        // A `set!` target in the enclosing top-level form (or a truncated
-        // pre-scan) means the global may hold a different value by the time
-        // the call executes — the same conservative bias as IR.isRedefined.
-        if (self.set_targets_all) return false;
-        if (self.set_targets) |st| {
-            if (st.contains(sym_name) or st.contains(base_name)) return false;
-        }
-        // A top-level `define`/`set!` of the name ANYWHERE in the compilation
-        // unit (kaappi#2457): a body compiled before the definition runs
-        // would otherwise bake the builtin in and silently discard the user's
-        // procedure, because this function's compile-time read of the global
-        // environment still sees the pristine binding. Whole-unit drivers
-        // populate the set; per-form entry points (REPL, eval) leave it null
-        // and keep the legacy answer. Declining only ever costs the
-        // superinstruction — the by-name call resolves the genuine binding
-        // when no redefinition intervenes.
-        if (passthrough.unit_top_level_targets) |unit_targets| {
-            if (unit_targets.contains(sym_name) or unit_targets.contains(base_name)) return false;
-        }
-
-        // No environment info (standalone/unit-test paths): keep the legacy
-        // optimistic behavior, mirroring IR.isRedefined's `orelse return false`.
-        const g = self.globals orelse return true;
-        const glk = globals_mod.acquireGlobalsRead(g);
-        defer globals_mod.releaseGlobalsRead(glk);
-
-        // Mirror lookupGlobalLocked's resolution: the name as spelled, then
-        // the hygienic-prefix fallback to the bare name.
-        var val: ?Value = g.get(sym_name);
-        if (val == null and !std.mem.eql(u8, sym_name, base_name)) {
-            val = g.get(base_name);
-        }
-        const v = val orelse {
-            // Not bound in the compile-time env. Inside a library (partial
-            // lib_env) or restricted environment the runtime may still find
-            // it elsewhere — the vm.globals fallback for a library body,
-            // nowhere at all for a restricted env — so decline the fast path
-            // rather than silently run the builtin for a name the program
-            // never bound (mirrors IR.isRedefined's restricted_env arm). At
-            // top level the name being absent is the legacy unbound case,
-            // which keeps the fast path exactly as before.
-            return !self.restricted_env;
-        };
-        if (!types.isPointer(v)) return false;
-        const obj = types.toObject(v);
-        if (obj.tag != .native_fn) return false;
-        const nfn = obj.as(types.NativeFn);
-        return std.mem.eql(u8, nfn.name, base_name);
-    }
-
     pub fn isLocalBoxed(self: *Compiler, name: []const u8) bool {
         var i: usize = self.locals.items.len;
         while (i > 0) {
@@ -605,8 +544,8 @@ pub const Compiler = struct {
             // could leave a `set!`-ed local unboxed and foldable, so a
             // truncated Part B scan falls back to the same
             // every-name-is-a-target conservatism the pre-scan uses.
-            var b = SetScanBudget{ .expansions_left = 0, .expand = false };
-            try collectSetTargets(self, expr, st, 0, &b);
+            var b = gate.SetScanBudget{ .expansions_left = 0, .expand = false };
+            try gate.collectSetTargets(self, expr, st, 0, &b);
             if (b.truncated) self.set_targets_all = true;
         }
     }
@@ -692,11 +631,11 @@ pub const Compiler = struct {
         // (including in nested lambda bodies, which inherit this set).
         var set_targets = std.StringHashMap(void).init(self.gc.allocator);
         defer set_targets.deinit();
-        var budget = SetScanBudget{ .expansions_left = prescan_expansion_limit };
-        try collectSetTargets(self, expr_root, &set_targets, 0, &budget);
+        var budget = gate.SetScanBudget{ .expansions_left = gate.prescan_expansion_limit };
+        try gate.collectSetTargets(self, expr_root, &set_targets, 0, &budget);
         self.set_targets = &set_targets;
         self.set_targets_all = budget.truncated;
-        if (budget.truncated) prescan_truncations += 1;
+        if (budget.truncated) gate.prescan_truncations += 1;
         defer {
             self.set_targets = null;
             self.set_targets_all = false;
@@ -1091,7 +1030,7 @@ pub const Compiler = struct {
                 const fast_ok = is_synth or
                     (self.resolveLocal(sym_name) == null and
                         (try self.resolveUpvalue(sym_name)) == null and
-                        self.globalBindingStillGenuine(sym_name, eff_name));
+                        gate.globalBindingStillGenuine(self, sym_name, eff_name));
                 if (fast_ok) {
                     if (std.mem.eql(u8, eff_name, "apply")) return passthrough.compileApplyForm(self, expr, dst, is_tail);
                     if (std.mem.eql(u8, eff_name, "call-with-values")) return passthrough.compileCallWithValuesForm(self, expr, dst, is_tail);
@@ -1277,290 +1216,6 @@ pub fn circularFormError() CompileError {
     @memcpy(syntax_error_detail[0..circular_form_message.len], circular_form_message);
     syntax_error_detail_len = circular_form_message.len;
     return CompileError.InvalidSyntax;
-}
-
-/// Work limit for one top-level `set!` pre-scan (kaappi#1775).
-///
-/// The pre-scan expands macros so it can see a `set!` a template introduces
-/// (#1250). That makes it a speculative *evaluator* of compile-time macro
-/// code, and it explores branches the real compiler never takes: at
-/// `(m kt kf)`, where `m` is a helper the enclosing expansion defined with
-/// `define-syntax`, the scan has no binding for `m`, so it treats `kt` and
-/// `kf` as ordinary sub-forms and expands macros inside *both*. The real
-/// compiler registers `m`, expands it, and follows exactly one. Every such
-/// fork doubles the work, so macros that generate macros — SRFI 148's
-/// `em-syntax-rules`, SRFI 257's CK-machine combinators — cost time
-/// exponential in the number of forks.
-///
-/// Exceeding the limit is safe by construction: the scan sets `truncated`,
-/// and Compiler.set_targets_all makes both consumers assume every name is a
-/// `set!` target. A truncated scan therefore loses optimization, never
-/// correctness.
-///
-/// 4096 is ~2.5x the highest count any non-pathological top-level form in
-/// this repo's Scheme suites reaches (p99.99 = 1649 expansions; 87% of forms
-/// need none at all) and well under the 6299+ the macro-generating cases
-/// start at. That headroom matters: a truncated scan boxes every local in the
-/// form, measured at ~2x runtime on compute-heavy code, so ordinary programs
-/// must never reach the limit.
-///
-/// A `var` only so tests can lower it and exercise the truncation path
-/// without a multi-second pathological program; nothing in the compiler
-/// writes it. Threadlocal for the same reason as `ir.optimize_enabled`: an
-/// SRFI-18 child thread compiling concurrently keeps the default rather than
-/// racing on whatever a test left in a shared global.
-pub threadlocal var prescan_expansion_limit: u32 = 4096;
-
-/// Number of top-level forms whose `set!` pre-scan truncated. Diagnostic
-/// only — read by tests to assert the guard did (or did not) engage.
-pub threadlocal var prescan_truncations: u64 = 0;
-
-const SetScanBudget = struct {
-    expansions_left: u32,
-    /// False for structure-only scans (Part B, the native backend): walk
-    /// and report truncation like any budgeted scan, but never speculatively
-    /// expand macros — expansion is the top-level pre-scan's job. With this
-    /// flag, a non-null budget no longer implies "expanding scan", so the
-    /// old null-vs-non-null distinction collapses to expand-vs-not and the
-    /// depth/spine caps report truncation on every caller (#2401 review:
-    /// a partial target set from a silently-truncated scan could leave a
-    /// `set!`-ed local unboxed and foldable).
-    expand: bool = true,
-    /// Set when the scan stopped early (budget exhausted or a cap hit),
-    /// meaning `out` is an under-approximation of the real target set.
-    truncated: bool = false,
-};
-
-/// Step cap on the let-syntax/letrec-syntax BINDINGS loop inside
-/// collectSetTargets (#2404) — the one cdr-spine the main walk's
-/// tortoise-and-hare guard below does not cover. A datum-label cycle
-/// (`#0=(let-syntax #1=(#1#) body)`, R7RS §7.1.2) makes that inner spine
-/// infinite; exhausting the cap marks the scan truncated — the same
-/// loses-optimization-never-correctness degradation the expansion budget
-/// takes. One million steps is far beyond any real form (the whole repo's
-/// suites stay under ~1.7k expansions per top-level form). Every caller
-/// propagates truncation: the pre-scan via set_targets_all, Part B via
-/// scanSetTargets, the native backend by eval-falling-back the form. The
-/// define-syntax/let-syntax spec walks still pass a structure-only budget
-/// with no propagation: a `set!` that only materializes when the spec's
-/// own macros run is caught at the macro's real use site, the same
-/// correct-late path as before.
-const SET_SCAN_SPINE_CAP: usize = 1_000_000;
-
-/// Recursively collect the symbol names that appear as the target of a
-/// `(set! <name> ...)` anywhere in `expr` into `out`. Used to suppress
-/// constant folding of those names within the enclosing form (see
-/// Compiler.set_targets) and to box locals for correct continuation
-/// semantics (R7RS §3.4). Conservative: it scans every sub-form except
-/// the interior of `quote`d data. When `budget` is non-null and a known
-/// macro is encountered, it is expanded and the expansion is scanned
-/// (#1250). Only the top-level pre-scan expands; the per-expansion Part B
-/// scan passes null (see scanSetTargets).
-///
-/// `self` is needed only to expand macros, i.e. only when `budget` is
-/// non-null — a null `budget` makes the whole walk a pure function of `expr`,
-/// which is what `scanSetTargetsWithoutMacros` below exposes to the LLVM
-/// native backend (it has no Compiler at all).
-fn collectSetTargets(self: ?*Compiler, expr: Value, out: *std.StringHashMap(void), depth: u16, budget: ?*SetScanBudget) CompileError!void {
-    // This is the scan's *own* recursion cap, deliberately not shared with
-    // compiler_macro.MAX_MACRO_EXPANSION_DEPTH despite both being 256: they
-    // count different things. That one bounds the real expansion of code that
-    // will be compiled, and exceeding it is a user-visible error (KP2003).
-    // This one bounds a speculative walk that also descends into branches the
-    // compiler discards, so it is reached by programs whose real expansion
-    // depth never comes close — measured: every SRFI 257 suite trips this cap
-    // several times per run while compiling and passing normally. Tying the
-    // two together would assert an equivalence the measurements contradict.
-    if (depth > 256) {
-        if (budget) |b| b.truncated = true;
-        return;
-    }
-    // #2403: the spine walk must terminate on circular data — R7RS datum
-    // labels can put a genuine cycle in code position. Every body path
-    // that resumes iteration does so via the continue expression, which
-    // advances exactly one cdr, so Floyd's tortoise-and-hare is exact: a
-    // tortoise advancing every other step can only re-meet `cur` on a
-    // real cycle, and an acyclic spine costs just one extra cdr per
-    // element. On detection the scan stops early exactly as the depth cap
-    // does — an under-approximation the truncated flag already models.
-    var cur = expr;
-    var tortoise = expr;
-    var step: usize = 0;
-    while (types.isPair(cur)) : ({
-        cur = types.cdr(cur);
-        step += 1;
-        if (step % 2 == 0) tortoise = types.cdr(tortoise);
-    }) {
-        if (step > 0 and cur == tortoise) {
-            if (budget) |b| b.truncated = true;
-            return;
-        }
-        const head = types.car(cur);
-        if (types.isSymbol(head)) {
-            const hname = types.stripHygienicPrefix(types.symbolName(head));
-            if (std.mem.eql(u8, hname, "quote")) return; // literal data, not code
-            if (std.mem.eql(u8, hname, "set!")) {
-                const rest = types.cdr(cur);
-                if (types.isPair(rest)) {
-                    const target = types.car(rest);
-                    if (types.isSymbol(target)) {
-                        out.put(types.symbolName(target), {}) catch return CompileError.OutOfMemory;
-                    }
-                }
-            } else if (budget) |b| {
-                // Only an expanding scan looks macros up, and only an
-                // expanding scan is ever handed a Compiler — so `self.?`
-                // below is reached only when `maybe_macro` was non-null,
-                // which requires one. Structure-only scans (b.expand ==
-                // false) never take this branch and keep walking the form
-                // literally.
-                const maybe_macro = if (b.expand) blk: {
-                    const c = self orelse break :blk null;
-                    break :blk c.lookupMacro(types.symbolName(head));
-                } else null;
-                if (maybe_macro) |transformer| {
-                    if (b.expansions_left == 0) {
-                        b.truncated = true;
-                        return;
-                    }
-                    b.expansions_left -= 1;
-                    const c = self.?;
-                    // Best-effort expansion: uses an empty UseSiteBindingCheck
-                    // (no locals exist at pre-scan time), so patterns with
-                    // literals may diverge from the real expansion.  Part B
-                    // (scanSetTargets in expandAndCompileMacroUse) corrects
-                    // any misses at real-expansion time.
-                    c.gc.no_collect += 1;
-                    const expanded = expander.expandMacro(
-                        c.gc,
-                        cur,
-                        transformer,
-                        c.globals,
-                        &c.macros,
-                        .{},
-                    ) catch {
-                        c.gc.no_collect -= 1;
-                        continue;
-                    };
-                    var expanded_root = expanded;
-                    c.gc.pushRoot(&expanded_root);
-                    defer c.gc.popRoot();
-                    c.gc.no_collect -= 1;
-                    // Fixed point (e.g. SRFI-219 rule 3: (define x e) →
-                    // (define x e)): the expansion is the input, so scanning
-                    // it again can only repeat what this pass already did.
-                    // expandAndCompileMacroUse detects the same case to hand
-                    // the form to its built-in handler; here it just stops the
-                    // scan from re-expanding until the depth cap (kaappi#1775).
-                    // Fall through to the sub-form walk below, which is what
-                    // compiling the built-in form will visit anyway.
-                    if (macro.valuesStructurallyEqual(expanded_root, cur, 128)) {
-                        continue;
-                    }
-                    try collectSetTargets(self, expanded_root, out, depth + 1, budget);
-                    return;
-                } else if (std.mem.eql(u8, hname, "define-syntax")) {
-                    // (define-syntax name <transformer-spec>): the spec is
-                    // compile-time data — it resolves to a transformer object
-                    // and never contributes a runtime `set!` to THIS form —
-                    // so walk it for literal `set!`s in templates but never
-                    // macro-expand inside it. Speculatively running a
-                    // SRFI 147 spec like SRFI 148's `(em-syntax-rules ...)`
-                    // drove the whole CK machine per definition, burning the
-                    // entire budget (and with it set_targets_all boxing) on
-                    // forms with no runtime code at all (kaappi#1802). A
-                    // `set!` that only materializes when the spec's own
-                    // macros run is caught at the macro's real use site —
-                    // its own form's pre-scan, or Part B — the same
-                    // correct-late path every divergent best-effort
-                    // expansion above already takes.
-                    const rest = types.cdr(cur);
-                    if (types.isPair(rest)) {
-                        // Skip the macro name; walk the spec without a budget.
-                        try collectSetTargets(self, types.cdr(rest), out, depth + 1, null);
-                    }
-                    return;
-                } else if (std.mem.eql(u8, hname, "let-syntax") or
-                    std.mem.eql(u8, hname, "letrec-syntax"))
-                {
-                    // ((name <transformer-spec>) ...) bindings are compile-time
-                    // data like define-syntax specs; the body is real code and
-                    // keeps the budgeted scan. Walk each spec individually,
-                    // skipping the binding NAME, so a binding pair is never
-                    // misread as a form: a macro bound under a special-form
-                    // name (R7RS lets a binding shadow `quote`, `set!`, ...)
-                    // would otherwise derail the walk — a binding literally
-                    // named `quote` early-returns before its own spec is
-                    // scanned. Verified unobservable end-to-end today (the
-                    // let-syntax body compiles via passthrough, where the
-                    // folder doesn't engage, and a late-discovered target is
-                    // still boxed via the box_local transition — pinned by
-                    // tests/scheme/hygiene/quote-shadow-boxing.scm), so this
-                    // is scan hygiene, not a bug fix.
-                    const rest = types.cdr(cur);
-                    if (!types.isPair(rest)) return;
-                    var bindings_cur = types.car(rest);
-                    var binding_steps: usize = 0;
-                    while (types.isPair(bindings_cur)) {
-                        binding_steps += 1;
-                        if (binding_steps > SET_SCAN_SPINE_CAP) {
-                            budget.?.truncated = true;
-                            return;
-                        }
-                        const binding = types.car(bindings_cur);
-                        if (types.isPair(binding)) {
-                            try collectSetTargets(self, types.cdr(binding), out, depth + 1, null);
-                        }
-                        bindings_cur = types.cdr(bindings_cur);
-                    }
-                    // The body keeps the budgeted scan. A sub-walk, not the
-                    // old two-cdr jump (`cur = cdr(rest); continue`): the
-                    // tortoise-and-hare spine guard above is exact only when
-                    // every iteration advances exactly one cdr, and a cycle
-                    // through the body (`#0=(let-syntax () . #0#)`) must hit
-                    // the depth cap as recursion, not loop forever (#2403).
-                    try collectSetTargets(self, types.cdr(rest), out, depth + 1, budget);
-                    return;
-                }
-            }
-        }
-        // depth+1, not depth: a sub-form is nesting like any other, and the
-        // same-depth recursion this used to make was unbounded — reader-cap
-        // fine for acyclic data, infinite on a car-side cycle
-        // (`(display #1=(p #1# q))`), which the spine guard above cannot
-        // see (#2403). The scan's depth cap now bounds it, at the same
-        // conservative-truncation cost the cap already charges elsewhere.
-        try collectSetTargets(self, head, out, depth + 1, budget);
-    }
-}
-
-/// The `set!`-target scan for callers with no Compiler — the LLVM native
-/// backend, which re-lowers each lambda/let body through a scratch IR and
-/// needs the same suppression set the interpreter's per-form pre-scan builds
-/// (#2117). Macros are not expanded, since that needs a Compiler.
-///
-/// For the body case that limit costs nothing: the backend declines native
-/// compilation of any body containing a macro use (`sexprHasMacroUse`,
-/// #1807), so a `set!` only a macro would reveal is in a body the
-/// interpreter — and its macro-expanding pre-scan — has already taken over.
-///
-/// At *top level across forms* the same is NOT true, and this scan does not
-/// close that: a macro use in form N that expands to `(set! + -)` leaves `+`
-/// unrecorded, so form N+1 can still fold it. That is kaappi#2212 — the
-/// pre-existing macro-blindness of #822's `collectRedefinedNames`, which this
-/// scan runs alongside rather than replaces. The interpreter is immune for an
-/// unrelated reason (it has already *executed* form N, so the globals check in
-/// isRedefined sees the rebound value), which is why only the compiled tier
-/// diverges.
-/// Returns true when the scan truncated (depth cap, spine cap, or — never,
-/// for this structure-only caller — expansion budget): `out` is then a
-/// partial answer, and the caller must not trust it to gate folding or
-/// boxing (the LLVM backend's conservative action is to eval-fallback the
-/// whole form; see native_compiler).
-pub fn scanSetTargetsWithoutMacros(expr: Value, out: *std.StringHashMap(void)) CompileError!bool {
-    var b = SetScanBudget{ .expansions_left = 0, .expand = false };
-    try collectSetTargets(null, expr, out, 0, &b);
-    return b.truncated;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -493,6 +493,18 @@ pub const Compiler = struct {
         if (self.set_targets) |st| {
             if (st.contains(sym_name) or st.contains(base_name)) return false;
         }
+        // A top-level `define`/`set!` of the name ANYWHERE in the compilation
+        // unit (kaappi#2457): a body compiled before the definition runs
+        // would otherwise bake the builtin in and silently discard the user's
+        // procedure, because this function's compile-time read of the global
+        // environment still sees the pristine binding. Whole-unit drivers
+        // populate the set; per-form entry points (REPL, eval) leave it null
+        // and keep the legacy answer. Declining only ever costs the
+        // superinstruction — the by-name call resolves the genuine binding
+        // when no redefinition intervenes.
+        if (passthrough.unit_top_level_targets) |unit_targets| {
+            if (unit_targets.contains(sym_name) or unit_targets.contains(base_name)) return false;
+        }
 
         // No environment info (standalone/unit-test paths): keep the legacy
         // optimistic behavior, mirroring IR.isRedefined's `orelse return false`.

--- a/src/compiler_gate.zig
+++ b/src/compiler_gate.zig
@@ -1,0 +1,377 @@
+//! Redefinition-awareness for the compiler (kaappi#2033, #2457, #1775).
+//!
+//! Two cooperating pieces live here because they answer the same question —
+//! "can a compile-time decision that a name still resolves to its built-in
+//! survive until the code runs?" — for two different redefinition routes:
+//!
+//!   * the builtin-bypass gate `globalBindingStillGenuine`, which decides the
+//!     `apply` / `call-with-values` / `call/cc` / `eval` superinstructions in
+//!     `compiler.zig` and the native tier's `emitApplyForm`, consuming both
+//!     the per-form `set!` pre-scan below and the whole-unit target set a
+//!     whole-unit driver installs (`compiler_passthrough.unit_top_level_targets`);
+//!   * the `set!` pre-scan (`collectSetTargets` and its budget), which
+//!     discovers the names a form (or a macro it uses) assigns before the
+//!     form compiles, feeding `Compiler.set_targets` and the LLVM backend's
+//!     `scanSetTargetsWithoutMacros`.
+//!
+//! Split out of compiler.zig along this seam (file-size policy, PR #2467
+//! review): every decl here is about names that may change under a
+//! compile-time binding read, none about emitting bytecode.
+
+const std = @import("std");
+const types = @import("types.zig");
+const expander = @import("expander.zig");
+const macro = @import("compiler_macro.zig");
+const globals_mod = @import("globals.zig");
+const compiler_mod = @import("compiler.zig");
+const passthrough = @import("compiler_passthrough.zig");
+
+const Compiler = compiler_mod.Compiler;
+const CompileError = compiler_mod.CompileError;
+const Value = types.Value;
+
+/// Answers whether a free global reference spelled `sym_name` (a bare
+/// name like `apply`, or a hygiene-renamed `__hyg_N_apply`) would still
+/// resolve to the genuine `(scheme base)` primitive `base_name` at run
+/// time — the gate the builtin superinstructions
+/// (apply/call-with-values in any position, eval/call/cc in tail
+/// position) need so a top-level
+/// redefinition of one of those names routes to the user's procedure
+/// instead of the baked-in builtin (kaappi#2033). Mirrors
+/// IR.isRedefined's fold gate and the resolution order of
+/// vm_dispatch_helpers.lookupGlobalLocked so the compile-time decision
+/// cannot disagree with what get_global would fetch.
+pub fn globalBindingStillGenuine(self: *const Compiler, sym_name: []const u8, base_name: []const u8) bool {
+    // A `set!` target in the enclosing top-level form (or a truncated
+    // pre-scan) means the global may hold a different value by the time
+    // the call executes — the same conservative bias as IR.isRedefined.
+    if (self.set_targets_all) return false;
+    if (self.set_targets) |st| {
+        if (st.contains(sym_name) or st.contains(base_name)) return false;
+    }
+    // A top-level `define`/`set!` of the name ANYWHERE in the compilation
+    // unit (kaappi#2457): a body compiled before the definition runs
+    // would otherwise bake the builtin in and silently discard the user's
+    // procedure, because this function's compile-time read of the global
+    // environment still sees the pristine binding. Whole-unit drivers
+    // populate the set; per-form entry points (REPL, eval) leave it null
+    // and keep the legacy answer. Declining only ever costs the
+    // superinstruction — the by-name call resolves the genuine binding
+    // when no redefinition intervenes.
+    if (passthrough.unit_top_level_targets) |unit_targets| {
+        if (unit_targets.contains(sym_name) or unit_targets.contains(base_name)) return false;
+    }
+
+    // No environment info (standalone/unit-test paths): keep the legacy
+    // optimistic behavior, mirroring IR.isRedefined's `orelse return false`.
+    const g = self.globals orelse return true;
+    const glk = globals_mod.acquireGlobalsRead(g);
+    defer globals_mod.releaseGlobalsRead(glk);
+
+    // Mirror lookupGlobalLocked's resolution: the name as spelled, then
+    // the hygienic-prefix fallback to the bare name.
+    var val: ?Value = g.get(sym_name);
+    if (val == null and !std.mem.eql(u8, sym_name, base_name)) {
+        val = g.get(base_name);
+    }
+    const v = val orelse {
+        // Not bound in the compile-time env. Inside a library (partial
+        // lib_env) or restricted environment the runtime may still find
+        // it elsewhere — the vm.globals fallback for a library body,
+        // nowhere at all for a restricted env — so decline the fast path
+        // rather than silently run the builtin for a name the program
+        // never bound (mirrors IR.isRedefined's restricted_env arm). At
+        // top level the name being absent is the legacy unbound case,
+        // which keeps the fast path exactly as before.
+        return !self.restricted_env;
+    };
+    if (!types.isPointer(v)) return false;
+    const obj = types.toObject(v);
+    if (obj.tag != .native_fn) return false;
+    const nfn = obj.as(types.NativeFn);
+    return std.mem.eql(u8, nfn.name, base_name);
+}
+
+/// Work limit for one top-level `set!` pre-scan (kaappi#1775).
+///
+/// The pre-scan expands macros so it can see a `set!` a template introduces
+/// (#1250). That makes it a speculative *evaluator* of compile-time macro
+/// code, and it explores branches the real compiler never takes: at
+/// `(m kt kf)`, where `m` is a helper the enclosing expansion defined with
+/// `define-syntax`, the scan has no binding for `m`, so it treats `kt` and
+/// `kf` as ordinary sub-forms and expands macros inside *both*. The real
+/// compiler registers `m`, expands it, and follows exactly one. Every such
+/// fork doubles the work, so macros that generate macros — SRFI 148's
+/// `em-syntax-rules`, SRFI 257's CK-machine combinators — cost time
+/// exponential in the number of forks.
+///
+/// Exceeding the limit is safe by construction: the scan sets `truncated`,
+/// and Compiler.set_targets_all makes both consumers assume every name is a
+/// `set!` target. A truncated scan therefore loses optimization, never
+/// correctness.
+///
+/// 4096 is ~2.5x the highest count any non-pathological top-level form in
+/// this repo's Scheme suites reaches (p99.99 = 1649 expansions; 87% of forms
+/// need none at all) and well under the 6299+ the macro-generating cases
+/// start at. That headroom matters: a truncated scan boxes every local in the
+/// form, measured at ~2x runtime on compute-heavy code, so ordinary programs
+/// must never reach the limit.
+///
+/// A `var` only so tests can lower it and exercise the truncation path
+/// without a multi-second pathological program; nothing in the compiler
+/// writes it. Threadlocal for the same reason as `ir.optimize_enabled`: an
+/// SRFI-18 child thread compiling concurrently keeps the default rather than
+/// racing on whatever a test left in a shared global.
+pub threadlocal var prescan_expansion_limit: u32 = 4096;
+
+/// Number of top-level forms whose `set!` pre-scan truncated. Diagnostic
+/// only — read by tests to assert the guard did (or did not) engage.
+pub threadlocal var prescan_truncations: u64 = 0;
+
+pub const SetScanBudget = struct {
+    expansions_left: u32,
+    /// False for structure-only scans (Part B, the native backend): walk
+    /// and report truncation like any budgeted scan, but never speculatively
+    /// expand macros — expansion is the top-level pre-scan's job. With this
+    /// flag, a non-null budget no longer implies "expanding scan", so the
+    /// old null-vs-non-null distinction collapses to expand-vs-not and the
+    /// depth/spine caps report truncation on every caller (#2401 review:
+    /// a partial target set from a silently-truncated scan could leave a
+    /// `set!`-ed local unboxed and foldable).
+    expand: bool = true,
+    /// Set when the scan stopped early (budget exhausted or a cap hit),
+    /// meaning `out` is an under-approximation of the real target set.
+    truncated: bool = false,
+};
+
+/// Step cap on the let-syntax/letrec-syntax BINDINGS loop inside
+/// collectSetTargets (#2404) — the one cdr-spine the main walk's
+/// tortoise-and-hare guard below does not cover. A datum-label cycle
+/// (`#0=(let-syntax #1=(#1#) body)`, R7RS §7.1.2) makes that inner spine
+/// infinite; exhausting the cap marks the scan truncated — the same
+/// loses-optimization-never-correctness degradation the expansion budget
+/// takes. One million steps is far beyond any real form (the whole repo's
+/// suites stay under ~1.7k expansions per top-level form). Every caller
+/// propagates truncation: the pre-scan via set_targets_all, Part B via
+/// scanSetTargets, the native backend by eval-falling-back the form. The
+/// define-syntax/let-syntax spec walks still pass a structure-only budget
+/// with no propagation: a `set!` that only materializes when the spec's
+/// own macros run is caught at the macro's real use site, the same
+/// correct-late path as before.
+const SET_SCAN_SPINE_CAP: usize = 1_000_000;
+
+/// Recursively collect the symbol names that appear as the target of a
+/// `(set! <name> ...)` anywhere in `expr` into `out`. Used to suppress
+/// constant folding of those names within the enclosing form (see
+/// Compiler.set_targets) and to box locals for correct continuation
+/// semantics (R7RS §3.4). Conservative: it scans every sub-form except
+/// the interior of `quote`d data. When `budget` is non-null and a known
+/// macro is encountered, it is expanded and the expansion is scanned
+/// (#1250). Only the top-level pre-scan expands; the per-expansion Part B
+/// scan passes null (see scanSetTargets).
+///
+/// `self` is needed only to expand macros, i.e. only when `budget` is
+/// non-null — a null `budget` makes the whole walk a pure function of `expr`,
+/// which is what `scanSetTargetsWithoutMacros` below exposes to the LLVM
+/// native backend (it has no Compiler at all).
+pub fn collectSetTargets(self: ?*Compiler, expr: Value, out: *std.StringHashMap(void), depth: u16, budget: ?*SetScanBudget) CompileError!void {
+    // This is the scan's *own* recursion cap, deliberately not shared with
+    // compiler_macro.MAX_MACRO_EXPANSION_DEPTH despite both being 256: they
+    // count different things. That one bounds the real expansion of code that
+    // will be compiled, and exceeding it is a user-visible error (KP2003).
+    // This one bounds a speculative walk that also descends into branches the
+    // compiler discards, so it is reached by programs whose real expansion
+    // depth never comes close — measured: every SRFI 257 suite trips this cap
+    // several times per run while compiling and passing normally. Tying the
+    // two together would assert an equivalence the measurements contradict.
+    if (depth > 256) {
+        if (budget) |b| b.truncated = true;
+        return;
+    }
+    // #2403: the spine walk must terminate on circular data — R7RS datum
+    // labels can put a genuine cycle in code position. Every body path
+    // that resumes iteration does so via the continue expression, which
+    // advances exactly one cdr, so Floyd's tortoise-and-hare is exact: a
+    // tortoise advancing every other step can only re-meet `cur` on a
+    // real cycle, and an acyclic spine costs just one extra cdr per
+    // element. On detection the scan stops early exactly as the depth cap
+    // does — an under-approximation the truncated flag already models.
+    var cur = expr;
+    var tortoise = expr;
+    var step: usize = 0;
+    while (types.isPair(cur)) : ({
+        cur = types.cdr(cur);
+        step += 1;
+        if (step % 2 == 0) tortoise = types.cdr(tortoise);
+    }) {
+        if (step > 0 and cur == tortoise) {
+            if (budget) |b| b.truncated = true;
+            return;
+        }
+        const head = types.car(cur);
+        if (types.isSymbol(head)) {
+            const hname = types.stripHygienicPrefix(types.symbolName(head));
+            if (std.mem.eql(u8, hname, "quote")) return; // literal data, not code
+            if (std.mem.eql(u8, hname, "set!")) {
+                const rest = types.cdr(cur);
+                if (types.isPair(rest)) {
+                    const target = types.car(rest);
+                    if (types.isSymbol(target)) {
+                        out.put(types.symbolName(target), {}) catch return CompileError.OutOfMemory;
+                    }
+                }
+            } else if (budget) |b| {
+                // Only an expanding scan looks macros up, and only an
+                // expanding scan is ever handed a Compiler — so `self.?`
+                // below is reached only when `maybe_macro` was non-null,
+                // which requires one. Structure-only scans (b.expand ==
+                // false) never take this branch and keep walking the form
+                // literally.
+                const maybe_macro = if (b.expand) blk: {
+                    const c = self orelse break :blk null;
+                    break :blk c.lookupMacro(types.symbolName(head));
+                } else null;
+                if (maybe_macro) |transformer| {
+                    if (b.expansions_left == 0) {
+                        b.truncated = true;
+                        return;
+                    }
+                    b.expansions_left -= 1;
+                    const c = self.?;
+                    // Best-effort expansion: uses an empty UseSiteBindingCheck
+                    // (no locals exist at pre-scan time), so patterns with
+                    // literals may diverge from the real expansion.  Part B
+                    // (scanSetTargets in expandAndCompileMacroUse) corrects
+                    // any misses at real-expansion time.
+                    c.gc.no_collect += 1;
+                    const expanded = expander.expandMacro(
+                        c.gc,
+                        cur,
+                        transformer,
+                        c.globals,
+                        &c.macros,
+                        .{},
+                    ) catch {
+                        c.gc.no_collect -= 1;
+                        continue;
+                    };
+                    var expanded_root = expanded;
+                    c.gc.pushRoot(&expanded_root);
+                    defer c.gc.popRoot();
+                    c.gc.no_collect -= 1;
+                    // Fixed point (e.g. SRFI 219 rule 3: (define x e) →
+                    // (define x e)): the expansion is the input, so scanning
+                    // it again can only repeat what this pass already did.
+                    // expandAndCompileMacroUse detects the same case to hand
+                    // the form to its built-in handler; here it just stops the
+                    // scan from re-expanding until the depth cap (kaappi#1775).
+                    // Fall through to the sub-form walk below, which is what
+                    // compiling the built-in form will visit anyway.
+                    if (macro.valuesStructurallyEqual(expanded_root, cur, 128)) {
+                        continue;
+                    }
+                    try collectSetTargets(self, expanded_root, out, depth + 1, budget);
+                    return;
+                } else if (std.mem.eql(u8, hname, "define-syntax")) {
+                    // (define-syntax name <transformer-spec>): the spec is
+                    // compile-time data — it resolves to a transformer object
+                    // and never contributes a runtime `set!` to THIS form —
+                    // so walk it for literal `set!`s in templates but never
+                    // macro-expand inside it. Speculatively running a
+                    // SRFI 147 spec like SRFI 148's `(em-syntax-rules ...)`
+                    // drove the whole CK machine per definition, burning the
+                    // entire budget (and with it set_targets_all boxing) on
+                    // forms with no runtime code at all (kaappi#1802). A
+                    // `set!` that only materializes when the spec's own
+                    // macros run is caught at the macro's real use site —
+                    // its own form's pre-scan, or Part B — the same
+                    // correct-late path every divergent best-effort
+                    // expansion above already takes.
+                    const rest = types.cdr(cur);
+                    if (types.isPair(rest)) {
+                        // Skip the macro name; walk the spec without a budget.
+                        try collectSetTargets(self, types.cdr(rest), out, depth + 1, null);
+                    }
+                    return;
+                } else if (std.mem.eql(u8, hname, "let-syntax") or
+                    std.mem.eql(u8, hname, "letrec-syntax"))
+                {
+                    // ((name <transformer-spec>) ...) bindings are compile-time
+                    // data like define-syntax specs; the body is real code and
+                    // keeps the budgeted scan. Walk each spec individually,
+                    // skipping the binding NAME, so a binding pair is never
+                    // misread as a form: a macro bound under a special-form
+                    // name (R7RS lets a binding shadow `quote`, `set!`, ...)
+                    // would otherwise derail the walk — a binding literally
+                    // named `quote` early-returns before its own spec is
+                    // scanned. Verified unobservable end-to-end today (the
+                    // let-syntax body compiles via passthrough, where the
+                    // folder doesn't engage, and a late-discovered target is
+                    // still boxed via the box_local transition — pinned by
+                    // tests/scheme/hygiene/quote-shadow-boxing.scm), so this
+                    // is scan hygiene, not a bug fix.
+                    const rest = types.cdr(cur);
+                    if (!types.isPair(rest)) return;
+                    var bindings_cur = types.car(rest);
+                    var binding_steps: usize = 0;
+                    while (types.isPair(bindings_cur)) {
+                        binding_steps += 1;
+                        if (binding_steps > SET_SCAN_SPINE_CAP) {
+                            budget.?.truncated = true;
+                            return;
+                        }
+                        const binding = types.car(bindings_cur);
+                        if (types.isPair(binding)) {
+                            try collectSetTargets(self, types.cdr(binding), out, depth + 1, null);
+                        }
+                        bindings_cur = types.cdr(bindings_cur);
+                    }
+                    // The body keeps the budgeted scan. A sub-walk, not the
+                    // old two-cdr jump (`cur = cdr(rest); continue`): the
+                    // tortoise-and-hare spine guard above is exact only when
+                    // every iteration advances exactly one cdr, and a cycle
+                    // through the body (`#0=(let-syntax () . #0#)`) must hit
+                    // the depth cap as recursion, not loop forever (#2403).
+                    try collectSetTargets(self, types.cdr(rest), out, depth + 1, budget);
+                    return;
+                }
+            }
+        }
+        // depth+1, not depth: a sub-form is nesting like any other, and the
+        // same-depth recursion this used to make was unbounded — reader-cap
+        // fine for acyclic data, infinite on a car-side cycle
+        // (`(display #1=(p #1# q))`), which the spine guard above cannot
+        // see (#2403). The scan's depth cap now bounds it, at the same
+        // conservative-truncation cost the cap already charges elsewhere.
+        try collectSetTargets(self, head, out, depth + 1, budget);
+    }
+}
+
+/// The `set!`-target scan for callers with no Compiler — the LLVM native
+/// backend, which re-lowers each lambda/let body through a scratch IR and
+/// needs the same suppression set the interpreter's per-form pre-scan builds
+/// (#2117). Macros are not expanded, since that needs a Compiler.
+///
+/// For the body case that limit costs nothing: the backend declines native
+/// compilation of any body containing a macro use (`sexprHasMacroUse`,
+/// #1807), so a `set!` only a macro would reveal is in a body the
+/// interpreter — and its macro-expanding pre-scan — has already taken over.
+///
+/// At *top level across forms* the same is NOT true, and this scan does not
+/// close that: a macro use in form N that expands to `(set! + -)` leaves `+`
+/// unrecorded, so form N+1 can still fold it. That is kaappi#2212 — the
+/// pre-existing macro-blindness of #822's `collectRedefinedNames`, which this
+/// scan runs alongside rather than replaces. The interpreter is immune for an
+/// unrelated reason (it has already *executed* form N, so the globals check in
+/// isRedefined sees the rebound value), which is why only the compiled tier
+/// diverges.
+/// Returns true when the scan truncated (depth cap, spine cap, or — never,
+/// for this structure-only caller — expansion budget): `out` is then a
+/// partial answer, and the caller must not trust it to gate folding or
+/// boxing (the LLVM backend's conservative action is to eval-fallback the
+/// whole form; see native_compiler).
+pub fn scanSetTargetsWithoutMacros(expr: Value, out: *std.StringHashMap(void)) CompileError!bool {
+    var b = SetScanBudget{ .expansions_left = 0, .expand = false };
+    try collectSetTargets(null, expr, out, 0, &b);
+    return b.truncated;
+}

--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -3,9 +3,145 @@ const types = @import("types.zig");
 const compiler_mod = @import("compiler.zig");
 const globals_mod = @import("globals.zig");
 const expander = @import("expander.zig");
+const reader_mod = @import("reader.zig");
+const memory = @import("memory.zig");
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
 const Value = types.Value;
+
+// -- Compilation-unit top-level targets (kaappi#2457) ------------------------
+//
+// `globalBindingStillGenuine` decides the builtin superinstruction fast paths
+// (apply / call-with-values in any position, eval / call/cc in tail) by
+// reading the live global environment at COMPILE time. That answer is wrong
+// for a procedure body compiled BEFORE a later top-level `(define apply ...)`
+// runs: R7RS 5.3.1 makes the definition essentially an assignment, so which
+// binding a call resolves is a run-time question the compile-time read cannot
+// settle in that order. The honest fix is a run-time decision (follow-up); the
+// interim is this set: when a driver that knows the whole compilation unit
+// (the file runner, stdin scripts, `kaappi compile`, `kaappi check`) sees the
+// name defined or assigned at top level ANYWHERE in the unit, every fast-path
+// decision in the unit declines, costing the superinstruction only in the
+// programs whose semantics it was getting wrong.
+//
+// Per-form entry points (the REPL, `eval`) have no future knowledge and leave
+// this null, keeping the legacy compile-time answer — a redefinition typed
+// later in a REPL session still cannot retro-fix an earlier-compiled body,
+// exactly as before.
+
+/// Names defined (define / define-values) or assigned (set!) at top level
+/// anywhere in the compilation unit currently being compiled. Keys are owned
+/// by the driver that populated the set and outlive every compile in the
+/// unit. Null on entry points without whole-unit knowledge.
+pub threadlocal var unit_top_level_targets: ?*const std.StringHashMap(void) = null;
+
+/// Fill `out` with every name a top-level `define`, `define-values` or `set!`
+/// targets anywhere in `source`, recursing into top-level `begin` and
+/// `cond-expand` splices (R7RS 5.1 / 4.2.1) like check.zig's lint collector.
+/// Names are duped into the map, which must outlive the unit's compiles; the
+/// transient datums read here are rooted only for the walk.
+///
+/// Structure-only, like Part B of the set! pre-scan: a redefinition that only
+/// materializes when a macro expands is not seen, so such a unit keeps the
+/// legacy behavior. (The per-form pre-scan catches those at the define's own
+/// form; a unit-level speculative expansion pass would cost the whole
+/// expansion budget on every file for the rare case.) A read error stops the
+/// scan — the real run reports it, and nothing past it executes.
+pub fn collectUnitTopLevelTargets(out: *std.StringHashMap(void), gc: *memory.GC, source: []const u8) void {
+    var r = reader_mod.Reader.init(gc, source);
+    defer r.deinit();
+    while (r.hasMore() catch false) {
+        var expr = r.readDatum() catch return;
+        gc.pushRoot(&expr);
+        collectTargetsFromUnitForm(out, expr);
+        gc.popRoot();
+    }
+}
+
+fn collectTargetsFromUnitForm(out: *std.StringHashMap(void), expr: Value) void {
+    if (!types.isPair(expr) or !types.isSymbol(types.car(expr))) return;
+    const head = types.stripHygienicPrefix(types.symbolName(types.car(expr)));
+    const rest = types.cdr(expr);
+
+    // Every spine walked below can carry a datum-label cycle in code position
+    // (R7RS 7.1.2 `#n=`/`#n#` — `(begin . #0=(1 . #0#))` is a real program
+    // the run loop diagnoses as KP2001), so each walk is a guarded SpineWalk,
+    // never a bare `while isPair` (the #2405 family).
+    if (std.mem.eql(u8, head, "define")) {
+        // (define name ...) or (define (name . formals) ...)
+        if (types.isPair(rest)) addUnitTarget(out, types.car(rest));
+    } else if (std.mem.eql(u8, head, "set!")) {
+        if (types.isPair(rest) and types.isSymbol(types.car(rest))) {
+            addUnitName(out, types.symbolName(types.car(rest)));
+        }
+    } else if (std.mem.eql(u8, head, "define-values")) {
+        // (define-values (a b . rest) expr) — every formal is bound.
+        if (types.isPair(rest)) {
+            var f = compiler_mod.SpineWalk.init(types.car(rest));
+            while (types.isPair(f.cur)) : (f.next()) {
+                if (f.cyclic()) return;
+                if (types.isSymbol(types.car(f.cur))) addUnitName(out, types.symbolName(types.car(f.cur)));
+            }
+            if (types.isSymbol(f.cur)) addUnitName(out, types.symbolName(f.cur));
+        }
+    } else if (std.mem.eql(u8, head, "begin")) {
+        // Top-level begin splices: each child is a top-level form (R7RS 5.1).
+        // The walk stops at a cycle rather than reporting it — the real run's
+        // own begin handler is the one that diagnoses, and it runs after (and
+        // independently of) this scan.
+        var cur = compiler_mod.SpineWalk.init(rest);
+        while (types.isPair(cur.cur)) : (cur.next()) {
+            if (cur.cyclic()) return;
+            collectTargetsFromUnitForm(out, types.car(cur.cur));
+        }
+    } else if (std.mem.eql(u8, head, "cond-expand")) {
+        // A top-level cond-expand splices the selected clause's body as
+        // top-level forms; without evaluating the feature requirements, take
+        // every clause body — the same conservative over-approximation
+        // check.zig's collector uses (the safe direction here too: an extra
+        // name only declines a fast path).
+        var clauses = compiler_mod.SpineWalk.init(rest);
+        while (types.isPair(clauses.cur)) : (clauses.next()) {
+            if (clauses.cyclic()) return;
+            const clause = types.car(clauses.cur);
+            if (!types.isPair(clause)) continue;
+            var body = compiler_mod.SpineWalk.init(types.cdr(clause));
+            while (types.isPair(body.cur)) : (body.next()) {
+                if (body.cyclic()) return;
+                collectTargetsFromUnitForm(out, types.car(body.cur));
+            }
+        }
+    }
+}
+
+/// The target of a `define`: a bare symbol, or the head of a possibly-curried
+/// procedure form `((name a) b)` — peel the leading pairs to the name symbol.
+/// The peel advances by car, so a car-side datum-label cycle
+/// (`(define #0=(#0# 1) ...)`) cannot use a cdr SpineWalk; a step cap bounds
+/// it instead (real curried definitions are two or three deep).
+fn addUnitTarget(out: *std.StringHashMap(void), target: Value) void {
+    var t = target;
+    var steps: usize = 0;
+    while (types.isPair(t)) : (t = types.car(t)) {
+        steps += 1;
+        if (steps > 256) return;
+    }
+    if (types.isSymbol(t)) addUnitName(out, types.symbolName(t));
+}
+
+fn addUnitName(out: *std.StringHashMap(void), name: []const u8) void {
+    if (out.contains(name)) return;
+    const owned = out.allocator.dupe(u8, name) catch return;
+    out.put(owned, {}) catch out.allocator.free(owned);
+    // Also record the hygiene-stripped spelling: since #2003 a macro
+    // template's define/set! target is renamed (__hyg_N_<name>), and the
+    // gate compares both the as-written and stripped spellings.
+    const stripped = types.stripHygienicPrefix(name);
+    if (stripped.len != name.len and !out.contains(stripped)) {
+        const owned2 = out.allocator.dupe(u8, stripped) catch return;
+        out.put(owned2, {}) catch out.allocator.free(owned2);
+    }
+}
 
 pub fn compileQuote(self: *Compiler, args: Value, dst: u16) CompileError!void {
     if (args == types.NIL) return CompileError.InvalidSyntax;
@@ -531,4 +667,46 @@ fn compileCallGlobal(self: *Compiler, expr: Value, operator: Value, dst: u16, is
         try self.emitU16(base);
         self.freeReg();
     }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "collectUnitTopLevelTargets: define shapes, splices, and non-captures" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+
+    var out = std.StringHashMap(void).init(std.testing.allocator);
+    defer {
+        var it = out.keyIterator();
+        while (it.next()) |k| std.testing.allocator.free(k.*);
+        out.deinit();
+    }
+
+    collectUnitTopLevelTargets(&out, &gc,
+        \\(define (nt) (apply + (list 1 2)))
+        \\(define (apply f xs) 'user)
+        \\(begin (define (call-with-values p c) 'user) 'ignored)
+        \\(cond-expand (kaappi (define eval 'user)) (else (define eval 'other)))
+        \\(define-values (call/cc rest-arg . r) (values 1 2 3))
+        \\(set! call-with-current-continuation (lambda (k) 'user))
+        \\(define (other xs) (apply f (list xs)))
+        \\(let ((q (quote (define not-a-target define)))) q)
+    );
+
+    // All five #2033 names, via every define shape and splice, plus set!.
+    try std.testing.expect(out.contains("apply"));
+    try std.testing.expect(out.contains("call-with-values"));
+    try std.testing.expect(out.contains("eval"));
+    try std.testing.expect(out.contains("call/cc"));
+    try std.testing.expect(out.contains("call-with-current-continuation"));
+    // define-values formals, including the rest formal.
+    try std.testing.expect(out.contains("rest-arg"));
+    // A lambda-local define, lambda formals, and quoted data contribute
+    // nothing: the walk is top-level-only (through begin/cond-expand
+    // splices) and never descends into other forms.
+    try std.testing.expect(!out.contains("not-a-target"));
+    try std.testing.expect(!out.contains("xs"));
+    try std.testing.expect(!out.contains("q"));
 }

--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -333,28 +333,28 @@ pub fn compileApplyForm(self: *Compiler, expr: Value, dst: u16, is_tail: bool) C
 
 pub fn compileCallWithValuesForm(self: *Compiler, expr: Value, dst: u16, is_tail: bool) CompileError!void {
     // (call-with-values producer consumer), either position.
-    // Emits bytecode directly: call `%call-with-values->list` with (producer,
-    // consumer) -> the list of produced values, then apply/tail_apply the
-    // consumer over that list. Applying the consumer from the dispatch loop
-    // rather than from inside the native `call-with-values` is what lets a
-    // continuation captured in the consumer be resumed after the form
-    // returns: in non-tail position that used to be the native's own
-    // `vm.callWithArgs` re-entry, whose Zig frame is gone by the time the
-    // continuation is reinstated (kaappi#2451). The *producer* still runs
-    // under `%call-with-values->list`'s own native frame in both positions,
-    // so a continuation captured there keeps the restriction.
+    // Emits bytecode directly: check both operands, call the producer with an
+    // ordinary `call` opcode, spread the produced values into an argument
+    // list, then apply/tail_apply the consumer over that list. Both halves of
+    // the form now run from the dispatch loop: the consumer since #2451, the
+    // producer since #2453 — its frame is a VM frame in this function's
+    // bytecode, copied by continuation capture and restored by resume, so a
+    // continuation captured inside it is resumable after the form returns in
+    // both positions. (Before, the producer ran under a native primitive's
+    // Zig frame — `%call-with-values->list`'s, and `callWithValuesFn`'s before
+    // that — which the resumed continuation cannot reinstall.)
     //
-    // `%call-with-values->list` takes the consumer only to type-check it —
-    // before running the producer, exactly where `callWithValuesFn` checked
-    // it — so a bad consumer is still reported as `call-with-values` rather
-    // than as the `apply` this compiles into.
+    // Diagnostic parity is why the sequence starts with a call to
+    // `%call-with-values-check`: callWithValuesFn type-checks BOTH operands,
+    // producer first, before anything runs, and reports each through
+    // `typeError("call-with-values", ...)` — so a bad consumer or producer is
+    // still reported as `call-with-values` rather than as the `apply` this
+    // compiles into, and still before the other operand's side effects. The
+    // internal primitive is loaded via self.emitTrueBuiltinLoad, which marks
+    // the reference to resolve through the pristine registry at run time
+    // rather than by ordinary name lookup, so neither a lexical shadow NOR a
+    // top-level redefinition of anything can divert it (#1715).
     //
-    // The callee is loaded via self.emitTrueBuiltinLoad, which marks the
-    // reference to resolve through the pristine registry at run time rather
-    // than by ordinary name lookup, so neither a lexical shadow NOR a later
-    // top-level redefinition can affect this call (#1715; the previous plain
-    // get_global/call_global-by-name approach only ever protected against the
-    // former).
     // A *proper* argument list of the wrong length is an arity question, not a
     // syntax question: route the form through the ordinary call path so the
     // runtime arity check reports KP3003 exactly as the same form one position
@@ -380,30 +380,46 @@ pub fn compileCallWithValuesForm(self: *Compiler, expr: Value, dst: u16, is_tail
 
     try self.compileExprViaIR(consumer, base, false);
 
-    const cwv_base = try self.allocReg();
+    const check_base = try self.allocReg();
     const producer_reg = try self.allocReg();
     const consumer_reg = try self.allocReg();
 
     try self.compileExprViaIR(producer, producer_reg, false);
 
     // The consumer is already evaluated (in `base`); pass a copy for the
-    // type check.
+    // type check. check_base/producer_reg/consumer_reg are consecutive, the
+    // layout `call check_base, 2` reads its callee and two operands from.
     try self.emitOp(.move);
     try self.emitU16(consumer_reg);
     try self.emitU16(base);
-    try self.emitTrueBuiltinLoad("%call-with-values->list", cwv_base);
+    try self.emitTrueBuiltinLoad("%call-with-values-check", check_base);
     try self.emitOp(.call);
-    try self.emitU16(cwv_base);
+    try self.emitU16(check_base);
     try self.emit(2);
 
     self.freeReg(); // consumer_reg
+
+    // The producer call: an ordinary `call` opcode, so its frame lives in the
+    // copied VM state (#2453). The result (a single value or a MultipleValues
+    // object) lands in producer_reg, the register `call` delivers into.
+    try self.emitOp(.call);
+    try self.emitU16(producer_reg);
+    try self.emit(0);
+
+    // Spread the produced value(s) into the consumer's argument list.
+    // check_base is dead since the check call returned and is exactly base+1
+    // — the register the apply below reads its list operand from.
+    try self.emitOp(.values_list);
+    try self.emitU16(check_base);
+    try self.emitU16(producer_reg);
+
     self.freeReg(); // producer_reg
 
     try self.emitOp(if (is_tail) .tail_apply else .apply);
     try self.emitU16(base);
     try self.emit(1);
 
-    self.freeReg(); // cwv_base
+    self.freeReg(); // check_base
     if (needs_rebase) {
         if (!is_tail) {
             try self.emitOp(.move);

--- a/src/disassembler.zig
+++ b/src/disassembler.zig
@@ -62,7 +62,7 @@ fn disassembleInstruction(func: *types.Function, code: []const u8, offset: usize
     const off_str = std.fmt.bufPrint(&buf, "  {d:0>4}  ", .{offset}) catch "  ????  ";
     writeStderr(off_str);
 
-    if (raw_op > @intFromEnum(OpCode.apply)) {
+    if (raw_op > @intFromEnum(OpCode.values_list)) {
         const s = std.fmt.bufPrint(&buf, "<invalid opcode 0x{x:0>2}>\n", .{raw_op}) catch "<invalid opcode>\n";
         writeStderr(s);
         return ip;
@@ -91,6 +91,7 @@ fn disassembleInstruction(func: *types.Function, code: []const u8, offset: usize
         .self_tail_call => 3,
         .tail_call_cc => 4,
         .tail_eval => 3,
+        .values_list => 4,
     };
     if (ip + fixed_operand_bytes > code.len) {
         writeStderr("<truncated instruction>\n");
@@ -161,6 +162,12 @@ fn disassembleInstruction(func: *types.Function, code: []const u8, offset: usize
             const nargs = code[ip];
             ip += 1;
             const s = std.fmt.bufPrint(&buf, "apply           r{d}, {d}\n", .{ base, nargs }) catch "apply\n";
+            writeStderr(s);
+        },
+        .values_list => {
+            const dst = readU16(code, &ip);
+            const src = readU16(code, &ip);
+            const s = std.fmt.bufPrint(&buf, "values_list     r{d}, r{d}\n", .{ dst, src }) catch "values_list\n";
             writeStderr(s);
         },
         .tail_apply => {

--- a/src/llvm_emit_forms.zig
+++ b/src/llvm_emit_forms.zig
@@ -28,6 +28,7 @@ const llvm_emit = @import("llvm_emit.zig");
 const LLVMEmitter = llvm_emit.LLVMEmitter;
 const EmitError = llvm_emit.EmitError;
 const NativeLambda = llvm_emit.NativeLambda;
+const compiler_passthrough = @import("compiler_passthrough.zig");
 
 const Value = types.Value;
 
@@ -37,6 +38,15 @@ const void_bits: i64 = @bitCast(types.VOID);
 // Cap on `do` loop variables — bounds the fixed-size scratch arrays below and
 // matches emitLet's 32-binding ceiling. A wider `do` falls back to eval.
 const MAX_DO_VARS = 32;
+
+/// Whether the compilation unit's whole-source scan saw a top-level
+/// define/set! of `name` (kaappi#2457) — the emitter-side mirror of the
+/// interpreter gate's unit arm. Null threadlocal (REPL-time evals, tests)
+/// answers false, keeping the legacy in-order behavior.
+fn unitRedefines(name: []const u8) bool {
+    const targets = compiler_passthrough.unit_top_level_targets orelse return false;
+    return targets.contains(name);
+}
 
 fn fmt(self: *LLVMEmitter, comptime f: []const u8, a: anytype) EmitError![]const u8 {
     return std.fmt.allocPrint(self.allocator(), f, a) catch return error.OutOfMemory;
@@ -1046,8 +1056,15 @@ pub fn emitApplyForm(self: *LLVMEmitter, expr: Value, is_tail: bool) EmitError![
     if (cur != types.NIL) return error.UnsupportedNodeType;
 
     const shadowed = self.isNameShadowed("apply");
+    // rebound: the name no longer denotes the builtin. rebound_globals and
+    // native_fns are in-order (a define/set! emitted BEFORE this form); the
+    // unit scan (kaappi#2457) adds the whole-unit answer — a define/set! of
+    // `apply` anywhere in the program declines the structural shape even for
+    // uses that precede it, the same interim the interpreter's
+    // globalBindingStillGenuine arm takes.
     const rebound = self.rebound_globals.contains("apply") or
-        self.native_fns.contains("apply");
+        self.native_fns.contains("apply") or
+        unitRedefines("apply");
 
     // Abandon to the interpreter only for the genuinely builtin shape: a
     // rebound `apply` with too few operands is a runtime arity/behavior

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,6 +10,7 @@ pub const memory = @import("memory.zig");
 pub const reader = @import("reader.zig");
 pub const compiler = @import("compiler.zig");
 pub const compiler_forms = @import("compiler_forms.zig");
+const compiler_passthrough = @import("compiler_passthrough.zig");
 pub const vm_mod = @import("vm.zig");
 pub const vm_eval = @import("vm_eval.zig");
 pub const primitives = @import("primitives.zig");
@@ -746,6 +747,38 @@ fn runCachedTopLevelFunc(vm: *vm_mod.VM, func: *types.Function, source: []const 
     printTopLevelResult(allocator, result);
 }
 
+/// Whole-unit top-level target set for one compilation unit (kaappi#2457):
+/// every name a top-level `define` / `define-values` / `set!` targets anywhere
+/// in the source, known before any form compiles. Installed into
+/// `compiler_passthrough.unit_top_level_targets` for the unit's duration so
+/// the superinstruction gate declines for names the unit redefines — a body
+/// compiled before the definition runs must not bake in the builtin. Owns its
+/// duped keys; `deinit` frees them.
+const UnitTargets = struct {
+    map: std.StringHashMap(void),
+
+    fn init(gc: *memory.GC, source: []const u8) UnitTargets {
+        var map = std.StringHashMap(void).init(gc.allocator);
+        compiler_passthrough.collectUnitTopLevelTargets(&map, gc, source);
+        return .{ .map = map };
+    }
+
+    fn deinit(self: *UnitTargets) void {
+        var it = self.map.keyIterator();
+        while (it.next()) |k| self.map.allocator.free(k.*);
+        self.map.deinit();
+    }
+
+    /// Point the compiler's threadlocal at this set (null when empty: an
+    /// unset threadlocal and an empty set behave identically, and most units
+    /// never touch these names). Call before the first compile of the unit;
+    /// the caller's `defer reset` must be registered after this.
+    fn install(self: *UnitTargets) void {
+        compiler_passthrough.unit_top_level_targets =
+            if (self.map.count() > 0) &self.map else null;
+    }
+};
+
 fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
     const allocator = vm.gc.allocator;
 
@@ -778,6 +811,15 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
         return;
     };
     defer allocator.free(source);
+
+    // Whole-unit define/set! targets, before any form of this unit compiles —
+    // both the cold compile and a cache HIT's declaration replay consult the
+    // same set (kaappi#2457). The reset defer is registered after install so
+    // it runs before the map's deinit.
+    var unit_targets = UnitTargets.init(vm.gc, source);
+    defer unit_targets.deinit();
+    unit_targets.install();
+    defer compiler_passthrough.unit_top_level_targets = null;
 
     const source_hash = bytecode_file.sourceHash(source);
 
@@ -1157,6 +1199,13 @@ fn runStdin(vm: *vm_mod.VM) !void {
     };
     defer allocator.free(source);
 
+    // Whole-unit define/set! targets before any form compiles (kaappi#2457);
+    // see runFile.
+    var unit_targets = UnitTargets.init(vm.gc, source);
+    defer unit_targets.deinit();
+    unit_targets.install();
+    defer compiler_passthrough.unit_top_level_targets = null;
+
     crash.note(.reading, "<stdin>");
 
     var r = reader.Reader.initWithName(vm.gc, source, "<stdin>");
@@ -1289,6 +1338,14 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
         return;
     };
     defer allocator.free(source);
+
+    // Whole-unit define/set! targets before any form compiles (kaappi#2457);
+    // see runFile. The decisions this scan drives are baked into the .sbc the
+    // same way the compile-time global read always was.
+    var unit_targets = UnitTargets.init(vm.gc, source);
+    defer unit_targets.deinit();
+    unit_targets.install();
+    defer compiler_passthrough.unit_top_level_targets = null;
 
     const source_hash = bytecode_file.sourceHash(source);
 

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -4,6 +4,7 @@ const types = @import("types.zig");
 const reader_mod = @import("reader.zig");
 const compiler = @import("compiler.zig");
 const compiler_passthrough = @import("compiler_passthrough.zig");
+const compiler_gate = @import("compiler_gate.zig");
 const vm_mod = @import("vm.zig");
 const ir_mod = @import("ir.zig");
 const expander = @import("expander.zig");
@@ -280,7 +281,7 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
         // truncation stay temporally correct). Only pathological inputs
         // reach the caps, so ordinary files keep their native lowering.
         if (!native_scan_truncated) {
-            native_scan_truncated = try compiler.scanSetTargetsWithoutMacros(expr, &redefined_names);
+            native_scan_truncated = try compiler_gate.scanSetTargetsWithoutMacros(expr, &redefined_names);
         }
         if (native_scan_truncated) {
             const passthrough_node = ir_instance.makePassthrough(expr) catch continue;
@@ -634,7 +635,7 @@ fn collectRedefinedNamesMacroAware(vm: *vm_mod.VM, expr: types.Value, map: *std.
         if (tobj.as(types.Transformer).kind != .syntax_rules) return;
 
         // Best-effort expansion with an empty use-site check (no locals at top
-        // level), mirroring compiler.collectSetTargets' pre-scan path. Held in
+        // level), mirroring compiler_gate.collectSetTargets' pre-scan path. Held in
         // the batch's existing no_collect window; take an extra guard anyway so
         // this is correct independent of the caller.
         vm.gc.no_collect += 1;

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -3,6 +3,7 @@ const platform = @import("platform.zig");
 const types = @import("types.zig");
 const reader_mod = @import("reader.zig");
 const compiler = @import("compiler.zig");
+const compiler_passthrough = @import("compiler_passthrough.zig");
 const vm_mod = @import("vm.zig");
 const ir_mod = @import("ir.zig");
 const expander = @import("expander.zig");
@@ -138,6 +139,22 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
         return err;
     };
     defer allocator.free(source);
+
+    // Whole-unit top-level define/set! targets (kaappi#2457): the emitter's
+    // `apply` fast path (emitApplyForm) declines for a name the unit
+    // redefines ANYWHERE — the same interim the interpreter's
+    // globalBindingStillGenuine arm takes, closing the same use-compiled-
+    // before-define order its own in-order rebound_globals set could not see.
+    var unit_targets = std.StringHashMap(void).init(allocator);
+    defer {
+        var uit = unit_targets.keyIterator();
+        while (uit.next()) |k| allocator.free(k.*);
+        unit_targets.deinit();
+    }
+    compiler_passthrough.collectUnitTopLevelTargets(&unit_targets, vm.gc, source);
+    compiler_passthrough.unit_top_level_targets =
+        if (unit_targets.count() > 0) &unit_targets else null;
+    defer compiler_passthrough.unit_top_level_targets = null;
 
     const saved_lib_dir = vm.current_lib_dir;
     vm.current_lib_dir = if (std.mem.lastIndexOfScalar(u8, path, '/')) |pos| path[0 .. pos + 1] else "";

--- a/src/primitives_control.zig
+++ b/src/primitives_control.zig
@@ -34,13 +34,15 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "dynamic-wind", .func = primitives.bootstrapStub("dynamic-wind"), .arity = .{ .exact = 3 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
     .{ .name = "values", .func = &valuesFn, .arity = .{ .variadic = 0 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
     .{ .name = "call-with-values", .func = &callWithValuesFn, .arity = .{ .exact = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
-    // The producer half of `call-with-values`, for the compiler's
-    // apply/tail_apply lowering of the form (kaappi#1715, kaappi#2451): checks
-    // both operands the way callWithValuesFn does, runs the producer, and
-    // hands back the produced values as a list for the consumer to be applied
-    // to. Keeping the checks here is what lets the lowering report a bad
-    // consumer as `call-with-values`, not as the `apply` it compiles into.
-    .{ .name = "%call-with-values->list", .func = &callWithValuesToListFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.internal) },
+    // The operand-check gate of `call-with-values`, for the compiler's
+    // call/values_list/apply lowering of the form (kaappi#1715, #2451,
+    // #2453): validates BOTH operands the way — and exactly where —
+    // callWithValuesFn does, producer first and before anything runs, so a
+    // bad producer or consumer is reported as `call-with-values`, not as the
+    // `apply` the form compiles into, and not after the other operand's side
+    // effects. Runs nothing; the lowering then calls the producer with an
+    // ordinary `call` opcode so its frame is resumable (#2453).
+    .{ .name = "%call-with-values-check", .func = &callWithValuesCheckFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.internal) },
     .{ .name = "%push-wind", .func = &pushWindFn, .arity = .{ .exact = 2 }, .libs = LS.initOne(.internal) },
     .{ .name = "%pop-wind", .func = &popWindFn, .arity = .{ .exact = 0 }, .libs = LS.initOne(.internal) },
     .{ .name = "%unwind-to-escape", .func = &unwindToEscapeFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.internal) },
@@ -557,32 +559,20 @@ fn callWithValuesFn(args: []const Value) PrimitiveError!Value {
     }
 }
 
-/// (%call-with-values->list producer consumer) → the list of values `producer`
-/// produced, after rejecting either operand that is not a procedure exactly as
-/// `callWithValuesFn` does.
-///
-/// The compiler lowers `(call-with-values p c)` to this followed by
-/// `apply`/`tail_apply` of `c` over the returned list, so the consumer runs in
-/// an ordinary VM frame and a continuation captured inside it can be resumed
-/// after the form returns (kaappi#2451). The producer still runs under this
-/// native frame — the restriction moved, it did not disappear.
-fn callWithValuesToListFn(args: []const Value) PrimitiveError!Value {
-    const vm = vm_mod.vm_instance orelse return PrimitiveError.InvalidBytecode; // no VM: internal invariant
-    const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-    const producer = args[0];
-    const consumer = args[1];
-
-    if (!types.isProcedure(producer)) return primitives.typeError("call-with-values", "procedure", producer);
-    if (!types.isProcedure(consumer)) return primitives.typeError("call-with-values", "procedure", consumer);
-
-    var produced = try vm.callThunkReturningToNative(producer);
-    gc.pushRoot(&produced);
-    defer gc.popRoot();
-    if (types.isMultipleValues(produced)) {
-        const mv = types.toObject(produced).as(types.MultipleValues);
-        return gc.makeList(mv.values) catch return PrimitiveError.OutOfMemory;
-    }
-    return gc.allocPair(produced, types.NIL) catch return PrimitiveError.OutOfMemory;
+/// (%call-with-values-check producer consumer) → void, after rejecting either
+/// operand that is not a procedure exactly as `callWithValuesFn` does:
+/// producer-first, both before anything runs, same texts. The compiler lowers
+/// `(call-with-values p c)` to a call of this followed by an ordinary `call`
+/// of the producer, `values_list`, and `apply`/`tail_apply` of the consumer —
+/// so both halves run from the dispatch loop and a continuation captured in
+/// either is resumable after the form returns (kaappi#2451 for the consumer,
+/// #2453 for the producer). The checks living here, rather than in the
+/// opcodes, is what keeps the diagnostics identical to the native
+/// `call-with-values`.
+fn callWithValuesCheckFn(args: []const Value) PrimitiveError!Value {
+    if (!types.isProcedure(args[0])) return primitives.typeError("call-with-values", "procedure", args[0]);
+    if (!types.isProcedure(args[1])) return primitives.typeError("call-with-values", "procedure", args[1]);
+    return types.VOID;
 }
 
 fn pushWindFn(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_control.zig
+++ b/src/primitives_control.zig
@@ -528,8 +528,11 @@ fn callWithValuesFn(args: []const Value) PrimitiveError!Value {
     if (!types.isProcedure(producer)) return primitives.typeError("call-with-values", "procedure", args[0]);
     if (!types.isProcedure(consumer)) return primitives.typeError("call-with-values", "procedure", args[1]);
 
-    // Call producer
-    const produced = vm.callThunk(producer) catch |err| {
+    // Call producer. Returns-to-native (#2453): its frame must report KP3000
+    // when a continuation captured inside it is resumed after this native
+    // call-with-values has returned, rather than delivering into whatever
+    // bytecode frame sits below the restored snapshot.
+    const produced = vm.callThunkReturningToNative(producer) catch |err| {
         return err;
     };
 
@@ -572,7 +575,7 @@ fn callWithValuesToListFn(args: []const Value) PrimitiveError!Value {
     if (!types.isProcedure(producer)) return primitives.typeError("call-with-values", "procedure", producer);
     if (!types.isProcedure(consumer)) return primitives.typeError("call-with-values", "procedure", consumer);
 
-    var produced = try vm.callThunk(producer);
+    var produced = try vm.callThunkReturningToNative(producer);
     gc.pushRoot(&produced);
     defer gc.popRoot();
     if (types.isMultipleValues(produced)) {

--- a/src/tests_check.zig
+++ b/src/tests_check.zig
@@ -316,3 +316,46 @@ test "cond-expand: an unsatisfied top-level clause is not an error (#1661)" {
     // No clause matches and there is no else: folds to void, no finding.
     try expectCounts("(cond-expand (no-such-feature (import (srfi 1))))", 0, 0, 0);
 }
+
+// ── Whole-unit superinstruction gate during analysis (kaappi#2457) ──────────
+// analyzeSource — the shared path of `run`, the tests, and the LSP — installs
+// the EXACT target set a run of the file would install, not the lint's
+// user_defined set: top-level `set!` targets count (PR #2467 review), and
+// define-syntax names are not part of it.
+
+test "unit gate: a top-level set! target reaches the gate set" {
+    // The reviewer's scenario: a unit using `apply` early and assigning it
+    // later. user_defined misses the set!; the gate set must not.
+    var h: Harness = .{};
+    try h.tc.init();
+    defer h.tc.deinit();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var targets = check.unitTargetSet(arena.allocator(), &h.tc.gc,
+        \\(define (f) (apply + (list 1 2)))
+        \\(set! apply (lambda args 'user))
+    );
+    try testing.expect(targets.contains("apply"));
+}
+
+test "unit gate: define-syntax names are not gate targets" {
+    var h: Harness = .{};
+    try h.tc.init();
+    defer h.tc.deinit();
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var targets = check.unitTargetSet(arena.allocator(), &h.tc.gc,
+        \\(define-syntax m (syntax-rules () ((_ x) x)))
+        \\(m 1)
+    );
+    try testing.expect(!targets.contains("m"));
+    try testing.expectEqual(@as(usize, 0), targets.count());
+}
+
+test "unit gate: installed only for the duration of the analysis" {
+    const compiler_passthrough = @import("compiler_passthrough.zig");
+    try testing.expect(compiler_passthrough.unit_top_level_targets == null);
+    try expectCounts("(define (f) (apply + (list 1 2)))\n(set! apply (lambda args 'user))", 0, 0, 0);
+    // The defer-based cleanup restored the per-form (null) answer.
+    try testing.expect(compiler_passthrough.unit_top_level_targets == null);
+}

--- a/src/tests_prescan.zig
+++ b/src/tests_prescan.zig
@@ -1,18 +1,18 @@
-// Regressions for the top-level `set!` pre-scan (compiler.collectSetTargets)
+// Regressions for the top-level `set!` pre-scan (compiler_gate.collectSetTargets)
 // and its work limit (kaappi#1775).
 //
 // The pre-scan expands macros so it can see a `set!` a macro template
 // introduces, which is what makes #1250's macro-introduced-set! cases box
 // correctly. That makes it a speculative evaluator of compile-time macro
 // code, and it can explore exponentially many branches the real compiler
-// never takes. It is therefore bounded (compiler.prescan_expansion_limit),
+// never takes. It is therefore bounded (compiler_gate.prescan_expansion_limit),
 // and hitting the bound must fall back to "assume every name is a `set!`
 // target" rather than silently returning a partial answer — the tests here
 // pin both halves of that contract.
 const std = @import("std");
 const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
-const compiler = @import("compiler.zig");
+const compiler_gate = @import("compiler_gate.zig");
 
 /// Evaluate `body` with the pre-scan limit lowered, assert it yields
 /// `expected`, and report how many top-level forms truncated meanwhile.
@@ -20,18 +20,18 @@ const compiler = @import("compiler.zig");
 /// than returned because the VM (and any heap value it produced) is gone
 /// once this returns.
 fn evalWithPrescanLimit(limit: u32, expected: i64, body: []const u8) !u64 {
-    const saved = compiler.prescan_expansion_limit;
-    defer compiler.prescan_expansion_limit = saved;
-    compiler.prescan_expansion_limit = limit;
+    const saved = compiler_gate.prescan_expansion_limit;
+    defer compiler_gate.prescan_expansion_limit = saved;
+    compiler_gate.prescan_expansion_limit = limit;
 
     var ctx: th.TestContext = undefined;
     try ctx.init();
     defer ctx.deinit();
 
-    const before = compiler.prescan_truncations;
+    const before = compiler_gate.prescan_truncations;
     const value = try ctx.vm.eval(body);
     try std.testing.expectEqual(expected, types.toFixnum(value));
-    return compiler.prescan_truncations - before;
+    return compiler_gate.prescan_truncations - before;
 }
 
 test "#1775: a truncated set! pre-scan still boxes a macro-introduced set! target" {
@@ -140,8 +140,8 @@ test "#1802: a macro use in transformer-spec position does not consume the pre-s
     //
     // With the limit at 0, ANY spec expansion truncates, so this fails
     // without the fix.
-    const saved = compiler.prescan_expansion_limit;
-    defer compiler.prescan_expansion_limit = saved;
+    const saved = compiler_gate.prescan_expansion_limit;
+    defer compiler_gate.prescan_expansion_limit = saved;
 
     var ctx: th.TestContext = undefined;
     try ctx.init();
@@ -152,11 +152,11 @@ test "#1802: a macro use in transformer-spec position does not consume the pre-s
         \\(define-syntax gen (syntax-rules () ((_) (syntax-rules () ((_ x) x)))))
     );
 
-    compiler.prescan_expansion_limit = 0;
-    const before = compiler.prescan_truncations;
+    compiler_gate.prescan_expansion_limit = 0;
+    const before = compiler_gate.prescan_truncations;
     _ = try ctx.vm.eval("(define-syntax my-id (gen))");
-    try std.testing.expectEqual(@as(u64, 0), compiler.prescan_truncations - before);
-    compiler.prescan_expansion_limit = saved;
+    try std.testing.expectEqual(@as(u64, 0), compiler_gate.prescan_truncations - before);
+    compiler_gate.prescan_expansion_limit = saved;
 
     // The real SRFI 147 resolution must be unaffected by the pre-scan skip.
     const result = try ctx.vm.eval("(my-id 42)");
@@ -173,8 +173,8 @@ test "#1802: let-syntax specs are skipped but the body keeps the budgeted scan" 
     //     to 7 before the reassignment runs => result 7.
     //   - correct: the one expansion goes to the body's `rebind`, `+` is a
     //     known target, the fold is suppressed => result 3, truncations 0.
-    const saved = compiler.prescan_expansion_limit;
-    defer compiler.prescan_expansion_limit = saved;
+    const saved = compiler_gate.prescan_expansion_limit;
+    defer compiler_gate.prescan_expansion_limit = saved;
 
     var ctx: th.TestContext = undefined;
     try ctx.init();
@@ -187,8 +187,8 @@ test "#1802: let-syntax specs are skipped but the body keeps the budgeted scan" 
         \\(define-syntax rebind (syntax-rules () ((_ a b) (set! a b))))
     );
 
-    compiler.prescan_expansion_limit = 1;
-    const before = compiler.prescan_truncations;
+    compiler_gate.prescan_expansion_limit = 1;
+    const before = compiler_gate.prescan_truncations;
     const result = try ctx.vm.eval(
         \\(let-syntax ((local-id (gen)))
         \\  (define (f) (+ 5 2))
@@ -196,7 +196,7 @@ test "#1802: let-syntax specs are skipped but the body keeps the budgeted scan" 
         \\  (local-id (f)))
     );
     try std.testing.expectEqual(@as(i64, 3), types.toFixnum(result));
-    try std.testing.expectEqual(@as(u64, 0), compiler.prescan_truncations - before);
+    try std.testing.expectEqual(@as(u64, 0), compiler_gate.prescan_truncations - before);
 }
 
 test "#1775: ordinary code does not trigger the pre-scan fallback" {
@@ -207,7 +207,7 @@ test "#1775: ordinary code does not trigger the pre-scan fallback" {
     try ctx.init();
     defer ctx.deinit();
 
-    const before = compiler.prescan_truncations;
+    const before = compiler_gate.prescan_truncations;
     const result = try ctx.vm.eval(
         \\(begin
         \\  (define-syntax swap!
@@ -218,7 +218,7 @@ test "#1775: ordinary code does not trigger the pre-scan fallback" {
         \\    (+ (* 10 x) y)))
     );
     try std.testing.expectEqual(@as(i64, 12), types.toFixnum(result));
-    try std.testing.expectEqual(@as(u64, 0), compiler.prescan_truncations - before);
+    try std.testing.expectEqual(@as(u64, 0), compiler_gate.prescan_truncations - before);
 }
 
 // #2404/#2401 review: the scan's caps must REPORT, never silently return a
@@ -236,13 +236,13 @@ test "#2404: scanSetTargetsWithoutMacros reports truncation on a cyclic form" {
     const cyclic = try ctx.vm.eval("'#0=(zz . #0#)");
     var targets = std.StringHashMap(void).init(std.testing.allocator);
     defer targets.deinit();
-    try std.testing.expect(try compiler.scanSetTargetsWithoutMacros(cyclic, &targets));
+    try std.testing.expect(try compiler_gate.scanSetTargetsWithoutMacros(cyclic, &targets));
 
     // The reporting is not hair-trigger: an ordinary small form scans to
     // completion and reports false.
     var targets2 = std.StringHashMap(void).init(std.testing.allocator);
     defer targets2.deinit();
-    try std.testing.expect(!try compiler.scanSetTargetsWithoutMacros(
+    try std.testing.expect(!try compiler_gate.scanSetTargetsWithoutMacros(
         try ctx.vm.eval("'(begin (set! a 1) (if x (set! b 2)))"),
         &targets2,
     ));

--- a/src/types.zig
+++ b/src/types.zig
@@ -1470,6 +1470,11 @@ pub const OpCode = enum(u8) {
     // comptime and so has no such guard — it decoded as garbage the moment the
     // numbering shifted. New opcodes go on the end.
     apply, // base:u16, nargs:u8
+    // Spread a call-with-values producer's return value (a single value or a
+    // MultipleValues object from `values`) into a fresh argument list for the
+    // apply/tail_apply that follows it (kaappi#2453). Appended at the end for
+    // the same .sbc-numbering reason as `apply` above.
+    values_list, // dst:u16, src:u16
 };
 
 // -- Doc sync gate ----------------------------------------------------------
@@ -1486,7 +1491,7 @@ pub const OpCode = enum(u8) {
 // than trusting the list — grep the *noun*, since the count is written at least
 // four ways ("31 opcodes", "31-opcode", "(31 opcodes)", and number-after-noun).
 comptime {
-    if (@typeInfo(OpCode).@"enum".fields.len != 32)
+    if (@typeInfo(OpCode).@"enum".fields.len != 33)
         @compileError("OpCode count changed. Update the table in docs/dev/bytecode.md, then every " ++
             "file quoting the count — known: docs/dev/architecture.md, docs/dev/README.md, " ++
             "docs/dev/claude-code-harness.md, .claude/skills/bytecode-isa/SKILL.md. Find any others " ++

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -1379,6 +1379,13 @@ pub const VM = struct {
         return vm_calls.callThunk(self, thunk_val);
     }
 
+    /// callThunk variant for thunks owned by a native caller: the closure
+    /// frame carries returns_to_native, so a late continuation resume past the
+    /// returned native raises KP3000 instead of mis-delivering (kaappi#2453).
+    pub fn callThunkReturningToNative(self: *VM, thunk_val: Value) VMError!Value {
+        return vm_calls.callThunkReturningToNative(self, thunk_val);
+    }
+
     pub fn callWithArgs(self: *VM, proc: Value, args: []const Value) VMError!Value {
         return vm_calls.callWithArgs(self, proc, args);
     }

--- a/src/vm_calls.zig
+++ b/src/vm_calls.zig
@@ -974,6 +974,25 @@ pub fn callThunk(vm: *VM, thunk_val: Value) VMError!Value {
     }
 }
 
+/// callThunk for a thunk whose result belongs to THIS native caller, not to a
+/// bytecode frame: the pushed closure frame is marked `returns_to_native`, so
+/// a continuation captured inside the thunk and resumed after the native
+/// caller has returned reports KP3000 at the thunk's return
+/// (`raiseDeadNativeReturn`) instead of delivering its value into whatever
+/// bytecode frame happens to sit below the restored snapshot (kaappi#2453 —
+/// call-with-values' producer used to misfire that way, surfacing as a
+/// misleading `apply` type error). The same marker `callWithArgs`-driven
+/// natives (map, fold, hash-table-walk, ...) already get for their callbacks.
+/// Native and native-closure thunks push no VM frame and fall back to
+/// `callThunk` unchanged.
+pub fn callThunkReturningToNative(vm: *VM, thunk_val: Value) VMError!Value {
+    if (types.isClosure(thunk_val)) {
+        const closure = types.toObject(thunk_val).as(types.Closure);
+        return callReentrant(vm, closure, computeReentrantBase(vm), &.{}, 0, true);
+    }
+    return callThunk(vm, thunk_val);
+}
+
 pub fn callWithArgs(vm: *VM, proc: Value, args: []const Value) VMError!Value {
     vm.native_call_was_tail = false; // SRFI 248: apply-style call, not a tail call
     if (types.isFfiFunction(proc)) {

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -152,7 +152,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
         if (frame.ip >= frame.code.len) return VMError.InvalidBytecode;
 
         const raw_op = frame.code[frame.ip];
-        if (raw_op > @intFromEnum(OpCode.apply)) return VMError.InvalidBytecode;
+        if (raw_op > @intFromEnum(OpCode.values_list)) return VMError.InvalidBytecode;
         const op: OpCode = @enumFromInt(raw_op);
         frame.ip += 1;
 
@@ -179,6 +179,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
             .self_tail_call => 3,
             .tail_call_cc => 4,
             .tail_eval => 3,
+            .values_list => 4,
         };
         try ensureOperands(self, frame, fixed_operand_bytes);
 
@@ -716,6 +717,31 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     if (err == VMError.Yielded) maybeRewindRetry(self, 1 + fixed_operand_bytes);
                     return err;
                 };
+            },
+            .values_list => {
+                // Spread a call-with-values producer's return value — a single
+                // value, or a MultipleValues object from `values` — into a
+                // fresh argument list for the apply/tail_apply the form's
+                // lowering emits right after this (kaappi#2453). The producer
+                // itself ran under an ordinary `call`, so by the time this
+                // executes its frame is bytecode like any other and a
+                // continuation captured inside it survives the form's return.
+                const dst = readU16(self, frame);
+                const src = readU16(self, frame);
+                const src_idx = try registerIndex(self, frame.base, src);
+                const dst_idx = try registerIndex(self, frame.base, dst);
+                var v = self.registers[src_idx];
+                // Root across the list allocation below: the pair/list
+                // constructors can collect, and `v` is a local the register
+                // window will not re-mark until the store lands.
+                self.gc.pushRoot(&v);
+                defer self.gc.popRoot();
+                if (types.isMultipleValues(v)) {
+                    const mv = types.toObject(v).as(types.MultipleValues);
+                    self.registers[dst_idx] = try buildRestList(self.gc, mv.values);
+                } else {
+                    self.registers[dst_idx] = self.gc.allocPair(v, types.NIL) catch return VMError.OutOfMemory;
+                }
             },
             .tail_apply => {
                 const base_reg = readU16(self, frame);

--- a/tests/scheme/audit/primitives_control-audit.scm
+++ b/tests/scheme/audit/primitives_control-audit.scm
@@ -883,14 +883,11 @@
             '(x ()) (with-exception-handler (lambda (a . rest) (list a rest))
                       (lambda () (raise-continuable 'x))))
 ;; tail_call_cc does check its receiver's arity — pinned so the fix for #2034
-;; does not have to guess which half was already right.  The receiver must sit
-;; in genuine tail position, so `raises?` wraps the call from outside.
-(test-equal "arity: a 2-argument call/cc receiver IS rejected in tail position"
-            "call/cc receiver: expected 1 argument, got arity 2"
-            (raised-msg ((lambda () (call/cc (lambda (a b) 1))))))
-(test-equal "arity: a 3-argument call/cc receiver IS rejected in tail position"
-            "call/cc receiver: expected 1 argument, got arity 3"
-            (raised-msg ((lambda () (call/cc (lambda (a b c) 1))))))
+;; does not have to guess which half was already right. Those two assertions
+;; live in tests/scheme/continuations/callcc-correctness.scm since #2457: this
+;; file redefines call/cc at top level (the #2033 section below), and a
+;; unit-wide define of the name now declines the superinstruction for the
+;; whole file, so the opcode's own diagnostic is unreachable from here.
 
 ;;; ------------------------------------------------------------------
 ;;; Tail-position superinstructions vs. the ordinary call path

--- a/tests/scheme/compile/native-apply-redefinition-order-2457.sh
+++ b/tests/scheme/compile/native-apply-redefinition-order-2457.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# Regression test for #2457 (LLVM native backend): a top-level redefinition
+# of `apply` that runs AFTER the code using it was compiled must win there
+# too, in the compiled binary — not just in the interpreter.
+#
+# emitApplyForm's structural @kaappi_apply shape was gated on
+# rebound_globals/native_fns, both populated IN ORDER as forms are emitted, so
+# a use preceding the define still baked in the builtin's flattening
+# semantics and the user's procedure was silently discarded. The native
+# compile driver now installs the same whole-unit top-level target scan the
+# interpreter's gate consults (compiler_passthrough.unit_top_level_targets),
+# and emitApplyForm declines the structural shape for any name the unit
+# redefines — the by-name generic call resolves the user's binding at
+# runtime, exactly like the interpreter.
+#
+# The convergence guarantee from #1803 is pinned too: a program that never
+# touches these names must keep its native @kaappi_apply call site (the unit
+# scan must not cost the fast path in clean programs).
+#
+# Usage: bash tests/scheme/compile/native-apply-redefinition-order-2457.sh [path-to-kaappi]
+
+set -euo pipefail
+
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+KAAPPI="${1:-$REPO_DIR/zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+ensure_runtime_lib "$REPO_DIR"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+FAILED=0
+
+compile_one() {
+    local label="$1"
+    local src="$DIR/${label}.scm" bin="$DIR/${label}.bin"
+    local compile_out compile_status=0
+    compile_out="$(cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" 2>&1)" || compile_status=$?
+    if [[ $compile_status -ne 0 ]]; then
+        echo "FAIL: $label — kaappi compile exited $compile_status: $compile_out" >&2
+        FAILED=1
+        return 1
+    fi
+    if [[ ! -x "$bin" ]]; then
+        echo "FAIL: $label — kaappi compile succeeded but produced no binary" >&2
+        FAILED=1
+        return 1
+    fi
+}
+
+# Run one program both ways and require identical output.
+check_both() {
+    local label="$1" expected="$2"
+    local src="$DIR/${label}.scm" bin="$DIR/${label}.bin"
+
+    local interp_out interp_status=0
+    interp_out="$(cd "$REPO_DIR" && KAAPPI_HOME="$DIR/home-i" "$KAAPPI_ABS" "$src" 2>&1)" || interp_status=$?
+    if [[ $interp_status -ne 0 ]]; then
+        echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        FAILED=1
+        return
+    fi
+    if [[ "$interp_out" != "$expected" ]]; then
+        echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        FAILED=1
+        return
+    fi
+
+    compile_one "$label" || return
+
+    local native_out native_status=0
+    native_out="$("$bin" 2>&1)" || native_status=$?
+    if [[ $native_status -ne 0 ]]; then
+        echo "FAIL: $label — compiled binary exited $native_status (output: '$native_out')" >&2
+        FAILED=1
+        return
+    fi
+    if [[ "$native_out" != "$interp_out" ]]; then
+        echo "FAIL: $label — native '$native_out' != interpreted '$interp_out'" >&2
+        FAILED=1
+    fi
+}
+
+# 1. The #2457 shape, non-tail and tail: the caller is compiled before the
+#    top-level redefinition runs; the user's binding must win everywhere.
+cat > "$DIR/order.scm" << 'SCHEME'
+(import (scheme base) (scheme write))
+(define (nt) (let ((v (apply + (list 1 2)))) v))
+(define (t) (apply + (list 1 2)))
+(define (apply f xs) 'user-apply)
+(write (list (nt) (t)))
+(newline)
+SCHEME
+check_both "order" "(user-apply user-apply)"
+
+# 2. Restored to the genuine binding, the builtin is reachable again through
+#    the same by-name call sites.
+cat > "$DIR/restore.scm" << 'SCHEME'
+(import (scheme base) (scheme write))
+(define (nt) (let ((v (apply + (list 1 2)))) v))
+(define orig apply)
+(define (apply f xs) 'user-apply)
+(define apply orig)
+(write (nt))
+(newline)
+SCHEME
+check_both "restore" "3"
+
+# 3. The #1803 convergence guarantee survives the scan: a program that never
+#    redefines apply keeps a native @kaappi_apply call site and no eval
+#    fallback in the emitted IR.
+cat > "$DIR/clean.scm" << 'SCHEME'
+(define (work n acc)
+  (if (= n 0) (apply + (list acc 0))
+      (work (- n 1) (+ acc (* n 3)))))
+(display (work 10000 0))
+(newline)
+SCHEME
+LL="$DIR/clean.ll"
+if (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$LL" "$DIR/clean.scm" > /dev/null 2>&1); then
+    evals=$(grep -c "call i64 @kaappi_eval" "$LL" || true)
+    if [[ "$evals" -ne 0 ]]; then
+        echo "FAIL: clean — expected 0 eval fallbacks in emitted IR, found $evals" >&2
+        FAILED=1
+    fi
+    if ! grep -q "@kaappi_apply(ptr %vm" "$LL"; then
+        echo "FAIL: clean — no native @kaappi_apply call site in emitted IR" >&2
+        FAILED=1
+    fi
+else
+    echo "FAIL: clean — --emit-llvm failed" >&2
+    FAILED=1
+fi
+
+if [[ $FAILED -ne 0 ]]; then
+    exit 1
+fi
+
+echo "PASS"

--- a/tests/scheme/compliance/top-level-redefinition-2033.scm
+++ b/tests/scheme/compliance/top-level-redefinition-2033.scm
@@ -94,6 +94,30 @@
 (define call-with-current-continuation saved-2033-orig-ccc)
 
 ;;; ------------------------------------------------------------------
+;;; A redefinition that is an earlier child of the SAME top-level `begin`.
+;;; The begin's children are compiled and executed one at a time, so the
+;;; definition has run by the time the use compiles — the gate's live-global
+;;; read sees the user's procedure and declines. (Moved here from
+;;; callcc-native-driver-reentry-2451.scm by #2457: a top-level define of one
+;;; of these names anywhere in a unit now declines the superinstruction for
+;;; the whole unit, so the two files' concerns no longer mix.)
+;;; ------------------------------------------------------------------
+
+(test-eq "a define earlier in the same begin beats the apply opcode"
+  'mine
+  (begin
+    (define (apply f xs) 'mine)
+    (let ((v (apply + (list 1 2)))) v)))
+(define apply saved-2033-orig-apply)
+
+(test-eq "a define earlier in the same begin beats the call-with-values lowering"
+  'mine
+  (begin
+    (define (call-with-values p c) 'mine)
+    (let ((v (call-with-values (lambda () 1) (lambda (x) x)))) v)))
+(define call-with-values saved-2033-orig-cwv)
+
+;;; ------------------------------------------------------------------
 ;;; A redefinition to a non-procedure value: the builtin must not run —
 ;;; the ordinary call path reports the type error.
 ;;; ------------------------------------------------------------------

--- a/tests/scheme/compliance/top-level-redefinition-order-2457.scm
+++ b/tests/scheme/compliance/top-level-redefinition-order-2457.scm
@@ -1,0 +1,163 @@
+;;; Regression tests for #2457: a top-level redefinition of apply,
+;;; call-with-values, eval, call/cc or call-with-current-continuation was
+;;; ignored by any procedure body compiled BEFORE the redefinition ran, in
+;;; both tail and non-tail position.
+;;;
+;;; R7RS 5.3.1: "At the top level of a program, a definition ... has
+;;; essentially the same effect as the assignment expression", so which
+;;; binding a call resolves is a run-time question. The superinstruction gate
+;;; (`globalBindingStillGenuine`) answered it by reading the live global
+;;; environment at COMPILE time, which is wrong whenever the compilation order
+;;; and the definition order differ. #2033 fixed the define-BEFORE-use order
+;;; that way; the use-BEFORE-define order kept silently running the builtin.
+;;;
+;;; The interim fix is a whole-unit conservative arm: a driver that knows the
+;;; entire compilation unit (file runs, stdin scripts, `kaappi compile`,
+;;; `kaappi check`) pre-scans the unit's top-level define/set! targets, and the
+;;; gate declines the fast path for those names everywhere in the unit. This
+;;; file's every section defines one of the five names at top level, so the
+;;; whole unit compiles by-name — which is exactly what the sections assert:
+;;; the user's binding wins from the first call, and restoring the genuine
+;;; binding makes the builtin visible again.
+;;;
+;;; NOT covered by the interim (kept as the legacy behavior, by design):
+;;; the REPL and `eval`, which have no future knowledge; and a redefinition
+;;; that only materializes when a macro expands. The honest run-time decision
+;;; is the recorded follow-up.
+;;;
+;;; `car` and `map` in the identical shape were always correct (they never had
+;;; a superinstruction to bake in) and run here as the contrast.
+
+(import (scheme base) (scheme write) (scheme eval) (srfi 64))
+
+(define %test-fail-count 0)
+(test-begin "top-level-redefinition-order-2457")
+
+(define saved-2457-orig-apply apply)
+(define saved-2457-orig-eval eval)
+(define saved-2457-orig-call/cc call/cc)
+(define saved-2457-orig-cwv call-with-values)
+(define saved-2457-orig-ccc call-with-current-continuation)
+
+;;; ------------------------------------------------------------------
+;;; The five names, the caller defined BEFORE the redefinition runs —
+;;; the reverse of #2033's order, both tail and non-tail position.
+;;; ------------------------------------------------------------------
+
+(define (nt-apply) (let ((v (apply + (list 1 2)))) v))
+(define (t-apply) (apply + (list 1 2)))
+(define (apply f xs) 'user-apply)
+(test-eq "apply: body compiled before the redefinition honours it (non-tail)"
+  'user-apply (nt-apply))
+(test-eq "apply: body compiled before the redefinition honours it (tail)"
+  'user-apply (t-apply))
+(define apply saved-2457-orig-apply)
+(test-eq "apply: genuine binding restored" 3 (nt-apply))
+
+(define (nt-cwv)
+  (let ((v (call-with-values (lambda () 1) (lambda (x) x)))) v))
+(define (t-cwv) (call-with-values (lambda () 1) (lambda (x) x)))
+(define (call-with-values p c) 'user-cwv)
+(test-eq "call-with-values: body compiled before the redefinition honours it (non-tail)"
+  'user-cwv (nt-cwv))
+(test-eq "call-with-values: body compiled before the redefinition honours it (tail)"
+  'user-cwv (t-cwv))
+(define call-with-values saved-2457-orig-cwv)
+(test-eq "call-with-values: genuine binding restored" 1 (nt-cwv))
+
+(define (nt-eval) (let ((v (eval '(+ 1 2) (interaction-environment)))) v))
+(define (t-eval) (eval '(+ 1 2) (interaction-environment)))
+(define (eval x . env) 'user-eval)
+(test-eq "eval: body compiled before the redefinition honours it (non-tail)"
+  'user-eval (nt-eval))
+(test-eq "eval: body compiled before the redefinition honours it (tail)"
+  'user-eval (t-eval))
+(define eval saved-2457-orig-eval)
+(test-eq "eval: genuine binding restored" 3 (nt-eval))
+
+(define (nt-callcc) (let ((v (call/cc (lambda (k) 1)))) v))
+(define (t-callcc) (call/cc (lambda (k) 1)))
+(define (call/cc f) 'user-callcc)
+(test-eq "call/cc: body compiled before the redefinition honours it (non-tail)"
+  'user-callcc (nt-callcc))
+(test-eq "call/cc: body compiled before the redefinition honours it (tail)"
+  'user-callcc (t-callcc))
+(define call/cc saved-2457-orig-call/cc)
+(test-eq "call/cc: genuine binding restored" 1 (nt-callcc))
+
+(define (nt-ccc)
+  (let ((v (call-with-current-continuation (lambda (k) 1)))) v))
+(define (t-ccc) (call-with-current-continuation (lambda (k) 1)))
+(define (call-with-current-continuation f) 'user-ccc)
+(test-eq "call-with-current-continuation: body compiled before the redefinition honours it (non-tail)"
+  'user-ccc (nt-ccc))
+(test-eq "call-with-current-continuation: body compiled before the redefinition honours it (tail)"
+  'user-ccc (t-ccc))
+(define call-with-current-continuation saved-2457-orig-ccc)
+(test-eq "call-with-current-continuation: genuine binding restored" 1 (nt-ccc))
+
+;;; ------------------------------------------------------------------
+;;; A set! in a later top-level form is the same hazard as a define in a
+;;; later form (R7RS 5.3.1 again), and the unit scan covers it the same way.
+;;; ------------------------------------------------------------------
+
+(define (nt-apply-set) (let ((v (apply + (list 1 2)))) v))
+(set! apply (lambda (f xs) 'set-user))
+(test-eq "apply: body compiled before a later set! honours it"
+  'set-user (nt-apply-set))
+(define apply saved-2457-orig-apply)
+(test-eq "apply: genuine binding restored after the set! test" 3 (nt-apply-set))
+
+;;; ------------------------------------------------------------------
+;;; A redefinition nested in a top-level begin splices as top-level forms
+;;; (R7RS 5.1), so the scan sees it and the whole unit declines.
+;;; ------------------------------------------------------------------
+
+(define (nt-apply-begin) (let ((v (apply + (list 1 2)))) v))
+(begin
+  (define (apply f xs) 'begin-user)
+  'ignored)
+(test-eq "apply: body compiled before a begin-spliced redefinition honours it"
+  'begin-user (nt-apply-begin))
+(define apply saved-2457-orig-apply)
+
+;;; ------------------------------------------------------------------
+;;; The contrast: car and map never had a fast path to bake in, and stay
+;;; correct in the identical shape (their calls always resolved by name).
+;;; ------------------------------------------------------------------
+
+(define (nt-car) (let ((v (car (list 1 2)))) v))
+(define (nt-map) (let ((v (map (lambda (x) x) (list 1 2)))) v))
+(define (car xs) 'user-car)
+(define (map f xs) 'user-map)
+(test-eq "car: control — always honoured" 'user-car (nt-car))
+(test-eq "map: control — always honoured" 'user-map (nt-map))
+
+;;; ------------------------------------------------------------------
+;;; #2033's original order (define BEFORE the caller) keeps working — the
+;;; unit scan only ever declines more; the by-name route resolves the user's
+;;; binding the same way the live-global read did.
+;;; ------------------------------------------------------------------
+
+(define (call-with-values p c) 'user-cwv-first)
+(define (cwv-first) (call-with-values (lambda () 1) (lambda (x) x)))
+(test-eq "call-with-values: define-first order still honoured"
+  'user-cwv-first (cwv-first))
+(define call-with-values saved-2457-orig-cwv)
+
+;;; ------------------------------------------------------------------
+;;; A redefinition to a non-procedure must not run the builtin either: the
+;;; declined path is an ordinary by-name call and reports the type error.
+;;; ------------------------------------------------------------------
+
+(define (t-apply-nonproc) (apply + (list 1 2)))
+(define apply 42)
+(test-assert "apply: redefined to a non-procedure raises, not the builtin"
+  (guard (e (#t (error-object? e))) (t-apply-nonproc)))
+(define apply saved-2457-orig-apply)
+(test-eq "apply: genuine binding restored after the non-procedure test"
+  3 (t-apply-nonproc))
+
+(set! %test-fail-count (test-runner-fail-count (test-runner-current)))
+(test-end "top-level-redefinition-order-2457")
+(if (> %test-fail-count 0) (exit 1))

--- a/tests/scheme/continuations/callcc-correctness.scm
+++ b/tests/scheme/continuations/callcc-correctness.scm
@@ -49,6 +49,23 @@
 (test-equal "dynamic-wind ordering" '(before during after)
   (reverse trace))
 
+;; 6. The tail_call_cc opcode checks its receiver's arity — pinned so a fix
+;;    like #2034 never has to guess which half was already right. The receiver
+;;    must sit in genuine tail position, so each call is wrapped from outside.
+;;    (Lives here since #2457, not in the primitives_control audit: that file
+;;    redefines call/cc at top level, which now declines the superinstruction
+;;    for its whole compilation unit.)
+(define-syntax raised-msg-cc
+  (syntax-rules ()
+    ((_ e) (guard (ex (#t (if (error-object? ex) (error-object-message ex) ex)))
+             (begin e 'no-raise)))))
+(test-equal "tail_call_cc: a 2-argument receiver IS rejected in tail position"
+  "call/cc receiver: expected 1 argument, got arity 2"
+  (raised-msg-cc ((lambda () (call/cc (lambda (a b) 1))))))
+(test-equal "tail_call_cc: a 3-argument receiver IS rejected in tail position"
+  "call/cc receiver: expected 1 argument, got arity 3"
+  (raised-msg-cc ((lambda () (call/cc (lambda (a b c) 1))))))
+
 (set! %test-fail-count (test-runner-fail-count (test-runner-current)))
 (test-end "callcc-correctness")
 (if (> %test-fail-count 0) (exit 1))

--- a/tests/scheme/continuations/callcc-cwv-native-kp3000-2453.scm
+++ b/tests/scheme/continuations/callcc-cwv-native-kp3000-2453.scm
@@ -1,0 +1,87 @@
+;; kaappi#2453 part 1: a continuation captured inside call-with-values'
+;; PRODUCER, resumed after the form returned, must report
+;; "continuation cannot resume across a returned native call" (KP3000) on
+;; every path that still drives the producer from a native frame — not a
+;; misleading `apply: last argument must be a list` blaming an operand the
+;; user never wrote.
+;;
+;; This file exercises the NATIVE call-with-values: the by-name route the
+;; form takes when the compiler's fast-path gate has declined, which is what
+;; a top-level redefinition that is later RESTORED to the genuine binding
+;; produces. The redefinition is compiled before the use (so the gate
+;; declines and the use becomes an ordinary by-name call), and the restore
+;; runs before the use executes (so the name resolves to the native again):
+;;
+;;   (define (call-with-values p c) ...)   ; gate declines from here on
+;;   (define (go) (call-with-values ...))  ; compiled by-name
+;;   (define call-with-values saved)       ; genuine native restored
+;;   (go)                                  ; native drives the producer
+;;
+;; The superinstruction lowering's own producer no longer runs under a
+;; native frame at all (part 2, and #2451 before it for the consumer); that
+;; half is covered by callcc-cwv-producer-reentry-2453.scm.
+;;
+;; Before this fix the producer's frame was pushed by callThunk with
+;; returns_to_native = false, so the late resume fell through the KP3000
+;; check and delivered the producer's value into a stale register of the
+;; enclosing bytecode frame — surfacing as KP3002 from an apply the user
+;; never wrote (or worse). callThunkReturningToNative marks the frame, and
+;; the resume now raises the honest error every other returned-native-call
+;; resume raises.
+
+(import (scheme base) (scheme write) (srfi 64))
+
+(define %test-fail-count 0)
+(test-begin "callcc-cwv-native-kp3000-2453")
+
+(define saved-2453-orig-cwv call-with-values)
+
+;; The shared state the producer mutates across resumes.
+(define saved-2453-k #f)
+(define n-2453 0)
+(define (p-2453)
+  (call/cc (lambda (k) (set! saved-2453-k k)))
+  (set! n-2453 (+ n-2453 1))
+  1)
+
+;; Decline the fast path by redefining first, compile the users by-name,
+;; then restore the genuine binding so the by-name call reaches the native.
+(define (call-with-values p c) 'user)
+(define (go-2453)
+  (call-with-values p-2453 (lambda (x) x)) 'done)          ; non-tail
+(define (go-2453-tail)
+  (call-with-values p-2453 (lambda (x) x)))                ; tail
+(define call-with-values saved-2453-orig-cwv)
+
+;; The guard must enclose the CAPTURE, not just the resume: invoking the
+;; continuation restores the handler stack as of capture time, so a guard
+;; entered after (go) returned is not on the restored stack and cannot see
+;; the error the resumed producer's return raises.
+(define (drive-2453 go-thunk)
+  (set! n-2453 0)
+  (guard (e ((error-object? e) (error-object-message e))
+            (#t 'not-an-error-object))
+    (go-thunk)
+    (saved-2453-k 'again)
+    'no-error))
+
+;; Non-tail: the producer ran under the native's frame; resuming after the
+;; form returned must raise the accurate KP3000 diagnostic.
+(test-equal "non-tail: resumed producer reports the returned-native diagnostic"
+  "continuation cannot resume across a returned native call"
+  (drive-2453 go-2453))
+
+;; Tail position: same native producer driving, same diagnostic.
+(test-equal "tail: resumed producer reports the returned-native diagnostic"
+  "continuation cannot resume across a returned native call"
+  (drive-2453 go-2453-tail))
+
+;; The diagnostic must not be the misleading apply type error the bug
+;; produced (the message names neither apply nor a list operand).
+(test-equal "genuine binding restored: ordinary call-with-values works again"
+  '(1 2)
+  (call-with-values (lambda () (values 1 2)) list))
+
+(set! %test-fail-count (test-runner-fail-count (test-runner-current)))
+(test-end "callcc-cwv-native-kp3000-2453")
+(if (> %test-fail-count 0) (exit 1))

--- a/tests/scheme/continuations/callcc-cwv-producer-reentry-2453.scm
+++ b/tests/scheme/continuations/callcc-cwv-producer-reentry-2453.scm
@@ -1,0 +1,103 @@
+;; kaappi#2453 part 2: a continuation captured inside call-with-values'
+;; PRODUCER must be resumable after that call has returned, in both positions.
+;;
+;; #2451 moved the form's CONSUMER into the dispatch loop (the apply/tail_apply
+;; the lowering emits); the producer kept running under the native
+;; `%call-with-values->list` frame, so resuming a continuation captured inside
+;; it raised KP3000 at best (part 1 made the diagnostic honest) — and before
+;; that misfired as `apply: last argument must be a list`.
+;;
+;; The producer is now called with an ordinary `call` opcode: its frame is a
+;; VM frame in the caller's bytecode, copied by continuation capture and
+;; restored by resume exactly like any other. A new `values_list` opcode
+;; spreads the produced value(s) into the argument list the consumer is
+;; applied over, so a resume re-runs that spread and the consumer with the
+;; newly produced values.
+;;
+;; The native path (a declined fast path routing to the built-in
+;; call-with-values) keeps the returned-native-call restriction and its honest
+;; KP3000; that half is covered by callcc-cwv-native-kp3000-2453.scm.
+
+(import (scheme base) (scheme write) (srfi 64))
+
+(define %test-fail-count 0)
+(test-begin "callcc-cwv-producer-reentry-2453")
+
+;; Calls `driver` with a producer that captures a continuation on every entry,
+;; then re-invokes that continuation until the producer has run three times.
+;; Returns the final count: 3 when the capture is resumable past the form's
+;; return, 1 (or an error) when it is not.
+(define (reentry-count driver produce)
+  (let ((saved #f) (n 0))
+    (define (p)
+      (call/cc (lambda (k) (set! saved k)))
+      (set! n (+ n 1))
+      (produce))
+    (driver p)
+    (if (< n 3) (saved 'again) n)))
+
+(test-eqv "non-tail: producer re-entry past the form's return"
+  3 (reentry-count (lambda (p) (call-with-values p (lambda (x) x)) 'done)
+                   (lambda () 1)))
+
+(test-eqv "tail: producer re-entry past the form's return"
+  3 (reentry-count (lambda (p) (call-with-values p (lambda (x) x)))
+                   (lambda () 1)))
+
+(test-eqv "producer re-entry with several values"
+  3 (reentry-count (lambda (p) (call-with-values p (lambda (a b) (+ a b))) 'done)
+                   (lambda () (values 1 2))))
+
+(test-eqv "producer re-entry with no values"
+  3 (reentry-count (lambda (p) (call-with-values p (lambda () 'any)) 'done)
+                   (lambda () (values))))
+
+;; A resume must re-run the spread and the consumer with the NEWLY produced
+;; values, not replay the first pass's: the producer below returns how many
+;; values it has produced so far, and the consumer records each one.
+(let ((saved #f) (total '()))
+  (define (p)
+    (call/cc (lambda (k) (set! saved k)))
+    (length total))
+  (define (consume x) (set! total (append total (list x))))
+  (call-with-values p consume)
+  (if (< (length total) 3) (saved 'again) #f)
+  (test-equal "resume re-spreads the newly produced values"
+    '(0 1 2) total))
+
+;; --- the ordinary semantics the lowering must not disturb ------------------
+
+(test-eqv "call-with-values passes a single value" 84
+  (call-with-values (lambda () 42) (lambda (x) (* x 2))))
+
+(test-eqv "call-with-values passes several values" 6
+  (call-with-values (lambda () (values 1 2 3)) +))
+
+(test-eq "call-with-values with no values calls the consumer with none" 'none
+  (call-with-values (lambda () (values)) (lambda () 'none)))
+
+(let ((producer-ran #f))
+  (test-equal "a non-procedure consumer names call-with-values, and the producer body never runs"
+    "type error in 'call-with-values': expected procedure, got 5"
+    (guard (e ((error-object? e) (error-object-message e)) (#t 'not-an-error))
+      (+ 0 (call-with-values (lambda () (set! producer-ran #t) 1) 5))))
+  (test-eq "the producer was not invoked before the consumer was rejected" #f producer-ran))
+
+(test-equal "a non-procedure producer names call-with-values"
+  "type error in 'call-with-values': expected procedure, got 5"
+  (guard (e ((error-object? e) (error-object-message e)) (#t 'not-an-error))
+    (+ 0 (call-with-values 5 (lambda (x) x)))))
+
+(test-equal "with both operands bad, the producer is reported first"
+  "type error in 'call-with-values': expected procedure, got 7"
+  (guard (e ((error-object? e) (error-object-message e)) (#t 'not-an-error))
+    (+ 0 (call-with-values 7 5))))
+
+(test-equal "a bad consumer arity is the consumer's arity error"
+  "expected 2 arguments, got 1"
+  (guard (e ((error-object? e) (error-object-message e)) (#t 'not-an-error))
+    (+ 0 (call-with-values (lambda () 1) (lambda (a b) a)))))
+
+(set! %test-fail-count (test-runner-fail-count (test-runner-current)))
+(test-end "callcc-cwv-producer-reentry-2453")
+(if (> %test-fail-count 0) (exit 1))

--- a/tests/scheme/continuations/callcc-native-driver-reentry-2451.scm
+++ b/tests/scheme/continuations/callcc-native-driver-reentry-2451.scm
@@ -105,21 +105,12 @@
     (call-with-values (lambda () 1) (lambda (x) x))))
 
 ;; ...and when the rebinding is an earlier child of the SAME top-level `begin`.
-;; The gate reads the live global environment rather than a set!-target list,
-;; so it needs the definition to have run by the time the use is compiled; a
-;; top-level `begin`'s children are compiled and executed one at a time, which
-;; is what makes that hold. (A body compiled BEFORE a later top-level
-;; redefinition does keep the builtin — the same compile-time property the
-;; constant folder has for `+`, and unchanged by #2451.)
-(test-eq "a define earlier in the same begin beats the apply opcode" 'mine
-  (begin
-    (define (apply f xs) 'mine)
-    (let ((v (apply + (list 1 2)))) v)))
-
-(test-eq "a define earlier in the same begin beats the call-with-values lowering" 'mine
-  (begin
-    (define (call-with-values p c) 'mine)
-    (let ((v (call-with-values (lambda () 1) (lambda (x) x)))) v)))
+;; Those two cases live in tests/scheme/compliance/top-level-redefinition-2033.scm
+;; since #2457: a top-level define of one of these names anywhere in a
+;; compilation unit now declines the superinstruction for the WHOLE unit, so
+;; keeping them here would route this file's re-entry tests through the native
+;; by-name path and conflate the two assertions (the opcode's re-entry
+;; guarantee with the gate's resolution rules).
 
 ;; Diagnostics: non-tail apply reports through the native applyFn's texts,
 ;; which the LLVM backend also produces (tests/scheme/compile/


### PR DESCRIPTION
## What

One PR for both issues because they edit the same lowering seam: #2453 rewrites the emission `compiler_passthrough.compileCallWithValuesForm` produces, and #2457 changes the compile-time gate (`globalBindingStillGenuine`) that decides whether that emission (and its four sibling fast paths) is used at all.

Closes #2457
Closes #2453

Three commits, matching #2453's own "separable and in this order":

1. **KP3000 diagnostic (#2453 part 1).** A continuation captured in `call-with-values`' producer, resumed after the form returned, misfired as `error[KP3002]: apply: last argument must be a list` — the producer's frame was pushed by `callThunk` with `returns_to_native = false`, so its late return fell through the dispatch loop's `raiseDeadNativeReturn` check and delivered into a stale register the following apply then misread. New `callThunkReturningToNative` marks the frame (the same marker `callWithArgs`-driven natives already use), so every route that still drives the producer natively raises the honest, catchable KP3000 instead. The repro goes KP3002 → KP3000.
2. **The lowering (#2453 part 2).** The producer is now called with an ordinary `call` opcode — its frame is a VM frame in the caller's bytecode, copied by capture and restored by resume — then a new `values_list` opcode (appended last in the enum per the `.sbc` numbering constraint; count gate and the four quoting docs updated to 33) spreads the produced value(s) into the argument list the existing `apply`/`tail_apply` consumes. A resume re-runs the spread and the consumer with the newly produced values. Diagnostic parity is kept by a new `%call-with-values-check` primitive called first: both operands type-checked producer-first, before anything runs, with `callWithValuesFn`'s exact texts. `%call-with-values->list` is deleted (nothing emits it). The repro now prints `ok` — the conformant outcome, in both positions.
3. **The gate (#2457, the issue's interim option).** Established first, per the issue's caveat: the #2033 gate is the *only* interpreter-tier decision that bakes the five names in — its decline path resolves by name at run time (`isContinuationBarrier` routes these names away from `call_global` toward the same by-name `get_global` + `call`, and neither constant folder folds them), and pre-#2452 the same gate decided the in-body non-tail path, which is why the issue's A/B was clean. The native tier has a second, independent gate: `emitApplyForm`'s `rebound_globals`/`native_fns` are populated in emission order, so it had the same use-before-define hole for the one name it lowers structurally. The interim: drivers with whole-unit knowledge (file runs cold and `.sbc`-HIT replay, stdin scripts, `kaappi compile`'s `.sbc` pass, `kaappi check` — and the native backend, whose `compileNative` installs the scan and whose `emitApplyForm` consults it) pre-scan the unit's top-level `define`/`define-values`/`set!` targets through `begin`/`cond-expand` splices, and the gate declines for those names everywhere in the unit. The run-time-decision redesign stays the recorded follow-up; the REPL, `eval`, and macro-materialized redefinitions deliberately keep the legacy compile-time answer. Every spine the scan walks is a guarded `SpineWalk` (a cyclic `(begin . #0=(1 . #0#))` must reach the run loop's KP2001 diagnosis, not spin in the pre-scan).

## Tests

- `tests/scheme/continuations/callcc-cwv-native-kp3000-2453.scm` — native-route producer resume reports KP3000, tail and non-tail (the guard encloses the capture: a resume restores the capture-time handler stack).
- `tests/scheme/continuations/callcc-cwv-producer-reentry-2453.scm` — producer re-entry past the form's return in both positions, several/no values, a resume re-spreading newly produced values, ordinary semantics, and the three diagnostic shapes (bad consumer before the producer body runs, bad producer, both-bad producer-first, consumer arity).
- `tests/scheme/compliance/top-level-redefinition-order-2457.scm` — all five #2033 names, tail and non-tail, use-compiled-before-define plus the define-first control, later `set!`, `begin`-spliced redefinition, non-procedure redefinition, `car`/`map` contrast.
- `tests/scheme/compile/native-apply-redefinition-order-2457.sh` — the compiled binary agrees with the interpreter for both orders, and a clean program keeps its native `@kaappi_apply` site with zero eval fallbacks (#1803's convergence guarantee).
- Zig: a collector unit test (all define shapes, splices, define-values formals, and non-captures).

Three existing tests moved, each because a unit-wide define of these names now declines the superinstruction for the whole file, which would conflate what they pin with the gate's resolution rules: the begin-sibling-define pair from `callcc-native-driver-reentry-2451.scm` to `top-level-redefinition-2033.scm`, and the two `tail_call_cc` receiver-arity pins from the `primitives_control` audit to `callcc-correctness.scm`. README's Known limitations drops the producer corner (#2452 had named it).

## Evidence

- `zig build test`: 1990/2011 pass, 21 skip, 0 fail; under `-Dgc-stress=true`: 1995/2011, 16 skip, 0 fail.
- `bash tests/scheme/run-all.sh`: **2140 pass, 0 fail** (745 Scheme files + the 1395-test R7RS suite), including `native-apply-lowering-1803.sh` and `native-apply-lexical-scope-1799.sh`.
- Both issue repros verified against the final build, on cold runs and `.sbc` cache-HIT replays: #2457 prints `(user-apply user-apply user-cwv user-cwv user-car user-map)`, #2453 prints `ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
