### PR TITLE
Detach SRFI-18 OS threads and back off in cross-thread waits (#2446)

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -75,6 +75,7 @@ investigations.
 | [deep-recursion-register-overflow](postmortems/2026-06-17-deep-recursion-register-overflow.md) | Fixed-capacity register file overflowed under deep non-tail recursion | Fixed 2026-06-30 |
 | [fixnum-overflow-promotion](postmortems/2026-06-18-fixnum-overflow-promotion.md) | Arithmetic results in the fixnum/i64 gap silently wrapped | Fixed 2026-06-18 |
 | [complex-number-test-precision](postmortems/2026-06-18-complex-number-test-precision.md) | `test-approx=?` didn't compare complex numbers component-wise | Fixed 2026-06-18 |
+| [netbsd-spinlock-starvation](postmortems/2026-09-02-netbsd-spinlock-starvation.md) | Pure spin-waits starved a preempted lock holder under NetBSD's 4BSD scheduler; misdiagnosed as an OS stranding the thread | Fixed 2026-09-02 |
 
 ## Reference notes
 

--- a/docs/dev/fibers-and-reactor.md
+++ b/docs/dev/fibers-and-reactor.md
@@ -108,7 +108,10 @@ Five things load-bearing enough to be worth knowing before touching this:
   `platform.spinBackoff`: a short pure spin, then `sched_yield`, then
   `nanosleep` doubling from 32 µs to 1 ms — and that includes the registry
   lock itself (`memory.spinLock`), the stop-the-world handshake on both sides
-  (`VM.stopForCollection`, `markLiveChildRoots`) and the globals RW lock. A
+  (`VM.stopForCollection`, `markLiveChildRoots`), the globals RW lock, and
+  `thread-join!`'s wait for a detached OS thread's exit flag (`reapOsThread`,
+  which replaced `pthread_join` — the joining LWP would otherwise inherit the
+  dead thread's CPU-usage estimate on NetBSD). A
   pure spin only works while the thread being waited for is *running*; once
   the kernel preempts it, the spinners compete with it for CPU, and on a
   priority-decay scheduler they win outright. That was kaappi#2446: on

--- a/docs/dev/fibers-and-reactor.md
+++ b/docs/dev/fibers-and-reactor.md
@@ -67,7 +67,7 @@ of these waits instead re-checked their own state every millisecond
 (`sleepNs(CROSS_THREAD_POLL_NS)` and the `pollCapNs` caps), which is why a
 `(thread-sleep! 60)` on a child thread used to wake 60,000 times.
 
-Four things load-bearing enough to be worth knowing before touching this:
+Five things load-bearing enough to be worth knowing before touching this:
 
 - **Enrolment is unconditional, and must stay that way.** Gating it on
   `crossThreadWaitPossible()` at entry looks like an obvious saving and is a
@@ -104,6 +104,22 @@ Four things load-bearing enough to be worth knowing before touching this:
   An atomic length gate read outside the lock is a store-buffering pattern
   against the enroller — both sides can miss the other's store — and with no
   poll cap left as a backstop that is a hang, not a latency blip.
+- **Every wait on another OS thread backs off to a sleep** —
+  `platform.spinBackoff`: a short pure spin, then `sched_yield`, then
+  `nanosleep` doubling from 32 µs to 1 ms — and that includes the registry
+  lock itself (`memory.spinLock`), the stop-the-world handshake on both sides
+  (`VM.stopForCollection`, `markLiveChildRoots`) and the globals RW lock. A
+  pure spin only works while the thread being waited for is *running*; once
+  the kernel preempts it, the spinners compete with it for CPU, and on a
+  priority-decay scheduler they win outright. That was kaappi#2446: on
+  NetBSD's 4BSD scheduler, 17 threads leaving `thread-sleep!` spun on the
+  registry lock at priority 25–27 while the holder — preempted inside the
+  `kevent` ring, at priority 0 after the work it had done — stayed runnable
+  and never ran again. Yielding does not help (it requeues behind LWPs of the
+  *same* priority); only a sleep takes the spinner off the run queue. The
+  holder's ring is still issued under the lock (one `notify()` per parked
+  thread); with the backoff that costs the ringed threads latency, never
+  liveness.
 
 A "never" deadline is a real one and reaches the backends: SRFI-18 reads
 `+inf.0` as "never times out", `saturatedNsFromSeconds` turns that into

--- a/docs/dev/lessons-learned.md
+++ b/docs/dev/lessons-learned.md
@@ -199,3 +199,11 @@ Full write-up: [postmortems/2026-06-17-deep-recursion-register-overflow.md](post
 **Lesson:** Approximate comparison must recurse into compound numeric types (component-wise for complex); when a conformance test fails, suspect the comparison machinery as well as the implementation.
 
 Full write-up: [postmortems/2026-06-18-complex-number-test-precision.md](postmortems/2026-06-18-complex-number-test-precision.md).
+
+## 15. A pure spin-wait is a bet on the scheduler
+
+**Symptom:** `thread-join!` hung intermittently on NetBSD and nowhere else (kaappi#2446). gdb showed a child thread with a frozen PC and no syscall, and the first diagnosis was that the OS never scheduled it — `blocked-upstream`. The kernel's per-LWP view (`ps -s`) showed the opposite: 17 threads spinning in `memory.spinLock` at priority 25–27 while the preempted lock holder sat runnable at priority 0, never chosen again by NetBSD's 4BSD scheduler.
+
+**Lesson:** A spin loop assumes the thread it waits for is running or will be run promptly. Fair schedulers (Linux, macOS) make that true; priority-decay schedulers do not, and the spinners starve the holder. Every wait on another OS thread goes through `platform.spinBackoff`, which sleeps after a bounded spin and yield. Underneath, a second NetBSD quirk made the starvation absolute: `pthread_join` transfers the dead LWP's CPU-usage estimate to the joiner uncapped, sinking it and all its future children to priority 0 — so SRFI-18 threads are detached at spawn and joined through an exit flag. And a frozen PC in gdb says nothing about *why* a thread is not running — get the scheduler's state before blaming the scheduler.
+
+Full write-up: [postmortems/2026-09-02-netbsd-spinlock-starvation.md](postmortems/2026-09-02-netbsd-spinlock-starvation.md).

--- a/docs/dev/netbsd.md
+++ b/docs/dev/netbsd.md
@@ -123,8 +123,11 @@ the call is a comptime no-op there and everywhere else.
 ## Scheduler: a preempted lock holder starves under a pure spin
 
 NetBSD's default scheduler is 4BSD (`sys/kern/sched_4bsd.c`): a user LWP's
-priority is `63 − estcpu/2048`, `estcpu` grows by 1024 on every clock tick
-the LWP is running and decays only slowly (90% in `5 × loadavg` seconds),
+priority is `63 − estcpu/2048 − p_nice` (`p_nice` is the nice value offset by
+20, so 20 for an ordinary process), `estcpu` grows by 1024 on every clock
+tick the LWP is running, is clamped at `18 × 2048` by that per-tick path —
+so running alone floors a nice-0 thread at 25 — and decays only slowly
+(90% in `5 × loadavg` seconds),
 and a new LWP **inherits its spawner's `estcpu`**. Each CPU always runs the
 highest-priority runnable LWP, and `sched_yield` requeues an LWP behind the
 others *of its own priority* — never behind a lower one.

--- a/docs/dev/netbsd.md
+++ b/docs/dev/netbsd.md
@@ -120,6 +120,65 @@ the call is a comptime no-op there and everywhere else.
   is a test-harness concern only — the interpreter itself runs fine in the
   default limits.
 
+## Scheduler: a preempted lock holder starves under a pure spin
+
+NetBSD's default scheduler is 4BSD (`sys/kern/sched_4bsd.c`): a user LWP's
+priority is `63 − estcpu/2048`, `estcpu` grows by 1024 on every clock tick
+the LWP is running and decays only slowly (90% in `5 × loadavg` seconds),
+and a new LWP **inherits its spawner's `estcpu`**. Each CPU always runs the
+highest-priority runnable LWP, and `sched_yield` requeues an LWP behind the
+others *of its own priority* — never behind a lower one.
+
+That combination turns any userspace pure spin into a hang under CPU
+contention (kaappi#2446): a thread that has been doing real work sits at
+priority 0; the moment the kernel preempts it while it holds a lock — say,
+inside the `kevent` ring `wakeCrossThreadWaiters` issues per parked thread —
+every thread that then arrives at that lock spins at a *higher* priority
+(fresh from a sleep, or a new LWP whose spawner had been idle), and with
+more spinners than CPUs the holder is never scheduled again. Observed as
+`srfi18-join-spawn-grandchild-2129.scm` running until killed at ~290% CPU:
+17 LWPs in `memory.spinLock` from `withdrawCrossThreadWaiter`, one LWP
+runnable (`R`, no wchan) at priority 0 inside `_sys___kevent50`. Linux CFS
+and macOS never reproduce it — a fair scheduler always gives the holder its
+share, so the same spin is a latency cost there, not a liveness one.
+
+Two kaappi-side rules follow, both of which hold everywhere but were only
+ever *needed* here:
+
+* **Never `pthread_join` a `thread-start!`ed thread.** `_lwp_wait` makes the
+  joining LWP absorb the dead LWP's `estcpu` with no cap
+  (`sched_lwp_collect` lacks the `ESTCPULIM` every other path applies), and
+  `sched_lwp_fork` copies the estimate into every LWP the joiner creates. A
+  nice-0 thread cannot get below priority 25 by running, but three joins of
+  busy threads put the joiner — and all its future children — at 0, below
+  every ordinary process, where CPU contention starves them outright. SRFI-18
+  threads are therefore detached at spawn and joined through a per-spawn
+  exit flag (`Fiber.os_exit`, raised after the child's outermost defer).
+* **Every cross-thread wait loop goes through `platform.spinBackoff`** (spin,
+  then yield, then sleep 32 µs doubling to 1 ms): `memory.spinLock`, the GC
+  stop-the-world handshake on both sides, the globals RW lock and the reap
+  wait above. A sleep is what a yield is not — it takes the waiter off the
+  run queue, so a preempted holder at the same priority gets its turn. A
+  bare `spinLoopHint` loop reintroduces the convoy on this platform.
+
+**Diagnosing a hang here.** gdb alone misleads: a starved LWP shows a frozen
+PC and no syscall, which reads as "the OS never scheduled this thread" (the
+original diagnosis of kaappi#2446). The kernel-side view is what settles
+it — per-LWP state, wait channel, priority and whether the process's CPU
+time is still climbing:
+
+```bash
+ps -s -o pid,lid,lstate,wchan,cpuid,pri,time,pcpu -p <pid>   # twice, a few seconds apart
+gdb -batch -p <pid> -ex 'info threads' -ex 'thread apply all bt 8'
+```
+
+`R` with no wchan and `pri 0` while other LWPs sit at 25+ and `TIME` grows by
+seconds per second is starvation by spinners; `S` with a wchan is a kernel
+sleep; a lone `R` LWP in an otherwise idle process would be the scheduler's
+fault. Measure under load (`sh -c 'while :; do :; done' &` × ncpu) — the
+hang needs more runnable LWPs than CPUs — and kill the burners by PID
+afterwards; orphaned ones poison every later measurement.
+
 ## Self-exe path
 
 NetBSD has `KERN_PROC_PATHNAME`, but filed under the `KERN_PROC_ARGS`

--- a/docs/dev/netbsd.md
+++ b/docs/dev/netbsd.md
@@ -154,6 +154,9 @@ ever *needed* here:
   every ordinary process, where CPU contention starves them outright. SRFI-18
   threads are therefore detached at spawn and joined through a per-spawn
   exit flag (`Fiber.os_exit`, raised after the child's outermost defer).
+  Upstream fixed the cap in trunk (`sched_4bsd.c` 1.48, 2026-03-01) and
+  netbsd-11, not netbsd-10 — so the rule stands for as long as 10.x is a
+  supported target (kaappi#2471 tracks the pull-up).
 * **Every cross-thread wait loop goes through `platform.spinBackoff`** (spin,
   then yield, then sleep 32 µs doubling to 1 ms): `memory.spinLock`, the GC
   stop-the-world handshake on both sides, the globals RW lock and the reap

--- a/docs/dev/postmortems/2026-09-02-netbsd-spinlock-starvation.md
+++ b/docs/dev/postmortems/2026-09-02-netbsd-spinlock-starvation.md
@@ -1,0 +1,219 @@
+# NetBSD: `thread-join!` hangs — uncapped priority inheritance through `pthread_join`, amplified by pure spin locks
+
+## Status
+
+**Fixed** (2026-09-02, kaappi#2446), in two parts. (1) SRFI-18 OS threads
+are detached at spawn and `thread-join!` waits on a per-spawn exit flag
+instead of `pthread_join`, because on NetBSD the joining LWP absorbs a
+reaped LWP's CPU-usage estimate with no cap and sinks, with every thread it
+spawns afterwards, to the lowest user priority. (2) `platform.spinBackoff`
+(spin, then yield, then sleep 32 µs doubling to 1 ms) replaces every pure
+spin in a cross-thread wait: `memory.spinLock`, `VM.stopForCollection`,
+`markLiveChildRoots`'s wait for children to stop, and `GlobalsRwLock`.
+Regression tests in `tests_srfi18.zig`: "contenders on a held spin lock
+sleep instead of burning CPU" and "thread-join! returns only after the
+child's whole epilogue". Measurements on the NetBSD 10.1 aarch64 reference
+VM under 4-CPU load are in "The fix" below.
+
+## Symptom
+
+`tests/scheme/srfi/srfi18-join-spawn-grandchild-2129.scm` — sub-second when
+it passes — intermittently ran until killed on NetBSD 10.1 aarch64, and once
+in the x86_64 `netbsd-test` CI job. Never on macOS, Linux, FreeBSD or
+OpenBSD. The rate was load-sensitive: 0/10 on an idle box, 5–9 out of 10
+with four CPU-burner shells running alongside.
+
+## The wrong diagnosis, and why it was convincing
+
+The first investigation attached gdb to hung processes and found a child
+LWP whose PC never moved — parked at `pthread__create_tramp+0`, or frozen
+mid-`threadEntryFn` with no syscall in progress — while the joiner sat in
+`pthread_join`. Instrumentation showed every other thread's lifecycle
+completing cleanly. The conclusion was that NetBSD (or the UTM/aarch64
+virtualization layer) strands a freshly created LWP and never schedules it
+again: an OS defect, `blocked-upstream`, with three kaappi-side mitigations
+(a spawn-start handshake with retry, ringing waiters outside the registry
+lock, a self-pipe notifier) that halved the rate but could not reach zero.
+
+Every observation in that account was real. The inference was wrong because
+gdb shows only the *userspace* view: a thread that is runnable but never
+scheduled and a thread the OS has lost look identical from there — frozen
+PC, no syscall. What gdb cannot show is *why* the kernel isn't running it.
+
+## What the kernel-side view showed
+
+`ps -s` lists every LWP with its scheduler state, wait channel, CPU and
+priority. Two samples five seconds apart on a hung process:
+
+```text
+ PID   LID STAT WCHAN   CPUID PRI    TIME %CPU
+3808 13115 R    -           0  26 2:04.32  290
+3808 28593 S    nanoslp     1  64 2:04.32  290
+3808 26365 I    lwpwait     0  64 2:04.32  290
+3808 12010 O    -           2  25 2:04.32  290
+3808 20262 R    -           0   0 2:04.32  290
+3808 18430 R    -           0   0 2:04.32  290     <- kevent, holds the lock
+3808  3455 R    -           0  26 2:04.32  290
+   ... 13 more R/O LWPs at PRI 25-27 ...
+3808  3808 I    lwpwait     2  85 2:04.32  290
+--- +5s ---                                2:20.20  291
+```
+
+Not one stranded thread: **23 LWPs, 18 of them runnable, the process
+burning three CPUs' worth of time every five seconds**. gdb then named the
+spinners — 17 threads in
+
+```text
+memory.spinLock () at memory.zig:97
+reactor.withdrawCrossThreadWaiter () at reactor.zig:278
+fiber_wait.CrossThreadEnrolment.release () at fiber_wait.zig:236
+primitives_srfi18.threadSleepFn () at primitives_srfi18.zig:1104
+```
+
+— grandchildren leaving their `(thread-sleep! 0.3)`, each withdrawing from
+the cross-thread wait registry, all spinning on its lock. The holder was LID
+18430: runnable (`R`, no wait channel), inside `_sys___kevent50` — that is
+`wakeCrossThreadWaiters` ringing every parked thread under the lock — and at
+**priority 0**, the lowest a user LWP can have, while every spinner sat at
+25–27. The kernel had preempted it mid-ring and, with 17 spinners and 4
+burners competing for 4 CPUs, never picked it again. The test's 12-iteration
+loop spawns a middle that returns without joining its grandchild, so a dozen
+sleeping grandchildren accumulate and all wake within the same few
+milliseconds, which is why this test and not another.
+
+## Why NetBSD and only NetBSD
+
+NetBSD's default scheduler is 4BSD (`sys/kern/sched_4bsd.c`):
+
+- A user LWP's priority is `63 − estcpu/2048`. `estcpu` grows by 1024 on
+  every clock tick the LWP is *running* and decays 90% over `5 × loadavg`
+  seconds — tens of seconds under load.
+- A new LWP inherits its spawner's `estcpu` (`sched_lwp_fork`).
+- Each CPU runs the highest-priority runnable LWP. `sched_yield` requeues
+  behind LWPs of the *same* priority, never behind a lower one.
+
+So a thread that has done real work — rung a dozen kevents, run a thunk,
+joined children — is at priority 0. Threads that just woke from a sleep, or
+were just spawned by an idle parent, are at 25+. Once the kernel preempts
+the busy thread while it holds a lock, a crowd of fresh waiters at higher
+priority spins, each spin tick keeps *their* estcpu high but the holder's
+never gets a chance to matter: it is simply never the best runnable LWP on
+any CPU. Yielding in the spin loop changes nothing, since the yielders only
+requeue behind each other. Linux CFS and macOS give every runnable thread a
+share of the CPU regardless of history, so there the same spin costs
+latency and never liveness — which is why four platforms never saw it.
+
+The earlier "child parked at `pthread__create_tramp+0`" captures are the
+same mechanism one step earlier: a new LWP inheriting a priority-0 spawner's
+`estcpu`, runnable from birth, never scheduled behind the spinning crowd.
+And the earlier mitigations helped for the same reason: retrying a spawn
+gave up on a starved LWP, and ringing outside the lock shortened the
+critical section in which the holder could be preempted. Neither removed
+the spinners.
+
+## Second round: why the backoff alone was not enough
+
+Sleeping instead of spinning took the hang from 5/8 to 0/10 in a first
+sample, then 4 of the next 8 runs hung again. Those captures had a new
+shape: the process used **no CPU at all** (`TIME` frozen), eight waiters
+asleep in the new backoff, eleven runnable at priority 0 in `sched_yield`,
+and the kevent holder runnable at priority 0. With every spinner asleep, the
+holder was still never chosen — because priority 0 is *below the floor* of
+the formula above. For a nice-0 process `pri = 63 − estcpu/2048 − 20`, and
+the per-tick accumulation clamps `estcpu` at `18 × 2048`, so the lowest a
+thread can reach by running is 25 — the same as the CPU burners. Something
+had pushed these LWPs below what running can do.
+
+The one unclamped path is `sched_lwp_collect` (`sched_4bsd.c`):
+
+```c
+/* Absorb estcpu value of collected LWP. */
+l->l_estcpu += t->l_estcpu;      /* no ESTCPULIM, unlike sched_proc_exit */
+```
+
+It runs in `lwp_wait` — that is, in `pthread_join` — on the **joining** LWP.
+The interpreter thread joins every middle thread; each arrives with a full
+`18 × 2048` after its work, and after three joins the joiner's estimate is
+past `43 × 2048`: priority 0, and decaying at ~7%/s under load it stays
+there for a long time. `sched_lwp_fork` then copies the estimate into every
+LWP the joiner creates, so each new middle thread — and, through it, each
+grandchild — is *born* at priority 0. Under contention from any ordinary
+nice-0 process (priority 25+) such an LWP gets CPU only when a burner is
+forced off by the round-robin tick, and with a dozen priority-0 siblings
+ahead of it in the queue, effectively never. That is the "child parked at
+`pthread__create_tramp+0` forever" of the first investigation, exactly.
+
+A 40-line C program pins it (`estcpu.c`, kept on the reference VM): join
+three threads that each spin for 1.5 s, then spawn a trivial child under
+four burners. The child's join took 0.8 s; with the same three threads
+*detached* instead of joined, 0 ms, as in the no-join control.
+
+Detached LWPs are freed in `lwp_exit` without `sched_lwp_collect`. Hence
+part (1) of the fix: SRFI-18 OS threads are detached the instant they are
+spawned, and `reapOsThread` waits on a per-spawn exit flag the child raises
+after its outermost defer, which covers everything `pthread_join` covered
+(the child's status is stored well before; the flag marks the end of its
+epilogue, descendant drain included).
+
+## The fix
+
+Part (2), the backoff, is still necessary: a thread that has merely done a
+lot of work sits at 25 like the burners, and a crowd spinning on its lock at
+25–27 outranks it on ties; the sleep is what ends the convoy.
+
+`platform.spinBackoff(spins)`: the first 32 iterations are a pure spin, the
+next 64 a `sched_yield`, and everything after sleeps, 32 µs doubling to a
+1 ms cap. The sleep is the part that matters: it takes the waiter *off the
+run queue*, so the preempted holder becomes the best runnable LWP and gets
+its CPU. The spin and yield phases keep the uncontended and briefly
+contended cases as fast as before — a healthy critical section under these
+locks is a few dozen instructions, and a stopped child reaches its safepoint
+in microseconds, so no sleep ever happens on a healthy machine.
+
+Used at every cross-thread wait that was a pure spin:
+
+| Site | Waits for |
+|------|-----------|
+| `memory.spinLock` | the holder of any of the 15 `std.atomic.Mutex` locks (wait registry, child registry, symbol table, channel waiter lists, …) |
+| `VM.stopForCollection` | the collecting parent to finish marking |
+| `markLiveChildRoots` (`primitives_srfi18.zig`) | each armed child to leave `.running` |
+| `GlobalsRwLock.lockShared` / `.lock` (`globals.zig`) | the writer, or readers draining |
+| `reapOsThread` (`primitives_srfi18.zig`) | the detached child's exit flag (part 1) |
+
+Measured on the NetBSD 10.1 aarch64 reference VM (4 vCPUs), 40 s bound per
+run, `srfi18-join-spawn-grandchild-2129.scm`:
+
+| build | 4 burners | 8 burners |
+|-------|-----------|-----------|
+| unmodified `main` | 5/8 hung | 4/10 hung |
+| backoff only | 0/10, then 4/8 hung | — |
+| backoff + detach | 0/20 hung (and 0/10 of `srfi18-terminate-native-wait-1982.scm`) | 0/30 hung |
+
+Not changed: `wakeCrossThreadWaiters` still rings under the lock. With
+backoff, a preempted ringer costs the waiters latency (bounded by the 1 ms
+sleep cap per probe), never liveness; moving the ring outside the lock
+would need per-entry retain/release on a path that must not allocate, and
+is a separate trade-off.
+
+## Lessons
+
+- **A frozen PC in gdb is not evidence about the scheduler.** It is
+  compatible with "the OS lost this thread", "this thread is runnable and
+  starved", and "this thread is asleep in a page fault". Only the kernel's
+  per-thread state distinguishes them. On NetBSD:
+  `ps -s -o pid,lid,lstate,wchan,cpuid,pri,time,pcpu -p <pid>`, sampled
+  twice — climbing `TIME` in a "hung" process means it is spinning, not
+  stuck. Linux: `/proc/<pid>/task/*/stat` (state, priority, utime);
+  macOS: `top -pid` thread counts plus `sample`.
+- **A userspace pure spin is a scheduler-policy bet.** It assumes the thread
+  being waited for is running, or will be run promptly. That holds on fair
+  schedulers and fails on priority-decay ones; the first priority-based
+  scheduler in the platform matrix turned a latency cost into a hang. Every
+  wait on another OS thread must be able to sleep.
+- **Blocked-upstream is a strong claim and needs the kernel's testimony.**
+  "No userspace program can produce this" should be backed by the state the
+  kernel reports for the thread, not by the absence of a syscall in a
+  userspace backtrace.
+- **Measure under load with the burners tracked by PID.** The hang needs more
+  runnable LWPs than CPUs. Orphaned burner shells from an aborted session
+  double the load and poison the next measurement.

--- a/docs/dev/postmortems/2026-09-02-netbsd-spinlock-starvation.md
+++ b/docs/dev/postmortems/2026-09-02-netbsd-spinlock-starvation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Fixed** (2026-09-02, kaappi#2446), in two parts. (1) SRFI-18 OS threads
+**Fixed** (2026-09-02, commit 96934bde via kaappi#2468, closing kaappi#2446), in two parts. (1) SRFI-18 OS threads
 are detached at spawn and `thread-join!` waits on a per-spawn exit flag
 instead of `pthread_join`, because on NetBSD the joining LWP absorbs a
 reaped LWP's CPU-usage estimate with no cap and sinks, with every thread it
@@ -54,7 +54,9 @@ priority. Two samples five seconds apart on a hung process:
 3808 20262 R    -           0   0 2:04.32  290
 3808 18430 R    -           0   0 2:04.32  290     <- kevent, holds the lock
 3808  3455 R    -           0  26 2:04.32  290
-   ... 13 more R/O LWPs at PRI 25-27 ...
+   ... 13 more R/O LWPs at PRI 25-27, one Z (an exited, unreaped
+       grandchild) and one more I/lwpwait (the interpreter thread,
+       joining a middle) elided ...
 3808  3808 I    lwpwait     2  85 2:04.32  290
 --- +5s ---                                2:20.20  291
 ```
@@ -85,7 +87,10 @@ milliseconds, which is why this test and not another.
 
 NetBSD's default scheduler is 4BSD (`sys/kern/sched_4bsd.c`):
 
-- A user LWP's priority is `63 − estcpu/2048`. `estcpu` grows by 1024 on
+- A user LWP's priority is `63 − estcpu/2048 − p_nice`, where `p_nice` is
+  the nice value offset by 20 (so 20 for an ordinary process) and the
+  per-tick accumulation clamps `estcpu` at `18 × 2048`: running alone takes a
+  nice-0 thread no lower than 25. `estcpu` grows by 1024 on
   every clock tick the LWP is *running* and decays 90% over `5 × loadavg`
   seconds — tens of seconds under load.
 - A new LWP inherits its spawner's `estcpu` (`sched_lwp_fork`).
@@ -209,8 +214,13 @@ is a separate trade-off.
   starved", and "this thread is asleep in a page fault". Only the kernel's
   per-thread state distinguishes them. On NetBSD:
   `ps -s -o pid,lid,lstate,wchan,cpuid,pri,time,pcpu -p <pid>`, sampled
-  twice — climbing `TIME` in a "hung" process means it is spinning, not
-  stuck. Linux: `/proc/<pid>/task/*/stat` (state, priority, utime);
+  twice. `TIME` there is the whole process, so climbing `TIME` alone only
+  says *something* is consuming CPU; it is the per-LWP columns that classify
+  the hang — many `R`/`O` rows with no wait channel while `TIME` climbs is a
+  spin, an `R` row that never becomes `O` is starvation, an `S` row with a
+  wait channel is a kernel sleep (and under a fair scheduler the *thread*
+  under investigation may be blocked while a sibling burns).
+  Linux: `/proc/<pid>/task/*/stat` (state, priority, utime);
   macOS: `top -pid` thread counts plus `sample`.
 - **A userspace pure spin is a scheduler-policy bet.** It assumes the thread
   being waited for is running, or will be run promptly. That holds on fair

--- a/docs/dev/postmortems/2026-09-02-netbsd-spinlock-starvation.md
+++ b/docs/dev/postmortems/2026-09-02-netbsd-spinlock-starvation.md
@@ -148,6 +148,13 @@ three threads that each spin for 1.5 s, then spawn a trivial child under
 four burners. The child's join took 0.8 s; with the same three threads
 *detached* instead of joined, 0 ms, as in the no-join control.
 
+NetBSD fixed this independently: `sys/kern/sched_4bsd.c` rev 1.48
+(2026-03-01, "honor the upper bound of l_estcpu", commit `a650477792e9`)
+adds exactly that `ESTCPULIM`, motivated by 10-second pauses in git's
+worker threads; it was pulled up to netbsd-11 (ticket #233) but **not to
+netbsd-10**, so every 10.x release — the reference VM and the CI image
+among them — still has the bug. kaappi#2471 tracks the pull-up.
+
 Detached LWPs are freed in `lwp_exit` without `sched_lwp_collect`. Hence
 part (1) of the fix: SRFI-18 OS threads are detached the instant they are
 spawned, and `reapOsThread` waits on a per-spawn exit flag the child raises

--- a/src/fiber.zig
+++ b/src/fiber.zig
@@ -38,6 +38,13 @@ pub const FiberStatus = enum(u8) {
     io_waiting,
 };
 
+/// kaappi#2446: the per-spawn exit flag an OS thread's joiner waits on in
+/// place of `pthread_join` (see `Fiber.os_exit`).
+pub const OsThreadExit = struct {
+    exited: std.atomic.Value(bool) = .init(false),
+    refs: std.atomic.Value(u32) = .init(2),
+};
+
 pub const Fiber = struct {
     header: types.Object,
     registers: []Value,
@@ -86,7 +93,23 @@ pub const Fiber = struct {
     /// them there too reproduces #1440's symptom by a different path.
     driving: bool = false,
     terminated: bool = false,
+    /// The `std.Thread` handle of a `thread-start!`ed OS thread, or null.
+    /// A **marker only** since kaappi#2446: the thread is detached the
+    /// instant it is spawned and is never joined -- see `os_exit`. Code
+    /// tests it for null to tell an OS thread from a cooperative fiber.
     os_thread: ?std.Thread = null,
+    /// kaappi#2446: how a joiner learns the OS thread has fully exited,
+    /// replacing the raw `pthread_join`. On NetBSD the joining LWP absorbs a
+    /// reaped LWP's CPU-usage estimate without a cap (`sched_lwp_collect`),
+    /// so a thread that joins a few busy threads sinks to the lowest user
+    /// priority and every thread it spawns is born there -- starved for
+    /// good behind any ordinary process under CPU contention. A detached
+    /// LWP is freed at exit without that transfer. Heap-allocated with two
+    /// references (the child releases its own as its very last action, the
+    /// joiner after observing `exited`); a never-joined thread leaks it,
+    /// exactly as its child GC/VM already leak. Never a Value: nothing for
+    /// the GC to trace.
+    os_exit: ?*OsThreadExit = null,
     /// #2129 (handle half): OS threads this fiber's thread has directly
     /// started (via `thread-start!`) whose `threadEntryFn` exit defer has
     /// not yet fired. Incremented in `threadStartImpl` before spawning,

--- a/src/globals.zig
+++ b/src/globals.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const platform = @import("platform.zig");
 const types = @import("types.zig");
 const Value = types.Value;
 
@@ -7,7 +8,10 @@ const Value = types.Value;
 /// std.Thread.RwLock; std.Io.RwLock needs an Io instance). Writer-preferring:
 /// once a writer sets its bit, new readers spin, existing readers drain, then
 /// the writer runs. Critical sections here are single hash-map operations, so
-/// spinning is bounded and short. Not reentrant — never nest acquisitions.
+/// contention is short -- but a holder the kernel preempts mid-operation is
+/// not, and waiters back off through `platform.spinBackoff` (spin, yield,
+/// then sleep) rather than spinning it into starvation (kaappi#2446). Not
+/// reentrant — never nest acquisitions.
 pub const GlobalsRwLock = struct {
     /// Bit 31 = writer holds/wants the lock; low 31 bits = active readers.
     state: std.atomic.Value(u32) = .init(0),
@@ -15,12 +19,13 @@ pub const GlobalsRwLock = struct {
     const WRITER: u32 = 0x8000_0000;
 
     pub fn lockShared(self: *GlobalsRwLock) void {
-        while (true) {
+        var spins: u32 = 0;
+        while (true) : (spins +|= 1) {
             const s = self.state.load(.monotonic);
             if (s & WRITER == 0) {
                 if (self.state.cmpxchgWeak(s, s + 1, .acquire, .monotonic) == null) return;
             }
-            std.atomic.spinLoopHint();
+            platform.spinBackoff(spins);
         }
     }
 
@@ -29,14 +34,16 @@ pub const GlobalsRwLock = struct {
     }
 
     pub fn lock(self: *GlobalsRwLock) void {
-        while (true) {
+        var spins: u32 = 0;
+        while (true) : (spins +|= 1) {
             const s = self.state.load(.monotonic);
             if (s & WRITER == 0) {
                 if (self.state.cmpxchgWeak(s, s | WRITER, .acquire, .monotonic) == null) break;
             }
-            std.atomic.spinLoopHint();
+            platform.spinBackoff(spins);
         }
-        while (self.state.load(.acquire) != WRITER) std.atomic.spinLoopHint();
+        var drain_spins: u32 = 0;
+        while (self.state.load(.acquire) != WRITER) : (drain_spins +|= 1) platform.spinBackoff(drain_spins);
     }
 
     pub fn unlock(self: *GlobalsRwLock) void {

--- a/src/memory.zig
+++ b/src/memory.zig
@@ -93,8 +93,15 @@ fn nextGcId() u32 {
     }
 }
 
+/// Acquire a `std.atomic.Mutex`, backing off through `platform.spinBackoff`
+/// (spin, then yield, then sleep) while it is held. Every critical section
+/// under one of these locks is short, but "short" is not "unpreemptible":
+/// a holder the kernel has descheduled needs CPU to finish, and a crowd of
+/// pure spinners can deny it that CPU indefinitely on a priority-decay
+/// scheduler -- the NetBSD hang of kaappi#2446 (see spinBackoff).
 pub fn spinLock(m: *std.atomic.Mutex) void {
-    while (!m.tryLock()) std.atomic.spinLoopHint();
+    var spins: u32 = 0;
+    while (!m.tryLock()) : (spins +|= 1) platform.spinBackoff(spins);
 }
 pub fn spinUnlock(m: *std.atomic.Mutex) void {
     m.unlock();

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -955,6 +955,53 @@ pub fn dirIterDestroy(it: *DirIter) void {
 // sleep
 // ---------------------------------------------------------------------------
 
+/// How many iterations `spinBackoff` spends in its pure-spin phase, then in
+/// its yield phase, before it starts sleeping. `pub` so a test can drive a
+/// wait loop past both.
+pub const spin_backoff_hint_iters: u32 = 32;
+pub const spin_backoff_yield_iters: u32 = 64;
+
+/// Back off one step in a wait loop on another OS thread: `spins` is how
+/// many times the caller has already found its condition false. The first
+/// `spin_backoff_hint_iters` are a pure spin (`spinLoopHint`), the next
+/// `spin_backoff_yield_iters` a `sched_yield`, and everything after sleeps,
+/// 32 us doubling to a 1 ms cap, so a waiter that has been at it for a while
+/// leaves the run queue entirely instead of competing for CPU.
+///
+/// The sleep phase is load-bearing, not a courtesy (kaappi#2446). A pure
+/// spin is only harmless while the thread it waits for is running on
+/// another CPU; the moment the kernel preempts that thread, every spinner
+/// competes with it for CPU. Under a fair scheduler (Linux CFS, macOS) that
+/// costs latency. Under a priority-decay scheduler -- NetBSD's 4BSD, where a
+/// user LWP's priority is 63 - estcpu/2048, estcpu grows with every tick
+/// spent running, and a new LWP inherits its spawner's -- a holder that has
+/// been doing real work sits at priority 0, below a crowd of freshly woken
+/// waiters at 25-27, and the crowd runs forever: 17 threads leaving
+/// `thread-sleep!` spun in `withdrawCrossThreadWaiter`'s lock while the
+/// holder, preempted inside a `kevent` ring, stayed runnable and never ran
+/// again (srfi18-join-spawn-grandchild-2129.scm, 40+ s at 290% CPU, until
+/// killed). Yielding alone does not help there either: `sched_yield`
+/// requeues behind LWPs of the same priority, and the holder is below all of
+/// them. Only a sleep takes the spinner off the run queue and lets the
+/// holder become the best runnable LWP.
+pub fn spinBackoff(spins: u32) void {
+    if (comptime builtin.single_threaded) {
+        std.atomic.spinLoopHint();
+        return;
+    }
+    if (spins < spin_backoff_hint_iters) {
+        std.atomic.spinLoopHint();
+        return;
+    }
+    if (spins < spin_backoff_hint_iters + spin_backoff_yield_iters) {
+        std.Thread.yield() catch {};
+        return;
+    }
+    const step = spins - (spin_backoff_hint_iters + spin_backoff_yield_iters);
+    const shift: u6 = @intCast(@min(step, 5));
+    sleepNs(@as(u64, 32_000) << shift);
+}
+
 /// Blocking whole-thread sleep. The fiber layer never calls this (its
 /// sleeps go through the reactor's bounded waits); only genuinely
 /// synchronous paths do.

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -956,8 +956,8 @@ pub fn dirIterDestroy(it: *DirIter) void {
 // ---------------------------------------------------------------------------
 
 /// How many iterations `spinBackoff` spends in its pure-spin phase, then in
-/// its yield phase, before it starts sleeping. `pub` so a test can drive a
-/// wait loop past both.
+/// its yield phase, before it starts sleeping. `pub` for tests_platform.zig,
+/// which checks the phase schedule against them.
 pub const spin_backoff_hint_iters: u32 = 32;
 pub const spin_backoff_yield_iters: u32 = 64;
 

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -305,16 +305,18 @@ pub fn markLiveChildRoots(gc: *memory.GC) void {
         // Once a full pass adds no child, every live child is armed; wait for
         // each to leave `.running` (safepoint stop, park, FFI, or a raw
         // thread join). A running child reaches its next safepoint within
-        // 1024 instructions, so spin-yield rather than sleep: a fixed 1ms
-        // poll would cost ~1ms per parent collection with a live child —
-        // pathological under -Dgc-stress, where collections run per
-        // allocation.
+        // 1024 instructions, so the wait STARTS as a spin, not a sleep: a
+        // fixed 1ms poll would cost ~1ms per parent collection with a live
+        // child — pathological under -Dgc-stress, where collections run per
+        // allocation. It must not STAY a spin, though (kaappi#2446): a child
+        // the kernel has preempted needs CPU to reach that safepoint, and on
+        // a priority-decay scheduler a spinning collector outranks it for
+        // good. spinBackoff sleeps once its spin and yield phases are spent.
         if (!added) break;
         for (armed.items) |vm| {
             var spins: u32 = 0;
-            while (vm.collection_state.load(.acquire) == .running) {
-                spins +%= 1;
-                if (spins & 0xFF == 0) std.Thread.yield() catch {};
+            while (vm.collection_state.load(.acquire) == .running) : (spins +|= 1) {
+                platform.spinBackoff(spins);
             }
         }
     }
@@ -565,8 +567,8 @@ pub fn raiseError(error_type: types.ErrorObject.ErrorType, msg: []const u8, reas
 /// spawns, and a child's own `(current-thread)` is a distinct fiber that
 /// ensureScheduler allocated on the child heap. So a fiber whose `owner` is not
 /// this GC is exactly the shared-global situation behind #1484: two threads
-/// clearing the same `os_thread` and double-`thread.join()`ing it (pthread-level
-/// UB), a losing joiner reading `target.result` before the winner has stored
+/// clearing the same `os_thread` and double-reaping it (a double release of
+/// the exit flag), a losing joiner reading `target.result` before the winner has stored
 /// it, or a foreign thread-terminate! mutating another scheduler's fiber. Refuse
 /// it up front -- the same total treatment channel-send/-receive/-close!/-closed?
 /// give a foreign channel (only the `thread?` predicate is exempt, mirroring
@@ -759,9 +761,10 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
     // markRoots reads the field; the stored value is always the same
     // function pointer, but the write must not be a plain store.
     @atomicStore(?*const fn (*memory.GC) void, &root_vm.gc.child_marker, &markLiveChildRoots, .release);
-    fiber.os_thread = std.Thread.spawn(.{}, threadEntryFn, .{
-        fiber, spawner, gc.allocator, root_vm, envelope,
-    }) catch {
+    // #2446: the exit flag the join waits on instead of pthread_join (see
+    // Fiber.os_exit). Allocated before the spawn so the child can never
+    // outrun it; c_allocator because it outlives both heaps' owners.
+    const exit_flag = std.heap.c_allocator.create(fiber_mod.OsThreadExit) catch {
         _ = @atomicRmw(usize, &live_child_threads, .Sub, 1, .release);
         if (spawner) |s| {
             _ = @atomicRmw(u32, &s.live_descendants, .Sub, 1, .release);
@@ -769,11 +772,55 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
         envelope.deinit();
         return PrimitiveError.OutOfMemory;
     };
+    exit_flag.* = .{};
+    fiber.os_exit = exit_flag;
+    const thread = std.Thread.spawn(.{}, threadEntryFn, .{
+        fiber, spawner, gc.allocator, root_vm, envelope, exit_flag,
+    }) catch {
+        fiber.os_exit = null;
+        std.heap.c_allocator.destroy(exit_flag);
+        _ = @atomicRmw(usize, &live_child_threads, .Sub, 1, .release);
+        if (spawner) |s| {
+            _ = @atomicRmw(u32, &s.live_descendants, .Sub, 1, .release);
+        }
+        envelope.deinit();
+        return PrimitiveError.OutOfMemory;
+    };
+    fiber.os_thread = thread;
+    // #2446: detach at once -- nothing ever joins this thread. On NetBSD a
+    // pthread_join (`_lwp_wait`) makes the joining LWP absorb the dead LWP's
+    // CPU-usage estimate uncapped (sched_lwp_collect lacks the ESTCPULIM the
+    // per-tick and process-exit paths apply), so after a few joins of busy
+    // threads the interpreter thread sits at user priority 0 -- below every
+    // nice-0 process at 25+ -- and so does every thread it spawns from then
+    // on (sched_lwp_fork copies the estimate). Under any CPU contention
+    // those LWPs get no CPU at all: the "child parked at
+    // pthread__create_tramp+0 forever" of the original report. A detached
+    // LWP is freed at exit with no transfer. reapOsThread waits on the exit
+    // flag instead, which the child raises after its very last defer.
+    thread.detach();
 
     return args[0];
 }
 
-fn threadEntryFn(fiber: *fiber_mod.Fiber, spawner: ?*fiber_mod.Fiber, allocator: std.mem.Allocator, root_vm: *vm_mod.VM, envelope: *shared_channel.Envelope) void {
+/// #2446: drop one of the two references to a spawn's exit flag. The child
+/// passes `exited = true` from threadEntryFn's outermost defer -- after every
+/// other defer, so once a joiner sees the flag the thread touches nothing of
+/// kaappi's again (only Zig's spawn-argument free and the pthread epilogue
+/// remain). The joiner passes false once it has observed the flag. Whoever
+/// drops the last reference frees it.
+fn releaseOsThreadExit(flag: *fiber_mod.OsThreadExit, exited: bool) void {
+    if (exited) flag.exited.store(true, .release);
+    if (flag.refs.fetchSub(1, .acq_rel) == 1) std.heap.c_allocator.destroy(flag);
+}
+
+fn threadEntryFn(fiber: *fiber_mod.Fiber, spawner: ?*fiber_mod.Fiber, allocator: std.mem.Allocator, root_vm: *vm_mod.VM, envelope: *shared_channel.Envelope, exit_flag: *fiber_mod.OsThreadExit) void {
+    // #2446: declared FIRST so it runs LAST -- after the live_child_threads
+    // decrement below and everything that precedes it. This is the signal
+    // reapOsThread's wait (the pthread_join replacement) accepts as "the
+    // thread is done with every kaappi structure"; nothing may be deferred
+    // above it.
+    defer releaseOsThreadExit(exit_flag, true);
     // `root_vm` is the ROOT VM (see threadStartImpl): its struct, GC and
     // shared maps are never freed, so the whole prologue below -- and this
     // thread's later symbol interning into GC.initForThread's shared tables
@@ -1011,7 +1058,7 @@ pub const SleepWait = struct {
     // costs one wakeup rather than 60,000. The cap is what a sleep falls
     // back to when the enrolment could not allocate -- the pre-#2395
     // behaviour, kept because losing termination visibility would hang the
-    // joining thread in reapOsThread's thread.join().
+    // joining thread in reapOsThread's exit-flag wait.
     pub fn pollCapNs(self: SleepWait) ?u64 {
         return if (self.enrolment.active()) null else CROSS_THREAD_POLL_NS;
     }
@@ -1198,7 +1245,8 @@ fn threadTerminateFn(args: []const Value) PrimitiveError!Value {
         // thread terminating itself would join as uncaught-exception with a
         // void reason instead of terminated-thread-exception. The store is
         // on the parent-heap handle, exactly like an external terminate's
-        // store: the parent's join (thread.join() in reapOsThread)
+        // store: the parent's join (reapOsThread's acquire of the exit flag
+        // this thread releases last)
         // synchronizes with this thread's exit, so threadJoinResult's plain
         // read is safe. Null on the main thread and on local fibers.
         if (ctx.vm.thread_handle) |h| {
@@ -1492,14 +1540,27 @@ fn reapOsThread(target: *fiber_mod.Fiber, fiber_val: Value) PrimitiveError!Value
         // — a livelock (seen as a multi-minute hang in
         // channel-promoted-owner-1934 under -Dgc-stress). During the join the
         // VM's frames/registers are stable, so it is safe to mark. Function-
-        // scope defer: a block-scoped one would fire before thread.join().
+        // scope defer: a block-scoped one would fire before the wait.
         const join_vm: ?*vm_mod.VM = if (vm_mod.vm_instance) |vm|
             if (!vm.owns_globals) vm else null
         else
             null;
         if (join_vm) |vm| vm.setCollectionInNative();
         defer if (join_vm) |vm| vm.setCollectionRunning();
-        thread.join();
+        // #2446: the thread was detached at spawn (see threadStartImpl);
+        // wait for its exit flag instead of joining it. The status this
+        // reap was gated on is stored well before the flag, so what remains
+        // is the child's epilogue -- its defers, including the drain of its
+        // own descendants -- which pthread_join used to cover the same way.
+        // spinBackoff sleeps once its spin and yield phases pass, so a long
+        // epilogue costs one wakeup per millisecond, not a CPU.
+        _ = thread;
+        if (target.os_exit) |flag| {
+            var spins: u32 = 0;
+            while (!flag.exited.load(.acquire)) : (spins +|= 1) platform.spinBackoff(spins);
+            target.os_exit = null;
+            releaseOsThreadExit(flag, false);
+        }
         target.os_thread = null;
     }
 
@@ -1639,7 +1700,7 @@ fn freeChildResourcesEntry(res: ChildThreadResources, heir: ?*memory.GC) void {
         // allocator, so the parent's next mark reads FREED_OWNER and panics
         // instead of finding a recycled object. gc-stress only; a no-op
         // elsewhere. Safe here -- the joining parent's thread, past
-        // reapOsThread's thread.join() -- because the handoff appends to the
+        // reapOsThread's exit-flag wait -- because the handoff appends to the
         // heir's quarantine list from this very thread; threadEntryFn's
         // descendant-side free passes null instead, since handing off from
         // THAT thread would race the heir's own concurrent collection.

--- a/src/tests_gc_tracing.zig
+++ b/src/tests_gc_tracing.zig
@@ -1801,8 +1801,11 @@ test "gc tracing: heap-struct field inventory is unchanged" {
         "thunk",             "result",               "waiting_on",         "id",
         "name",              "specific",             "param_overrides",    "deadline_ns",
         "timed_out",         "driving",              "terminated",         "os_thread",
-        "live_descendants",  "io_fd",                "io_interest",        "io_buffer",
-        "sched_idx",         "queued",               "rv_demand_on",       "owned_mutexes",
+        // #2446: a plain pointer to the spawn's exit flag, never a Value --
+        // no marking or sweeping obligation, only this re-pin.
+        "os_exit",           "live_descendants",     "io_fd",              "io_interest",
+        "io_buffer",         "sched_idx",            "queued",             "rv_demand_on",
+        "owned_mutexes",
     });
     expectFields(types.Channel, &.{
         "header", "head", "tail", "queue_len", "capacity", "rv_demand", "closed", "shared",

--- a/src/tests_platform.zig
+++ b/src/tests_platform.zig
@@ -151,31 +151,25 @@ test "denormal arithmetic survives after normalizeFpEnvBestEffort" {
 // memory.spinLock, VM.stopForCollection, markLiveChildRoots and reapOsThread
 // all rely on. The cap iteration (five doublings past the phases) sleeps a
 // full millisecond.
-fn monotonicNs() u64 {
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.MONOTONIC, &ts);
-    return @as(u64, @intCast(ts.sec)) * 1_000_000_000 + @as(u64, @intCast(ts.nsec));
-}
-
 test "kaappi#2446: spinBackoff spins, then yields, then sleeps" {
     if (comptime is_wasm or builtin.single_threaded) return error.SkipZigTest;
     const phases = platform.spin_backoff_hint_iters + platform.spin_backoff_yield_iters;
     // Every iteration inside the two non-sleeping phases together must stay
     // far below one sleep quantum: 96 hints and yields are microseconds.
-    const t0 = monotonicNs();
+    const t0 = platform.monotonicNs();
     var i: u32 = 0;
     while (i < phases) : (i += 1) platform.spinBackoff(i);
-    const non_sleeping_ns = monotonicNs() - t0;
+    const non_sleeping_ns = platform.monotonicNs() - t0;
     // The first sleeping iteration is 32 us; the capped one (>= 5 doublings
     // past the phases) is 1 ms. nanosleep never returns early, so the lower
     // bounds are exact; there is deliberately no upper bound (a loaded box
     // oversleeps freely).
-    const t1 = monotonicNs();
+    const t1 = platform.monotonicNs();
     platform.spinBackoff(phases);
-    const first_sleep_ns = monotonicNs() - t1;
-    const t2 = monotonicNs();
+    const first_sleep_ns = platform.monotonicNs() - t1;
+    const t2 = platform.monotonicNs();
     platform.spinBackoff(phases + 5);
-    const capped_sleep_ns = monotonicNs() - t2;
+    const capped_sleep_ns = platform.monotonicNs() - t2;
     try std.testing.expect(first_sleep_ns >= 32_000);
     try std.testing.expect(capped_sleep_ns >= 1_000_000);
     if (non_sleeping_ns >= 1_000_000) {

--- a/src/tests_platform.zig
+++ b/src/tests_platform.zig
@@ -143,3 +143,43 @@ test "denormal arithmetic survives after normalizeFpEnvBestEffort" {
     try std.testing.expect(q > 0.0);
     try std.testing.expect(q == std.math.floatTrueMin(f64));
 }
+
+// kaappi#2446: the backoff's phase schedule. Iterations inside the spin and
+// yield phases must return without sleeping, and the first iteration past
+// them must actually sleep -- that sleep is the whole point (it is what takes
+// a waiter off the run queue), and the phase constants are what
+// memory.spinLock, VM.stopForCollection, markLiveChildRoots and reapOsThread
+// all rely on. The cap iteration (five doublings past the phases) sleeps a
+// full millisecond.
+fn monotonicNs() u64 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.MONOTONIC, &ts);
+    return @as(u64, @intCast(ts.sec)) * 1_000_000_000 + @as(u64, @intCast(ts.nsec));
+}
+
+test "kaappi#2446: spinBackoff spins, then yields, then sleeps" {
+    if (comptime is_wasm or builtin.single_threaded) return error.SkipZigTest;
+    const phases = platform.spin_backoff_hint_iters + platform.spin_backoff_yield_iters;
+    // Every iteration inside the two non-sleeping phases together must stay
+    // far below one sleep quantum: 96 hints and yields are microseconds.
+    const t0 = monotonicNs();
+    var i: u32 = 0;
+    while (i < phases) : (i += 1) platform.spinBackoff(i);
+    const non_sleeping_ns = monotonicNs() - t0;
+    // The first sleeping iteration is 32 us; the capped one (>= 5 doublings
+    // past the phases) is 1 ms. nanosleep never returns early, so the lower
+    // bounds are exact; there is deliberately no upper bound (a loaded box
+    // oversleeps freely).
+    const t1 = monotonicNs();
+    platform.spinBackoff(phases);
+    const first_sleep_ns = monotonicNs() - t1;
+    const t2 = monotonicNs();
+    platform.spinBackoff(phases + 5);
+    const capped_sleep_ns = monotonicNs() - t2;
+    try std.testing.expect(first_sleep_ns >= 32_000);
+    try std.testing.expect(capped_sleep_ns >= 1_000_000);
+    if (non_sleeping_ns >= 1_000_000) {
+        std.debug.print("spin+yield phases took {d} us\n", .{non_sleeping_ns / 1000});
+        return error.NonSleepingPhasesSlept;
+    }
+}

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const platform = @import("platform.zig");
 const th = @import("testing_helpers.zig");
 const types = @import("types.zig");
@@ -999,4 +1000,81 @@ test "a channel-send park that errors out leaves the fiber runnable (#2433)" {
     ,
         \\(guard (e (#t (error-object-message e))) (read-bytevector 4 p))
     , "channel-send");
+}
+
+// ---------------------------------------------------------------------------
+// kaappi#2446: waiting on a held spin lock must not burn CPU
+// ---------------------------------------------------------------------------
+
+fn processCpuNs() u64 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.PROCESS_CPUTIME_ID, &ts);
+    return @as(u64, @intCast(ts.sec)) * 1_000_000_000 + @as(u64, @intCast(ts.nsec));
+}
+
+// A thread that finds a spin lock held must stop consuming CPU while it
+// waits. On NetBSD's 4BSD scheduler a crowd of pure spinners outranks the
+// preempted holder for good -- the holder's priority is decayed by the work
+// it did, the spinners' is not, and sched_yield never requeues behind a
+// lower priority -- so srfi18-join-spawn-grandchild-2129.scm hung at 290%
+// CPU with 17 threads in withdrawCrossThreadWaiter's spinLock and the
+// holder runnable but never run. That scheduler-level hang cannot be
+// reproduced on a fair scheduler, so this pins the property that prevents
+// it: contenders on a held lock burn (almost) no CPU. Pre-fix, four
+// contenders spinning through a 120 ms hold cost the process ~4 x 120 ms of
+// CPU time (all of one CPU for the whole hold on a single-core box); with
+// platform.spinBackoff they spin for microseconds, yield a few dozen times
+// and then sleep, so the process gains a few milliseconds at most.
+test "kaappi#2446: contenders on a held spin lock sleep instead of burning CPU" {
+    if (comptime (platform.is_wasm or platform.is_windows or builtin.single_threaded)) return error.SkipZigTest;
+    const Ctx = struct {
+        lock: std.atomic.Mutex = .unlocked,
+        acquired: std.atomic.Value(u32) = .init(0),
+        fn contend(self: *@This()) void {
+            memory.spinLock(&self.lock);
+            _ = self.acquired.fetchAdd(1, .acq_rel);
+            memory.spinUnlock(&self.lock);
+        }
+    };
+    var ctx: Ctx = .{};
+    const hold_ns: u64 = 120_000_000;
+    memory.spinLock(&ctx.lock);
+    const cpu_before = processCpuNs();
+    var threads: [4]std.Thread = undefined;
+    for (&threads) |*t| t.* = try std.Thread.spawn(.{}, Ctx.contend, .{&ctx});
+    platform.sleepNs(hold_ns);
+    memory.spinUnlock(&ctx.lock);
+    for (threads) |t| t.join();
+    const cpu_ns = processCpuNs() - cpu_before;
+    try std.testing.expectEqual(@as(u32, 4), ctx.acquired.load(.acquire));
+    // 60 ms: half of what even ONE pure spinner burns through the hold, so a
+    // regression to spinning fails regardless of how many CPUs the box has.
+    if (cpu_ns > 60_000_000) {
+        std.debug.print("contenders burned {d} ms of CPU across a {d} ms hold\n", .{ cpu_ns / 1_000_000, hold_ns / 1_000_000 });
+        return error.SpinLockContendersBurnCpu;
+    }
+}
+
+// kaappi#2446: OS threads are detached at spawn and thread-join! waits on
+// the spawn's exit flag instead of pthread_join. That flag is raised after
+// the thread's very last defer, so by the time a join returns the child has
+// released its live-thread count and every registry entry: hasLiveChildThreads
+// is false again immediately, never "still true for a few microseconds while
+// the LWP finishes". A reap that returned early (or a defer accidentally
+// declared after the flag's) shows up here as a true reading.
+test "kaappi#2446: thread-join! returns only after the child's whole epilogue" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // thread-start! is unregistered on wasm
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    var i: usize = 0;
+    while (i < 8) : (i += 1) {
+        const v = try ctx.vm.eval(
+            \\(let ((t (make-thread (lambda () (thread-sleep! 0.001) 'done))))
+            \\  (thread-start! t)
+            \\  (thread-join! t))
+        );
+        try std.testing.expect(types.isSymbol(v));
+        try std.testing.expect(!srfi18.hasLiveChildThreads());
+    }
 }

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -1006,9 +1006,11 @@ test "a channel-send park that errors out leaves the fiber runnable (#2433)" {
 // kaappi#2446: waiting on a held spin lock must not burn CPU
 // ---------------------------------------------------------------------------
 
-fn processCpuNs() u64 {
+fn processCpuNs() !u64 {
     var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.PROCESS_CPUTIME_ID, &ts);
+    // Every current POSIX target supports this clock; a future one that
+    // rejects it must skip loudly, not compare against an undefined `ts`.
+    if (std.c.clock_gettime(.PROCESS_CPUTIME_ID, &ts) != 0) return error.SkipZigTest;
     return @as(u64, @intCast(ts.sec)) * 1_000_000_000 + @as(u64, @intCast(ts.nsec));
 }
 
@@ -1029,8 +1031,10 @@ test "kaappi#2446: contenders on a held spin lock sleep instead of burning CPU" 
     if (comptime (platform.is_wasm or platform.is_windows or builtin.single_threaded)) return error.SkipZigTest;
     const Ctx = struct {
         lock: std.atomic.Mutex = .unlocked,
+        contending: std.atomic.Value(u32) = .init(0),
         acquired: std.atomic.Value(u32) = .init(0),
         fn contend(self: *@This()) void {
+            _ = self.contending.fetchAdd(1, .release);
             memory.spinLock(&self.lock);
             _ = self.acquired.fetchAdd(1, .acq_rel);
             memory.spinUnlock(&self.lock);
@@ -1039,13 +1043,18 @@ test "kaappi#2446: contenders on a held spin lock sleep instead of burning CPU" 
     var ctx: Ctx = .{};
     const hold_ns: u64 = 120_000_000;
     memory.spinLock(&ctx.lock);
-    const cpu_before = processCpuNs();
     var threads: [4]std.Thread = undefined;
     for (&threads) |*t| t.* = try std.Thread.spawn(.{}, Ctx.contend, .{&ctx});
+    // Under load a worker may not run until after the hold ends, and would
+    // then acquire the lock uncontended -- passing without exercising the
+    // held-lock path. Start the clock only once every worker has reached
+    // the lock call.
+    while (ctx.contending.load(.acquire) != @as(u32, threads.len)) std.Thread.yield() catch {};
+    const cpu_before = try processCpuNs();
     platform.sleepNs(hold_ns);
     memory.spinUnlock(&ctx.lock);
     for (threads) |t| t.join();
-    const cpu_ns = processCpuNs() - cpu_before;
+    const cpu_ns = (try processCpuNs()) - cpu_before;
     try std.testing.expectEqual(@as(u32, 4), ctx.acquired.load(.acquire));
     // 60 ms: half of what even ONE pure spinner burns through the hold, so a
     // regression to spinning fails regardless of how many CPUs the box has.

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 const memory = @import("memory.zig");
+const platform = @import("platform.zig");
 
 const diagnostics = @import("diagnostics.zig");
 const compiler_mod = @import("compiler.zig");
@@ -1023,7 +1024,12 @@ pub const VM = struct {
     /// registers/frames are consistent for the parent's mark pass.
     pub fn stopForCollection(self: *VM) void {
         self.collection_state.store(.stopped, .release);
-        while (self.collection_stop.load(.acquire)) std.atomic.spinLoopHint();
+        // Spin, then yield, then sleep -- never a pure spin: the parent's
+        // mark phase runs for milliseconds, and every stopped child that
+        // keeps spinning competes with the collector for the CPU it needs
+        // to finish (kaappi#2446; see platform.spinBackoff).
+        var spins: u32 = 0;
+        while (self.collection_stop.load(.acquire)) : (spins +|= 1) platform.spinBackoff(spins);
         self.collection_state.store(.running, .release);
     }
 


### PR DESCRIPTION
Closes #2446.

## What was actually happening

The `blocked-upstream` diagnosis on the issue was wrong. gdb showed a child LWP with a frozen PC and no syscall, which reads as "the kernel never scheduled it" — but a starved runnable thread looks exactly the same from userspace. The kernel's per-LWP view (`ps -s -o pid,lid,lstate,wchan,cpuid,pri,time,pcpu`) showed the hung process with 23 LWPs, 18 runnable, burning three CPUs' worth of time: **17 threads leaving `thread-sleep!` spinning in `memory.spinLock` inside `withdrawCrossThreadWaiter` at priority 25–27, while the holder — preempted inside the `kevent` ring `wakeCrossThreadWaiters` issues under the lock — sat runnable at priority 0 and was never scheduled again.**

Two NetBSD 4BSD-scheduler facts combine into that:

1. **`pthread_join` poisons the joiner's priority.** A nice-0 LWP's priority is `63 − estcpu/2048 − 20`, and the per-tick accumulation clamps `estcpu` at `18 × 2048`, so running can take a thread no lower than 25. But `sched_lwp_collect` — run in `_lwp_wait` on the *joining* LWP — adds the reaped LWP's `estcpu` with no cap, and `sched_lwp_fork` copies the joiner's estimate into every LWP it creates. The interpreter thread joins every middle thread; after three joins it is at priority 0 and so is every thread it spawns from then on — born below every ordinary process, which under CPU contention starves them outright. That is the "child parked at `pthread__create_tramp+0` forever" of the original report. A 40-line C program pins it: join three threads that each spin 1.5 s, then spawn a trivial child under four burners — the child's join took 0.8 s; detach the three instead and it took 0 ms, like the no-join control.
2. **`sched_yield` only requeues behind LWPs of the same priority**, so a crowd spinning — or yielding — on a lock held by a preempted thread never lets it back in.

Linux CFS and macOS give every runnable thread a share regardless of history, which is why four platforms only ever paid latency for the same code.

## The fix

- **Detach SRFI-18 OS threads at spawn** (a detached LWP is freed at exit with no `estcpu` transfer) and have `thread-join!` wait on a per-spawn exit flag (`Fiber.os_exit`) that the child raises after its outermost defer — covering exactly what `pthread_join` covered, descendant drain included.
- **`platform.spinBackoff`** — 32 spins, 64 yields, then sleeps doubling from 32 µs to 1 ms — replaces every pure spin in a cross-thread wait: `memory.spinLock`, `VM.stopForCollection`, `markLiveChildRoots`' wait for children to stop, `GlobalsRwLock`, and the new reap wait. The sleep is what takes a waiter off the run queue. The uncontended path is unchanged; no sleep ever happens on a healthy machine.

The backoff alone took the hang from 5/8 to 0/10 in a first sample and then hung 4 of the next 8 — with the process at *zero* CPU and every LWP at priority 0, which is what exposed the join-inheritance mechanism.

## Measurements

NetBSD 10.1 aarch64 reference VM (4 vCPUs), 40 s bound per run, `srfi18-join-spawn-grandchild-2129.scm`:

| build | 4 burners | 8 burners |
|-------|-----------|-----------|
| unmodified `main` | 5/8 hung | 4/10 hung |
| backoff only | 0/10, then 4/8 hung | — |
| backoff + detach | **0/20 hung** (and 0/10 of `srfi18-terminate-native-wait-1982.scm`, the other test the CI kill hit) | **0/30 hung** |

## Tests

- `tests_srfi18.zig` "kaappi#2446: contenders on a held spin lock sleep instead of burning CPU" — fails against the old lock (four contenders burned 518 ms of CPU across a 120 ms hold), passes with the backoff.
- `tests_srfi18.zig` "kaappi#2446: thread-join! returns only after the child's whole epilogue" — pins the exit-flag ordering the reap relies on.
- Host: full unit suite green (1992 passed, 21 skipped), all 33 `srfi18*.scm`, a `-Dgc-stress=true` subset over the thread/join/child tests, `zig build wasm` and the `aarch64-netbsd` cross-build.

## Docs

Postmortem `docs/dev/postmortems/2026-09-02-netbsd-spinlock-starvation.md` (with the wrong-diagnosis analysis and the `ps -s` recipe), a new scheduler section in `docs/dev/netbsd.md`, a fifth load-bearing bullet in `docs/dev/fibers-and-reactor.md`, and lessons-learned #15.

## Follow-ups (not in this PR)

- #2471 — `sched_lwp_collect`'s missing `ESTCPULIM` turns out to be fixed upstream already (trunk rev 1.48, 2026-03-01; pulled up to netbsd-11, **not** netbsd-10), so 10.x releases keep needing the detach; the issue now tracks the netbsd-10 pull-up.
- #2470 — `wakeCrossThreadWaiters` still rings under the registry lock; with the backoff that costs waiters latency, never liveness. Moving the ring outside the lock needs per-entry retain/release on a path that must not allocate — a separate trade-off.
- #2472 — the one remaining bare spin, WinSock init on Windows.
- #2473 — `thread-start!` leaves the fiber rooted in `extra_roots` when the spawn fails (pre-existing, noticed on the way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
