### PR TITLE
CI: require a CHANGELOG.md entry for src/lib/vendor changes unless labeled no-changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,62 @@ jobs:
   # than written as the work lands -- v0.22.0 shipped with 14 of 100 commits
   # reflected in it, v0.22.1 with 5 of 16. Ask for the entry here, while the
   # change is fresh and its author is present to write it.
+  #
+  # A previous version of this gate was dropped in #2103 because concurrent
+  # PRs appending under [Unreleased] conflict with each other. #2475 brought it
+  # back anyway: the alternative (reconstructing entries at release time) put
+  # the bulk of the work on whoever cut v0.22.0/v0.22.1, and #2467 merged with
+  # no entry at all. Scope is now all of src/, lib/ and vendor/ (#2475);
+  # tests/**-only changes are deliberately outside it, and the check is
+  # presence-only -- wording stays with the author.
+  changelog:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Require a CHANGELOG entry for user-visible changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Labels are read live rather than from github.event, because
+          # re-running a job replays the ORIGINAL event payload -- a
+          # `no-changelog` label added in response to this job failing would
+          # be invisible to it, making the documented escape hatch a dead end.
+          if gh pr view "$PR" --repo "$REPO" --json labels \
+               --jq '.labels[].name' | grep -qx 'no-changelog'; then
+            echo "Labelled 'no-changelog' -- skipping."
+            exit 0
+          fi
+
+          # Same paginated endpoint as the `format` classifier: no checkout
+          # needed, and push/pull_request would share a shape if this ever
+          # grows beyond PRs.
+          files=$(gh api --paginate \
+            "repos/${REPO}/pulls/${PR}/files" --jq '.[].filename')
+
+          if ! grep -qE '^(src|lib|vendor)/' <<<"$files"; then
+            echo "No src/, lib/ or vendor/ changes -- CHANGELOG entry not required."
+            exit 0
+          fi
+          if grep -qx 'CHANGELOG.md' <<<"$files"; then
+            echo "CHANGELOG.md updated."
+            exit 0
+          fi
+
+          echo "::error::This PR changes src/, lib/ or vendor/ but does not touch CHANGELOG.md."
+          echo "::error::Add an entry under [Unreleased] describing the user-visible effect."
+          echo "::error::If the change is not user-visible (refactor, tests, CI), apply the"
+          echo "::error::'no-changelog' label and re-run this job -- labels are read live, so"
+          echo "::error::a re-run picks it up without pushing a commit."
+          exit 1
+
   test:
     needs: format
     # Deliberately NOT gated `if: docs_only != 'true'` at the job level, unlike

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **CI CHANGELOG gate (#2475)** — a `changelog` job in CI fails a PR that
+  changes `src/`, `lib/` or `vendor/` without also touching `CHANGELOG.md`,
+  unless the PR carries the `no-changelog` label (read live, so labelling
+  and re-running the job is enough). Tests-only and docs-only changes are
+  outside the gate, and the check is presence-only — entry wording stays
+  with the author. Restores, with a wider scope, the gate dropped in #2103.
 - **`run-process` and the `process-timeout` condition (KEP-0022 Phase 4,
   #2417)** — the one-shot layer over `spawn-process`:
   `(run-process argv opt…)` spawns, feeds an optional `input:`, drains


### PR DESCRIPTION
## What

Restores a per-PR CHANGELOG gate, dropped in #2103, with the wider scope #2475 asks for. A new `changelog` job in `.github/workflows/ci.yml` fails a PR whose diff touches `src/**`, `lib/**` or `vendor/**` but not `CHANGELOG.md`, unless the PR carries the `no-changelog` label.

## Decisions (per the issue, already made there)

- `tests/**`-only changes do **not** require an entry — the path filter expresses this directly (only the top-level `tests/` dir is outside the gate; `src/tests_*.zig` is under `src/` and so counts, matching the issue's `src/**` filter verbatim).
- Presence-only check: the job verifies `CHANGELOG.md` appears in the diff, never diffs the entry. Wording stays with the author.

## Notes on the implementation

- The label is read **live** (`gh pr view --json labels`), not from `github.event.pull_request.labels`, because re-running a job replays the original event payload — a `no-changelog` label added in response to the failure would be invisible to a re-run, making the escape hatch a dead end. This insight is inherited from the pre-#2103 gate and kept in a comment.
- The file list uses the same paginated `pulls/{n}/files` endpoint as the `format` classifier — no checkout, consistent shape.
- The `no-changelog` label already exists in the repo (verified with `gh label list`), so nothing to create.
- The job-level comment records why the gate is back despite the #2103 merge-conflict concern: the reconstruction cost at release time (14/100 commits reflected in v0.22.0's `[Unreleased]`) was the bulk of the release work, and #2467 merged with no entry at all.
- CHANGELOG.md carries its own `[Unreleased]` entry for this change (dogfooding the gate).

## Validation

The repo has no test harness for CI workflow scripts (checked `tools/` and `docs/dev/`), so the gate's decision logic was validated by dry-running the exact `grep` decision core against 12 synthetic changed-file sets:

| Case | Result |
|------|--------|
| `src/vm.zig` alone | fails (gate fires) |
| `src/vm.zig` + `CHANGELOG.md` | passes |
| `src/vm.zig` + `no-changelog` label | skips |
| `lib/srfi/1.sld` alone | fails |
| `vendor/isocline/src/isocline.c` alone | fails |
| `src/tests_io.zig` | fails (under `src/`) |
| `tests/scheme/**` only | passes (no gate) |
| `docs/**` + `README.md` only | passes |
| `.github/workflows/ci.yml` only | passes |
| `srcfoo/bar.zig` (prefix near-miss) | passes (no false match) |
| unrelated label (`refactor`) + src change | fails |
| mixed docs + src without entry | fails |

Also validated: `ci.yml` parses as YAML; `npx markdownlint-cli2` on the tree is clean (0 issues).

Closes #2475