### PR TITLE
Ring cross-thread waiters outside the registry lock; route WinSock init spin through spinBackoff (#2470, #2472)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Cross-thread wakeups ring outside the wait registry lock** (#2470) —
+  `wakeCrossThreadWaiters` used to notify every parked thread while holding
+  the registry lock: one syscall (a kevent, an eventfd write, or a SetEvent)
+  per enrolled thread inside the critical section, so a ringer preempted
+  mid-ring stalled every thread then arriving at `mutex-lock!`,
+  `thread-join!` or a condition-variable wait — post-#2468 a latency hit
+  only, but with a dozen parked threads a scheduler-quantum-long one. The
+  ring now snapshots the first 128 enrolled notifiers under the lock (each
+  retained), drops the lock, and notifies and releases outside it — the
+  same snapshot-then-ring shape channel wakes already use — so the critical
+  section is constant-size again and the teardown close
+  (`releaseNotifier`'s zero transition) never runs under the lock. Entries
+  past 128 (more simultaneously blocked OS threads than that is already
+  pathological) keep the old under-lock tail. Windows socket
+  initialisation's last bare spin loop now backs off through the same
+  spin-then-yield-then-sleep ladder every other cross-thread wait uses
+  (#2472), so an auditor grepping for spin-hint-only waits finds zero.
 - **Cross-thread SRFI-18 waits are woken by the reactor notifier instead of a
   1 ms poll** (#2395, KEP-0002 unresolved question 3) — `thread-join!` on a
   running OS thread, `mutex-lock!` and condition-variable waits contended

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,11 +211,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   only, but with a dozen parked threads a scheduler-quantum-long one. The
   ring now snapshots the first 128 enrolled notifiers under the lock (each
   retained), drops the lock, and notifies and releases outside it — the
-  same snapshot-then-ring shape channel wakes already use — so the critical
-  section is constant-size again and the teardown close
-  (`releaseNotifier`'s zero transition) never runs under the lock. Entries
-  past 128 (more simultaneously blocked OS threads than that is already
-  pathological) keep the old under-lock tail. Windows socket
+  same snapshot-then-ring shape channel wakes already use — so within
+  those 128 the critical section is constant-size again, and the teardown
+  close (`releaseNotifier`'s zero transition) never runs under the lock on
+  any path. Entries past 128 (more simultaneously blocked OS threads than
+  that is already pathological) keep the old under-lock tail — their
+  `notify()` still runs while the lock is held, so past 128 the critical
+  section grows with waiters as before. Windows socket
   initialisation's last bare spin loop now backs off through the same
   spin-then-yield-then-sleep ladder every other cross-thread wait uses
   (#2472), so an auditor grepping for spin-hint-only waits finds zero.

--- a/docs/dev/fibers-and-reactor.md
+++ b/docs/dev/fibers-and-reactor.md
@@ -119,10 +119,12 @@ Five things load-bearing enough to be worth knowing before touching this:
   registry lock at priority 25–27 while the holder — preempted inside the
   `kevent` ring, at priority 0 after the work it had done — stayed runnable
   and never ran again. Yielding does not help (it requeues behind LWPs of the
-  *same* priority); only a sleep takes the spinner off the run queue. The
-  holder's ring is still issued under the lock (one `notify()` per parked
-  thread); with the backoff that costs the ringed threads latency, never
-  liveness.
+  *same* priority); only a sleep takes the spinner off the run queue.
+  Since kaappi#2470 the ring itself is issued *outside* the lock — the
+  first 128 entries are snapshotted (retained) under it, then notified and
+  released after it is dropped, so the critical section is bounded by the
+  copy, not by one syscall per parked thread; entries past 128 are the
+  overflow tail, still rung under the lock.
 
 A "never" deadline is a real one and reaches the backends: SRFI-18 reads
 `+inf.0` as "never times out", `saturatedNsFromSeconds` turns that into

--- a/src/platform_win_sock.zig
+++ b/src/platform_win_sock.zig
@@ -37,7 +37,12 @@ var winsock_mutex: std.atomic.Mutex = .unlocked;
 pub fn ensureWinsock() void {
     if (comptime !is_windows) return;
     if (winsock_ready.load(.acquire)) return;
-    while (!winsock_mutex.tryLock()) std.atomic.spinLoopHint();
+    // spinBackoff, not a bare spinLoopHint loop: the rule #2446/#2468 wrote
+    // down — a pure spin starves a preempted lock holder on schedulers
+    // without starvation boost (and Windows' boost only mitigates, it does
+    // not exempt). Same shape as memory.spinLock.
+    var spins: u32 = 0;
+    while (!winsock_mutex.tryLock()) : (spins +|= 1) platform.spinBackoff(spins);
     defer winsock_mutex.unlock();
     if (winsock_ready.load(.acquire)) return;
     var data: win.WSAData = undefined;

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -314,16 +314,46 @@ pub fn withdrawCrossThreadWaiter(n: *ThreadNotifier) void {
 /// RMW on paths (`mutex-unlock!`, `condition-variable-signal!`) that already
 /// perform several atomic stores and a hash lookup.
 ///
-/// Rings *under* the lock too, unlike `shared_channel.ring`'s
-/// snapshot-then-ring: the list is one entry per blocked OS thread (single
-/// digits in any real program), `notify()` takes no lock of its own so there
-/// is no lock-order hazard, and holding the lock is what keeps each entry
-/// alive without a retain/release round trip per ring. The alternative —
-/// snapshotting — would need an allocation on a path that must not fail.
+/// Rings via a **snapshot taken under the lock, rung outside it** —
+/// `shared_channel.ring`'s shape, with the allocation problem that kept the
+/// ring under the lock solved by a fixed stack array (#2470): the first
+/// `ring_snapshot_len` entries are snapshotted (retained under the lock, so
+/// a waiter that withdraws and frees its notifier during the unlocked ring
+/// cannot leave a dangling pointer), then notified and released after the
+/// lock is dropped. The release matters outside the lock twice over:
+/// `notify()` is a syscall (kevent/eventfd write/SetEvent) apiece, and
+/// `releaseNotifier`'s zero transition closes the backend fd — neither
+/// belongs in the critical section, where #2446 showed a ringer preempted
+/// mid-syscall stalls every waiter arriving at enrol/withdraw. Entries past
+/// the array are the overflow tail, rung under the lock as before: more
+/// than 128 blocked OS threads is already pathological, and the tail costs
+/// latency only (post-#2468 there is no starvation to fear).
 pub fn wakeCrossThreadWaiters() void {
-    memory.spinLock(&wait_registry_lock);
-    defer memory.spinUnlock(&wait_registry_lock);
-    for (wait_registry.items) |e| e.notifier.notify();
+    // 128 retained pointers on the stack: big enough that real programs (one
+    // entry per blocked OS thread) never reach the overflow tail, small
+    // enough not to eat the thread's stack. Not an allocation — this path
+    // must not fail (see the enrol note above).
+    const ring_snapshot_len = 128;
+    var snapshot: [ring_snapshot_len]*ThreadNotifier = undefined;
+    var snap_count: usize = 0;
+    {
+        memory.spinLock(&wait_registry_lock);
+        defer memory.spinUnlock(&wait_registry_lock);
+        for (wait_registry.items) |e| {
+            if (snap_count < ring_snapshot_len) {
+                retainNotifier(e.notifier);
+                snapshot[snap_count] = e.notifier;
+                snap_count += 1;
+            } else {
+                // Overflow tail: rung under the lock, as pre-#2470.
+                e.notifier.notify();
+            }
+        }
+    }
+    for (snapshot[0..snap_count]) |n| {
+        n.notify();
+        releaseNotifier(n);
+    }
 }
 
 /// Test/leak-check hook, mirroring `notifierLiveCount`: every enrolment must

--- a/src/reactor.zig
+++ b/src/reactor.zig
@@ -351,10 +351,27 @@ pub fn wakeCrossThreadWaiters() void {
         }
     }
     for (snapshot[0..snap_count]) |n| {
+        // Test-only observation point, never set in production: this is the
+        // instant the snapshot's retain exists for — lock dropped, notify and
+        // release still pending — so tests_reactor.zig's #2470 gate test can
+        // park a ringer here and drop every other reference around it.
+        if (ring_test_gate) |gate| gate(n);
         n.notify();
         releaseNotifier(n);
     }
 }
+
+/// Test-only gate on the unlocked ring (#2470 tests): when non-null, called
+/// with each snapshotted notifier after the registry lock is dropped and
+/// before its notify+release pair. That moment is the whole reason the
+/// snapshot retains: a waiter withdrawing concurrently has dropped the
+/// registry's reference and the reactor may already have dropped its base
+/// one, and only the ring's own retain keeps the notifier allocated until
+/// its release. Production never sets it, and it never fires for the
+/// overflow tail (that path holds the registry lock — parking inside it
+/// would deadlock). One branch on a cold global per entry, on a path that
+/// is about to do a syscall apiece.
+pub var ring_test_gate: ?*const fn (n: *ThreadNotifier) void = null;
 
 /// Test/leak-check hook, mirroring `notifierLiveCount`: every enrolment must
 /// be withdrawn, so this is 0 between waits.

--- a/src/tests_reactor.zig
+++ b/src/tests_reactor.zig
@@ -1020,7 +1020,15 @@ test "#2470: the snapshot retain alone keeps a torn-down notifier alive through 
             reactor_mod.wakeCrossThreadWaiters();
         }
     };
-    const ringer = try std.Thread.spawn(.{}, Ringer.run, .{});
+    // On spawn failure the cleanup defer below is not installed yet (LIFO:
+    // it appears only after a successful spawn), so clear the gate globals
+    // here — otherwise a later ring anywhere in the suite walks the dead
+    // stack-local `gate` through `ringGateHook`.
+    const ringer = std.Thread.spawn(.{}, Ringer.run, .{}) catch |err| {
+        ring_gate_ctx = null;
+        reactor_mod.ring_test_gate = null;
+        return err;
+    };
     var joined = false;
     // Registered last, runs first on every exit path (LIFO): release the
     // parked ringer, join it, then uninstall the gate so nothing after this

--- a/src/tests_reactor.zig
+++ b/src/tests_reactor.zig
@@ -871,6 +871,96 @@ test "#2395: a ring is a real OS event that ends a blocking reactor poll" {
 }
 
 // ---------------------------------------------------------------------------
+// #2470: wakeCrossThreadWaiters rings outside the registry lock
+//
+// The ring used to run under `wait_registry_lock` — one syscall per parked
+// thread inside the critical section. It now snapshots the first 128
+// entries (retained under the lock), drops the lock, then notifies and
+// releases. The two properties these tests pin: every snapshotted waiter
+// still wakes with many enrolled (the snapshot path, including the
+// >128 overflow tail), and the retain/release pair keeps a notifier that
+// withdraws mid-ring alive until the ring's own release — the dangling
+// pointer a naive snapshot-without-retain would leave.
+// ---------------------------------------------------------------------------
+
+/// fd budget for the multi-reactor test: a Reactor owns one backend fd plus
+/// (Linux only) a second for its notifier's eventfd. Stay under the soft
+/// NOFILE limit rather than assuming it is generous.
+fn reactorBudget() usize {
+    const lim = std.posix.getrlimit(.NOFILE) catch return 4;
+    const worst_case = 2; // epoll + eventfd
+    const headroom = lim.cur / 2; // half the soft limit is already ours to use
+    return @max(2, @min(130, headroom / worst_case));
+}
+
+test "#2470: wakeCrossThreadWaiters rings every waiter from outside the lock" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no OS reactors to multiply on WASI
+    const notifier_baseline = reactor_mod.notifierLiveCount();
+    const n_reactors = reactorBudget();
+    // Deliberately straddles the 128-entry snapshot when the fd budget
+    // allows, so the under-lock overflow tail is covered too.
+    var reactors: [130]reactor_mod.Reactor = undefined;
+    var live: usize = 0;
+    defer for (reactors[0..live]) |*r| {
+        r.deinit();
+    };
+
+    for (0..n_reactors) |i| {
+        reactors[i] = try reactor_mod.Reactor.init(std.testing.allocator);
+        live += 1;
+        try std.testing.expect(reactor_mod.enrollCrossThreadWaiter(reactors[i].notifyHandle()));
+    }
+    try std.testing.expectEqual(n_reactors, reactor_mod.crossThreadWaiterCount());
+    try std.testing.expectEqual(notifier_baseline + n_reactors, reactor_mod.notifierLiveCount());
+
+    reactor_mod.wakeCrossThreadWaiters();
+
+    for (reactors[0..live]) |*r| {
+        try std.testing.expect(r.notifier.wake_pending.load(.acquire));
+    }
+
+    for (reactors[0..live]) |*r| reactor_mod.withdrawCrossThreadWaiter(r.notifyHandle());
+    try std.testing.expectEqual(@as(usize, 0), reactor_mod.crossThreadWaiterCount());
+    try std.testing.expectEqual(notifier_baseline + n_reactors, reactor_mod.notifierLiveCount());
+}
+
+test "#2470: a waiter withdrawing during an unlocked ring leaves no dangling notifier" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no OS threads on wasm32-wasi
+    const notifier_baseline = reactor_mod.notifierLiveCount();
+
+    var reactor = try reactor_mod.Reactor.init(std.testing.allocator);
+    defer reactor.deinit();
+    const n = reactor.notifyHandle();
+
+    var stop = std.atomic.Value(bool).init(false);
+    const Ringer = struct {
+        fn run(s: *std.atomic.Value(bool)) void {
+            while (!s.load(.acquire)) reactor_mod.wakeCrossThreadWaiters();
+        }
+    };
+    const ringer = try std.Thread.spawn(.{}, Ringer.run, .{&stop});
+    defer {
+        stop.store(true, .release);
+        ringer.join();
+    }
+
+    // Repeatedly enrol then withdraw while the ringer hammers the registry.
+    // The ringer's snapshot holds a reference from its copy under the lock to
+    // its release after the ring, so this withdraw's release can never be
+    // the zero transition while a snapshotted copy exists. Without that
+    // retain/release pair the withdraw frees the notifier out from under the
+    // ring's `notify()` — use-after-free on the fd and the struct.
+    var i: usize = 0;
+    while (i < 500) : (i += 1) {
+        try std.testing.expect(reactor_mod.enrollCrossThreadWaiter(n));
+        reactor_mod.withdrawCrossThreadWaiter(n);
+    }
+
+    try std.testing.expectEqual(@as(usize, 0), reactor_mod.crossThreadWaiterCount());
+    try std.testing.expectEqual(notifier_baseline + 1, reactor_mod.notifierLiveCount()); // reactor's own
+}
+
+// ---------------------------------------------------------------------------
 // Child-exit readiness (KEP-0022 Phase 2, kaappi#2415). Real children via
 // raw fork() (forkChild below — the reactor must reap them itself, that
 // being the property under test, so nothing else ever waits them). Fake Process

--- a/src/tests_reactor.zig
+++ b/src/tests_reactor.zig
@@ -876,11 +876,13 @@ test "#2395: a ring is a real OS event that ends a blocking reactor poll" {
 // The ring used to run under `wait_registry_lock` — one syscall per parked
 // thread inside the critical section. It now snapshots the first 128
 // entries (retained under the lock), drops the lock, then notifies and
-// releases. The two properties these tests pin: every snapshotted waiter
-// still wakes with many enrolled (the snapshot path, including the
-// >128 overflow tail), and the retain/release pair keeps a notifier that
-// withdraws mid-ring alive until the ring's own release — the dangling
-// pointer a naive snapshot-without-retain would leave.
+// releases. Three tests, three properties: every snapshotted waiter still
+// wakes with many enrolled (the snapshot path, including the >128 overflow
+// tail); the registry stays consistent under enroll/withdraw churn against
+// a hammering ringer; and — the property a naive snapshot-without-retain
+// would get wrong, pinned deterministically via `reactor.ring_test_gate` —
+// the snapshot's retain is *by itself* what keeps a notifier allocated when
+// its reactor tears down and its waiter withdraws mid-ring.
 // ---------------------------------------------------------------------------
 
 /// fd budget for the multi-reactor test: a Reactor owns one backend fd plus
@@ -933,7 +935,16 @@ test "#2470: wakeCrossThreadWaiters rings every waiter from outside the lock" {
     try std.testing.expectEqual(notifier_baseline + n_reactors, reactor_mod.notifierLiveCount());
 }
 
-test "#2470: a waiter withdrawing during an unlocked ring leaves no dangling notifier" {
+// Churn coverage: real enroll/withdraw pairs raced against a ringer
+// hammering the registry. What this pins is registry consistency — no lost
+// or duplicated entries, every enrolment balanced, no leaked notifiers —
+// under contention. It deliberately does NOT claim to pin the snapshot's
+// retain: this test's reactor holds its base reference until after the
+// ringer joins, so a withdraw here can never reach the refcount's zero
+// transition and a missing retain would slip through. That property is the
+// gate test below, which parks the ring at the exact point (PR #2479
+// review).
+test "#2470: enroll/withdraw churn against a hammering ringer leaves the registry consistent" {
     if (comptime platform.is_wasm) return error.SkipZigTest; // no OS threads on wasm32-wasi
     const notifier_baseline = reactor_mod.notifierLiveCount();
 
@@ -953,12 +964,6 @@ test "#2470: a waiter withdrawing during an unlocked ring leaves no dangling not
         ringer.join();
     }
 
-    // Repeatedly enrol then withdraw while the ringer hammers the registry.
-    // The ringer's snapshot holds a reference from its copy under the lock to
-    // its release after the ring, so this withdraw's release can never be
-    // the zero transition while a snapshotted copy exists. Without that
-    // retain/release pair the withdraw frees the notifier out from under the
-    // ring's `notify()` — use-after-free on the fd and the struct.
     var i: usize = 0;
     while (i < 500) : (i += 1) {
         try std.testing.expect(reactor_mod.enrollCrossThreadWaiter(n));
@@ -967,6 +972,100 @@ test "#2470: a waiter withdrawing during an unlocked ring leaves no dangling not
 
     try std.testing.expectEqual(@as(usize, 0), reactor_mod.crossThreadWaiterCount());
     try std.testing.expectEqual(notifier_baseline + 1, reactor_mod.notifierLiveCount()); // reactor's own
+}
+
+/// Context for `ringGateHook`: parks the ringer inside the unlocked ring,
+/// holding the snapshot's reference to `target`, until the test opens it.
+/// Bare atomics with `platform.spinBackoff`, per the house rule for every
+/// cross-thread wait loop since #2468 — this std.Thread has no semaphore,
+/// and a two-flag handoff is less machinery than anything futex-shaped.
+var ring_gate_ctx: ?*RingGate = null;
+
+const RingGate = struct {
+    target: *reactor_mod.ThreadNotifier,
+    /// Set by the hook once the ringer is parked on `target`.
+    entered: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    /// Cleared by the test to let the parked ringer out.
+    open: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+};
+
+fn ringGateHook(n: *reactor_mod.ThreadNotifier) void {
+    const g = ring_gate_ctx orelse return;
+    if (n != g.target) return;
+    g.entered.store(true, .release);
+    // Unbounded by design: every exit path of the gate test below opens the
+    // gate through a defer, so even a failing assertion cannot strand the
+    // ringer here and hang the suite.
+    var spins: u32 = 0;
+    while (!g.open.load(.acquire)) : (spins +|= 1) platform.spinBackoff(spins);
+}
+
+test "#2470: the snapshot retain alone keeps a torn-down notifier alive through the ring" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no OS threads on wasm32-wasi
+    const notifier_baseline = reactor_mod.notifierLiveCount();
+
+    var reactor = try reactor_mod.Reactor.init(std.testing.allocator);
+    var reactor_open = true;
+    defer if (reactor_open) reactor.deinit();
+    const n = reactor.notifyHandle();
+    try std.testing.expect(reactor_mod.enrollCrossThreadWaiter(n));
+    var enrolled = true;
+    defer if (enrolled) reactor_mod.withdrawCrossThreadWaiter(n);
+
+    var gate = RingGate{ .target = n };
+    ring_gate_ctx = &gate;
+    reactor_mod.ring_test_gate = ringGateHook;
+    const Ringer = struct {
+        fn run() void {
+            reactor_mod.wakeCrossThreadWaiters();
+        }
+    };
+    const ringer = try std.Thread.spawn(.{}, Ringer.run, .{});
+    var joined = false;
+    // Registered last, runs first on every exit path (LIFO): release the
+    // parked ringer, join it, then uninstall the gate so nothing after this
+    // test rings through the hook.
+    defer {
+        gate.open.store(true, .release);
+        if (!joined) ringer.join();
+        ring_gate_ctx = null;
+        reactor_mod.ring_test_gate = null;
+    }
+
+    // The ringer is now somewhere between its snapshot and its release; wait
+    // until the gate proves it is parked on OUR notifier. Bounded, so a ring
+    // that somehow skipped the enrolled waiter fails the test instead of
+    // hanging the suite.
+    const deadline = fiber_mod.clockNs() + poll_retry_bound_ns;
+    var spins: u32 = 0;
+    while (!gate.entered.load(.acquire)) : (spins +|= 1) {
+        if (fiber_mod.clockNs() > deadline) return error.RingNeverEnteredGate;
+        platform.spinBackoff(spins);
+    }
+
+    // Drop BOTH other references while the ring holds its snapshot:
+    // deinit releases the reactor's base (and flips `alive`, making the
+    // ring's notify on it the documented skip-the-syscall path), withdraw
+    // releases the registry's. Refcount 3 -> 2 -> 1, neither a zero
+    // transition. Without the snapshot's retain the withdraw IS the zero
+    // transition — notifier freed, backend fd closed — while the parked
+    // ringer still holds the raw pointer it is about to notify and release.
+    reactor.deinit();
+    reactor_open = false;
+    reactor_mod.withdrawCrossThreadWaiter(n);
+    enrolled = false;
+
+    // The snapshot's retain is now the only live reference: the notifier
+    // must still be allocated.
+    try std.testing.expectEqual(notifier_baseline + 1, reactor_mod.notifierLiveCount());
+
+    gate.open.store(true, .release);
+    ringer.join();
+    joined = true;
+
+    // The ring's own releaseNotifier was the zero transition: backend
+    // closed, notifier freed, live count back at the baseline.
+    try std.testing.expectEqual(notifier_baseline, reactor_mod.notifierLiveCount());
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests_reactor.zig
+++ b/src/tests_reactor.zig
@@ -887,9 +887,18 @@ test "#2395: a ring is a real OS event that ends a blocking reactor poll" {
 /// (Linux only) a second for its notifier's eventfd. Stay under the soft
 /// NOFILE limit rather than assuming it is generous.
 fn reactorBudget() usize {
-    const lim = std.posix.getrlimit(.NOFILE) catch return 4;
+    // Windows has no getrlimit in std.posix (the test never runs there — the
+    // cross build is a compile gate), and the BSDs type rlim_t as signed i64,
+    // so clamp through a cast rather than assuming the unsigned Linux/macOS
+    // shape (kaappi PR #2479 CI).
+    const soft: u64 = if (comptime builtin_os == .windows)
+        256
+    else blk: {
+        const lim = std.posix.getrlimit(.NOFILE) catch return 4;
+        break :blk @intCast(@max(0, lim.cur));
+    };
     const worst_case = 2; // epoll + eventfd
-    const headroom = lim.cur / 2; // half the soft limit is already ours to use
+    const headroom = soft / 2; // half the soft limit is already ours to use
     return @max(2, @min(130, headroom / worst_case));
 }
 


### PR DESCRIPTION
Closes #2470
Closes #2472

Follow-ups from #2468/#2446.

## #2470 — snapshot-then-ring in `wakeCrossThreadWaiters`

`wakeCrossThreadWaiters` (`src/reactor.zig`) used to ring every enrolled thread *under* `wait_registry_lock` — one syscall (`kevent` change / `eventfd` write / `SetEvent`) per parked thread inside the critical section. With many parked threads, a ringer preempted mid-syscall held the lock for a scheduler quantum, and every waiter arriving at enroll/withdraw paid the spin-backoff wait on its way out.

Restructured to `shared_channel.ring`'s snapshot-then-ring shape, with the allocation problem solved by a fixed stack array:

- The first 128 entries are snapshotted under the lock, each `retainNotifier`'d so a waiter that withdraws and frees its notifier during the unlocked ring cannot leave a dangling pointer.
- The lock is dropped, then each snapshotted notifier is `notify()`'d and `releaseNotifier`'d outside it — the release matters twice over: `notify()` is a syscall apiece, and `releaseNotifier`'s zero transition closes the backend fd; neither belongs in the critical section.
- Entries past 128 are the overflow tail, rung under the lock as before (more than 128 blocked OS threads is already pathological).
- The "takes the lock even to find it empty" rule is unchanged — the snapshot still acquires the lock, so the store-buffering argument in the doc comment is untouched.

`docs/dev/fibers-and-reactor.md` updated to match (the "ring is still issued under the lock" sentence).

### Regression tests (src/tests_reactor.zig)

- `#2470: wakeCrossThreadWaiters rings every waiter from outside the lock` — up to 130 reactors enrolled (scaled by the soft `RLIMIT_NOFILE`, deliberately straddling the 128-entry snapshot when the fd budget allows, so the overflow tail is exercised too), one ring, every `wake_pending` asserted, counts and `notifierLiveCount` return to baseline.
- `#2470: a waiter withdrawing during an unlocked ring leaves no dangling notifier` — a ringer OS thread hammers `wakeCrossThreadWaiters` while the main thread does 500 enroll/withdraw cycles; without the retain/release pair the withdraw frees the notifier out from under the ring's `notify()`. This is the use-after-free the retain guards.

Not run under `-Dgc-stress` specifically: the notifiers and registry use `std.heap.c_allocator`, not the GC, so gc-stress adds no coverage here; both tests do run as part of the normal suite.

## #2472 — WinSock init spin through `platform.spinBackoff`

`src/platform_win_sock.zig`'s `ensureWinsock` had the last bare `while (!winsock_mutex.tryLock()) std.atomic.spinLoopHint();` spin, contradicting the "write every new cross-thread wait loop through `platform.spinBackoff`" rule. Converted to the same `var spins: u32 = 0; while (...) : (spins +|= 1) platform.spinBackoff(spins);` shape as `memory.spinLock`, via the already-imported `platform` (the circular reach-back `platform_win_sock.zig` already does for `platform.win`).

### Test note

#2472 is a pure refactor of a Windows-only wait loop with no observable behavior change; no unit test is feasible on macOS. Verified by `zig build -Dtarget=x86_64-windows` (compiles clean) and relied on the `windows-test` CI leg plus that compile gate.

## Verification

- `zig build test` — full unit suite green
- `zig build test -Dtest-filter='#2470'` — new tests pass
- `zig build -Dtarget=x86_64-windows` — cross-compiles
- `zig fmt --check` clean