### PR TITLE
thread-start!: unwind the extra_roots entry on spawn failure

### DIFF
--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -764,12 +764,8 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
     // #2446: the exit flag the join waits on instead of pthread_join (see
     // Fiber.os_exit). Allocated before the spawn so the child can never
     // outrun it; c_allocator because it outlives both heaps' owners.
-    const exit_flag = std.heap.c_allocator.create(fiber_mod.OsThreadExit) catch {
-        _ = @atomicRmw(usize, &live_child_threads, .Sub, 1, .release);
-        if (spawner) |s| {
-            _ = @atomicRmw(u32, &s.live_descendants, .Sub, 1, .release);
-        }
-        envelope.deinit();
+    const exit_flag = os_thread_exit_allocator.create(fiber_mod.OsThreadExit) catch {
+        abandonSpawn(gc, fiber, args[0], spawner, envelope);
         return PrimitiveError.OutOfMemory;
     };
     exit_flag.* = .{};
@@ -779,11 +775,7 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
     }) catch {
         fiber.os_exit = null;
         std.heap.c_allocator.destroy(exit_flag);
-        _ = @atomicRmw(usize, &live_child_threads, .Sub, 1, .release);
-        if (spawner) |s| {
-            _ = @atomicRmw(u32, &s.live_descendants, .Sub, 1, .release);
-        }
-        envelope.deinit();
+        abandonSpawn(gc, fiber, args[0], spawner, envelope);
         return PrimitiveError.OutOfMemory;
     };
     fiber.os_thread = thread;
@@ -801,6 +793,36 @@ fn threadStartImpl(args: []const Value) PrimitiveError!Value {
     thread.detach();
 
     return args[0];
+}
+
+/// #2473 test seam: the exit flag is allocated from the C heap because it
+/// outlives both heaps' owners (and freed there by releaseOsThreadExit). In
+/// unit tests this is swapped for an OomAllocator-backed allocator to force
+/// the create failure; only the failure path ever runs under a substitute,
+/// so no flag is allocated or freed through it.
+pub var os_thread_exit_allocator: std.mem.Allocator = std.heap.c_allocator;
+
+/// #2473: single unwind for every pre-spawn failure after the extra_roots
+/// append in threadStartImpl. Without it, a failed `c_allocator.create` or
+/// `std.Thread.spawn` undid the counters and the envelope but left the fiber
+/// rooted in extra_roots forever: its status stays `.running`, so
+/// no later thread-join! ever reaches reapOsThread (the only other remover)
+/// and the fiber, its thunk and everything the thunk closes over stay
+/// reachable for the life of the GC. Restores the fiber to exactly its
+/// pre-start state so it is again an unstarted handle.
+fn abandonSpawn(gc: *memory.GC, fiber: *fiber_mod.Fiber, handle: Value, spawner: ?*fiber_mod.Fiber, envelope: *shared_channel.Envelope) void {
+    for (gc.extra_roots.items, 0..) |v, idx| {
+        if (v == handle) {
+            _ = gc.extra_roots.swapRemove(idx);
+            break;
+        }
+    }
+    _ = @atomicRmw(usize, &live_child_threads, .Sub, 1, .release);
+    if (spawner) |s| {
+        _ = @atomicRmw(u32, &s.live_descendants, .Sub, 1, .release);
+    }
+    envelope.deinit();
+    fiber.status = .created;
 }
 
 /// #2446: drop one of the two references to a spawn's exit flag. The child

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -1087,3 +1087,43 @@ test "kaappi#2446: thread-join! returns only after the child's whole epilogue" {
         try std.testing.expect(!srfi18.hasLiveChildThreads());
     }
 }
+
+// kaappi#2473: the two pre-spawn failure paths after the extra_roots append
+// (the exit-flag create and std.Thread.spawn) used to unwind the counters and
+// the envelope but leave the fiber rooted in extra_roots forever -- its status
+// never returned to .created, so no thread-join! ever reached reapOsThread,
+// the only other remover. This forces the exit-flag allocation to fail via an
+// OomAllocator countdown (std.Thread.spawn failure has no injection point)
+// and asserts the root count comes back down. Single-threaded by design: the
+// injector is thread-affine, and no child is ever spawned.
+test "kaappi#2473: thread-start! unwinds extra_roots when the spawn setup fails" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // thread-start! is unregistered on wasm
+    // The injector wraps ONLY the exit-flag seam allocator: a countdown on
+    // the GC's own allocator would fire during compilation of the form,
+    // before thread-start! is ever reached.
+    var oom = memory.OomAllocator.init(std.testing.allocator);
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    // Build the handle without starting it.
+    _ = try vm.eval("(define leak-t (make-thread (lambda () 1)))");
+    // extra_roots doubles as the VM's scratch during execution, so compare
+    // relative to the post-define baseline, not to zero.
+    const before = gc.extra_roots.items.len;
+
+    // Route the exit-flag create through the armed injector: the very next
+    // raw allocation on this thread fails, which is the OsThreadExit create.
+    const saved = srfi18.os_thread_exit_allocator;
+    srfi18.os_thread_exit_allocator = oom.allocator();
+    defer srfi18.os_thread_exit_allocator = saved;
+    oom.countdown = 0;
+    const result = vm.eval("(thread-start! leak-t)");
+    oom.countdown = null;
+    try std.testing.expectError(error.OutOfMemory, result);
+
+    // The fiber must no longer be rooted: without the fix the failed spawn
+    // leaves one extra entry, which stays for the life of the GC.
+    try std.testing.expectEqual(before, gc.extra_roots.items.len);
+}


### PR DESCRIPTION
## Summary

`threadStartImpl` roots the fiber in `gc.extra_roots` before spawning, but the two failure paths after the append (the `OsThreadExit` `c_allocator.create` and `std.Thread.spawn`) unwound every other piece of pre-spawn bookkeeping — the `live_child_threads` / `live_descendants` decrements and the envelope deinit — while leaving the root in place. Since the fiber's status stayed `.running`, no later `thread-join!` ever reached `reapOsThread` (the only other remover), so the fiber, its thunk, and everything the thunk closes over stayed reachable for the life of the GC.

This PR:

- Revives an `abandonSpawn`-style single unwind helper that swap-removes the handle from `extra_roots` alongside the counter decrements and the envelope deinit, and restores the fiber to `.created` so a failed start leaves an unstarted handle again. Both post-append failure paths now use it.
- Routes the exit-flag create through `os_thread_exit_allocator` — a test seam that defaults to the C heap — so a unit test can force the create failure with a `memory.OomAllocator` countdown.
- Adds the regression test `kaappi#2473: thread-start! unwinds extra_roots when the spawn setup fails` in `src/tests_srfi18.zig`, asserting `extra_roots` returns to its pre-call length (verified to fail without the fix). `std.Thread.spawn` failure has no injection point, so the allocation path is the covered one, as suggested in the issue.

## Testing

- `zig build test` — green
- `zig build test -Dtest-filter=srfi18` — green
- `zig build test -Dgc-stress=true` — green

Closes #2473