### PR TITLE
Make the builtin-superinstruction gate a run-time decision (#2469)

### DIFF
--- a/.claude/skills/bytecode-isa/SKILL.md
+++ b/.claude/skills/bytecode-isa/SKILL.md
@@ -5,7 +5,7 @@ description: Reference for the Kaappi bytecode instruction set
 # Bytecode ISA
 
 The instruction set reference lives in `docs/dev/bytecode.md` — read that
-file for the full 33-opcode table, operand encodings, closure capture
+file for the full 34-opcode table, operand encodings, closure capture
 encoding, and disassembler output format. Do not duplicate the table here;
 that doc is the single source of truth.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,28 +69,6 @@ this file — put the *why* in the commit body instead.
 
 ### Fixed
 
-- **The builtin-superinstruction gate is now a run-time decision** (#2469,
-  R7RS 5.3.1) — #2457 pre-scanned a compilation unit for top-level
-  redefinitions of `apply`, `call-with-values`, `eval`, `call/cc` and
-  `call-with-current-continuation`, which left every route without
-  whole-unit knowledge baking the builtin into bodies compiled before the
-  redefinition ran: a file's own use-before-define order under `load`, a
-  redefinition inside an `eval`'d `begin` or performed by a later `eval`,
-  the REPL and the WASM playground, and a `set!` that only materializes
-  when a macro expands. Each superinstruction now sits behind a new
-  `guard_builtin` opcode that resolves the operator's global (through the
-  same per-function cache as `get_global`), takes the fast path only while
-  that value is still the pristine primitive, and otherwise jumps to an
-  ordinary call of whatever the global holds; the native backend's
-  `emitApplyForm` makes the same decision through
-  `kaappi_builtin_is_pristine`. The whole-unit scan, its install sites in
-  the file, stdin, `compile` and `check` drivers, and the REPL/`eval`
-  carve-outs are gone, and `call-with-values` now evaluates its producer
-  before its consumer, like any other call. Found alongside: a natively
-  compiled `set!` of a global (`kaappi_set_global`) never invalidated the
-  interpreter's per-function global caches, so an interpreted body could
-  keep serving the old binding; it now bumps `global_version` like the
-  `set_global` opcode.
 - **A continuation captured inside `call-with-values`' producer can be
   resumed after the form returned** (#2453) — the producer kept running
   under the native `%call-with-values->list` frame even after #2451 moved
@@ -265,10 +243,9 @@ this file — put the *why* in the commit body instead.
   `MultipleValues` object from `values` — into the fresh argument list the
   consumer's apply reads. `%call-with-values-check` replaces
   `%call-with-values->list` for the operand type checks, still reported as
-  `call-with-values` before anything runs. `values_list` is appended
-  last per the `.sbc` numbering rule (the count is 34 with #2469's
-  `guard_builtin`); no `.sbc` format bump, since the cache is keyed by
-  compiler hash. Internally, the
+  `call-with-values` before anything runs. The opcode count is now 33
+  (`values_list` appended last per the `.sbc` numbering rule); no `.sbc`
+  format bump, since the cache is keyed by compiler hash. Internally, the
   builtin gate (`globalBindingStillGenuine`) and the `set!` pre-scan moved
   from `compiler.zig` to the new `compiler_gate.zig` (file-size policy).
 - **Cross-thread SRFI-18 waits are woken by the reactor notifier instead of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,9 +267,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `MultipleValues` object from `values` — into the fresh argument list the
   consumer's apply reads. `%call-with-values-check` replaces
   `%call-with-values->list` for the operand type checks, still reported as
-  `call-with-values` before anything runs. The opcode count is now 33
-  (`values_list` appended last per the `.sbc` numbering rule); no `.sbc`
-  format bump, since the cache is keyed by compiler hash. Internally, the
+  `call-with-values` before anything runs. `values_list` is appended
+  last per the `.sbc` numbering rule (the count is 34 with #2469's
+  `guard_builtin`); no `.sbc` format bump, since the cache is keyed by
+  compiler hash. Internally, the
   builtin gate (`globalBindingStillGenuine`) and the `set!` pre-scan moved
   from `compiler.zig` to the new `compiler_gate.zig` (file-size policy).
 - **Cross-thread SRFI-18 waits are woken by the reactor notifier instead of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **The builtin-superinstruction gate is now a run-time decision** (#2469,
+  R7RS 5.3.1) — #2457 pre-scanned a compilation unit for top-level
+  redefinitions of `apply`, `call-with-values`, `eval`, `call/cc` and
+  `call-with-current-continuation`, which left every route without
+  whole-unit knowledge baking the builtin into bodies compiled before the
+  redefinition ran: a file's own use-before-define order under `load`, a
+  redefinition inside an `eval`'d `begin` or performed by a later `eval`,
+  the REPL and the WASM playground, and a `set!` that only materializes
+  when a macro expands. Each superinstruction now sits behind a new
+  `guard_builtin` opcode that resolves the operator's global (through the
+  same per-function cache as `get_global`), takes the fast path only while
+  that value is still the pristine primitive, and otherwise jumps to an
+  ordinary call of whatever the global holds; the native backend's
+  `emitApplyForm` makes the same decision through
+  `kaappi_builtin_is_pristine`. The whole-unit scan, its install sites in
+  the file, stdin, `compile` and `check` drivers, and the REPL/`eval`
+  carve-outs are gone, and `call-with-values` now evaluates its producer
+  before its consumer, like any other call. Found alongside: a natively
+  compiled `set!` of a global (`kaappi_set_global`) never invalidated the
+  interpreter's per-function global caches, so an interpreted body could
+  keep serving the old binding; it now bumps `global_version` like the
+  `set_global` opcode.
 - **A continuation captured inside `call-with-values`' producer can be
   resumed after the form returned** (#2453) — the producer kept running
   under the native `%call-with-values->list` frame even after #2451 moved

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -81,7 +81,7 @@ investigations.
 
 | Document | Contents |
 |----------|----------|
-| [bytecode.md](bytecode.md) | Bytecode instruction set (33 opcodes), encoding, disassembler |
+| [bytecode.md](bytecode.md) | Bytecode instruction set (34 opcodes), encoding, disassembler |
 | [repl.md](repl.md) | REPL reference: line editing, comma commands, completion |
 | [unicode-case-mapping.md](unicode-case-mapping.md) | Case-conversion coverage by script |
 | [fuzzing-feasibility.md](fuzzing-feasibility.md) | Why neither Fuzzilli nor AFL++ is the tool, the existing `std.testing.fuzz` targets, and where fuzzing can improve |

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -97,8 +97,8 @@ its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 | `compiler_advanced.zig` | case, case-lambda, guard, quasiquote |
 | `compiler_macro.zig` | Macro-use path: expandAndCompileMacroUse, hygiene injection walks, free-ref collection; re-exports compiler_define_syntax.zig |
 | `compiler_define_syntax.zig` | Macro-defining forms: define-syntax, let-syntax, letrec-syntax, define-property, transformer-spec resolution (SRFI 147), syntax-rules parsing, transformer finalization |
-| `compiler_passthrough.zig` | The `passthrough` path's form compilers: quote, if, call, and the tail-position specializations (`apply`, `call-with-values`, `call/cc`, `eval`); owns the whole-unit top-level target set (`unit_top_level_targets`, kaappi#2457) |
-| `compiler_gate.zig` | Redefinition-awareness: the builtin-bypass gate `globalBindingStillGenuine` (superinstruction decisions for redefined built-ins) and the `set!` pre-scan that feeds it (`collectSetTargets`, `scanSetTargetsWithoutMacros`) |
+| `compiler_passthrough.zig` | The `passthrough` path's form compilers: quote, if, call, and the builtin superinstructions (`apply`, `call-with-values`, `call/cc`, `eval`) with the run-time `guard_builtin` gate and slow path each is emitted behind (kaappi#2469) |
+| `compiler_gate.zig` | Redefinition-awareness: the builtin-bypass heuristic `globalBindingStillGenuine` (whether a superinstruction is worth emitting; correctness is `guard_builtin`'s since kaappi#2469) and the `set!` pre-scan that feeds it (`collectSetTargets`, `scanSetTargetsWithoutMacros`) |
 | `compiler_forms.zig` | Re-export hub (thin file, don't edit directly) |
 
 ### VM (split into 11 files)
@@ -333,7 +333,7 @@ enum value followed by operands.
 
 ### Opcodes
 
-33 opcodes, defined by the `OpCode` enum in `src/types.zig`. Register, slot,
+34 opcodes, defined by the `OpCode` enum in `src/types.zig`. Register, slot,
 constant-index and symbol-index operands are u16 (big-endian); only `nargs` and
 a closure capture descriptor's `is_local` flag are u8.
 

--- a/docs/dev/bytecode.md
+++ b/docs/dev/bytecode.md
@@ -5,7 +5,7 @@ the ISA — the `/bytecode-isa` skill points here.
 
 ## Instruction set
 
-33 opcodes, register-based, variable-length encoding. Register/slot,
+34 opcodes, register-based, variable-length encoding. Register/slot,
 constant-index and symbol-index operands are all u16 (big-endian); jump
 offsets are i16 (signed, relative to the instruction after the jump). The
 only u8 operands are `nargs` and the `is_local` flag in a closure capture
@@ -51,6 +51,7 @@ operand-width table — it is what `ensureOperands` validates against, so the
 | 30 | `tail_eval` | base:u16, nargs:u8 | 4 | `eval` in tail position: compiles the expression at base+0 (optional environment at base+1) and tail-calls it |
 | 31 | `apply` | base:u16, nargs:u8 | 4 | Non-tail apply with list unpacking: flattens the final operand list into base+1… and calls the procedure at base+0 with an ordinary frame, result → base |
 | 32 | `values_list` | dst:u16, src:u16 | 5 | Spread a call-with-values producer's return value (single value or `MultipleValues`) into a fresh argument list → dst, for the apply that follows |
+| 33 | `guard_builtin` | dst:u16, sym:u16, kind:u8, offset:i16 | 8 | Run-time gate for a builtin superinstruction: resolve global sym → dst like `get_global`, fall through while it is still the pristine primitive `kind`, else jump offset to the ordinary call emitted after the fast path |
 
 `self_tail_call` skips the global lookup, type check, and arity check for
 direct self-recursion and named `let` loops — see
@@ -87,6 +88,38 @@ ordinary `call` of the producer, `values_list`, then `apply`/`tail_apply` of
 the consumer. Because the producer runs under an ordinary call opcode, its
 frame is part of the copied VM state and a continuation captured inside it is
 resumable after the form returns — the same property #2451 gave the consumer.
+
+`guard_builtin` is what makes every superinstruction honest about
+redefinition (kaappi#2469). R7RS 5.3.1 makes a top-level definition
+essentially an assignment, so which binding `(apply f xs)` reaches is a
+run-time question; a compile-time read of the global (#2033) or a whole-unit
+pre-scan for later definitions (#2457) is baked into bytecode that may run
+after a `load`, an `eval`, a REPL form, or a macro-materialized `set!` rebinds
+the name. Every user-text `apply` / `call-with-values` / `call/cc` /
+`call-with-current-continuation` / `eval` fast path is therefore emitted as
+
+```text
+<operands into base+1 ...>
+guard_builtin  base, sym, kind, ->slow   ; base := current global binding
+<superinstruction over base+1 ...>       ; only while still pristine
+move dst, <result>                       ; (non-tail)
+jump ->end
+slow:
+call / tail_call  base, n                ; whatever the global holds now
+end:
+```
+
+`kind` indexes `library.fast_path_builtins`, and the value compared against
+is `LibraryRegistry.fast_path_pristine[kind]`, snapshotted at registration
+and root-marked so a redefinition cannot free it. The lookup goes through
+the same per-function global cache as `get_global`
+(`vm_dispatch_helpers.lookupGlobalCached`), so a genuine call pays one cached
+load and one compare. The jump over the slow path is emitted in tail
+position too: a continuation captured by `tail_call_cc` resumes at the
+instruction after it, which must be the form's exit rather than the slow
+path's call. Only compiler-synthesized references (`baseBindingSymbol`),
+which resolve through the pristine registry by construction, are emitted
+unguarded.
 
 ### Encoding details
 

--- a/docs/dev/claude-code-harness.md
+++ b/docs/dev/claude-code-harness.md
@@ -258,7 +258,7 @@ missing type dispatch).
 ### `/bytecode-isa`
 
 Reference for the bytecode instruction set. Points at
-[bytecode.md](bytecode.md) (the single source of truth for the 33-opcode
+[bytecode.md](bytecode.md) (the single source of truth for the 34-opcode
 table and encodings) and carries the adding-a-new-opcode checklist. Used
 when working on the compiler or VM.
 

--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -635,17 +635,20 @@ expression in the body (~19x on kaappi#1803's arithmetic-loop reproducer). So
 `emitApplyForm` (`llvm_emit.zig`), which mirrors the interpreter's own dispatch
 (`compiler.zig`) case for case:
 
-- **tail + unshadowed + unrebound + ≥2 operands** — structural apply with
-  built-in semantics: the callee and fixed arguments are emitted like
-  `emitCallNode`'s, and the final operand is passed as a Value to `@kaappi_apply`
-  (`runtime_exports.zig`), which splices it with `primitives.applyFn`'s exact
-  semantics — same `isProcedure` validation, same tortoise-and-hare
-  proper-list check (a circular list raises rather than hangs), same
-  `typeError` texts. Since #2033 the interpreter's `tail_apply` opcode honours
-  a top-level rebinding of `apply` (R7RS 5.3.1), gated on the compile-time
-  global binding — so this path is gated the same way: a define/set! of
-  `apply` in the module marks it rebound and routes the form through an
-  ordinary indirect call instead.
+- **unshadowed + unrebound + ≥2 operands** — the guarded shape (kaappi#2469).
+  The operands are emitted once, the `apply` global is resolved, and
+  `@kaappi_builtin_is_pristine` (`runtime_exports.zig`) decides at run time
+  which of two arms runs: the structural apply with built-in semantics — the
+  callee and fixed arguments passed like `emitCallNode`'s, the final operand
+  as a Value to `@kaappi_apply`, which splices it with `primitives.applyFn`'s
+  exact semantics (same `isProcedure` validation, same tortoise-and-hare
+  proper-list check, same `typeError` texts) — or an ordinary indirect call
+  of whatever the global holds now. This is the same decision the
+  interpreter's `guard_builtin` opcode makes (R7RS 5.3.1 makes a top-level
+  redefinition essentially an assignment, so a body compiled before
+  `(define (apply …))` ran must still reach it); `rebound_globals`/`native_fns`
+  only short-circuit to the indirect call when the emitter can already see
+  the name rebound in an earlier form.
 - **tail + unshadowed + unrebound + <2 operands** — the interpreter raises
   InvalidSyntax at compile time; abandoning native compilation of the enclosing
   scope (`error.UnsupportedNodeType`) routes the form to that exact error. A
@@ -653,10 +656,10 @@ expression in the body (~19x on kaappi#1803's arithmetic-loop reproducer). So
   routes it through the ordinary call path (its #2033 gate), and so does the
   generic indirect call here, raising whatever the user's procedure (or the
   built-in arity check) raises at run time.
-- **everything else resolvable** — a lexically shadowed `apply`, a rebound
-  `apply` (tail or non-tail), or a non-tail form with too few operands — is an
-  ordinary indirect call through whatever `apply` resolves to in scope,
-  matching the interpreter's plain `call_global`/local call.
+- **everything else resolvable** — a lexically shadowed `apply`, an `apply`
+  already seen rebound (tail or non-tail), or a non-tail form with too few
+  operands — is an ordinary indirect call through whatever `apply` resolves
+  to in scope, matching the interpreter's plain `call_global`/local call.
 
 Since kaappi#2451 the interpreter has a **non-tail** `apply` opcode as well,
 which calls the flattened callee with an ordinary VM frame so a continuation

--- a/src/bytecode_file_read.zig
+++ b/src/bytecode_file_read.zig
@@ -10,6 +10,7 @@
 const std = @import("std");
 const platform = @import("platform.zig");
 const types = @import("types.zig");
+const library = @import("library.zig");
 const memory = @import("memory.zig");
 const file_utils = @import("file_utils.zig");
 const bf = @import("bytecode_file.zig");
@@ -342,7 +343,7 @@ fn validateFunctionBytecode(func: *Function) BytecodeError!void {
     var ip: usize = 0;
     while (ip < code.len) {
         const raw = code[ip];
-        if (raw > @intFromEnum(OpCode.values_list)) return BytecodeError.CorruptedFile;
+        if (raw > @intFromEnum(OpCode.guard_builtin)) return BytecodeError.CorruptedFile;
         const op: OpCode = @enumFromInt(raw);
         ip += 1;
 
@@ -374,6 +375,20 @@ fn validateFunctionBytecode(func: *Function) BytecodeError!void {
             .tail_call_cc => {
                 if (ip + 4 > code.len) return BytecodeError.CorruptedFile;
                 ip += 4;
+            },
+            .guard_builtin => {
+                // dst:u16, sym_idx:u16, kind:u8, offset:i16 (kaappi#2469): the
+                // symbol must be a constant, the kind a fast_path_builtins
+                // index, and the jump must land inside the function.
+                if (ip + 7 > code.len) return BytecodeError.CorruptedFile;
+                ip += 2; // dst
+                const idx = try readU16FromCode(code, &ip);
+                try validateSymbolConstant(func, idx);
+                if (code[ip] >= library.fast_path_builtins.len) return BytecodeError.CorruptedFile;
+                ip += 1; // kind
+                const off = try readI16FromCode(code, &ip);
+                const target = @as(i64, @intCast(ip)) + @as(i64, off);
+                if (target < 0 or target > code.len) return BytecodeError.CorruptedFile;
             },
             .get_global => {
                 if (ip + 4 > code.len) return BytecodeError.CorruptedFile;

--- a/src/check.zig
+++ b/src/check.zig
@@ -28,7 +28,6 @@ const std = @import("std");
 const types = @import("types.zig");
 const reader = @import("reader.zig");
 const compiler = @import("compiler.zig");
-const compiler_passthrough = @import("compiler_passthrough.zig");
 const vm_mod = @import("vm.zig");
 const vm_library = @import("vm_library.zig");
 const ir_mod = @import("ir.zig");
@@ -130,36 +129,8 @@ pub fn analyzeSource(vm: *VM, ctx: *check_lint.Context, source: []const u8, path
         ir_mod.optimize_enabled = saved_opt;
     }
 
-    // The exact whole-unit target set a run of this source would install
-    // (kaappi#2457) drives the superinstruction gate during the compiles
-    // below: a top-level define OR set! of one of the five fast-path names
-    // anywhere in the file declines the fast path everywhere in it, so an
-    // analysis compiles exactly what a run compiles. Collected by
-    // unitTargetSet — not the lint's user_defined, which misses top-level
-    // `set!` targets — and installed here, the shared path, so every entry
-    // point (`run`, tests, the LSP) gets it and the three surfaces cannot
-    // drift (kaappi#1981).
-    var unit_targets = unitTargetSet(ctx.arena, vm.gc, source);
-    compiler_passthrough.unit_top_level_targets =
-        if (unit_targets.count() > 0) &unit_targets else null;
-    defer compiler_passthrough.unit_top_level_targets = null;
-
     analyze(vm, ctx, ctx.arena, source, path);
     std.mem.sort(check_lint.Finding, ctx.findings.items, {}, findingLess);
-}
-
-/// The exact whole-unit target set for the superinstruction gate
-/// (kaappi#2457): every name a top-level `define` / `define-values` / `set!`
-/// targets anywhere in `source`, collected by
-/// `compiler_passthrough.collectUnitTopLevelTargets` — the same scan a run of
-/// the file installs. Deliberately NOT the lint's user_defined set, which
-/// additionally gathers define-syntax names and, crucially, misses top-level
-/// `set!` targets. Keys are duped into `arena`; the returned map is valid as
-/// long as the arena is.
-pub fn unitTargetSet(arena: std.mem.Allocator, gc: *@import("memory.zig").GC, source: []const u8) std.StringHashMap(void) {
-    var out = std.StringHashMap(void).init(arena);
-    compiler_passthrough.collectUnitTopLevelTargets(&out, gc, source);
-    return out;
 }
 
 fn analyze(vm: *VM, ctx: *check_lint.Context, arena: std.mem.Allocator, source: []const u8, path: []const u8) void {

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -6,6 +6,7 @@ const forms = @import("compiler_forms.zig");
 const advanced = @import("compiler_advanced.zig");
 const passthrough = @import("compiler_passthrough.zig");
 const gate = @import("compiler_gate.zig");
+const library = @import("library.zig");
 const macro = @import("compiler_macro.zig");
 const ir_mod = @import("ir.zig");
 const compiler_ir = @import("compiler_ir.zig");
@@ -1020,26 +1021,35 @@ pub const Compiler = struct {
                     std.mem.eql(u8, eff_name, "call/cc") or
                     std.mem.eql(u8, eff_name, "eval"))))
             {
-                // #2033: a *user-text* reference must resolve like any other
-                // global — R7RS 5.3.1 makes a top-level redefinition
-                // essentially an assignment, so the builtin's superinstruction
-                // is only sound while the global binding is still the genuine
-                // primitive. Local/upvalue shadowing and the compile-time
-                // global binding (plus the form's own set! pre-scan) gate the
-                // fast path; synthesized references skip the gate entirely.
+                // A *user-text* reference is gated at RUN time (kaappi#2469):
+                // each fast path below is emitted behind a `guard_builtin`
+                // that compares the global's current binding against the
+                // pristine primitive and falls back to an ordinary call, so
+                // a top-level redefinition — in a later form, via `load`,
+                // `eval`, the REPL, or a macro-materialized `set!` — reaches
+                // the user's procedure even from a body compiled before it
+                // ran (R7RS 5.3.1 makes the definition essentially an
+                // assignment). The compile-time checks here only decide
+                // whether the guarded shape is worth emitting: a lexical
+                // shadow, or a global the compiler can already see rebound
+                // (#2033's define-before-use order), takes the ordinary call
+                // path outright. Synthesized references resolve through the
+                // pristine registry by construction and are emitted unguarded.
                 const fast_ok = is_synth or
                     (self.resolveLocal(sym_name) == null and
                         (try self.resolveUpvalue(sym_name)) == null and
                         gate.globalBindingStillGenuine(self, sym_name, eff_name));
                 if (fast_ok) {
-                    if (std.mem.eql(u8, eff_name, "apply")) return passthrough.compileApplyForm(self, expr, dst, is_tail);
-                    if (std.mem.eql(u8, eff_name, "call-with-values")) return passthrough.compileCallWithValuesForm(self, expr, dst, is_tail);
+                    const guard: ?u8 = if (is_synth) null else (library.fastPathKind(eff_name) orelse
+                        return passthrough.compileCall(self, expr, dst, is_tail));
+                    if (std.mem.eql(u8, eff_name, "apply")) return passthrough.compileApplyForm(self, expr, dst, is_tail, guard);
+                    if (std.mem.eql(u8, eff_name, "call-with-values")) return passthrough.compileCallWithValuesForm(self, expr, dst, is_tail, guard);
                     if (std.mem.eql(u8, eff_name, "call-with-current-continuation") or
                         std.mem.eql(u8, eff_name, "call/cc"))
                     {
-                        return passthrough.compileCallCCTail(self, expr, dst);
+                        return passthrough.compileCallCCTail(self, expr, dst, guard);
                     }
-                    if (std.mem.eql(u8, eff_name, "eval")) return passthrough.compileEvalTail(self, expr, dst);
+                    if (std.mem.eql(u8, eff_name, "eval")) return passthrough.compileEvalTail(self, expr, dst, guard);
                 }
             }
         }

--- a/src/compiler_gate.zig
+++ b/src/compiler_gate.zig
@@ -1,14 +1,17 @@
-//! Redefinition-awareness for the compiler (kaappi#2033, #2457, #1775).
+//! Redefinition-awareness for the compiler (kaappi#2033, #2457, #2469, #1775).
 //!
 //! Two cooperating pieces live here because they answer the same question —
 //! "can a compile-time decision that a name still resolves to its built-in
 //! survive until the code runs?" — for two different redefinition routes:
 //!
-//!   * the builtin-bypass gate `globalBindingStillGenuine`, which decides the
-//!     `apply` / `call-with-values` / `call/cc` / `eval` superinstructions in
-//!     `compiler.zig` and the native tier's `emitApplyForm`, consuming both
-//!     the per-form `set!` pre-scan below and the whole-unit target set a
-//!     whole-unit driver installs (`compiler_passthrough.unit_top_level_targets`);
+//!   * the builtin-bypass heuristic `globalBindingStillGenuine`, which decides
+//!     whether the `apply` / `call-with-values` / `call/cc` / `eval`
+//!     superinstructions in `compiler.zig` are worth emitting for a form,
+//!     consuming the per-form `set!` pre-scan below. It is no longer what
+//!     keeps them correct: since kaappi#2469 every emitted superinstruction
+//!     sits behind a run-time `guard_builtin` (see `compiler_passthrough.zig`),
+//!     so this read only avoids emitting a fast path the guard would reject
+//!     on every execution;
 //!   * the `set!` pre-scan (`collectSetTargets` and its budget), which
 //!     discovers the names a form (or a macro it uses) assigns before the
 //!     form compiles, feeding `Compiler.set_targets` and the LLVM backend's
@@ -24,23 +27,30 @@ const expander = @import("expander.zig");
 const macro = @import("compiler_macro.zig");
 const globals_mod = @import("globals.zig");
 const compiler_mod = @import("compiler.zig");
-const passthrough = @import("compiler_passthrough.zig");
 
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
 const Value = types.Value;
 
 /// Answers whether a free global reference spelled `sym_name` (a bare
-/// name like `apply`, or a hygiene-renamed `__hyg_N_apply`) would still
-/// resolve to the genuine `(scheme base)` primitive `base_name` at run
-/// time — the gate the builtin superinstructions
-/// (apply/call-with-values in any position, eval/call/cc in tail
-/// position) need so a top-level
-/// redefinition of one of those names routes to the user's procedure
-/// instead of the baked-in builtin (kaappi#2033). Mirrors
+/// name like `apply`, or a hygiene-renamed `__hyg_N_apply`) resolves to
+/// the genuine `(scheme base)` primitive `base_name` as far as the
+/// compiler can tell — the heuristic that decides whether the builtin
+/// superinstructions (apply/call-with-values in any position, eval/call/cc
+/// in tail position) are worth emitting for a user-text reference.
+///
+/// This is an optimization, not the correctness mechanism. R7RS 5.3.1 makes
+/// a top-level redefinition essentially an assignment, so a body compiled
+/// before `(define (apply f xs) ...)` runs cannot know at compile time which
+/// binding its call will reach; since kaappi#2469 every emitted
+/// superinstruction sits behind a run-time `guard_builtin` that compares the
+/// global's current binding against the pristine primitive and falls back to
+/// an ordinary call. A `true` here therefore never bakes the builtin in; a
+/// `false` only skips emitting a guarded fast path that the compile-time
+/// environment already shows would be rejected on every execution (#2033's
+/// define-before-use order, or a `set!` in the enclosing form). Mirrors
 /// IR.isRedefined's fold gate and the resolution order of
-/// vm_dispatch_helpers.lookupGlobalLocked so the compile-time decision
-/// cannot disagree with what get_global would fetch.
+/// vm_dispatch_helpers.lookupGlobalLocked.
 pub fn globalBindingStillGenuine(self: *const Compiler, sym_name: []const u8, base_name: []const u8) bool {
     // A `set!` target in the enclosing top-level form (or a truncated
     // pre-scan) means the global may hold a different value by the time
@@ -49,19 +59,6 @@ pub fn globalBindingStillGenuine(self: *const Compiler, sym_name: []const u8, ba
     if (self.set_targets) |st| {
         if (st.contains(sym_name) or st.contains(base_name)) return false;
     }
-    // A top-level `define`/`set!` of the name ANYWHERE in the compilation
-    // unit (kaappi#2457): a body compiled before the definition runs
-    // would otherwise bake the builtin in and silently discard the user's
-    // procedure, because this function's compile-time read of the global
-    // environment still sees the pristine binding. Whole-unit drivers
-    // populate the set; per-form entry points (REPL, eval) leave it null
-    // and keep the legacy answer. Declining only ever costs the
-    // superinstruction — the by-name call resolves the genuine binding
-    // when no redefinition intervenes.
-    if (passthrough.unit_top_level_targets) |unit_targets| {
-        if (unit_targets.contains(sym_name) or unit_targets.contains(base_name)) return false;
-    }
-
     // No environment info (standalone/unit-test paths): keep the legacy
     // optimistic behavior, mirroring IR.isRedefined's `orelse return false`.
     const g = self.globals orelse return true;

--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -571,8 +571,25 @@ pub fn compileCallCCTail(self: *Compiler, expr: Value, dst: u16, guard: ?u8) Com
 pub fn compileEvalTail(self: *Compiler, expr: Value, dst: u16, guard: ?u8) CompileError!void {
     // (eval expr) or (eval expr env) in tail position
     // Emits tail_eval opcode: compiles expr at runtime and tail-calls the result.
+    //
+    // A *proper* argument list of the wrong length is an arity question, not a
+    // syntax question: route the form through the ordinary call path so the
+    // runtime arity check reports KP3003 exactly as the same form one position
+    // away does (#2036) — and so a redefined `eval` receives every operand,
+    // not the two this lowering knows about (PR #2481 review). Only an
+    // improper list is malformed syntax. #2405: guarded — a cyclic argument
+    // spine spun the count forever.
+    {
+        var count: usize = 0;
+        var walk = compiler_mod.SpineWalk.init(types.cdr(expr));
+        while (types.isPair(walk.cur)) : (walk.next()) {
+            if (walk.cyclic()) return compiler_mod.circularFormError();
+            count += 1;
+        }
+        if (walk.cur != types.NIL) return CompileError.InvalidSyntax;
+        if (count < 1 or count > 2) return compileCall(self, expr, dst, true);
+    }
     const args = types.cdr(expr);
-    if (args == types.NIL or !types.isPair(args)) return CompileError.InvalidSyntax;
 
     const needs_rebase = (dst + 1 != self.next_register);
     const base = if (needs_rebase) try self.allocReg() else dst;

--- a/src/compiler_passthrough.zig
+++ b/src/compiler_passthrough.zig
@@ -3,145 +3,9 @@ const types = @import("types.zig");
 const compiler_mod = @import("compiler.zig");
 const globals_mod = @import("globals.zig");
 const expander = @import("expander.zig");
-const reader_mod = @import("reader.zig");
-const memory = @import("memory.zig");
 const Compiler = compiler_mod.Compiler;
 const CompileError = compiler_mod.CompileError;
 const Value = types.Value;
-
-// -- Compilation-unit top-level targets (kaappi#2457) ------------------------
-//
-// `globalBindingStillGenuine` decides the builtin superinstruction fast paths
-// (apply / call-with-values in any position, eval / call/cc in tail) by
-// reading the live global environment at COMPILE time. That answer is wrong
-// for a procedure body compiled BEFORE a later top-level `(define apply ...)`
-// runs: R7RS 5.3.1 makes the definition essentially an assignment, so which
-// binding a call resolves is a run-time question the compile-time read cannot
-// settle in that order. The honest fix is a run-time decision (follow-up); the
-// interim is this set: when a driver that knows the whole compilation unit
-// (the file runner, stdin scripts, `kaappi compile`, `kaappi check`) sees the
-// name defined or assigned at top level ANYWHERE in the unit, every fast-path
-// decision in the unit declines, costing the superinstruction only in the
-// programs whose semantics it was getting wrong.
-//
-// Per-form entry points (the REPL, `eval`) have no future knowledge and leave
-// this null, keeping the legacy compile-time answer — a redefinition typed
-// later in a REPL session still cannot retro-fix an earlier-compiled body,
-// exactly as before.
-
-/// Names defined (define / define-values) or assigned (set!) at top level
-/// anywhere in the compilation unit currently being compiled. Keys are owned
-/// by the driver that populated the set and outlive every compile in the
-/// unit. Null on entry points without whole-unit knowledge.
-pub threadlocal var unit_top_level_targets: ?*const std.StringHashMap(void) = null;
-
-/// Fill `out` with every name a top-level `define`, `define-values` or `set!`
-/// targets anywhere in `source`, recursing into top-level `begin` and
-/// `cond-expand` splices (R7RS 5.1 / 4.2.1) like check.zig's lint collector.
-/// Names are duped into the map, which must outlive the unit's compiles; the
-/// transient datums read here are rooted only for the walk.
-///
-/// Structure-only, like Part B of the set! pre-scan: a redefinition that only
-/// materializes when a macro expands is not seen, so such a unit keeps the
-/// legacy behavior. (The per-form pre-scan catches those at the define's own
-/// form; a unit-level speculative expansion pass would cost the whole
-/// expansion budget on every file for the rare case.) A read error stops the
-/// scan — the real run reports it, and nothing past it executes.
-pub fn collectUnitTopLevelTargets(out: *std.StringHashMap(void), gc: *memory.GC, source: []const u8) void {
-    var r = reader_mod.Reader.init(gc, source);
-    defer r.deinit();
-    while (r.hasMore() catch false) {
-        var expr = r.readDatum() catch return;
-        gc.pushRoot(&expr);
-        collectTargetsFromUnitForm(out, expr);
-        gc.popRoot();
-    }
-}
-
-fn collectTargetsFromUnitForm(out: *std.StringHashMap(void), expr: Value) void {
-    if (!types.isPair(expr) or !types.isSymbol(types.car(expr))) return;
-    const head = types.stripHygienicPrefix(types.symbolName(types.car(expr)));
-    const rest = types.cdr(expr);
-
-    // Every spine walked below can carry a datum-label cycle in code position
-    // (R7RS 7.1.2 `#n=`/`#n#` — `(begin . #0=(1 . #0#))` is a real program
-    // the run loop diagnoses as KP2001), so each walk is a guarded SpineWalk,
-    // never a bare `while isPair` (the #2405 family).
-    if (std.mem.eql(u8, head, "define")) {
-        // (define name ...) or (define (name . formals) ...)
-        if (types.isPair(rest)) addUnitTarget(out, types.car(rest));
-    } else if (std.mem.eql(u8, head, "set!")) {
-        if (types.isPair(rest) and types.isSymbol(types.car(rest))) {
-            addUnitName(out, types.symbolName(types.car(rest)));
-        }
-    } else if (std.mem.eql(u8, head, "define-values")) {
-        // (define-values (a b . rest) expr) — every formal is bound.
-        if (types.isPair(rest)) {
-            var f = compiler_mod.SpineWalk.init(types.car(rest));
-            while (types.isPair(f.cur)) : (f.next()) {
-                if (f.cyclic()) return;
-                if (types.isSymbol(types.car(f.cur))) addUnitName(out, types.symbolName(types.car(f.cur)));
-            }
-            if (types.isSymbol(f.cur)) addUnitName(out, types.symbolName(f.cur));
-        }
-    } else if (std.mem.eql(u8, head, "begin")) {
-        // Top-level begin splices: each child is a top-level form (R7RS 5.1).
-        // The walk stops at a cycle rather than reporting it — the real run's
-        // own begin handler is the one that diagnoses, and it runs after (and
-        // independently of) this scan.
-        var cur = compiler_mod.SpineWalk.init(rest);
-        while (types.isPair(cur.cur)) : (cur.next()) {
-            if (cur.cyclic()) return;
-            collectTargetsFromUnitForm(out, types.car(cur.cur));
-        }
-    } else if (std.mem.eql(u8, head, "cond-expand")) {
-        // A top-level cond-expand splices the selected clause's body as
-        // top-level forms; without evaluating the feature requirements, take
-        // every clause body — the same conservative over-approximation
-        // check.zig's collector uses (the safe direction here too: an extra
-        // name only declines a fast path).
-        var clauses = compiler_mod.SpineWalk.init(rest);
-        while (types.isPair(clauses.cur)) : (clauses.next()) {
-            if (clauses.cyclic()) return;
-            const clause = types.car(clauses.cur);
-            if (!types.isPair(clause)) continue;
-            var body = compiler_mod.SpineWalk.init(types.cdr(clause));
-            while (types.isPair(body.cur)) : (body.next()) {
-                if (body.cyclic()) return;
-                collectTargetsFromUnitForm(out, types.car(body.cur));
-            }
-        }
-    }
-}
-
-/// The target of a `define`: a bare symbol, or the head of a possibly-curried
-/// procedure form `((name a) b)` — peel the leading pairs to the name symbol.
-/// The peel advances by car, so a car-side datum-label cycle
-/// (`(define #0=(#0# 1) ...)`) cannot use a cdr SpineWalk; a step cap bounds
-/// it instead (real curried definitions are two or three deep).
-fn addUnitTarget(out: *std.StringHashMap(void), target: Value) void {
-    var t = target;
-    var steps: usize = 0;
-    while (types.isPair(t)) : (t = types.car(t)) {
-        steps += 1;
-        if (steps > 256) return;
-    }
-    if (types.isSymbol(t)) addUnitName(out, types.symbolName(t));
-}
-
-fn addUnitName(out: *std.StringHashMap(void), name: []const u8) void {
-    if (out.contains(name)) return;
-    const owned = out.allocator.dupe(u8, name) catch return;
-    out.put(owned, {}) catch out.allocator.free(owned);
-    // Also record the hygiene-stripped spelling: since #2003 a macro
-    // template's define/set! target is renamed (__hyg_N_<name>), and the
-    // gate compares both the as-written and stripped spellings.
-    const stripped = types.stripHygienicPrefix(name);
-    if (stripped.len != name.len and !out.contains(stripped)) {
-        const owned2 = out.allocator.dupe(u8, stripped) catch return;
-        out.put(owned2, {}) catch out.allocator.free(owned2);
-    }
-}
 
 pub fn compileQuote(self: *Compiler, args: Value, dst: u16) CompileError!void {
     if (args == types.NIL) return CompileError.InvalidSyntax;
@@ -405,11 +269,93 @@ fn compileSelfTailCall(self: *Compiler, expr: Value, dst: u16, nargs: u8) Compil
     }
 }
 
+// -- Builtin superinstructions and their run-time gate (kaappi#2469) ---------
+//
+// `(apply f a ... lst)` and `(call-with-values p c)` in any position, and
+// `(call/cc r)` / `(call-with-current-continuation r)` / `(eval e [env])` in
+// tail position, lower to a superinstruction instead of an ordinary call.
+// R7RS 5.3.1 makes a top-level definition essentially an assignment, so
+// *which* binding one of those names denotes when the call runs is a
+// run-time question: a body compiled before `(define (apply f xs) ...)`
+// executed must still reach the user's procedure. The compiler used to answer
+// it by reading the global environment at compile time (#2033), then by
+// pre-scanning the whole compilation unit for later definitions (#2457); both
+// baked the answer into bytecode compiled before the redefinition ran, and
+// the scan could not see `load`, `eval`, the REPL, or a `set!` a macro
+// materializes.
+//
+// The decision is now made where it belongs, by the `guard_builtin` opcode
+// emitted between a form's operands and its superinstruction:
+//
+//     <operands into base+1 ...>
+//     guard_builtin  base, sym, kind, ->slow   ; base := current global; jump
+//                                              ; unless still the pristine one
+//     <superinstruction over base+1 ...>       ; fast path
+//     move dst, <result>                       ; (non-tail only)
+//     jump ->end
+//   slow:
+//     call / tail_call  base, n                ; whatever the global holds now
+//     move dst, base                           ; (non-tail, rebased only)
+//   end:
+//
+// `base` is reserved for the fetched binding so the slow path is an ordinary
+// call over the operands already in place. Only a compiler-synthesized
+// reference (`globals_mod.baseBindingSymbol`, which resolves through the
+// pristine registry by construction) is emitted unguarded; every user-text
+// reference is guarded, whichever entry point compiled it.
+
+/// Emit `guard_builtin` for the operator `operator` — as spelled, so the
+/// run-time lookup resolves it exactly as `get_global` would, hygienic rename
+/// and all — into `callee_reg`; returns the offset of its jump operand for
+/// `patchJump` once the slow path's position is known.
+fn emitBuiltinGuard(self: *Compiler, operator: Value, kind: u8, callee_reg: u16) CompileError!usize {
+    const sym_idx = try self.addConstant(operator);
+    try self.emitOp(.guard_builtin);
+    try self.emitU16(callee_reg);
+    try self.emitU16(sym_idx);
+    try self.emit(kind);
+    const jump = self.currentOffset();
+    try self.emitI16(0);
+    return jump;
+}
+
+/// Close a guarded superinstruction: move the non-tail fast path's result
+/// from `result_reg` to `dst`, jump over the slow path, then emit the slow
+/// path itself — an ordinary call of the fetched binding in `base` over the
+/// `nargs` operands at base+1.. — leaving `dst` holding the result either way.
+///
+/// The jump is emitted in tail position too, although a tail
+/// superinstruction never falls through: a continuation `tail_call_cc`
+/// captured resumes at the instruction after it, which must be the form's
+/// exit, not the slow path's call.
+fn emitBuiltinSlowPath(self: *Compiler, guard_jump: usize, base: u16, nargs: u8, result_reg: u16, dst: u16, is_tail: bool) CompileError!void {
+    if (!is_tail) {
+        try self.emitOp(.move);
+        try self.emitU16(dst);
+        try self.emitU16(result_reg);
+    }
+    try self.emitOp(.jump);
+    const end_jump = self.currentOffset();
+    try self.emitI16(0);
+    try self.patchJump(guard_jump);
+    try self.emitOp(if (is_tail) .tail_call else .call);
+    try self.emitU16(base);
+    try self.emit(nargs);
+    if (!is_tail and base != dst) {
+        try self.emitOp(.move);
+        try self.emitU16(dst);
+        try self.emitU16(base);
+    }
+    try self.patchJump(end_jump);
+}
+
 /// `(apply f a ... lst)` in either position (kaappi#2451). Tail position emits
 /// `tail_apply`; non-tail emits the `apply` opcode, which — unlike the native
 /// `applyFn` it replaces there — calls the flattened callee with an ordinary VM
 /// frame, so a continuation captured inside it survives the call's return.
-pub fn compileApplyForm(self: *Compiler, expr: Value, dst: u16, is_tail: bool) CompileError!void {
+/// `guard` is the operator's `fast_path_builtins` index for a user-text
+/// reference (gated at run time, see above) and null for a synthesized one.
+pub fn compileApplyForm(self: *Compiler, expr: Value, dst: u16, is_tail: bool, guard: ?u8) CompileError!void {
     var arg_list = types.cdr(expr);
     // A *proper* operand list of the wrong length (< 2) is an arity question,
     // not a syntax question: route the form through the ordinary call path so
@@ -425,12 +371,18 @@ pub fn compileApplyForm(self: *Compiler, expr: Value, dst: u16, is_tail: bool) C
         }
         if (walk.cur != types.NIL) return CompileError.InvalidSyntax;
         if (count < 2) return compileCall(self, expr, dst, is_tail);
+        // The guarded slow path is a call over the operator's binding plus
+        // every operand, and a call's nargs is a u8.
+        if (guard != null and count > 254) return compileCall(self, expr, dst, is_tail);
     }
 
+    // Layout: `base` holds the operator's run-time binding (guarded forms),
+    // the procedure sits at base+1 and its operands follow.
     const needs_rebase = (dst + 1 != self.next_register);
     const base = if (needs_rebase) try self.allocReg() else dst;
+    const proc_reg = try self.allocReg();
 
-    try self.compileExprViaIR(types.car(arg_list), base, false);
+    try self.compileExprViaIR(types.car(arg_list), proc_reg, false);
     arg_list = types.cdr(arg_list);
 
     // The count walk above proved this spine acyclic; cyclic() stays as the
@@ -447,27 +399,29 @@ pub fn compileApplyForm(self: *Compiler, expr: Value, dst: u16, is_tail: bool) C
     if (nargs_count > 255) return CompileError.InternalLimit;
     const nargs: u8 = @intCast(nargs_count);
 
+    const guard_jump: ?usize = if (guard) |kind| try emitBuiltinGuard(self, types.car(expr), kind, base) else null;
     try self.emitOp(if (is_tail) .tail_apply else .apply);
-    try self.emitU16(base);
+    try self.emitU16(proc_reg);
     try self.emit(nargs);
 
     var i: u8 = 0;
     while (i < nargs) : (i += 1) {
         self.freeReg();
     }
-    if (needs_rebase) {
-        // The non-tail opcode leaves its result in `base`, exactly as `call`
-        // does; `tail_apply` never returns here at all.
-        if (!is_tail) {
-            try self.emitOp(.move);
-            try self.emitU16(dst);
-            try self.emitU16(base);
-        }
-        self.freeReg();
+    if (guard_jump) |gj| {
+        try emitBuiltinSlowPath(self, gj, base, nargs + 1, proc_reg, dst, is_tail);
+    } else if (!is_tail) {
+        // The non-tail opcode leaves its result in `proc_reg`, exactly as
+        // `call` does; `tail_apply` never returns here at all.
+        try self.emitOp(.move);
+        try self.emitU16(dst);
+        try self.emitU16(proc_reg);
     }
+    self.freeReg(); // proc_reg
+    if (needs_rebase) self.freeReg();
 }
 
-pub fn compileCallWithValuesForm(self: *Compiler, expr: Value, dst: u16, is_tail: bool) CompileError!void {
+pub fn compileCallWithValuesForm(self: *Compiler, expr: Value, dst: u16, is_tail: bool, guard: ?u8) CompileError!void {
     // (call-with-values producer consumer), either position.
     // Emits bytecode directly: check both operands, call the producer with an
     // ordinary `call` opcode, spread the produced values into an argument
@@ -480,7 +434,7 @@ pub fn compileCallWithValuesForm(self: *Compiler, expr: Value, dst: u16, is_tail
     // Zig frame — `%call-with-values->list`'s, and `callWithValuesFn`'s before
     // that — which the resumed continuation cannot reinstall.)
     //
-    // Diagnostic parity is why the sequence starts with a call to
+    // Diagnostic parity is why the fast path starts with a call to
     // `%call-with-values-check`: callWithValuesFn type-checks BOTH operands,
     // producer first, before anything runs, and reports each through
     // `typeError("call-with-values", ...)` — so a bad consumer or producer is
@@ -489,7 +443,9 @@ pub fn compileCallWithValuesForm(self: *Compiler, expr: Value, dst: u16, is_tail
     // internal primitive is loaded via self.emitTrueBuiltinLoad, which marks
     // the reference to resolve through the pristine registry at run time
     // rather than by ordinary name lookup, so neither a lexical shadow NOR a
-    // top-level redefinition of anything can divert it (#1715).
+    // top-level redefinition of anything can divert it (#1715). The check
+    // sits after the guard: a user's `call-with-values` decides for itself
+    // what it accepts.
     //
     // A *proper* argument list of the wrong length is an arity question, not a
     // syntax question: route the form through the ordinary call path so the
@@ -508,65 +464,78 @@ pub fn compileCallWithValuesForm(self: *Compiler, expr: Value, dst: u16, is_tail
     }
     const args = types.cdr(expr);
     const producer = types.car(args);
-    const rest = types.cdr(args);
-    const consumer = types.car(rest);
+    const consumer = types.car(types.cdr(args));
 
+    // Layout: `base` holds the operator's run-time binding (guarded forms);
+    // the producer and consumer follow in operand order, which is the slow
+    // path's `call base, 2`; three scratch registers above them serve the
+    // fast path. The producer is called from the topmost of those so its
+    // callee window cannot clobber the consumer or the spread list below it.
     const needs_rebase = (dst + 1 != self.next_register);
     const base = if (needs_rebase) try self.allocReg() else dst;
-
-    try self.compileExprViaIR(consumer, base, false);
-
-    const check_base = try self.allocReg();
     const producer_reg = try self.allocReg();
     const consumer_reg = try self.allocReg();
-
     try self.compileExprViaIR(producer, producer_reg, false);
+    try self.compileExprViaIR(consumer, consumer_reg, false);
 
-    // The consumer is already evaluated (in `base`); pass a copy for the
-    // type check. check_base/producer_reg/consumer_reg are consecutive, the
-    // layout `call check_base, 2` reads its callee and two operands from.
+    const guard_jump: ?usize = if (guard) |kind| try emitBuiltinGuard(self, types.car(expr), kind, base) else null;
+
+    // check_base/producer_copy/consumer_copy are consecutive, the layout
+    // `call check_base, 2` reads its callee and two operands from.
+    const check_base = try self.allocReg();
+    const producer_copy = try self.allocReg();
+    const consumer_copy = try self.allocReg();
     try self.emitOp(.move);
+    try self.emitU16(producer_copy);
+    try self.emitU16(producer_reg);
+    try self.emitOp(.move);
+    try self.emitU16(consumer_copy);
     try self.emitU16(consumer_reg);
-    try self.emitU16(base);
     try self.emitTrueBuiltinLoad("%call-with-values-check", check_base);
     try self.emitOp(.call);
     try self.emitU16(check_base);
     try self.emit(2);
 
-    self.freeReg(); // consumer_reg
+    self.freeReg(); // consumer_copy
 
     // The producer call: an ordinary `call` opcode, so its frame lives in the
     // copied VM state (#2453). The result (a single value or a MultipleValues
-    // object) lands in producer_reg, the register `call` delivers into.
-    try self.emitOp(.call);
+    // object) lands in producer_copy, the register `call` delivers into.
+    try self.emitOp(.move);
+    try self.emitU16(producer_copy);
     try self.emitU16(producer_reg);
+    try self.emitOp(.call);
+    try self.emitU16(producer_copy);
     try self.emit(0);
 
     // Spread the produced value(s) into the consumer's argument list.
-    // check_base is dead since the check call returned and is exactly base+1
-    // — the register the apply below reads its list operand from.
+    // check_base is dead since the check call returned and is exactly
+    // consumer_reg+1 — the register the apply below reads its list operand
+    // from.
     try self.emitOp(.values_list);
     try self.emitU16(check_base);
-    try self.emitU16(producer_reg);
+    try self.emitU16(producer_copy);
 
-    self.freeReg(); // producer_reg
+    self.freeReg(); // producer_copy
 
     try self.emitOp(if (is_tail) .tail_apply else .apply);
-    try self.emitU16(base);
+    try self.emitU16(consumer_reg);
     try self.emit(1);
 
     self.freeReg(); // check_base
-    if (needs_rebase) {
-        if (!is_tail) {
-            try self.emitOp(.move);
-            try self.emitU16(dst);
-            try self.emitU16(base);
-        }
-        self.freeReg();
+    if (guard_jump) |gj| {
+        try emitBuiltinSlowPath(self, gj, base, 2, consumer_reg, dst, is_tail);
+    } else if (!is_tail) {
+        try self.emitOp(.move);
+        try self.emitU16(dst);
+        try self.emitU16(consumer_reg);
     }
+    self.freeReg(); // consumer_reg
+    self.freeReg(); // producer_reg
+    if (needs_rebase) self.freeReg();
 }
 
-pub fn compileCallCCTail(self: *Compiler, expr: Value, dst: u16) CompileError!void {
+pub fn compileCallCCTail(self: *Compiler, expr: Value, dst: u16, guard: ?u8) CompileError!void {
     // A *proper* argument list of the wrong length is an arity question, not a
     // syntax question: route the form through the ordinary call path so the
     // runtime arity check reports KP3003 exactly as the same form one position
@@ -586,18 +555,20 @@ pub fn compileCallCCTail(self: *Compiler, expr: Value, dst: u16) CompileError!vo
 
     const needs_rebase = (dst + 1 != self.next_register);
     const base = if (needs_rebase) try self.allocReg() else dst;
-    try self.compileExprViaIR(receiver, base, false);
+    const receiver_reg = try self.allocReg();
+    try self.compileExprViaIR(receiver, receiver_reg, false);
 
+    const guard_jump: ?usize = if (guard) |kind| try emitBuiltinGuard(self, types.car(expr), kind, base) else null;
     try self.emitOp(.tail_call_cc);
-    try self.emitU16(base);
+    try self.emitU16(receiver_reg);
     try self.emitU16(dst);
+    if (guard_jump) |gj| try emitBuiltinSlowPath(self, gj, base, 1, receiver_reg, dst, true);
 
-    if (needs_rebase) {
-        self.freeReg();
-    }
+    self.freeReg(); // receiver_reg
+    if (needs_rebase) self.freeReg();
 }
 
-pub fn compileEvalTail(self: *Compiler, expr: Value, dst: u16) CompileError!void {
+pub fn compileEvalTail(self: *Compiler, expr: Value, dst: u16, guard: ?u8) CompileError!void {
     // (eval expr) or (eval expr env) in tail position
     // Emits tail_eval opcode: compiles expr at runtime and tail-calls the result.
     const args = types.cdr(expr);
@@ -605,21 +576,25 @@ pub fn compileEvalTail(self: *Compiler, expr: Value, dst: u16) CompileError!void
 
     const needs_rebase = (dst + 1 != self.next_register);
     const base = if (needs_rebase) try self.allocReg() else dst;
+    const expr_reg = try self.allocReg();
 
-    try self.compileExprViaIR(types.car(args), base, false);
+    try self.compileExprViaIR(types.car(args), expr_reg, false);
     const rest = types.cdr(args);
     var nargs: u8 = 1;
     if (rest != types.NIL and types.isPair(rest)) {
-        const arg_reg = try self.allocReg();
-        try self.compileExprViaIR(types.car(rest), arg_reg, false);
+        const env_reg = try self.allocReg();
+        try self.compileExprViaIR(types.car(rest), env_reg, false);
         nargs = 2;
     }
 
+    const guard_jump: ?usize = if (guard) |kind| try emitBuiltinGuard(self, types.car(expr), kind, base) else null;
     try self.emitOp(.tail_eval);
-    try self.emitU16(base);
+    try self.emitU16(expr_reg);
     try self.emit(nargs);
+    if (guard_jump) |gj| try emitBuiltinSlowPath(self, gj, base, nargs, expr_reg, dst, true);
 
     if (nargs == 2) self.freeReg();
+    self.freeReg(); // expr_reg
     if (needs_rebase) self.freeReg();
 }
 
@@ -667,46 +642,4 @@ fn compileCallGlobal(self: *Compiler, expr: Value, operator: Value, dst: u16, is
         try self.emitU16(base);
         self.freeReg();
     }
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-test "collectUnitTopLevelTargets: define shapes, splices, and non-captures" {
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-
-    var out = std.StringHashMap(void).init(std.testing.allocator);
-    defer {
-        var it = out.keyIterator();
-        while (it.next()) |k| std.testing.allocator.free(k.*);
-        out.deinit();
-    }
-
-    collectUnitTopLevelTargets(&out, &gc,
-        \\(define (nt) (apply + (list 1 2)))
-        \\(define (apply f xs) 'user)
-        \\(begin (define (call-with-values p c) 'user) 'ignored)
-        \\(cond-expand (kaappi (define eval 'user)) (else (define eval 'other)))
-        \\(define-values (call/cc rest-arg . r) (values 1 2 3))
-        \\(set! call-with-current-continuation (lambda (k) 'user))
-        \\(define (other xs) (apply f (list xs)))
-        \\(let ((q (quote (define not-a-target define)))) q)
-    );
-
-    // All five #2033 names, via every define shape and splice, plus set!.
-    try std.testing.expect(out.contains("apply"));
-    try std.testing.expect(out.contains("call-with-values"));
-    try std.testing.expect(out.contains("eval"));
-    try std.testing.expect(out.contains("call/cc"));
-    try std.testing.expect(out.contains("call-with-current-continuation"));
-    // define-values formals, including the rest formal.
-    try std.testing.expect(out.contains("rest-arg"));
-    // A lambda-local define, lambda formals, and quoted data contribute
-    // nothing: the walk is top-level-only (through begin/cond-expand
-    // splices) and never descends into other forms.
-    try std.testing.expect(!out.contains("not-a-target"));
-    try std.testing.expect(!out.contains("xs"));
-    try std.testing.expect(!out.contains("q"));
 }

--- a/src/disassembler.zig
+++ b/src/disassembler.zig
@@ -62,7 +62,7 @@ fn disassembleInstruction(func: *types.Function, code: []const u8, offset: usize
     const off_str = std.fmt.bufPrint(&buf, "  {d:0>4}  ", .{offset}) catch "  ????  ";
     writeStderr(off_str);
 
-    if (raw_op > @intFromEnum(OpCode.values_list)) {
+    if (raw_op > @intFromEnum(OpCode.guard_builtin)) {
         const s = std.fmt.bufPrint(&buf, "<invalid opcode 0x{x:0>2}>\n", .{raw_op}) catch "<invalid opcode>\n";
         writeStderr(s);
         return ip;
@@ -92,6 +92,7 @@ fn disassembleInstruction(func: *types.Function, code: []const u8, offset: usize
         .tail_call_cc => 4,
         .tail_eval => 3,
         .values_list => 4,
+        .guard_builtin => 7,
     };
     if (ip + fixed_operand_bytes > code.len) {
         writeStderr("<truncated instruction>\n");
@@ -343,6 +344,16 @@ fn disassembleInstruction(func: *types.Function, code: []const u8, offset: usize
             const s = std.fmt.bufPrint(&buf, "tail_eval       r{d}, {d}\n", .{ base, nargs }) catch "tail_eval\n";
             writeStderr(s);
         },
+        .guard_builtin => {
+            const dst = readU16(code, &ip);
+            const sym_idx = readU16(code, &ip);
+            const kind = code[ip];
+            ip += 1;
+            const off = readI16(code, &ip);
+            const target = @as(i64, @intCast(ip)) + @as(i64, off);
+            const s = std.fmt.bufPrint(&buf, "guard_builtin   r{d}, const[{d}], {d}, -> {d}\n", .{ dst, sym_idx, kind, target }) catch "guard_builtin\n";
+            writeStderr(s);
+        },
     }
     return ip;
 }
@@ -506,6 +517,14 @@ test "disassemble all opcodes" {
     emit.op(func, allocator, .self_tail_call);
     emit.u16val(func, allocator, 0); // base register
     emit.byte(func, allocator, 1); // nargs (stays u8)
+
+    // guard_builtin r0, const[0], 0, +0 (kaappi#2469)
+    emit.op(func, allocator, .guard_builtin);
+    emit.u16val(func, allocator, 0); // dst register
+    emit.u16val(func, allocator, 0); // symbol constant index
+    emit.byte(func, allocator, 0); // kind: fast_path_builtins[0] = apply
+    emit.byte(func, allocator, 0); // jump offset high
+    emit.byte(func, allocator, 0); // jump offset low
 
     // Verify all opcodes are present in the bytecode
     try std.testing.expect(func.code.items.len > 120);

--- a/src/library.zig
+++ b/src/library.zig
@@ -86,6 +86,17 @@ pub const LibraryRegistry = struct {
     /// call them from Scheme source — that export is the program-facing half
     /// and has nothing to do with this snapshot.
     internal_bindings: std.StringHashMap(Value),
+    /// The pristine `(scheme base)` primitive behind each name in
+    /// `fast_path_builtins`, snapshotted at registration (kaappi#2469). The
+    /// `guard_builtin` opcode and the native tier's
+    /// `kaappi_builtin_is_pristine` compare a call site's *current* global
+    /// binding against this entry at run time — which is what lets a
+    /// top-level redefinition from a later form, `load`, `eval`, the REPL, or
+    /// a macro-materialized `set!` reach bodies compiled before it ran. VOID
+    /// when the primitive was never registered (a sandbox that excludes it);
+    /// a guard then never takes its fast path. Root-marked by `markVmRoots`,
+    /// since a redefinition drops the object from `globals`.
+    fast_path_pristine: [fast_path_builtins.len]Value = [_]Value{types.VOID} ** fast_path_builtins.len,
 
     pub fn init(allocator: std.mem.Allocator) LibraryRegistry {
         return .{
@@ -175,6 +186,22 @@ fn addExportsForLib(library: *Library, lib: Lib, globals: *std.StringHashMap(Val
 /// hence safe under `--sandbox` and on WASM.
 pub const extra_std_libraries = [_][]const u8{ "scheme.case-lambda", "srfi.9" };
 
+/// The names whose calls the compiler lowers to a superinstruction —
+/// `apply` and `call-with-values` in any position, `call/cc`,
+/// `call-with-current-continuation` and `eval` in tail position — and the
+/// `kind` operand of the `guard_builtin` opcode that gates each one
+/// (kaappi#2469). The index is part of the bytecode encoding and of the
+/// native tier's `kaappi_builtin_is_pristine` ABI: append, never reorder.
+pub const fast_path_builtins = [_][]const u8{ "apply", "call-with-values", "call/cc", "call-with-current-continuation", "eval" };
+
+/// `name`'s index in `fast_path_builtins`, or null for any other name.
+pub fn fastPathKind(name: []const u8) ?u8 {
+    for (fast_path_builtins, 0..) |candidate, i| {
+        if (std.mem.eql(u8, candidate, name)) return @intCast(i);
+    }
+    return null;
+}
+
 /// Snapshot the `.internal` primitives into `registry.internal_bindings` —
 /// see that field for why they live outside `libraries` (#1856). Runs from
 /// both registrars, since compiler-synthesized code needs these under
@@ -186,6 +213,12 @@ fn snapshotInternalBindings(registry: *LibraryRegistry, globals: *std.StringHash
         if (globals.get(spec.name)) |val| {
             try registry.internal_bindings.put(spec.name, val);
         }
+    }
+    // The run-time gate's reference values (kaappi#2469): whatever the
+    // registrar just bound each fast-path name to is, by definition, the
+    // pristine primitive a guard compares against.
+    for (fast_path_builtins, 0..) |name, i| {
+        if (globals.get(name)) |val| registry.fast_path_pristine[i] = val;
     }
 }
 

--- a/src/llvm_emit_forms.zig
+++ b/src/llvm_emit_forms.zig
@@ -22,13 +22,13 @@
 const std = @import("std");
 const ir = @import("ir.zig");
 const types = @import("types.zig");
+const library = @import("library.zig");
 const printer = @import("printer.zig");
 
 const llvm_emit = @import("llvm_emit.zig");
 const LLVMEmitter = llvm_emit.LLVMEmitter;
 const EmitError = llvm_emit.EmitError;
 const NativeLambda = llvm_emit.NativeLambda;
-const compiler_passthrough = @import("compiler_passthrough.zig");
 
 const Value = types.Value;
 
@@ -38,15 +38,6 @@ const void_bits: i64 = @bitCast(types.VOID);
 // Cap on `do` loop variables — bounds the fixed-size scratch arrays below and
 // matches emitLet's 32-binding ceiling. A wider `do` falls back to eval.
 const MAX_DO_VARS = 32;
-
-/// Whether the compilation unit's whole-source scan saw a top-level
-/// define/set! of `name` (kaappi#2457) — the emitter-side mirror of the
-/// interpreter gate's unit arm. Null threadlocal (REPL-time evals, tests)
-/// answers false, keeping the legacy in-order behavior.
-fn unitRedefines(name: []const u8) bool {
-    const targets = compiler_passthrough.unit_top_level_targets orelse return false;
-    return targets.contains(name);
-}
 
 fn fmt(self: *LLVMEmitter, comptime f: []const u8, a: anytype) EmitError![]const u8 {
     return std.fmt.allocPrint(self.allocator(), f, a) catch return error.OutOfMemory;
@@ -1054,17 +1045,18 @@ pub fn emitApplyForm(self: *LLVMEmitter, expr: Value, is_tail: bool) EmitError![
         operands.append(self.backing_alloc, types.car(cur)) catch return error.OutOfMemory;
     }
     if (cur != types.NIL) return error.UnsupportedNodeType;
+    const nargs = operands.items.len;
 
     const shadowed = self.isNameShadowed("apply");
-    // rebound: the name no longer denotes the builtin. rebound_globals and
-    // native_fns are in-order (a define/set! emitted BEFORE this form); the
-    // unit scan (kaappi#2457) adds the whole-unit answer — a define/set! of
-    // `apply` anywhere in the program declines the structural shape even for
-    // uses that precede it, the same interim the interpreter's
-    // globalBindingStillGenuine arm takes.
-    const rebound = self.rebound_globals.contains("apply") or
-        self.native_fns.contains("apply") or
-        unitRedefines("apply");
+    // rebound: the emitter can already see that the name no longer denotes
+    // the builtin — rebound_globals and native_fns are in-order (a
+    // define/set! emitted BEFORE this form). That knowledge only saves
+    // emitting a guarded fast path whose guard would fail on every
+    // execution; the run-time guard below is what makes a redefinition no
+    // scan can see — a later form, `load`, `eval`, a macro-materialized
+    // `set!` — reach the user's procedure (kaappi#2469), exactly as the
+    // interpreter's `guard_builtin` opcode does.
+    const rebound = self.rebound_globals.contains("apply") or self.native_fns.contains("apply");
 
     // Abandon to the interpreter only for the genuinely builtin shape: a
     // rebound `apply` with too few operands is a runtime arity/behavior
@@ -1072,67 +1064,17 @@ pub fn emitApplyForm(self: *LLVMEmitter, expr: Value, is_tail: bool) EmitError![
     // (whose #2033 gate routes it through the ordinary call path), so it
     // falls through to the generic indirect call below, not this compile
     // error.
-    if (!shadowed and !rebound and is_tail and operands.items.len < 2)
+    if (!shadowed and !rebound and is_tail and nargs < 2)
         return error.UnsupportedNodeType;
 
-    const is_builtin_apply = !shadowed and !rebound;
+    const guarded = !shadowed and !rebound and nargs >= 2;
 
-    if (is_builtin_apply and operands.items.len >= 2) {
-        const n_fixed = operands.items.len - 2;
-        const callee = try self.emitScopedOperand(operands.items[0]);
-        // Root the callee and every fixed argument across the remaining
-        // operand emissions (each can allocate). The final list operand
-        // needs no root: nothing allocates between its value and the call
-        // (emitCallNode's discipline for its own last argument).
-        var root_count: usize = 1;
-        try self.emitRootPush(callee);
-        const fixed_tmps = self.allocator().alloc([]const u8, n_fixed) catch return error.OutOfMemory;
-        for (0..n_fixed) |i| {
-            fixed_tmps[i] = try self.emitScopedOperand(operands.items[1 + i]);
-            try self.emitRootPush(fixed_tmps[i]);
-            root_count += 1;
-        }
-        const list_tmp = try self.emitScopedOperand(operands.items[operands.items.len - 1]);
-        try self.emitPopRoots(root_count);
-
-        const result = try self.freshTemp();
-        if (n_fixed == 0) {
-            const call_prefix: []const u8 = if (is_tail) "tail call" else "call";
-            try self.print("  {s} = {s} i64 @kaappi_apply(ptr %vm, i64 {s}, ptr null, i64 0, i64 {s})\n", .{ result, call_prefix, callee, list_tmp });
-        } else {
-            const args_alloca = try self.freshTemp();
-            try self.print("  {s} = alloca [{d} x i64], align 8\n", .{ args_alloca, n_fixed });
-            for (0..n_fixed) |i| {
-                const gep = try self.freshTemp();
-                try self.print("  {s} = getelementptr [1 x i64], ptr {s}, i64 {d}\n", .{ gep, args_alloca, i });
-                try self.print("  store i64 {s}, ptr {s}\n", .{ fixed_tmps[i], gep });
-            }
-            try self.print("  {s} = call i64 @kaappi_apply(ptr %vm, i64 {s}, ptr {s}, i64 {d}, i64 {s})\n", .{ result, callee, args_alloca, n_fixed, list_tmp });
-        }
-
-        if (is_tail) {
-            // Balance the frame-entry GC roots and any live let-binding
-            // roots before returning through this tail call, exactly as
-            // emitCallNode does (#1498/#1585) — a deep apply-driven loop
-            // must not leak one root set per iteration.
-            try self.emitPopRoots(self.frame_entry_roots + self.body_scope_roots);
-            try self.print("  ret i64 {s}\n", .{result});
-            try self.emitOrphanAfterTail();
-        }
-        return result;
-    }
-
-    // Generic path: resolve `apply` like any variable reference (a
-    // parameter, local, upvalue, or the current global binding) and call
-    // it with the operands — emitCallNode's indirect-call tail, inlined.
-    const callee = try self.emitGlobalRef(types.car(expr));
-    const nargs = operands.items.len;
-    var root_count: usize = 0;
-    if (nargs > 0) {
-        try self.emitRootPush(callee);
-        root_count += 1;
-    }
+    // Every operand once, in order, each rooted across the operand emissions
+    // that follow it (any can allocate). The final operand needs no root:
+    // nothing allocates between its value and either call below
+    // (emitCallNode's discipline for its own last argument).
     const arg_tmps = self.allocator().alloc([]const u8, nargs) catch return error.OutOfMemory;
+    var root_count: usize = 0;
     for (operands.items, 0..) |operand, i| {
         arg_tmps[i] = try self.emitScopedOperand(operand);
         if (i + 1 < nargs) {
@@ -1140,8 +1082,88 @@ pub fn emitApplyForm(self: *LLVMEmitter, expr: Value, is_tail: bool) EmitError![
             root_count += 1;
         }
     }
+    // The operator resolves after its operands, as the interpreter's
+    // call_global and guard_builtin do — a parameter, local, upvalue, or the
+    // current global binding. Resolution allocates nothing, so it needs no
+    // root of its own.
+    const callee = try self.emitGlobalRef(types.car(expr));
     try self.emitPopRoots(root_count);
 
+    if (!guarded) return emitApplyIndirect(self, callee, arg_tmps, is_tail);
+
+    // Guarded: branch on whether the global still holds the pristine
+    // primitive. Each arm is a complete call. In tail position each arm
+    // returns through the frame (both helpers balance the frame roots first,
+    // as emitCallNode does); otherwise the arms meet in a phi.
+    const kind_apply: u8 = comptime library.fastPathKind("apply").?;
+    const pristine = try self.freshTemp();
+    try self.print("  {s} = call i64 @kaappi_builtin_is_pristine(ptr %vm, i64 {s}, i64 {d})\n", .{ pristine, callee, kind_apply });
+    const cmp = try self.freshTemp();
+    try self.print("  {s} = icmp ne i64 {s}, 0\n", .{ cmp, pristine });
+    const fast_label = try self.freshLabel("apply_fast");
+    const slow_label = try self.freshLabel("apply_slow");
+    const merge_label = try self.freshLabel("apply_merge");
+    try self.print("  br i1 {s}, label %{s}, label %{s}\n", .{ cmp, fast_label, slow_label });
+
+    try self.startBlock(fast_label);
+    const fast_val = try emitApplyStructural(self, arg_tmps, is_tail);
+    const fast_end = self.current_block;
+    // In tail position the structural arm has already `ret`ed and left an
+    // orphan block open; LLVM IR still wants a terminator on it.
+    try self.print("  br label %{s}\n", .{if (is_tail) slow_label else merge_label});
+
+    try self.startBlock(slow_label);
+    const slow_val = try emitApplyIndirect(self, callee, arg_tmps, is_tail);
+    if (is_tail) return slow_val;
+    const slow_end = self.current_block;
+    try self.print("  br label %{s}\n", .{merge_label});
+
+    try self.startBlock(merge_label);
+    const result = try self.freshTemp();
+    try self.print("  {s} = phi i64 [ {s}, %{s} ], [ {s}, %{s} ]\n", .{ result, fast_val, fast_end, slow_val, slow_end });
+    return result;
+}
+
+/// The structural `@kaappi_apply` shape of a builtin `(apply f a ... lst)`
+/// (kaappi#1803): arg_tmps[0] is the callee, the last operand the list, and
+/// everything between them the fixed arguments — at least two operands. In
+/// tail position this returns through the frame.
+fn emitApplyStructural(self: *LLVMEmitter, arg_tmps: []const []const u8, is_tail: bool) EmitError![]const u8 {
+    const callee = arg_tmps[0];
+    const n_fixed = arg_tmps.len - 2;
+    const fixed_tmps = arg_tmps[1 .. 1 + n_fixed];
+    const list_tmp = arg_tmps[arg_tmps.len - 1];
+    const result = try self.freshTemp();
+    if (n_fixed == 0) {
+        const call_prefix: []const u8 = if (is_tail) "tail call" else "call";
+        try self.print("  {s} = {s} i64 @kaappi_apply(ptr %vm, i64 {s}, ptr null, i64 0, i64 {s})\n", .{ result, call_prefix, callee, list_tmp });
+    } else {
+        const args_alloca = try self.freshTemp();
+        try self.print("  {s} = alloca [{d} x i64], align 8\n", .{ args_alloca, n_fixed });
+        for (fixed_tmps, 0..) |tmp, i| {
+            const gep = try self.freshTemp();
+            try self.print("  {s} = getelementptr [1 x i64], ptr {s}, i64 {d}\n", .{ gep, args_alloca, i });
+            try self.print("  store i64 {s}, ptr {s}\n", .{ tmp, gep });
+        }
+        try self.print("  {s} = call i64 @kaappi_apply(ptr %vm, i64 {s}, ptr {s}, i64 {d}, i64 {s})\n", .{ result, callee, args_alloca, n_fixed, list_tmp });
+    }
+    if (is_tail) {
+        // Balance the frame-entry GC roots and any live let-binding roots
+        // before returning through this tail call, exactly as emitCallNode
+        // does (#1498/#1585) — a deep apply-driven loop must not leak one
+        // root set per iteration.
+        try self.emitPopRoots(self.frame_entry_roots + self.body_scope_roots);
+        try self.print("  ret i64 {s}\n", .{result});
+        try self.emitOrphanAfterTail();
+    }
+    return result;
+}
+
+/// Call `callee` — whatever `apply` resolved to — with the operands as
+/// ordinary arguments: emitCallNode's indirect-call tail, inlined. In tail
+/// position this returns through the frame.
+fn emitApplyIndirect(self: *LLVMEmitter, callee: []const u8, arg_tmps: []const []const u8, is_tail: bool) EmitError![]const u8 {
+    const nargs = arg_tmps.len;
     const result = try self.freshTemp();
     if (nargs == 0) {
         const call_prefix: []const u8 = if (is_tail) "tail call" else "call";
@@ -1149,10 +1171,10 @@ pub fn emitApplyForm(self: *LLVMEmitter, expr: Value, is_tail: bool) EmitError![
     } else {
         const args_alloca = try self.freshTemp();
         try self.print("  {s} = alloca [{d} x i64], align 8\n", .{ args_alloca, nargs });
-        for (0..nargs) |i| {
+        for (arg_tmps, 0..) |tmp, i| {
             const gep = try self.freshTemp();
             try self.print("  {s} = getelementptr [1 x i64], ptr {s}, i64 {d}\n", .{ gep, args_alloca, i });
-            try self.print("  store i64 {s}, ptr {s}\n", .{ arg_tmps[i], gep });
+            try self.print("  store i64 {s}, ptr {s}\n", .{ tmp, gep });
         }
         try self.print("  {s} = call i64 @kaappi_call_scheme(ptr %vm, i64 {s}, ptr {s}, i64 {d})\n", .{ result, callee, args_alloca, nargs });
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,7 +10,6 @@ pub const memory = @import("memory.zig");
 pub const reader = @import("reader.zig");
 pub const compiler = @import("compiler.zig");
 pub const compiler_forms = @import("compiler_forms.zig");
-const compiler_passthrough = @import("compiler_passthrough.zig");
 pub const vm_mod = @import("vm.zig");
 pub const vm_eval = @import("vm_eval.zig");
 pub const primitives = @import("primitives.zig");
@@ -747,38 +746,6 @@ fn runCachedTopLevelFunc(vm: *vm_mod.VM, func: *types.Function, source: []const 
     printTopLevelResult(allocator, result);
 }
 
-/// Whole-unit top-level target set for one compilation unit (kaappi#2457):
-/// every name a top-level `define` / `define-values` / `set!` targets anywhere
-/// in the source, known before any form compiles. Installed into
-/// `compiler_passthrough.unit_top_level_targets` for the unit's duration so
-/// the superinstruction gate declines for names the unit redefines — a body
-/// compiled before the definition runs must not bake in the builtin. Owns its
-/// duped keys; `deinit` frees them.
-const UnitTargets = struct {
-    map: std.StringHashMap(void),
-
-    fn init(gc: *memory.GC, source: []const u8) UnitTargets {
-        var map = std.StringHashMap(void).init(gc.allocator);
-        compiler_passthrough.collectUnitTopLevelTargets(&map, gc, source);
-        return .{ .map = map };
-    }
-
-    fn deinit(self: *UnitTargets) void {
-        var it = self.map.keyIterator();
-        while (it.next()) |k| self.map.allocator.free(k.*);
-        self.map.deinit();
-    }
-
-    /// Point the compiler's threadlocal at this set (null when empty: an
-    /// unset threadlocal and an empty set behave identically, and most units
-    /// never touch these names). Call before the first compile of the unit;
-    /// the caller's `defer reset` must be registered after this.
-    fn install(self: *UnitTargets) void {
-        compiler_passthrough.unit_top_level_targets =
-            if (self.map.count() > 0) &self.map else null;
-    }
-};
-
 fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
     const allocator = vm.gc.allocator;
 
@@ -811,15 +778,6 @@ fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
         return;
     };
     defer allocator.free(source);
-
-    // Whole-unit define/set! targets, before any form of this unit compiles —
-    // both the cold compile and a cache HIT's declaration replay consult the
-    // same set (kaappi#2457). The reset defer is registered after install so
-    // it runs before the map's deinit.
-    var unit_targets = UnitTargets.init(vm.gc, source);
-    defer unit_targets.deinit();
-    unit_targets.install();
-    defer compiler_passthrough.unit_top_level_targets = null;
 
     const source_hash = bytecode_file.sourceHash(source);
 
@@ -1199,13 +1157,6 @@ fn runStdin(vm: *vm_mod.VM) !void {
     };
     defer allocator.free(source);
 
-    // Whole-unit define/set! targets before any form compiles (kaappi#2457);
-    // see runFile.
-    var unit_targets = UnitTargets.init(vm.gc, source);
-    defer unit_targets.deinit();
-    unit_targets.install();
-    defer compiler_passthrough.unit_top_level_targets = null;
-
     crash.note(.reading, "<stdin>");
 
     var r = reader.Reader.initWithName(vm.gc, source, "<stdin>");
@@ -1338,14 +1289,6 @@ fn compileFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) !void
         return;
     };
     defer allocator.free(source);
-
-    // Whole-unit define/set! targets before any form compiles (kaappi#2457);
-    // see runFile. The decisions this scan drives are baked into the .sbc the
-    // same way the compile-time global read always was.
-    var unit_targets = UnitTargets.init(vm.gc, source);
-    defer unit_targets.deinit();
-    unit_targets.install();
-    defer compiler_passthrough.unit_top_level_targets = null;
 
     const source_hash = bytecode_file.sourceHash(source);
 

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -3,7 +3,6 @@ const platform = @import("platform.zig");
 const types = @import("types.zig");
 const reader_mod = @import("reader.zig");
 const compiler = @import("compiler.zig");
-const compiler_passthrough = @import("compiler_passthrough.zig");
 const compiler_gate = @import("compiler_gate.zig");
 const vm_mod = @import("vm.zig");
 const ir_mod = @import("ir.zig");
@@ -140,22 +139,6 @@ pub fn emitLlvmFile(vm: *vm_mod.VM, path: []const u8, output_path: ?[]const u8) 
         return err;
     };
     defer allocator.free(source);
-
-    // Whole-unit top-level define/set! targets (kaappi#2457): the emitter's
-    // `apply` fast path (emitApplyForm) declines for a name the unit
-    // redefines ANYWHERE — the same interim the interpreter's
-    // globalBindingStillGenuine arm takes, closing the same use-compiled-
-    // before-define order its own in-order rebound_globals set could not see.
-    var unit_targets = std.StringHashMap(void).init(allocator);
-    defer {
-        var uit = unit_targets.keyIterator();
-        while (uit.next()) |k| allocator.free(k.*);
-        unit_targets.deinit();
-    }
-    compiler_passthrough.collectUnitTopLevelTargets(&unit_targets, vm.gc, source);
-    compiler_passthrough.unit_top_level_targets =
-        if (unit_targets.count() > 0) &unit_targets else null;
-    defer compiler_passthrough.unit_top_level_targets = null;
 
     const saved_lib_dir = vm.current_lib_dir;
     vm.current_lib_dir = if (std.mem.lastIndexOfScalar(u8, path, '/')) |pos| path[0 .. pos + 1] else "";

--- a/src/native_decls.zig
+++ b/src/native_decls.zig
@@ -32,6 +32,8 @@ pub const decls: []const Decl = &.{
     .{ .export_name = "kaappi_call_scheme", .scheme_name = null, .param_types = &.{ .ptr, .i64, .ptr, .i64 }, .ret = .i64, .inline_kind = .not_inlined },
     // Argument-splicing call for natively lowered `apply` (kaappi#1803).
     .{ .export_name = "kaappi_apply", .scheme_name = null, .param_types = &.{ .ptr, .i64, .ptr, .i64, .i64 }, .ret = .i64, .inline_kind = .not_inlined },
+    // Run-time half of the builtin-superinstruction gate (kaappi#2469).
+    .{ .export_name = "kaappi_builtin_is_pristine", .scheme_name = null, .param_types = &.{ .ptr, .i64, .i64 }, .ret = .i64, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_define_global", .scheme_name = null, .param_types = &.{ .ptr, .ptr, .i64, .i64 }, .ret = .void_ty, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_set_global", .scheme_name = null, .param_types = &.{ .ptr, .ptr, .i64, .i64 }, .ret = .void_ty, .inline_kind = .not_inlined },
     .{ .export_name = "kaappi_make_string", .scheme_name = null, .param_types = &.{ .ptr, .ptr, .i64 }, .ret = .i64, .inline_kind = .not_inlined },

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -118,6 +118,12 @@ pub export fn kaappi_set_global(vm: ?*vm_mod.VM, name_ptr: [*]const u8, name_len
     const name = name_ptr[0..len];
     if (v.globals.getPtr(name)) |ptr| {
         ptr.* = val;
+        // Invalidate every function's per-function global cache, as the
+        // interpreter's set_global does: an interpreted body (an eval
+        // fallback, say) that cached this global — including the pristine
+        // primitive a guard_builtin compares against (kaappi#2469) — must
+        // not keep serving the old value.
+        v.global_version +%= 1;
     } else {
         _ = platform.write(2, "set!: unbound variable '", 24);
         _ = platform.write(2, name_ptr, len);
@@ -447,6 +453,20 @@ pub export fn kaappi_apply(vm: ?*vm_mod.VM, callee: u64, fixed_args: ?[*]const u
     };
     return applySpliced(v, callee, fixed_args, n_fixed, list) catch |err|
         fatalVMError(v, "runtime error in apply", err);
+}
+
+// The native tier's half of the run-time builtin-superinstruction gate
+// (kaappi#2469), the counterpart of the interpreter's `guard_builtin` opcode:
+// 1 when `val` — the *current* global binding a compiled call site just
+// resolved — is still the pristine primitive `library.fast_path_builtins[kind]`,
+// so the site may take its structural @kaappi_apply shape; 0 otherwise, so it
+// calls `val` like any procedure. A never-registered primitive (VOID slot) or
+// an out-of-range kind answers 0: the ordinary call is always the safe path.
+pub export fn kaappi_builtin_is_pristine(vm: ?*vm_mod.VM, val: u64, kind: u64) callconv(.c) u64 {
+    const v = vm orelse return 0;
+    if (kind >= library.fast_path_builtins.len) return 0;
+    const pristine = v.libraries.fast_path_pristine[@intCast(kind)];
+    return @intFromBool(pristine != types.VOID and val == pristine);
 }
 
 fn applySpliced(v: *vm_mod.VM, callee: u64, fixed_args: ?[*]const u64, n_fixed: u64, list: u64) !u64 {

--- a/src/tests_check.zig
+++ b/src/tests_check.zig
@@ -317,45 +317,12 @@ test "cond-expand: an unsatisfied top-level clause is not an error (#1661)" {
     try expectCounts("(cond-expand (no-such-feature (import (srfi 1))))", 0, 0, 0);
 }
 
-// ── Whole-unit superinstruction gate during analysis (kaappi#2457) ──────────
-// analyzeSource — the shared path of `run`, the tests, and the LSP — installs
-// the EXACT target set a run of the file would install, not the lint's
-// user_defined set: top-level `set!` targets count (PR #2467 review), and
-// define-syntax names are not part of it.
+// ── Superinstruction gate during analysis (kaappi#2457, #2469) ──────────────
+// A file that uses `apply` before assigning it at top level analyzes clean:
+// the compiles `check` runs emit the same run-time-guarded fast path a run
+// would, with no whole-unit pre-scan to install or forget (the #2467 scan
+// that once lived here was retired by #2469).
 
-test "unit gate: a top-level set! target reaches the gate set" {
-    // The reviewer's scenario: a unit using `apply` early and assigning it
-    // later. user_defined misses the set!; the gate set must not.
-    var h: Harness = .{};
-    try h.tc.init();
-    defer h.tc.deinit();
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    var targets = check.unitTargetSet(arena.allocator(), &h.tc.gc,
-        \\(define (f) (apply + (list 1 2)))
-        \\(set! apply (lambda args 'user))
-    );
-    try testing.expect(targets.contains("apply"));
-}
-
-test "unit gate: define-syntax names are not gate targets" {
-    var h: Harness = .{};
-    try h.tc.init();
-    defer h.tc.deinit();
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    var targets = check.unitTargetSet(arena.allocator(), &h.tc.gc,
-        \\(define-syntax m (syntax-rules () ((_ x) x)))
-        \\(m 1)
-    );
-    try testing.expect(!targets.contains("m"));
-    try testing.expectEqual(@as(usize, 0), targets.count());
-}
-
-test "unit gate: installed only for the duration of the analysis" {
-    const compiler_passthrough = @import("compiler_passthrough.zig");
-    try testing.expect(compiler_passthrough.unit_top_level_targets == null);
+test "use-before-set! of a fast-path name analyzes without findings" {
     try expectCounts("(define (f) (apply + (list 1 2)))\n(set! apply (lambda args 'user))", 0, 0, 0);
-    // The defer-based cleanup restored the per-form (null) answer.
-    try testing.expect(compiler_passthrough.unit_top_level_targets == null);
 }

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -499,6 +499,66 @@ test "top-level redefinition honoured in tail position (#2033)" {
     try std.testing.expectEqualStrings("user-ccc", types.symbolName(try ctx.vm.eval("(ccc-tail)")));
 }
 
+// #2469: the decision moved to run time. A body compiled BEFORE the
+// redefinition — here form by form through vm.eval, the REPL's own route,
+// which #2457's whole-unit pre-scan could never cover — must still reach the
+// user's procedure, and restoring the genuine binding brings the builtin
+// back through the very same bytecode.
+test "per-form use-before-define of every fast-path name is honoured (REPL route, #2469)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(define (nt-apply) (let ((v (apply + (list 1 2)))) v))");
+    _ = try ctx.vm.eval("(define (t-apply) (apply + (list 1 2)))");
+    _ = try ctx.vm.eval("(define (nt-cwv) (let ((v (call-with-values (lambda () 1) (lambda (x) x)))) v))");
+    _ = try ctx.vm.eval("(define (t-cwv) (call-with-values (lambda () 1) (lambda (x) x)))");
+    _ = try ctx.vm.eval("(define (t-cc) (call/cc (lambda (k) 1)))");
+    _ = try ctx.vm.eval("(define (t-ccc) (call-with-current-continuation (lambda (k) 1)))");
+    _ = try ctx.vm.eval("(define (t-eval) (eval '(+ 1 2)))");
+    _ = try ctx.vm.eval("(define (all) (list (nt-apply) (t-apply) (nt-cwv) (t-cwv) (t-cc) (t-ccc) (t-eval)))");
+    _ = try ctx.vm.eval("(define saved (list apply call-with-values call/cc call-with-current-continuation eval))");
+
+    try std.testing.expect(types.isTruthy(try ctx.vm.eval("(equal? (all) '(3 3 1 1 1 1 3))")));
+
+    _ = try ctx.vm.eval("(define (apply f xs) 'ua)");
+    _ = try ctx.vm.eval("(define (call-with-values p c) 'uc)");
+    _ = try ctx.vm.eval("(define (call/cc r) 'uk)");
+    _ = try ctx.vm.eval("(define (call-with-current-continuation r) 'ukk)");
+    _ = try ctx.vm.eval("(define (eval x . env) 'ue)");
+    try std.testing.expect(types.isTruthy(try ctx.vm.eval("(equal? (all) '(ua ua uc uc uk ukk ue))")));
+
+    _ = try ctx.vm.eval("(set! apply (list-ref saved 0))");
+    _ = try ctx.vm.eval("(set! call-with-values (list-ref saved 1))");
+    _ = try ctx.vm.eval("(set! call/cc (list-ref saved 2))");
+    _ = try ctx.vm.eval("(set! call-with-current-continuation (list-ref saved 3))");
+    _ = try ctx.vm.eval("(set! eval (list-ref saved 4))");
+    try std.testing.expect(types.isTruthy(try ctx.vm.eval("(equal? (all) '(3 3 1 1 1 1 3))")));
+}
+
+// #2469: a redefinition drops the pristine primitive from globals, but every
+// guard_builtin compiled before it still compares against that object. The
+// registry's fast_path_pristine slots are root-marked so a full collection
+// in between neither frees it (a dangling compare) nor lets a recycled
+// object alias it (a false "still pristine").
+test "pristine fast-path primitives survive a full collection after a redefinition (#2469)" {
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    _ = try ctx.vm.eval("(define (t) (apply + (list 1 2)))");
+    _ = try ctx.vm.eval("(define orig apply)");
+    _ = try ctx.vm.eval("(define (apply f xs) 'user)");
+    ctx.vm.gc.collectFull();
+    ctx.vm.gc.collectFull();
+    // Churn the heap so a freed slot would be recycled before the compare.
+    _ = try ctx.vm.eval("(let loop ((i 0) (acc '())) (if (< i 2000) (loop (+ i 1) (cons (make-string 8 #\\a) acc)) (length acc)))");
+    try std.testing.expectEqualStrings("user", types.symbolName(try ctx.vm.eval("(t)")));
+    _ = try ctx.vm.eval("(set! apply orig)");
+    ctx.vm.gc.collectFull();
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(try ctx.vm.eval("(t)")));
+}
+
 test "environment accepts import-set modifiers (#1189)" {
     var ctx: th.TestContext = undefined;
     try ctx.init();

--- a/src/tests_native.zig
+++ b/src/tests_native.zig
@@ -820,7 +820,7 @@ test "native declare table covers all runtime exports in preamble" {
             return error.TestExpectedEqual;
         }
     }
-    try std.testing.expectEqual(@as(usize, 28), native_decls.decls.len);
+    try std.testing.expectEqual(@as(usize, 29), native_decls.decls.len);
 }
 
 // -- Compile-once eval-fallback cache (#1494) --

--- a/src/types.zig
+++ b/src/types.zig
@@ -1475,6 +1475,15 @@ pub const OpCode = enum(u8) {
     // apply/tail_apply that follows it (kaappi#2453). Appended at the end for
     // the same .sbc-numbering reason as `apply` above.
     values_list, // dst:u16, src:u16
+    // Run-time gate for the builtin superinstructions (kaappi#2469): resolve
+    // the global that `sym_idx` names into `dst` exactly as `get_global`
+    // would, then fall through to the fast path that follows only while that
+    // value is still the pristine `(scheme base)` primitive `kind` (an index
+    // into `library.fast_path_builtins`); otherwise jump `offset` to the
+    // ordinary call of whatever the global holds now, emitted right after the
+    // fast path. Appended at the end for the same .sbc-numbering reason as
+    // `apply` above.
+    guard_builtin, // dst:u16, sym_idx:u16, kind:u8, offset:i16
 };
 
 // -- Doc sync gate ----------------------------------------------------------
@@ -1491,7 +1500,7 @@ pub const OpCode = enum(u8) {
 // than trusting the list — grep the *noun*, since the count is written at least
 // four ways ("31 opcodes", "31-opcode", "(31 opcodes)", and number-after-noun).
 comptime {
-    if (@typeInfo(OpCode).@"enum".fields.len != 33)
+    if (@typeInfo(OpCode).@"enum".fields.len != 34)
         @compileError("OpCode count changed. Update the table in docs/dev/bytecode.md, then every " ++
             "file quoting the count — known: docs/dev/architecture.md, docs/dev/README.md, " ++
             "docs/dev/claude-code-harness.md, .claude/skills/bytecode-isa/SKILL.md. Find any others " ++

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -305,6 +305,11 @@ pub fn markVmRoots(gc: *memory.GC, vm: *VM) void {
         // name is all it takes for globals to stop holding them.
         var iit = vm.libraries.internal_bindings.valueIterator();
         while (iit.next()) |v| gc.markValue(v.*);
+        // The run-time builtin gate's reference values (kaappi#2469): a user
+        // redefinition of `apply` drops the pristine primitive from globals,
+        // and every `guard_builtin` compiled before it still compares
+        // against it.
+        for (vm.libraries.fast_path_pristine) |v| gc.markValue(v);
     }
 
     // Mark library environments being built by handleDefineLibrary

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -35,6 +35,8 @@ const tooManyApplyArgs = vm_dispatch_helpers.tooManyApplyArgs;
 const rejectImmutableEnv = vm_dispatch_helpers.rejectImmutableEnv;
 const raiseUndefinedVariable = vm_dispatch_helpers.raiseUndefinedVariable;
 const lookupGlobalLocked = vm_dispatch_helpers.lookupGlobalLocked;
+const lookupGlobalCached = vm_dispatch_helpers.lookupGlobalCached;
+const guardBuiltin = vm_dispatch_helpers.guardBuiltin;
 const raiseDeadNativeReturn = vm_dispatch_helpers.raiseDeadNativeReturn;
 const dispatchApply = vm_dispatch_helpers.dispatchApply;
 const raiseCrossHeapStoreVM = vm_dispatch_helpers.raiseCrossHeapStoreVM;
@@ -152,7 +154,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
         if (frame.ip >= frame.code.len) return VMError.InvalidBytecode;
 
         const raw_op = frame.code[frame.ip];
-        if (raw_op > @intFromEnum(OpCode.values_list)) return VMError.InvalidBytecode;
+        if (raw_op > @intFromEnum(OpCode.guard_builtin)) return VMError.InvalidBytecode;
         const op: OpCode = @enumFromInt(raw_op);
         frame.ip += 1;
 
@@ -180,6 +182,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
             .tail_call_cc => 4,
             .tail_eval => 3,
             .values_list => 4,
+            .guard_builtin => 7,
         };
         try ensureOperands(self, frame, fixed_operand_bytes);
 
@@ -235,55 +238,12 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const dst = readU16(self, frame);
                 const sym_idx = readU16(self, frame);
                 const closure = frame.closure orelse return VMError.InvalidBytecode;
-                const func = closure.func;
                 const dst_idx = try registerIndex(self, frame.base, dst);
-                if (func.env == null) {
-                    if (func.global_cache) |cache| {
-                        if (func.cache_version == self.global_version and
-                            sym_idx < cache.len and cache[sym_idx] != types.VOID)
-                        {
-                            self.registers[dst_idx] = cache[sym_idx];
-                            continue;
-                        }
-                        if (func.cache_version != self.global_version) {
-                            @memset(cache, types.VOID);
-                            func.cache_version = self.global_version;
-                        }
-                    }
-                }
-                const sym = try constantAt(self, func, sym_idx);
-                if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
-                const name = types.symbolName(sym);
-                // #1812: skip caching a def_env_binding_prefix reference — its
-                // resolution isn't invalidated by self.global_version (a
-                // library's own internal set! on its def_env doesn't bump it,
-                // since that mutation's func.env isn't null), so caching it
-                // under that version could go stale.
-                const def_env_parts = vm_mod.globals_mod.parseDefEnvBindingSymbolName(name);
-                const val = lookupGlobalLocked(self, func, name) orelse
-                    return raiseUndefinedVariable(self, name);
-                self.registers[dst_idx] = val;
-                if (func.env == null and def_env_parts == null and (types.isClosure(val) or types.isNativeFn(val))) {
-                    if (func.global_cache) |cache| {
-                        if (sym_idx < cache.len) cache[sym_idx] = val;
-                    } else {
-                        const cache = self.gc.allocator.alloc(Value, func.constants.items.len) catch continue;
-                        @memset(cache, types.VOID);
-                        cache[sym_idx] = val;
-                        func.global_cache = cache;
-                        func.cache_version = self.global_version;
-                    }
-                    // #1961 (review): the cached value is root-marked right
-                    // now (it is also in the globals map), but a later
-                    // rebinding by another function orphans this slot — only
-                    // this function's own next global op clears it — and the
-                    // generational minor mark reaches the orphaned young
-                    // value only through the remembered set. The function
-                    // itself may already be promoted, including on the
-                    // fresh-cache path.
-                    self.gc.writeBarrier(&func.header, val);
-                }
+                self.registers[dst_idx] = try lookupGlobalCached(self, closure.func, sym_idx);
             },
+            // The run-time builtin-superinstruction gate (kaappi#2469); the
+            // body is `guardBuiltin` in vm_dispatch_helpers.zig.
+            .guard_builtin => try guardBuiltin(self, frame),
             .set_global => {
                 const sym_idx = readU16(self, frame);
                 const src = readU16(self, frame);

--- a/src/vm_dispatch_helpers.zig
+++ b/src/vm_dispatch_helpers.zig
@@ -15,6 +15,7 @@ const VMError = vm_mod.VMError;
 const CallFrame = vm_mod.CallFrame;
 
 const memory = @import("memory.zig");
+const library = @import("library.zig");
 
 /// kaappi#1924: the catchable error a bytecode store (set_upvalue,
 /// set_box_local, set_global, define_global) raises when it would install a
@@ -356,6 +357,96 @@ inline fn resolveBaseBindingLocked(self: *VM, env: *std.StringHashMap(Value), ba
     self.lockGlobalsShared();
     defer self.unlockGlobalsShared();
     return env.get(base_name);
+}
+
+/// Resolve the global that constant `sym_idx` names, through `func`'s
+/// per-function global cache when it has one — the read `get_global`
+/// performs, shared with `guard_builtin` (kaappi#2469). A cache entry is
+/// only ever a closure or native procedure resolved through the ordinary
+/// (non-def-env, #1812) route, and the whole cache is dropped whenever
+/// `global_version` moves, so a stale procedure can never be served after a
+/// rebinding (#812). Raises the undefined-variable error for an unbound name.
+pub fn lookupGlobalCached(self: *VM, func: *types.Function, sym_idx: u16) VMError!Value {
+    if (func.env == null) {
+        if (func.global_cache) |cache| {
+            if (func.cache_version == self.global_version and
+                sym_idx < cache.len and cache[sym_idx] != types.VOID)
+            {
+                return cache[sym_idx];
+            }
+            if (func.cache_version != self.global_version) {
+                @memset(cache, types.VOID);
+                func.cache_version = self.global_version;
+            }
+        }
+    }
+    const sym = try constantAt(self, func, sym_idx);
+    if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
+    const name = types.symbolName(sym);
+    // #1812: skip caching a def_env_binding_prefix reference — its
+    // resolution isn't invalidated by self.global_version (a library's own
+    // internal set! on its def_env doesn't bump it, since that mutation's
+    // func.env isn't null), so caching it under that version could go stale.
+    const def_env_parts = vm_mod.globals_mod.parseDefEnvBindingSymbolName(name);
+    const val = lookupGlobalLocked(self, func, name) orelse
+        return raiseUndefinedVariable(self, name);
+    if (func.env == null and def_env_parts == null and (types.isClosure(val) or types.isNativeFn(val))) {
+        if (func.global_cache) |cache| {
+            if (sym_idx < cache.len) cache[sym_idx] = val;
+        } else {
+            // A cache is an optimization: no memory for one just means the
+            // next reference resolves by name again.
+            const cache = self.gc.allocator.alloc(Value, func.constants.items.len) catch return val;
+            @memset(cache, types.VOID);
+            cache[sym_idx] = val;
+            func.global_cache = cache;
+            func.cache_version = self.global_version;
+        }
+        // #1961 (review): the cached value is root-marked right now (it is
+        // also in the globals map), but a later rebinding by another
+        // function orphans this slot — only this function's own next global
+        // op clears it — and the generational minor mark reaches the
+        // orphaned young value only through the remembered set. The function
+        // itself may already be promoted, including on the fresh-cache path.
+        self.gc.writeBarrier(&func.header, val);
+    }
+    return val;
+}
+
+/// `guard_builtin dst, sym_idx, kind, offset` (kaappi#2469): the run-time
+/// half of the builtin-superinstruction gate. Resolves the operator's global
+/// into `dst` exactly as `get_global` would, then lets execution fall through
+/// to the superinstruction only while that value is still the pristine
+/// primitive `library.fast_path_builtins[kind]`; anything else — a user
+/// procedure, a non-procedure, a re-registered primitive — jumps `offset` to
+/// the ordinary call the compiler emitted after the fast path, which calls
+/// whatever `dst` now holds. R7RS 5.3.1 makes a top-level definition
+/// essentially an assignment, so this is the only place the question can be
+/// answered honestly: a compile-time read (#2033) or a whole-unit pre-scan
+/// (#2457) is baked into bytecode that may run after a `load`, an `eval`, a
+/// REPL form, or a macro-materialized `set!` rebinds the name.
+///
+/// A pristine slot left VOID (the primitive was never registered, e.g. a
+/// sandbox that excludes `eval`) never matches, so such a guard always takes
+/// the ordinary call — which is also where an unbound name reports its
+/// undefined-variable error, from the lookup above.
+pub fn guardBuiltin(self: *VM, frame: *CallFrame) VMError!void {
+    const dst = readU16(self, frame);
+    const sym_idx = readU16(self, frame);
+    const kind = readU8(self, frame);
+    const offset = readI16(self, frame);
+    const closure = frame.closure orelse return VMError.InvalidBytecode;
+    const dst_idx = try registerIndex(self, frame.base, dst);
+    if (kind >= library.fast_path_builtins.len) return VMError.InvalidBytecode;
+    const val = try lookupGlobalCached(self, closure.func, sym_idx);
+    self.registers[dst_idx] = val;
+    const pristine = self.libraries.fast_path_pristine[kind];
+    if (pristine != types.VOID and val == pristine) return;
+    const new_ip = @as(isize, @intCast(frame.ip)) + offset;
+    if (new_ip < 0) return VMError.InvalidBytecode;
+    const target: usize = @intCast(new_ip);
+    if (target > frame.code.len) return VMError.InvalidBytecode;
+    frame.ip = target;
 }
 
 pub fn buildRestList(gc: *memory.GC, args: []const Value) VMError!Value {

--- a/tests/scheme/compile/native-apply-redefinition-order-2457.sh
+++ b/tests/scheme/compile/native-apply-redefinition-order-2457.sh
@@ -6,16 +6,15 @@
 # emitApplyForm's structural @kaappi_apply shape was gated on
 # rebound_globals/native_fns, both populated IN ORDER as forms are emitted, so
 # a use preceding the define still baked in the builtin's flattening
-# semantics and the user's procedure was silently discarded. The native
-# compile driver now installs the same whole-unit top-level target scan the
-# interpreter's gate consults (compiler_passthrough.unit_top_level_targets),
-# and emitApplyForm declines the structural shape for any name the unit
-# redefines — the by-name generic call resolves the user's binding at
-# runtime, exactly like the interpreter.
+# semantics and the user's procedure was silently discarded. #2457's interim
+# was a whole-unit pre-scan; since #2469 the emitted code decides at run
+# time: it resolves the `apply` global, asks @kaappi_builtin_is_pristine
+# whether it is still the genuine primitive, and branches to the structural
+# shape or to an ordinary indirect call of whatever the global holds.
 #
 # The convergence guarantee from #1803 is pinned too: a program that never
-# touches these names must keep its native @kaappi_apply call site (the unit
-# scan must not cost the fast path in clean programs).
+# touches these names must keep its native @kaappi_apply call site (the
+# guard must not cost the fast path in clean programs).
 #
 # Usage: bash tests/scheme/compile/native-apply-redefinition-order-2457.sh [path-to-kaappi]
 

--- a/tests/scheme/compile/native-apply-redefinition-order-2469.sh
+++ b/tests/scheme/compile/native-apply-redefinition-order-2469.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# Regression test for #2469 (LLVM native backend): the builtin `apply`
+# fast path is gated at RUN time in compiled binaries, not at compile time.
+#
+# #2457's interim pre-scanned the compilation unit's top-level define/set!
+# targets, so a redefinition it could not see — one that only materializes
+# when a macro expands, or one `eval` performs at run time — still baked the
+# builtin's flattening semantics into every body compiled before it ran.
+# emitApplyForm now resolves the `apply` global at the call, asks
+# @kaappi_builtin_is_pristine (runtime_exports.zig) whether it is still the
+# genuine primitive, and branches to the structural @kaappi_apply shape or to
+# an ordinary indirect call of whatever the global holds — the same decision
+# the interpreter's guard_builtin opcode makes.
+#
+# Usage: bash tests/scheme/compile/native-apply-redefinition-order-2469.sh [path-to-kaappi]
+
+set -euo pipefail
+
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+KAAPPI="${1:-$REPO_DIR/zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+
+ensure_runtime_lib "$REPO_DIR"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+FAILED=0
+
+compile_one() {
+    local label="$1"
+    local src="$DIR/${label}.scm" bin="$DIR/${label}.bin"
+    local compile_out compile_status=0
+    compile_out="$(cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$src" -o "$bin" 2>&1)" || compile_status=$?
+    if [[ $compile_status -ne 0 ]]; then
+        echo "FAIL: $label — kaappi compile exited $compile_status: $compile_out" >&2
+        FAILED=1
+        return 1
+    fi
+    if [[ ! -x "$bin" ]]; then
+        echo "FAIL: $label — kaappi compile succeeded but produced no binary" >&2
+        FAILED=1
+        return 1
+    fi
+}
+
+# Run one program three ways — a cold interpreter run, a second run that is
+# a bytecode-cache HIT (the .sbc round trip; skipped with a third argument
+# "nocache" for programs the cache declines by design), and the native binary
+# — and require identical, expected output.
+check_all() {
+    local label="$1" expected="$2" cache_mode="${3:-cache}"
+    local src="$DIR/${label}.scm" bin="$DIR/${label}.bin" home="$DIR/home-$label"
+
+    local interp_out interp_status=0
+    interp_out="$(cd "$REPO_DIR" && KAAPPI_HOME="$home" "$KAAPPI_ABS" "$src" 2>&1)" || interp_status=$?
+    if [[ $interp_status -ne 0 || "$interp_out" != "$expected" ]]; then
+        echo "FAIL: $label — interpreter exited $interp_status, expected '$expected', got '$interp_out'" >&2
+        FAILED=1
+        return
+    fi
+
+    # The guard_builtin opcode must survive the .sbc round trip (kaappi#2469
+    # appended an opcode; the loader's validator must accept it): the cold run
+    # above wrote a cache entry, so this second run loads it instead of
+    # compiling.
+    if [[ "$cache_mode" == "cache" ]]; then
+        if ! (cd "$REPO_DIR" && KAAPPI_HOME="$home" "$KAAPPI_ABS" cache status 2>/dev/null | grep -q "$src"); then
+            echo "FAIL: $label — the cold run left no bytecode-cache entry for $src" >&2
+            FAILED=1
+            return
+        fi
+        local hit_out hit_status=0
+        hit_out="$(cd "$REPO_DIR" && KAAPPI_HOME="$home" "$KAAPPI_ABS" "$src" 2>&1)" || hit_status=$?
+        if [[ $hit_status -ne 0 || "$hit_out" != "$expected" ]]; then
+            echo "FAIL: $label — cache-HIT run exited $hit_status, expected '$expected', got '$hit_out'" >&2
+            FAILED=1
+            return
+        fi
+    fi
+
+    compile_one "$label" || return
+
+    local native_out native_status=0
+    native_out="$("$bin" 2>&1)" || native_status=$?
+    if [[ $native_status -ne 0 || "$native_out" != "$expected" ]]; then
+        echo "FAIL: $label — compiled binary exited $native_status, expected '$expected', got '$native_out'" >&2
+        FAILED=1
+    fi
+}
+
+# 1. A set! that only materializes when a macro expands: invisible to any
+#    structure-only scan, decided at run time by the guard. No cache leg: a
+#    program with a top-level define-syntax is never cached (by design).
+cat > "$DIR/macro.scm" << 'SCHEME'
+(import (scheme base) (scheme write))
+(define (nt) (let ((v (apply + (list 1 2)))) v))
+(define (t) (apply + (list 1 2)))
+(define-syntax redef! (syntax-rules () ((_ n v) (set! n v))))
+(redef! apply (lambda (f xs) 'macro-set))
+(write (list (nt) (t) (apply + '(1 2))))
+(newline)
+SCHEME
+check_all "macro" "(macro-set macro-set macro-set)" nocache
+
+# 2. A redefinition performed by eval at run time.
+cat > "$DIR/eval.scm" << 'SCHEME'
+(import (scheme base) (scheme write) (scheme eval))
+(define (nt) (let ((v (apply + (list 1 2)))) v))
+(eval '(define (apply f xs) 'eval-user) (interaction-environment))
+(write (nt))
+(newline)
+SCHEME
+check_all "eval" "eval-user"
+
+# 3. The binding changes while the caller is on the stack: each call decides
+#    afresh, and restoring the genuine binding brings the builtin back.
+cat > "$DIR/flip.scm" << 'SCHEME'
+(import (scheme base) (scheme write))
+(define orig apply)
+(define (go)
+  (let* ((a (apply + (list 1 2)))
+         (b (begin (set! apply (lambda (f xs) 'flipped)) (apply + (list 1 2))))
+         (c (begin (set! apply orig) (apply + (list 1 2)))))
+    (list a b c)))
+(write (go))
+(newline)
+SCHEME
+check_all "flip" "(3 flipped 3)"
+
+# 4. The emitted IR carries the guard and keeps the structural call site; a
+#    clean program still has no eval fallback (#1803's convergence).
+cat > "$DIR/clean.scm" << 'SCHEME'
+(define (work n acc)
+  (if (= n 0) (apply + (list acc 0))
+      (work (- n 1) (+ acc (* n 3)))))
+(display (work 10000 0))
+(newline)
+SCHEME
+LL="$DIR/clean.ll"
+if (cd "$REPO_DIR" && "$KAAPPI_ABS" --emit-llvm -o "$LL" "$DIR/clean.scm" > /dev/null 2>&1); then
+    evals=$(grep -c "call i64 @kaappi_eval" "$LL" || true)
+    if [[ "$evals" -ne 0 ]]; then
+        echo "FAIL: clean — expected 0 eval fallbacks in emitted IR, found $evals" >&2
+        FAILED=1
+    fi
+    if ! grep -q "@kaappi_apply(ptr %vm" "$LL"; then
+        echo "FAIL: clean — no native @kaappi_apply call site in emitted IR" >&2
+        FAILED=1
+    fi
+    if ! grep -q "@kaappi_builtin_is_pristine(ptr %vm" "$LL"; then
+        echo "FAIL: clean — no run-time guard (@kaappi_builtin_is_pristine) in emitted IR" >&2
+        FAILED=1
+    fi
+else
+    echo "FAIL: clean — --emit-llvm failed" >&2
+    FAILED=1
+fi
+
+if [[ $FAILED -ne 0 ]]; then
+    exit 1
+fi
+
+echo "PASS"

--- a/tests/scheme/compliance/top-level-redefinition-order-2457.scm
+++ b/tests/scheme/compliance/top-level-redefinition-order-2457.scm
@@ -11,19 +11,17 @@
 ;;; and the definition order differ. #2033 fixed the define-BEFORE-use order
 ;;; that way; the use-BEFORE-define order kept silently running the builtin.
 ;;;
-;;; The interim fix is a whole-unit conservative arm: a driver that knows the
-;;; entire compilation unit (file runs, stdin scripts, `kaappi compile`,
-;;; `kaappi check`) pre-scans the unit's top-level define/set! targets, and the
-;;; gate declines the fast path for those names everywhere in the unit. This
-;;; file's every section defines one of the five names at top level, so the
-;;; whole unit compiles by-name — which is exactly what the sections assert:
-;;; the user's binding wins from the first call, and restoring the genuine
-;;; binding makes the builtin visible again.
-;;;
-;;; NOT covered by the interim (kept as the legacy behavior, by design):
-;;; the REPL and `eval`, which have no future knowledge; and a redefinition
-;;; that only materializes when a macro expands. The honest run-time decision
-;;; is the recorded follow-up.
+;;; #2457's interim fix was a whole-unit pre-scan of top-level define/set!
+;;; targets that declined the fast path for those names everywhere in the
+;;; unit. #2469 replaced it with the honest run-time decision: every
+;;; superinstruction now sits behind a `guard_builtin` opcode that compares
+;;; the global's current binding against the pristine primitive at each call
+;;; and falls back to an ordinary call. This file keeps asserting what both
+;;; fixes had to deliver — the user's binding wins from the first call, and
+;;; restoring the genuine binding makes the builtin visible again — through
+;;; every whole-unit shape (a later define, a later set!, a begin-spliced
+;;; define). The routes the scan could not see (`load`, `eval`, the REPL, a
+;;; macro-materialized set!) are top-level-redefinition-runtime-2469.scm.
 ;;;
 ;;; `car` and `map` in the identical shape were always correct (they never had
 ;;; a superinstruction to bake in) and run here as the contrast.

--- a/tests/scheme/compliance/top-level-redefinition-runtime-2469.scm
+++ b/tests/scheme/compliance/top-level-redefinition-runtime-2469.scm
@@ -20,7 +20,7 @@
 ;;; listed as still baking the builtin in.
 
 (import (scheme base) (scheme write) (scheme eval) (scheme load) (scheme file)
-        (scheme process-context) (srfi 64))
+        (scheme process-context) (scheme time) (srfi 64))
 
 (define %test-fail-count 0)
 (test-begin "top-level-redefinition-runtime-2469")
@@ -139,6 +139,25 @@
 (test-eq "library body: use-before-define of a library-local apply honours it"
   'lib-user (lib-use))
 (test-eq "library body: the program's own apply is untouched" 3 (apply + '(1 2)))
+
+;;; ------------------------------------------------------------------
+;;; A tail-position `eval` with a third operand is an arity question for
+;;; whatever `eval` is bound to, so the redefined procedure must receive
+;;; every operand, evaluated in order (PR #2481 review).
+;;; ------------------------------------------------------------------
+
+(define eval-3-log '())
+(define (t-eval-3)
+  (eval 'e (begin (set! eval-3-log (cons 'env eval-3-log)) 'env-arg)
+        (begin (set! eval-3-log (cons 'extra eval-3-log)) 'extra-arg)))
+(define (eval x env extra) (list 'user-eval-3 x env extra))
+(test-equal "eval: a redefined 3-ary eval receives all three operands"
+  '(user-eval-3 e env-arg extra-arg) (t-eval-3))
+(test-equal "eval: the third operand's side effect ran, after the second's"
+  '(extra env) eval-3-log)
+(define eval saved-2469-orig-eval)
+(test-assert "eval: genuine 3-operand eval reports an arity error, not silence"
+  (guard (e (#t (error-object? e))) (t-eval-3) #f))
 
 ;;; ------------------------------------------------------------------
 ;;; A non-procedure rebinding through eval reports the ordinary call's type

--- a/tests/scheme/compliance/top-level-redefinition-runtime-2469.scm
+++ b/tests/scheme/compliance/top-level-redefinition-runtime-2469.scm
@@ -1,0 +1,157 @@
+;;; Regression tests for #2469: the builtin-superinstruction gate is a
+;;; run-time decision.
+;;;
+;;; `apply` / `call-with-values` (any position) and `eval` / `call/cc` /
+;;; `call-with-current-continuation` (tail position) compile to a
+;;; superinstruction. R7RS 5.3.1 makes a top-level definition essentially an
+;;; assignment, so which binding a call reaches is a run-time question. #2033
+;;; answered it by reading the global environment at compile time and #2457
+;;; by pre-scanning the whole compilation unit for later definitions; both
+;;; baked the answer into bytecode compiled before the redefinition ran, and
+;;; the scan could not see a redefinition arriving through `load`, `eval`, the
+;;; REPL, or a `set!` a macro materializes. Every superinstruction now sits
+;;; behind a `guard_builtin` opcode that compares the global's current
+;;; binding against the pristine primitive and falls back to an ordinary
+;;; call — so this file's every section redefines a name through a route the
+;;; scan was blind to, from a body compiled before the redefinition existed.
+;;;
+;;; The whole-unit shapes (#2457's own file) and the define-before-use order
+;;; (#2033's) keep their own suites; this one covers only the routes #2469
+;;; listed as still baking the builtin in.
+
+(import (scheme base) (scheme write) (scheme eval) (scheme load) (scheme file)
+        (scheme process-context) (srfi 64))
+
+(define %test-fail-count 0)
+(test-begin "top-level-redefinition-runtime-2469")
+
+(define saved-2469-orig-apply apply)
+(define saved-2469-orig-eval eval)
+(define saved-2469-orig-call/cc call/cc)
+(define saved-2469-orig-cwv call-with-values)
+(define saved-2469-orig-ccc call-with-current-continuation)
+
+;;; ------------------------------------------------------------------
+;;; eval: the redefinition and the caller both live inside an `eval`'d
+;;; `begin`, compiled as one per-form unit with no future knowledge.
+;;; ------------------------------------------------------------------
+
+(eval '(begin (define (nt-eval-apply) (apply + (list 1 2)))
+              (define (apply f xs) 'eval-user))
+      (interaction-environment))
+(test-eq "eval: use-before-define of apply inside one eval'd begin honours it"
+  'eval-user (nt-eval-apply))
+(define apply saved-2469-orig-apply)
+(test-eq "eval: genuine apply restored" 3 (nt-eval-apply))
+
+;;; A caller compiled by THIS file, redefined by a later eval.
+(define (t-eval-cwv) (call-with-values (lambda () 1) (lambda (x) x)))
+(eval '(define (call-with-values p c) 'eval-user-cwv) (interaction-environment))
+(test-eq "eval: a redefinition eval'd later reaches a body this file compiled"
+  'eval-user-cwv (t-eval-cwv))
+(define call-with-values saved-2469-orig-cwv)
+(test-eq "eval: genuine call-with-values restored" 1 (t-eval-cwv))
+
+;;; ------------------------------------------------------------------
+;;; load: the loaded file's own use-before-define order. The loaded file is
+;;; compiled form by form as it is read, so its first body has no knowledge
+;;; of the define that follows.
+;;; ------------------------------------------------------------------
+
+(define load-path-2469
+  (string-append "kaappi-2469-load-" (number->string (exact (floor (current-second)))) ".scm"))
+(when (file-exists? load-path-2469) (delete-file load-path-2469))
+(with-output-to-file load-path-2469
+  (lambda ()
+    (write '(define (nt-loaded) (apply + (list 1 2))))
+    (newline)
+    (write '(define (apply f xs) 'loaded-user))
+    (newline)
+    (write '(define loaded-result (nt-loaded)))
+    (newline)))
+(load load-path-2469)
+(delete-file load-path-2469)
+(test-eq "load: the loaded file's use-before-define of apply honours it"
+  'loaded-user loaded-result)
+(test-eq "load: the loaded redefinition reaches this file's later calls too"
+  'loaded-user (nt-loaded))
+(define apply saved-2469-orig-apply)
+(test-eq "load: genuine apply restored" 3 (nt-loaded))
+
+;;; ------------------------------------------------------------------
+;;; A set! that only materializes when a macro expands, targeting the
+;;; use-site name: invisible to any structure-only scan of the source.
+;;; ------------------------------------------------------------------
+
+(define (nt-macro-apply) (let ((v (apply + (list 1 2)))) v))
+(define (t-macro-eval) (eval '(+ 1 2) (interaction-environment)))
+(define (t-macro-callcc) (call/cc (lambda (k) 1)))
+(define (t-macro-ccc) (call-with-current-continuation (lambda (k) 1)))
+(define-syntax redef!
+  (syntax-rules ()
+    ((_ name value) (set! name value))))
+(redef! apply (lambda (f xs) 'macro-set-apply))
+(redef! eval (lambda (x . env) 'macro-set-eval))
+(redef! call/cc (lambda (r) 'macro-set-callcc))
+(redef! call-with-current-continuation (lambda (r) 'macro-set-ccc))
+(test-eq "macro set!: apply (non-tail)" 'macro-set-apply (nt-macro-apply))
+(test-eq "macro set!: apply at the use site too" 'macro-set-apply (apply + '(1 2)))
+(test-eq "macro set!: eval (tail)" 'macro-set-eval (t-macro-eval))
+(test-eq "macro set!: call/cc (tail)" 'macro-set-callcc (t-macro-callcc))
+(test-eq "macro set!: call-with-current-continuation (tail)" 'macro-set-ccc (t-macro-ccc))
+(define apply saved-2469-orig-apply)
+(define eval saved-2469-orig-eval)
+(define call/cc saved-2469-orig-call/cc)
+(define call-with-current-continuation saved-2469-orig-ccc)
+(test-equal "macro set!: all four genuine bindings restored"
+  '(3 3 1 1)
+  (list (nt-macro-apply) (t-macro-eval) (t-macro-callcc) (t-macro-ccc)))
+
+;;; ------------------------------------------------------------------
+;;; The redefinition happens WHILE a caller is on the stack: the guard reads
+;;; the binding at each call, not once per body.
+;;; ------------------------------------------------------------------
+
+(define (twice thunk) (let ((first (thunk))) (list first (thunk))))
+(define (flip-then-apply)
+  (twice (lambda ()
+           (let ((v (apply + (list 1 2))))
+             (set! apply (lambda (f xs) 'flipped))
+             v))))
+(test-equal "mid-flight set!: the second call in the same body sees the new binding"
+  '(3 flipped) (flip-then-apply))
+(define apply saved-2469-orig-apply)
+
+;;; ------------------------------------------------------------------
+;;; A library body's own use-before-define order: `apply` is excluded from
+;;; the import so the library's later define is a fresh binding, and the
+;;; first body was compiled before it existed.
+;;; ------------------------------------------------------------------
+
+(define-library (kaappi-2469 lib)
+  (import (except (scheme base) apply))
+  (export lib-use lib-apply)
+  (begin
+    (define (lib-use) (apply + (list 1 2)))
+    (define (apply f xs) 'lib-user)
+    (define lib-apply apply)))
+(import (kaappi-2469 lib))
+(test-eq "library body: use-before-define of a library-local apply honours it"
+  'lib-user (lib-use))
+(test-eq "library body: the program's own apply is untouched" 3 (apply + '(1 2)))
+
+;;; ------------------------------------------------------------------
+;;; A non-procedure rebinding through eval reports the ordinary call's type
+;;; error rather than running the builtin.
+;;; ------------------------------------------------------------------
+
+(define (t-nonproc) (call/cc (lambda (k) 1)))
+(eval '(define call/cc 42) (interaction-environment))
+(test-assert "eval: call/cc rebound to a non-procedure raises, not the builtin"
+  (guard (e (#t (error-object? e))) (t-nonproc) #f))
+(define call/cc saved-2469-orig-call/cc)
+(test-eq "eval: genuine call/cc restored" 1 (t-nonproc))
+
+(set! %test-fail-count (test-runner-fail-count (test-runner-current)))
+(test-end "top-level-redefinition-runtime-2469")
+(if (> %test-fail-count 0) (exit 1))


### PR DESCRIPTION
Closes #2469.

## What

The builtin-superinstruction gate is now a run-time decision. `apply` /
`call-with-values` (any position) and `eval` / `call/cc` /
`call-with-current-continuation` (tail position) still compile to their
superinstructions, but every user-text site is emitted behind a new
`guard_builtin` opcode:

```text
<operands into base+1 ...>
guard_builtin  base, sym, kind, ->slow   ; base := current global binding
<superinstruction over base+1 ...>       ; only while still pristine
move dst, <result>                       ; (non-tail)
jump ->end
slow:
call / tail_call  base, n                ; whatever the global holds now
end:
```

The guard resolves the operator's global through the same per-function
cache `get_global` uses (`vm_dispatch_helpers.lookupGlobalCached`, extracted
from the `get_global` arm and now shared), compares it against
`LibraryRegistry.fast_path_pristine[kind]` (snapshotted at registration,
root-marked so a redefinition cannot free it), and jumps to an ordinary
call of the fetched value otherwise. A genuine call pays one cached load and
one compare.

The native backend's `emitApplyForm` makes the same decision: it resolves
the `apply` global, asks the new `kaappi_builtin_is_pristine` runtime
export, and branches to the structural `@kaappi_apply` shape or an
indirect call, joined by a phi (non-tail) or two `ret`s (tail).

## What this retires

- #2467's whole-unit scan: `collectUnitTopLevelTargets`,
  `unit_top_level_targets`, and its install sites in the file, stdin,
  `compile`, `check` (`unitTargetSet`) and native drivers, plus the native
  `unitRedefines` helper. The WASM playground entry named in the issue
  comment needs nothing now.
- The REPL / `eval` / `load` / macro-materialized-`set!` carve-outs. All
  four routes from the issue table now print the user's binding.
- `globalBindingStillGenuine` stays, re-documented as a heuristic: a
  compile-time `false` only skips emitting a guarded fast path the guard
  would reject on every execution (#2033's define-before-use order, a
  `set!` in the enclosing form). Correctness no longer depends on it.

## Behavior notes

- `call-with-values` now evaluates its producer before its consumer, like an
  ordinary call. The previous consumer-first order was a register-layout
  artefact of #2453; R7RS 4.1.3 leaves operand order unspecified.
- The jump over the slow path is emitted in tail position too: a
  continuation captured by `tail_call_cc` resumes at the instruction after
  it, which must be the form's exit rather than the slow path's call.
- A guarded non-tail `apply` with more than 254 operands takes the ordinary
  call path (the slow path's `call` nargs is a u8 and includes the callee).
- Review found an adjacent pre-existing gap: the native runtime's
  `kaappi_set_global` wrote the global without bumping `global_version`, so
  an interpreted body's per-function global cache (which the guard now reads
  through) could keep serving the old binding after a natively compiled
  `set!`. It now bumps the version like the `set_global` opcode.
- Design deviation from the pre-implementation discussion: rather than
  extending each superinstruction with an internal fall-through, one guard
  opcode covers all five names. The superinstructions read their operands
  from a different register layout than an ordinary call would, so an
  internal fall-through would have needed register shuffling in four VM
  arms; the guard plus a reserved callee slot leaves them untouched and
  costs about 14 bytes per site.

## Tests

- `tests/scheme/compliance/top-level-redefinition-runtime-2469.scm`: the
  `eval` route (both inside one eval'd `begin` and a later eval reaching a
  body this file compiled), the `load` route (the loaded file's own
  use-before-define order), macro-materialized `set!` for four names, a
  `set!` while the caller is on the stack, a library body's own
  use-before-define order, and a non-procedure rebinding through `eval`.
- `src/tests_core_eval.zig`: the REPL route (form-by-form `vm.eval`,
  which no unit scan could cover) for all five names, and pristine
  primitives surviving two full collections plus heap churn after a
  redefinition.
- `tests/scheme/compile/native-apply-redefinition-order-2469.sh`: the
  macro and eval routes and the mid-flight flip, each run cold, as a
  bytecode-cache HIT (the `.sbc` round trip through the loader's validator),
  and natively; pins that a clean program keeps its `@kaappi_apply` site,
  carries the guard, and has no eval fallback.
- `src/tests_check.zig`: the three whole-unit-gate tests are replaced by a
  use-before-`set!` file analyzing clean. The disassembler's all-opcodes
  test covers `guard_builtin`.
- Existing `#2457` and `#2033` suites and native scripts pass unchanged in
  substance (comments updated to describe the interim as history).

## Docs

`docs/dev/bytecode.md` (opcode 33, encoding sketch, count 34),
`docs/dev/llvm-backend.md` (native `apply` cases), `docs/dev/architecture.md`
(file table), the opcode-count quotes in `docs/dev/README.md`,
`docs/dev/claude-code-harness.md` and `.claude/skills/bytecode-isa/SKILL.md`.
No CHANGELOG.md edit: per #2482 the release notes come from the commit
bodies, which carry the full description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
