### PR TITLE
Drop the per-PR CHANGELOG gate; write CHANGELOG.md at release time

### DIFF
--- a/.claude/skills/github-release/SKILL.md
+++ b/.claude/skills/github-release/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Cut a GitHub release for Kaappi — bumps version strings, updates CHANGELOG.md and the downloads page, commits, tags, pushes, and verifies the release workflow. Use when the user asks to make a release, cut a release, publish a version, tag a release, ship a version, or prepare a release.
+description: Cut a GitHub release for Kaappi — bumps version strings, writes the CHANGELOG.md section from the commit log, updates the downloads page, commits, tags, pushes, and verifies the release workflow. Use when the user asks to make a release, cut a release, publish a version, tag a release, ship a version, or prepare a release.
 ---
 
 # GitHub Release
@@ -40,11 +40,13 @@ Present the analysis and recommendation, then ask for confirmation before contin
 
 ## Step 2: Generate release notes
 
-**Derive the notes from `git log` since the previous tag** — that is the primary
-source. There is no CI gate requiring a `CHANGELOG.md` entry per PR (it was
-removed: it conflicted constantly across concurrent branches, since every PR
-edited the same few lines at the top of one file), so `[Unreleased]` is
-normally sparse or empty and cannot be relied on.
+**Derive the notes from `git log` since the previous tag** — that is the only
+source. PRs do not edit `CHANGELOG.md`: a per-PR CI gate was tried twice
+(dropped in #2103, restored with a wider scope in #2475, dropped again in
+2026-09) and each time concurrent branches conflicted on the same few lines
+at the top of one file. So `[Unreleased]` is empty by design, and this step
+is where the version's section gets written — budget for it (v0.22.0 had
+100 commits to cover).
 
 ```bash
 git log --no-merges --pretty='%h %s' "$(git describe --tags --abbrev=0)"..HEAD

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,5 @@
 - [ ] Scheme test suites pass (`bash tests/scheme/run-all.sh`)
 - [ ] New tests added for new behavior
 - [ ] Documentation updated (if applicable)
+- [ ] Commit body explains *why* — release notes are written from it at
+      release time; do not edit `CHANGELOG.md`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,65 +175,13 @@ jobs:
       - name: Markdown lint
         uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
 
-  # `[Unreleased]` has been reconstructed from `git log` at release time rather
-  # than written as the work lands -- v0.22.0 shipped with 14 of 100 commits
-  # reflected in it, v0.22.1 with 5 of 16. Ask for the entry here, while the
-  # change is fresh and its author is present to write it.
-  #
-  # A previous version of this gate was dropped in #2103 because concurrent
-  # PRs appending under [Unreleased] conflict with each other. #2475 brought it
-  # back anyway: the alternative (reconstructing entries at release time) put
-  # the bulk of the work on whoever cut v0.22.0/v0.22.1, and #2467 merged with
-  # no entry at all. Scope is now all of src/, lib/ and vendor/ (#2475);
-  # tests/**-only changes are deliberately outside it, and the check is
-  # presence-only -- wording stays with the author.
-  changelog:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      pull-requests: read
-    steps:
-      - name: Require a CHANGELOG entry for user-visible changes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          # Labels are read live rather than from github.event, because
-          # re-running a job replays the ORIGINAL event payload -- a
-          # `no-changelog` label added in response to this job failing would
-          # be invisible to it, making the documented escape hatch a dead end.
-          if gh pr view "$PR" --repo "$REPO" --json labels \
-               --jq '.labels[].name' | grep -qx 'no-changelog'; then
-            echo "Labelled 'no-changelog' -- skipping."
-            exit 0
-          fi
-
-          # Same paginated endpoint as the `format` classifier: no checkout
-          # needed, and push/pull_request would share a shape if this ever
-          # grows beyond PRs.
-          files=$(gh api --paginate \
-            "repos/${REPO}/pulls/${PR}/files" --jq '.[].filename')
-
-          if ! grep -qE '^(src|lib|vendor)/' <<<"$files"; then
-            echo "No src/, lib/ or vendor/ changes -- CHANGELOG entry not required."
-            exit 0
-          fi
-          if grep -qx 'CHANGELOG.md' <<<"$files"; then
-            echo "CHANGELOG.md updated."
-            exit 0
-          fi
-
-          echo "::error::This PR changes src/, lib/ or vendor/ but does not touch CHANGELOG.md."
-          echo "::error::Add an entry under [Unreleased] describing the user-visible effect."
-          echo "::error::If the change is not user-visible (refactor, tests, CI), apply the"
-          echo "::error::'no-changelog' label and re-run this job -- labels are read live, so"
-          echo "::error::a re-run picks it up without pushing a commit."
-          exit 1
+  # There is deliberately no CHANGELOG gate here. One existed until #2103
+  # dropped it, because concurrent PRs appending under [Unreleased] conflict
+  # with each other on the same few lines; #2475 brought it back with a wider
+  # scope and the conflicts came back with it. CHANGELOG.md is now written at
+  # release time from `git log` (`/github-release` Step 2) and PRs do not edit
+  # it -- the commit body is where the "why" goes, since that is what the
+  # release notes are written from.
 
   test:
     needs: format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,14 @@ All notable changes to Kaappi are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+Each version's section is written at release time from the commit history
+since the previous tag (`/github-release` Step 2). Pull requests do not edit
+this file — put the *why* in the commit body instead.
+
 ## [Unreleased]
 
 ### Added
 
-- **CI CHANGELOG gate (#2475)** — a `changelog` job in CI fails a PR that
-  changes `src/`, `lib/` or `vendor/` without also touching `CHANGELOG.md`,
-  unless the PR carries the `no-changelog` label (read live, so labelling
-  and re-running the job is enough). Tests-only and docs-only changes are
-  outside the gate, and the check is presence-only — entry wording stays
-  with the author. Restores, with a wider scope, the gate dropped in #2103.
 - **`run-process` and the `process-timeout` condition (KEP-0022 Phase 4,
   #2417)** — the one-shot layer over `spawn-process`:
   `(run-process argv opt…)` spawns, feeds an optional `input:`, drains

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,6 +481,15 @@ every release across `ubuntu-latest`, `ubuntu-24.04-arm`, and `macos-latest`.
 Adding a platform means teaching its `detect_platform` the `uname` spelling and
 its `rt_artifact` case — `docs/dev/porting.md` Stage 6.
 
+## Changelog
+
+**Do not edit `CHANGELOG.md` in a PR.** Each version's section is written
+once, at release time, by `/github-release` Step 2 from `git log` since the
+previous tag — so the commit body is the release-note source, and the *why*
+belongs there. Per-PR entries were tried twice as a CI gate (dropped
+in #2103, restored in #2475, dropped again) and both times every concurrent
+PR conflicted on the same few lines at the top of one file.
+
 ## Issue tracker
 
 **Every issue you file or triage gets exactly one `priority:` label** —
@@ -541,6 +550,7 @@ Skills in `.claude/skills/`: `/add-builtin`, `/audit-primitives`,
 | GC safety checklist | Path-scoped rule (auto-loaded) | `.claude/rules/gc-safety.md` |
 | Compiler form checklist | Path-scoped rule (auto-loaded) | `.claude/rules/compiler-forms.md` |
 | Bug fixes need tests | Advisory only | This file (Tests) |
+| No per-PR `CHANGELOG.md` edits | Advisory only | This file (Changelog) |
 | Files ≤ 1500 lines | Advisory only | This file (File size policy) |
 | One `priority:` label per issue | Advisory only | This file, `docs/dev/github-issues.md` |
 | Commit message format | Advisory only | Parent `CLAUDE.md` (Conventions) |

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -32,8 +32,9 @@ All of the following must be met before tagging `1.0.0`:
 
 ## Release process
 
-1. Update `CHANGELOG.md`: move the `[Unreleased]` section to a new version
-   heading.
+1. Write the new version section in `CHANGELOG.md` from `git log` since the
+   previous tag (`/github-release` Step 2). Entries are not accumulated per
+   PR — the commit body is the source.
 2. Update `pub const version` in `src/main.zig`.
 3. Commit, tag (`git tag v0.2.0`), and push (`git push --tags`).
 4. The release workflow builds cross-compiled binaries and creates a GitHub

--- a/docs/dev/claude-code-harness.md
+++ b/docs/dev/claude-code-harness.md
@@ -267,8 +267,9 @@ when working on the compiler or VM.
 Full release workflow with 10 steps and multiple confirmation gates:
 
 1. Analyze changes since last tag, recommend semver bump.
-2. Generate release notes from CHANGELOG.md and unreflected commits.
-3. Update CHANGELOG.md (clear Unreleased, insert new version section).
+2. Generate release notes from `git log` since the previous tag — this is
+   where `CHANGELOG.md` gets written; PRs never touch it.
+3. Update CHANGELOG.md (insert the new version section).
 4. Bump version in `main.zig`, `thottam.zig`, `build.zig.zon`, and the docs
    site download page.
 5. Build verification (`zig build`).

--- a/docs/dev/github-issues.md
+++ b/docs/dev/github-issues.md
@@ -59,7 +59,6 @@ Three of these are load-bearing beyond navigation, because they predict the
 | `fuzz-finding` | Automated report from the scheduled Fuzz workflow |
 | `epic` | Umbrella tracking issue; children are separate issues |
 | `blocked-upstream` | Blocked on an upstream dependency fix |
-| `no-changelog` | Not user-visible; exempt from the CHANGELOG check |
 | `good first issue`, `help wanted` | Contributor onboarding |
 
 ## The priority rubric


### PR DESCRIPTION
## Summary

Updating `CHANGELOG.md` in every PR conflicts constantly: each concurrent branch appends under the same `[Unreleased]` heading. This removes the per-PR requirement and makes release-time generation the documented policy.

- Remove the `changelog` CI job restored by #2475 (not a required branch-protection check, so mergeability is unchanged). A comment records why so it is not re-added a third time.
- Repo `CLAUDE.md`: new **Changelog** section ("do not edit `CHANGELOG.md` in a PR"), plus an enforcement-map row.
- `/github-release` skill: Step 2 states `git log` is the only source and `[Unreleased]` is empty by design; description updated.
- `VERSIONING.md`, `docs/dev/claude-code-harness.md`: release process wording now matches.
- `docs/dev/github-issues.md`: drop the `no-changelog` label row (the label itself is left in place, but nothing consults it).
- `CHANGELOG.md`: header paragraph states the policy; the `[Unreleased]` entry describing the #2475 gate is removed since it never ships.
- PR template: checklist item asking for a *why* in the commit body, since that is now the release-note source.

The workspace-level `../CLAUDE.md` (not a git repo) was updated the same way.

## Checklist

- [x] `npx markdownlint-cli2` passes (0 issues in 92 files)
- [x] `ci.yml` still parses
- [ ] `zig build test` — no Zig changes
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)