### PR TITLE
CI: raise the macOS ReleaseSafe test cap to 50 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,12 +241,17 @@ jobs:
           # default here: a clean ReleaseSafe run now lands at ~35 min (build
           # ~2, unit tests ~10, Scheme suites ~18+), so the cap cancels healthy
           # runs mid-suite — the recurrence the timeout comment above predicted
-          # ("hit macOS ReleaseSafe repeatedly"). 40 restores headroom, same as
-          # the Debug leg; timeout is an include-only key that merges into this
-          # existing os+optimize combination without renaming its required check.
+          # ("hit macOS ReleaseSafe repeatedly"). 40 restored headroom, same as
+          # the Debug leg, until a slow runner ate that too: PR #2481's re-run
+          # (2026-09-02) was cancelled at 40:04 on its LAST step with every
+          # suite green — build 4, unit tests 13.5, Scheme suites 21.5 min.
+          # 50 leaves ~10 min over that run while still catching a real hang
+          # (healthy runs sit at 18–24 min). timeout is an include-only key
+          # that merges into this existing os+optimize combination without
+          # renaming its required check.
           - os: macos-latest
             optimize: ReleaseSafe
-            timeout: 40
+            timeout: 50
           - os: ubuntu-latest
             optimize: ReleaseFast
 


### PR DESCRIPTION
Workflow-only change: the `test (macos-latest, ReleaseSafe)` leg's `timeout` goes from 40 to 50 minutes.

**Why:** the 40-minute cap was set when 30 began cancelling healthy runs, with a clean run estimated at ~35 minutes. Slow-runner variance has now eaten that margin as well. kaappi/kaappi#2481's macOS re-run on 2026-09-02 (run 33626023261, attempt 2) was cancelled at 40:04 on its **last** step with every suite green:

| Step | Duration |
|---|---|
| build | 4 min |
| unit tests | 13.5 min |
| Scheme suites | 21.5 min |
| sandbox / robustness / E2E | < 1 min |
| thottam integration | cut off at 40:04 |

Healthy macOS runs still sit at 18–24 minutes, so 50 keeps the cap useful for hang detection while leaving ~10 minutes over the slowest observed run. `timeout` is an include-only matrix key, so the pinned job name and the required check are unchanged. Linux legs stay at 30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
