### PR TITLE
Stop the mark worklist from leaving freed-but-dirty pages behind every full collection (#2464)

### DIFF
--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -807,7 +807,7 @@ fn markObjectContents(gc: *GC, obj: *Object) void {
 //
 // One enumeration of a port's Values, three different things to do with
 // each. This is what replaced the hand-kept triplicate: markPortValues
-// (recursive, for markObjectContents), an inline worklist.append list in
+// (recursive, for markObjectContents), an inline wlPush list in
 // markValueInner, and an inline isYoungPointer list in referencesYoung.
 // Each visitor keeps its own arm's exact previous semantics -- in
 // particular markValueInner still appends to the caller's worklist rather
@@ -825,16 +825,35 @@ fn markVisitor(gc: *GC, v: Value) bool {
     return false;
 }
 
-/// markValueInner: push every referent onto the caller's worklist.
+/// markValueInner: push every pointer referent onto the caller's worklist
+/// (immediates skipped — see wlPush).
 const WorklistVisitor = struct {
     gc: *GC,
     worklist: *std.ArrayList(Value),
 
     fn visit(self: WorklistVisitor, v: Value) bool {
-        self.worklist.append(self.gc.allocator, v) catch @panic("GC mark: worklist OOM");
+        wlPush(self.gc, self.worklist, v);
         return false;
     }
 };
+
+/// Push one referent onto the mark worklist, skipping immediates. The
+/// drain's markValueInner returns at its `isPointer` check, so an immediate
+/// on the worklist could only ever be popped and discarded — pushing one is
+/// pure transient growth. #2464: a wide container of immediates (the
+/// array-copy scratch vector of fixnums that motivated the issue) peaked
+/// the worklist at the container's full width every full collection, and
+/// the post-drain buffer release made each collection regrow through the
+/// same realloc chain — the backing libc malloc never decommits those freed
+/// large blocks, so peak RSS accumulated ~10 MB of resident-dirty pages per
+/// full collection (~65x the live heap) until the program ended. The pair
+/// arm's car push keeps its own car_is_ptr guard (it also steers the cdr
+/// tail-iteration); wlPush's check is what covers every container arm's
+/// fields.
+inline fn wlPush(gc: *GC, worklist: *std.ArrayList(Value), v: Value) void {
+    if (!types.isPointer(v)) return;
+    worklist.append(gc.allocator, v) catch @panic("GC mark: worklist OOM");
+}
 
 /// Record a reachable ephemeron for the post-mark weak fixpoint without tracing
 /// its key or value — those are decided by processWeakRefs.
@@ -955,8 +974,18 @@ pub fn markValue(gc: *GC, v: Value) void {
     gc.marking = false;
 
     // Cap retained capacity so one pathologically wide object (e.g. a
-    // 10M-element vector) doesn't keep ~80 MB allocated forever.
-    const max_retained = 64 * 1024;
+    // 10M-element vector of pointers) doesn't keep ~80 MB allocated
+    // forever. The floor is generous (#2464): releasing the buffer after
+    // every collection made each full mark regrow it through the same
+    // realloc chain, and the backing libc malloc does not decommit the
+    // freed large blocks — on macOS each freed ~10 MB top block stayed
+    // resident-dirty, so peak RSS accumulated roughly one chain per full
+    // collection (observed ~65x the live heap) even though every byte was
+    // freed. Retaining up to 8 MB (1M entries) of a buffer whose growth
+    // was driven by live pointer-reachability costs at most a fraction of
+    // the structure that caused it; only the excess past the floor is
+    // released.
+    const max_retained = 1024 * 1024;
     if (gc.mark_worklist.capacity > max_retained)
         gc.mark_worklist.clearAndFree(gc.allocator);
 }
@@ -1008,7 +1037,7 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
                 // Push car onto worklist instead of recursing -- this is
                 // the key change that prevents stack overflow on deep
                 // structures like (((((...)))))).
-                worklist.append(gc.allocator, car) catch @panic("GC mark: worklist OOM");
+                wlPush(gc, worklist, car);
                 cur = cdr;
             } else if (cdr_is_ptr) {
                 cur = cdr;
@@ -1026,82 +1055,82 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
         .pair => unreachable,
         .closure => {
             const cls = obj.as(Closure);
-            worklist.append(gc.allocator, types.makePointer(&cls.func.header)) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, types.makePointer(&cls.func.header));
             for (cls.upvalues) |uv| {
-                worklist.append(gc.allocator, uv) catch @panic("GC mark: worklist OOM");
+                wlPush(gc, worklist, uv);
             }
         },
         .function => {
             const func = obj.as(Function);
             for (func.constants.items) |c| {
-                worklist.append(gc.allocator, c) catch @panic("GC mark: worklist OOM");
+                wlPush(gc, worklist, c);
             }
             if (func.global_cache) |cache| {
-                for (cache) |c| worklist.append(gc.allocator, c) catch @panic("GC mark: worklist OOM");
+                for (cache) |c| wlPush(gc, worklist, c);
             }
-            worklist.append(gc.allocator, func.env_val) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, func.env_val);
         },
         .transformer => {
             const tx = obj.as(Transformer);
             for (tx.literals) |lit| {
-                worklist.append(gc.allocator, lit) catch @panic("GC mark: worklist OOM");
+                wlPush(gc, worklist, lit);
             }
             for (tx.patterns) |pat| {
-                worklist.append(gc.allocator, pat) catch @panic("GC mark: worklist OOM");
+                wlPush(gc, worklist, pat);
             }
             for (tx.templates) |tmpl| {
-                worklist.append(gc.allocator, tmpl) catch @panic("GC mark: worklist OOM");
+                wlPush(gc, worklist, tmpl);
             }
-            worklist.append(gc.allocator, tx.def_env_val) catch @panic("GC mark: worklist OOM");
-            worklist.append(gc.allocator, tx.proc) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, tx.def_env_val);
+            wlPush(gc, worklist, tx.proc);
             for (tx.let_syntax_peer_vals) |pv| {
-                worklist.append(gc.allocator, pv) catch @panic("GC mark: worklist OOM");
+                wlPush(gc, worklist, pv);
             }
         },
         .error_object => {
             const err = obj.as(types.ErrorObject);
-            worklist.append(gc.allocator, err.message) catch @panic("GC mark: worklist OOM");
-            worklist.append(gc.allocator, err.irritants) catch @panic("GC mark: worklist OOM");
-            worklist.append(gc.allocator, err.uncaught_reason) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, err.message);
+            wlPush(gc, worklist, err.irritants);
+            wlPush(gc, worklist, err.uncaught_reason);
         },
         .record_type => {
             const rt = obj.as(RecordType);
             if (rt.parent) |p| {
-                worklist.append(gc.allocator, types.makePointer(&p.header)) catch @panic("GC mark: worklist OOM");
+                wlPush(gc, worklist, types.makePointer(&p.header));
             }
         },
         .record_instance => {
             const ri = obj.as(RecordInstance);
-            worklist.append(gc.allocator, types.makePointer(&ri.record_type.header)) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, types.makePointer(&ri.record_type.header));
             for (ri.fields) |field| {
-                worklist.append(gc.allocator, field) catch @panic("GC mark: worklist OOM");
+                wlPush(gc, worklist, field);
             }
         },
         .continuation => {
             const cont = obj.as(Continuation);
             for (cont.registers) |reg| {
-                worklist.append(gc.allocator, reg) catch @panic("GC mark: worklist OOM");
+                wlPush(gc, worklist, reg);
             }
             for (cont.frames[0..cont.frame_count]) |frame| {
                 if (frame.closure) |cls| {
-                    worklist.append(gc.allocator, types.makePointer(&cls.header)) catch @panic("GC mark: worklist OOM");
+                    wlPush(gc, worklist, types.makePointer(&cls.header));
                 }
                 if (frame.native) |nf| {
-                    worklist.append(gc.allocator, types.makePointer(&nf.header)) catch @panic("GC mark: worklist OOM");
+                    wlPush(gc, worklist, types.makePointer(&nf.header));
                 }
             }
             for (cont.handlers[0..cont.handler_count]) |handler| {
-                worklist.append(gc.allocator, handler.handler) catch @panic("GC mark: worklist OOM");
+                wlPush(gc, worklist, handler.handler);
             }
             for (cont.wind_records[0..cont.wind_count]) |wr| {
-                worklist.append(gc.allocator, wr.before) catch @panic("GC mark: worklist OOM");
-                worklist.append(gc.allocator, wr.after) catch @panic("GC mark: worklist OOM");
+                wlPush(gc, worklist, wr.before);
+                wlPush(gc, worklist, wr.after);
             }
         },
         .multiple_values => {
             const mv = obj.as(MultipleValues);
             for (mv.values) |val| {
-                worklist.append(gc.allocator, val) catch @panic("GC mark: worklist OOM");
+                wlPush(gc, worklist, val);
             }
         },
         .vector => {
@@ -1110,19 +1139,19 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
             // iterate the last element directly via tail call.
             if (vec.data.len > 0) {
                 for (vec.data[0 .. vec.data.len - 1]) |elem| {
-                    worklist.append(gc.allocator, elem) catch @panic("GC mark: worklist OOM");
+                    wlPush(gc, worklist, elem);
                 }
                 markValueInner(gc, vec.data[vec.data.len - 1], worklist);
             }
         },
         .promise => {
             const p = obj.as(Promise);
-            worklist.append(gc.allocator, p.value) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, p.value);
         },
         .parameter => {
             const param = obj.as(types.ParameterObject);
-            worklist.append(gc.allocator, param.value) catch @panic("GC mark: worklist OOM");
-            worklist.append(gc.allocator, param.converter) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, param.value);
+            wlPush(gc, worklist, param.converter);
         },
         // Same enumeration as markObjectContents and referencesYoung, a
         // different action: this switch drives an explicit worklist rather
@@ -1134,33 +1163,33 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
         ),
         .hash_table => {
             const ht = obj.as(HashTable);
-            if (ht.equiv_fn != 0) worklist.append(gc.allocator, ht.equiv_fn) catch @panic("GC mark: worklist OOM");
-            if (ht.hash_fn != 0) worklist.append(gc.allocator, ht.hash_fn) catch @panic("GC mark: worklist OOM");
+            if (ht.equiv_fn != 0) wlPush(gc, worklist, ht.equiv_fn);
+            if (ht.hash_fn != 0) wlPush(gc, worklist, ht.hash_fn);
             for (ht.entries[0..ht.capacity]) |entry| {
                 if (entry.state == .occupied) {
-                    worklist.append(gc.allocator, entry.key) catch @panic("GC mark: worklist OOM");
-                    worklist.append(gc.allocator, entry.value) catch @panic("GC mark: worklist OOM");
+                    wlPush(gc, worklist, entry.key);
+                    wlPush(gc, worklist, entry.value);
                 }
             }
         },
         .rational => {
             const rat = obj.as(Rational);
-            worklist.append(gc.allocator, rat.numerator) catch @panic("GC mark: worklist OOM");
-            worklist.append(gc.allocator, rat.denominator) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, rat.numerator);
+            wlPush(gc, worklist, rat.denominator);
         },
         .complex => {
             const cx = obj.as(types.Complex);
-            worklist.append(gc.allocator, cx.real) catch @panic("GC mark: worklist OOM");
-            worklist.append(gc.allocator, cx.imag) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, cx.real);
+            wlPush(gc, worklist, cx.imag);
         },
         .ffi_library => {},
         .ffi_function => {
             const ffi_fn = obj.as(FfiFunction);
-            worklist.append(gc.allocator, ffi_fn.library) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, ffi_fn.library);
         },
         .ffi_callback => {
             const cb = obj.as(FfiCallback);
-            worklist.append(gc.allocator, cb.closure) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, cb.closure);
         },
         .fiber => {
             const fiber_mod = @import("fiber.zig");
@@ -1169,30 +1198,30 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
         },
         .channel => {
             const ch = obj.as(types.Channel);
-            worklist.append(gc.allocator, ch.head) catch @panic("GC mark: worklist OOM");
-            worklist.append(gc.allocator, ch.tail) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, ch.head);
+            wlPush(gc, worklist, ch.tail);
         },
         .process => {
             const proc = obj.as(types.Process);
-            worklist.append(gc.allocator, proc.stdin_port) catch @panic("GC mark: worklist OOM");
-            worklist.append(gc.allocator, proc.stdout_port) catch @panic("GC mark: worklist OOM");
-            worklist.append(gc.allocator, proc.stderr_port) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, proc.stdin_port);
+            wlPush(gc, worklist, proc.stdout_port);
+            wlPush(gc, worklist, proc.stderr_port);
         },
         .mutex => {
             const m = obj.as(types.Mutex);
-            worklist.append(gc.allocator, m.name) catch @panic("GC mark: worklist OOM");
-            worklist.append(gc.allocator, m.owner) catch @panic("GC mark: worklist OOM");
-            worklist.append(gc.allocator, m.owner_thread) catch @panic("GC mark: worklist OOM");
-            worklist.append(gc.allocator, m.specific) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, m.name);
+            wlPush(gc, worklist, m.owner);
+            wlPush(gc, worklist, m.owner_thread);
+            wlPush(gc, worklist, m.specific);
         },
         .condition_variable => {
             const cv = obj.as(types.ConditionVariable);
-            worklist.append(gc.allocator, cv.name) catch @panic("GC mark: worklist OOM");
-            worklist.append(gc.allocator, cv.specific) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, cv.name);
+            wlPush(gc, worklist, cv.specific);
         },
         .native_closure => {
             const nc = obj.as(types.NativeClosure);
-            for (nc.upvalues) |uv| worklist.append(gc.allocator, uv) catch @panic("GC mark: worklist OOM");
+            for (nc.upvalues) |uv| wlPush(gc, worklist, uv);
         },
         .scheme_environment => {
             const se = obj.as(types.SchemeEnvironment);
@@ -1202,7 +1231,7 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
             // redundancy.
             if (!se.owned) return;
             var vit = se.env.valueIterator();
-            while (vit.next()) |val| worklist.append(gc.allocator, val.*) catch @panic("GC mark: worklist OOM");
+            while (vit.next()) |val| wlPush(gc, worklist, val.*);
         },
         .ephemeron => {
             // Weak key, conditional value: the ephemeron object survives (it
@@ -1216,8 +1245,8 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
             if (g.is_transport) {
                 // Transport cells are held strongly; marking each cell defers
                 // its key and traces its value via the `.transport_cell` arm.
-                for (g.registered.items) |e| worklist.append(gc.allocator, e.watched) catch @panic("GC mark: worklist OOM");
-                for (g.ready.items) |e| worklist.append(gc.allocator, e.watched) catch @panic("GC mark: worklist OOM");
+                for (g.registered.items) |e| wlPush(gc, worklist, e.watched);
+                for (g.ready.items) |e| wlPush(gc, worklist, e.watched);
             } else {
                 // Both queues are weakly held — ready (resurrected) contents
                 // are weak resurrections, registered elements await their
@@ -1228,7 +1257,7 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
         .transport_cell => {
             // Value strong, key deferred to processWeakRefs (#2006).
             const tc = obj.as(TransportCell);
-            worklist.append(gc.allocator, tc.value) catch @panic("GC mark: worklist OOM");
+            wlPush(gc, worklist, tc.value);
             gc.pending_transport_cells.append(gc.allocator, cur) catch @panic("GC mark: pending transport cells OOM");
         },
         .symbol, .string, .native_fn, .flonum, .bytevector, .bignum, .file_info, .user_info, .group_info, .directory_object, .random_source, .srfi18_time, .numeric_vector => {},

--- a/src/gc_collect.zig
+++ b/src/gc_collect.zig
@@ -983,11 +983,19 @@ pub fn markValue(gc: *GC, v: Value) void {
     // collection (observed ~65x the live heap) even though every byte was
     // freed. Retaining up to 8 MB (1M entries) of a buffer whose growth
     // was driven by live pointer-reachability costs at most a fraction of
-    // the structure that caused it; only the excess past the floor is
-    // released.
+    // the structure that caused it. A frontier wider than the floor
+    // releases the whole grown buffer but re-reserves the floor, so the
+    // next collection's regrowth starts at 8 MB rather than zero — the
+    // above-floor portion is still rebuilt (and, on mallocs that keep
+    // freed large blocks dirty, still accrues); a decommitting backing
+    // allocator is the follow-up #2464 suggests.
     const max_retained = 1024 * 1024;
-    if (gc.mark_worklist.capacity > max_retained)
+    if (gc.mark_worklist.capacity > max_retained) {
         gc.mark_worklist.clearAndFree(gc.allocator);
+        // A failed re-reserve just means the next collection grows from
+        // zero, exactly the pre-fix behaviour — not worth failing over.
+        gc.mark_worklist.ensureTotalCapacityPrecise(gc.allocator, max_retained) catch {};
+    }
 }
 
 fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
@@ -1163,8 +1171,10 @@ fn markValueInner(gc: *GC, v: Value, worklist: *std.ArrayList(Value)) void {
         ),
         .hash_table => {
             const ht = obj.as(HashTable);
-            if (ht.equiv_fn != 0) wlPush(gc, worklist, ht.equiv_fn);
-            if (ht.hash_fn != 0) wlPush(gc, worklist, ht.hash_fn);
+            // The raw-0 empty fields need no explicit guard: 0 is the
+            // flonum +0.0, which wlPush's isPointer check rejects.
+            wlPush(gc, worklist, ht.equiv_fn);
+            wlPush(gc, worklist, ht.hash_fn);
             for (ht.entries[0..ht.capacity]) |entry| {
                 if (entry.state == .occupied) {
                     wlPush(gc, worklist, entry.key);

--- a/src/tests_gc_worklist.zig
+++ b/src/tests_gc_worklist.zig
@@ -119,3 +119,30 @@ test "#2464: the worklist buffer is retained below the 1M-entry floor" {
     gc.collect();
     try std.testing.expectEqual(cap_after_first, gc.mark_worklist.capacity);
 }
+
+test "#2464: an over-floor frontier re-reserves exactly the floor" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    gc.enabled = false;
+
+    // Hardcoded against markValue's max_retained, deliberately: this is
+    // the pin for the over-floor branch (clearAndFree + re-reserve), so a
+    // future edit that drops the re-reserve — or moves the floor — must
+    // fail here, not pass silently.
+    const floor = 1024 * 1024;
+    var pair = try gc.allocPair(types.makeFixnum(1), types.NIL);
+    gc.pushRoot(&pair);
+    defer gc.popRoot();
+    // One pair, referenced floor+64 times: the vector arm pushes every slot
+    // before the drain pops any, so the worklist peaks above the floor with
+    // a single heap object behind it.
+    var vec = try gc.allocVectorFill(floor + 64, pair);
+    gc.pushRoot(&vec);
+    defer gc.popRoot();
+
+    gc.collect();
+    try std.testing.expectEqual(@as(usize, floor), gc.mark_worklist.capacity);
+    gc.collect();
+    try std.testing.expectEqual(@as(usize, floor), gc.mark_worklist.capacity);
+    try std.testing.expect(types.isPair(types.toVector(vec).data[floor]));
+}

--- a/src/tests_gc_worklist.zig
+++ b/src/tests_gc_worklist.zig
@@ -1,0 +1,116 @@
+//! Mark-worklist memory behavior (#2464).
+//!
+//! Two properties of `gc.mark_worklist` that the reachability switches in
+//! tests_gc_tracing.zig say nothing about, both load-bearing for peak RSS:
+//!
+//!   * **Immediates are never pushed.** The drain's `markValueInner` returns
+//!     at its `isPointer` check, so an immediate on the worklist is popped
+//!     and discarded — pushing one is pure transient growth. Before #2464 a
+//!     wide container of immediates (the array-copy scratch vector of
+//!     fixnums from the issue) peaked the worklist at the container's full
+//!     width every full collection.
+//!   * **The buffer is retained below the 1M-entry floor.** Releasing it
+//!     after every collection made each full mark regrow through the same
+//!     realloc chain, and the backing libc malloc does not decommit those
+//!     freed large blocks — peak RSS accumulated ~10 MB of resident-dirty
+//!     pages per full collection (~65x the live heap) until the program
+//!     ended. The old 64K-entry floor cleared exactly the buffers that
+//!     churned.
+//!
+//! Both are asserted through `mark_worklist.capacity`, which persists across
+//! collections (see also the older "mark worklist retains capacity across
+//! collections" test in memory.zig — that one pins capacity *persistence*,
+//! these pin what may grow it and when it is released).
+
+const std = @import("std");
+const memory = @import("memory.zig");
+const types = @import("types.zig");
+const build_options = @import("build_options");
+
+// Sizes chosen against the pre-fix release floor (64K entries), so each
+// test's discriminating assertion actually observes the retained buffer:
+// 40k pushes grew capacity to ~52k — *under* the old floor, hence retained
+// and visible; 70k grew past it, so the old code cleared the buffer to zero
+// after every collection. Under gc-stress the collection-per-allocation
+// makes a 70k-pair build quadratic, so only the single-allocation
+// immediate-only case runs there.
+const immediate_len = 40_000;
+const wide_len = if (build_options.gc_stress) 50_000 else 70_000;
+
+test "#2464: a wide vector of immediates never grows the mark worklist" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    gc.enabled = false;
+
+    var vec = try gc.allocVectorFill(immediate_len, types.makeFixnum(7));
+    gc.pushRoot(&vec);
+    defer gc.popRoot();
+
+    gc.collect();
+    // Pre-fix: every element was pushed, growing capacity to ~52k (under
+    // the old 64K floor, so retained). Post-fix: no push happens at all,
+    // so the threshold has generous margin.
+    try std.testing.expect(gc.mark_worklist.capacity <= 4096);
+    // The container itself must still be live and intact.
+    try std.testing.expect(types.isVector(vec));
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(types.toVector(vec).data[0]));
+    try std.testing.expectEqual(@as(i64, 7), types.toFixnum(types.toVector(vec).data[immediate_len - 1]));
+}
+
+test "#2464: pointer elements still reach the worklist and stay live" {
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    gc.enabled = false;
+
+    // Alternating pair/fixnum: only the pairs may be pushed, and they are
+    // reachable ONLY through the vector, so survival double-checks that the
+    // skip-immediates change never widened into skipping pointers.
+    const n = 1000;
+    var items: [n]types.Value = undefined;
+    for (&items, 0..) |*slot, i| {
+        if (i % 2 == 0) {
+            slot.* = try gc.allocPair(types.makeFixnum(@intCast(i)), types.NIL);
+        } else {
+            slot.* = types.makeFixnum(@intCast(i));
+        }
+    }
+    var vec = try gc.allocVector(&items);
+    gc.pushRoot(&vec);
+    defer gc.popRoot();
+
+    gc.collect();
+
+    for (0..n) |i| {
+        if (i % 2 != 0) continue;
+        const pair = types.toVector(vec).data[i];
+        try std.testing.expect(types.isPair(pair));
+        try std.testing.expectEqual(@as(i64, @intCast(i)), types.toFixnum(types.car(pair)));
+    }
+}
+
+test "#2464: the worklist buffer is retained below the 1M-entry floor" {
+    if (comptime build_options.gc_stress) return error.SkipZigTest;
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    gc.enabled = false;
+
+    // wide_len pair-referents: marking pushes one entry per pair, landing
+    // above the old 64K floor (which freed the whole buffer) and far below
+    // the new 1M floor.
+    const n = wide_len;
+    var items: [n]types.Value = undefined;
+    for (&items, 0..) |*slot, i| {
+        slot.* = try gc.allocPair(types.makeFixnum(@intCast(i)), types.NIL);
+    }
+    var vec = try gc.allocVector(&items);
+    gc.pushRoot(&vec);
+    defer gc.popRoot();
+
+    gc.collect();
+    try std.testing.expect(gc.mark_worklist.capacity >= n);
+    // And a second collection keeps it — no regrowth from zero, which is
+    // the churn that left the freed realloc tops resident-dirty.
+    const cap_after_first = gc.mark_worklist.capacity;
+    gc.collect();
+    try std.testing.expectEqual(cap_after_first, gc.mark_worklist.capacity);
+}

--- a/src/tests_gc_worklist.zig
+++ b/src/tests_gc_worklist.zig
@@ -32,10 +32,12 @@ const build_options = @import("build_options");
 // 40k pushes grew capacity to ~52k — *under* the old floor, hence retained
 // and visible; 70k grew past it, so the old code cleared the buffer to zero
 // after every collection. Under gc-stress the collection-per-allocation
-// makes a 70k-pair build quadratic, so only the single-allocation
-// immediate-only case runs there.
+// makes the 70k-pair build quadratic, so only that one test skips; the
+// other two run there too (the immediate-only case is a single allocation,
+// and the pointer-elements case allocates with `enabled = false`, so its
+// 1000 allocPairs never collect).
 const immediate_len = 40_000;
-const wide_len = if (build_options.gc_stress) 50_000 else 70_000;
+const wide_len = 70_000;
 
 test "#2464: a wide vector of immediates never grows the mark worklist" {
     var gc = memory.GC.init(std.testing.allocator);
@@ -47,9 +49,10 @@ test "#2464: a wide vector of immediates never grows the mark worklist" {
     defer gc.popRoot();
 
     gc.collect();
-    // Pre-fix: every element was pushed, growing capacity to ~52k (under
-    // the old 64K floor, so retained). Post-fix: no push happens at all,
-    // so the threshold has generous margin.
+    // Pre-fix: every element was pushed (all but the tail-iterated last,
+    // which still grew capacity to ~52k — under the old 64K floor, so
+    // retained). Post-fix: no push happens at all, so the threshold has
+    // generous margin.
     try std.testing.expect(gc.mark_worklist.capacity <= 4096);
     // The container itself must still be live and intact.
     try std.testing.expect(types.isVector(vec));
@@ -94,9 +97,9 @@ test "#2464: the worklist buffer is retained below the 1M-entry floor" {
     defer gc.deinit();
     gc.enabled = false;
 
-    // wide_len pair-referents: marking pushes one entry per pair, landing
-    // above the old 64K floor (which freed the whole buffer) and far below
-    // the new 1M floor.
+    // wide_len pair-referents: the vector arm pushes every element except
+    // the last (that one is iterated directly), landing above the old 64K
+    // floor (which freed the whole buffer) and far below the new 1M floor.
     const n = wide_len;
     var items: [n]types.Value = undefined;
     for (&items, 0..) |*slot, i| {
@@ -107,7 +110,9 @@ test "#2464: the worklist buffer is retained below the 1M-entry floor" {
     defer gc.popRoot();
 
     gc.collect();
-    try std.testing.expect(gc.mark_worklist.capacity >= n);
+    // n-1 is what the mark path guarantees; capacity today exceeds it by
+    // the ~50% growth slack, but the guarantee is the bound to pin.
+    try std.testing.expect(gc.mark_worklist.capacity >= n - 1);
     // And a second collection keeps it — no regrowth from zero, which is
     // the churn that left the freed realloc tops resident-dirty.
     const cap_after_first = gc.mark_worklist.capacity;

--- a/src/vm_tests.zig
+++ b/src/vm_tests.zig
@@ -24,6 +24,7 @@ test {
     _ = @import("tests_robustness.zig");
     _ = @import("tests_gc_root_boundary.zig");
     _ = @import("tests_gc_tracing.zig");
+    _ = @import("tests_gc_worklist.zig");
     _ = @import("tests_gc_runtime_stress.zig");
     _ = @import("tests_fuzz.zig");
     _ = @import("tests_deepcopy.zig");


### PR DESCRIPTION
Closes #2464.

## Root cause

The issue's repro (SRFI 231 `array-copy` of a 1000×1000 u8 array) left peak RSS at ~670 MB against a ~10.6 MB live heap. Tracing the allocations showed the memory was neither the churn nor a leak in Kaappi's own accounting — it was the **mark worklist**:

1. `array-copy` keeps a 1M-element scratch vector of *fixnums* live through the whole copy (`views.sld`'s accumulate-then-materialize shape). Every full collection marks it, and `markValueInner`'s container arms pushed **every element — immediates included** onto the worklist, even though the drain discards an immediate at its `isPointer` check. Worklist peak: ~1.3M entries ≈ 10.4 MB, grown through libc `realloc`.
2. After the drain, `markValue` released the whole buffer (`max_retained` was 64K entries), so the *next* full collection regrew the identical realloc chain — 155 times in this run.
3. macOS libmalloc does not decommit freed large blocks in this pattern. Verified with a standalone C reproduction (60 rounds of realloc-grow-to-10.4MB/free/touch): **691 MB peak RSS**, matching Kaappi's. Each chain left ~10 MB of resident-dirty pages behind: 155 chains ≈ 640 MB ≈ the observed 65×.

vmmap mid-run confirmed it: 59 `MALLOC_LARGE (empty)` regions of exactly 10.0 MB each — freed by malloc, still resident — while `MALLOC_TINY` (the actual pair/closure churn) held only 96 KB.

## The fix (two changes, both in the mark path)

- **`wlPush` skips immediates at every one of the 56 worklist push sites** (all container arms in `markValueInner` plus the port visitor). Semantically identical — the drain's `markValueInner` returns at its `isPointer` check, so an immediate on the worklist could only ever be popped and discarded. A wide container of immediates now needs no worklist at all.
- **The post-drain retention floor rises from 64K to 1M entries (512 KB → 8 MB)**, so a genuinely pointer-wide frontier no longer frees and regrows its buffer every full collection. A frontier *wider* than the floor releases the grown buffer but re-reserves the 8 MB floor, so the next regrowth starts at 8 MB rather than zero; the above-floor portion is still rebuilt each wide collection, and on mallocs that keep freed large blocks dirty (macOS) those tops stay resident — bounded retention over unbounded churn, with a decommitting backing allocator as the follow-up #2464 itself suggests.

## Measurements (macOS aarch64, ReleaseSafe)

| workload | before | after |
|---|---|---|
| issue repro, 1000×1000 (1M elems) | **701 MB** | **19.3 MB** |
| 250×250 | 13.8 MB | 9.8 MB |
| 500×500 | 13.8 MB | 11.8 MB |
| 1414×1414 (2M) | 1.56 GB | 29.3 MB |
| 2000×2000 (4M) | (cliff, ~3 GB by scaling) | 49.4 MB |
| 300k live pairs + 3M-pair churn | 48.3 MB | 46.4 MB |
| 2M-element live vector of pairs + 5M-pair churn | 212 MB | 173 MB |

The cliff between 500k and 1M elements is gone; RSS now tracks the live heap. The repro also runs **~15% faster** (total mark time 1648 ms → 432 ms — a million skipped push/pop pairs per full collection were real work).

## Tests

- New `src/tests_gc_worklist.zig`, registered in `vm_tests.zig`. Both discriminating tests verified to **fail on the pre-fix code and pass after**:
  - a 40k-element immediate vector leaves the worklist untouched (40k appends grew capacity to ~52k — under the old 64K floor, so pre-fix the growth was retained and visible; sizes above the old floor were cleared to zero pre-fix and would pass vacuously);
  - a 70k-pair vector — above the old floor, below the new one — retains its buffer across collections (pre-fix: cleared every time).
  - a third test pins that pointer elements still reach the worklist (the skip must never widen to pointers).
- `zig build test`: 2001/2022 pass (21 pre-existing skips).
- `zig build test -Dgc-stress=true`: 2005/2022 pass (17 skips).
- `bash tests/scheme/run-all.sh`: **2140 pass, 0 fail** (an earlier concurrent run showed 2 failures that were load flakes from sharing the machine with the gc-stress suite; clean serial run is fully green).
- All six SRFI 231 suites pass individually (the heaviest `array-copy` users).

## Not addressed here (follow-up material, per the issue's own framing)

The second suggested direction — the `apply`-of-a-rest-list shape inside library bulk loops allocating ~16 pairs + 2 closures per element — is allocation *volume*, not retention. This PR fixes the retention symptom (RSS ≈ live heap). Reducing the churn itself is a separate optimization with its own trade-offs.
