### PR TITLE
Share the globals generation counter with child-thread VMs (#2483)

### DIFF
--- a/docs/dev/thread-value-sharing.md
+++ b/docs/dev/thread-value-sharing.md
@@ -240,6 +240,23 @@ raise.
 Nothing else is checked. Every other type on the uncopyable list is fully
 usable from a child thread through a global.
 
+The map's *generation counter* is shared the same way. Every function
+caches the globals it resolves (`Function.global_cache`, validated by
+`cache_version` against the current generation), and the generation lives
+on the `GlobalsRwLock` object every VM chained to the map holds by pointer
+(`GlobalsRwLock.version`, read through `VM.globalVersion`). Until
+kaappi#2483 it was a per-VM field that `initForThread` neither copied nor
+shared, so a child's caches were invalidated only by the child's own
+rebindings: after the root redefined a global, a child that had already
+cached it kept calling the old binding, and a `guard_builtin`
+(kaappi#2469) in the child stayed on its fast path after the root
+redefined the builtin. Two ordering rules keep the shared counter honest
+across threads: a writer bumps it inside the locked region that made the
+store and re-validates its own slot with the value *that* bump returned,
+and a reader snapshots it once *before* the map read and stamps the
+snapshot — a fresh load after the read could bless a value another thread
+had rebound in between (`VM.bumpGlobalVersion`, `VM.globalVersion`).
+
 ## The actual matrix
 
 Verified at `e24e594e`, ReleaseSafe, isolated `KAAPPI_HOME` — except the
@@ -389,6 +406,7 @@ thread gets its own VM and GC with an independent heap.
 | `GC.deepCopy` / `deepCopyValue` | `src/memory.zig` (impl in `gc_deep_copy.zig`) | Deep-copies values between GC heaps; owns the 11-tag refusal list |
 | `VM.initForThread` | `src/vm.zig` | Per-thread VM, sharing the **root's** globals and libraries **by pointer** |
 | `VM.owns_globals` | `src/vm.zig` | Stops a child VM freeing the shared maps on deinit |
+| `GlobalsRwLock.version` | `src/globals.zig` | kaappi#2483: the globals generation every per-function global cache is validated against, on the lock object all threads share by pointer — so the root's rebinding invalidates a child's cache and vice versa |
 | `symbol_mutex` | `src/memory.zig` | Spinlock protecting concurrent symbol interning |
 | `child_resources` | `src/primitives_srfi18.zig` | Global map holding child GC/VM references; entries are freed at `thread-join!` or, when the join retires them because the thread still has live descendants, by the last descendant's `threadEntryFn` defer once the subtree drains (kaappi#2129) |
 | `markLiveChildRoots` | `src/primitives_srfi18.zig` | kaappi#1933: registered on the **root** GC as `gc.child_marker`; the root's collector stops every live child at a dispatch-loop safepoint (or finds it already parked / in an FFI call) and marks its roots with the root's gc, so a parent-heap object referenced only from a live child's registers is never freed under it. Children spawned mid-collection spin on `collection_in_progress` before their first shared-globals read. The child side reports `collection_state` (`.running`/`.parked`/`.stopped`/`.in_native`) from the safepoint (`stopForCollection`), the park (`parkOnReactor`) and FFI (`callFfi`) sites |

--- a/src/globals.zig
+++ b/src/globals.zig
@@ -15,6 +15,18 @@ const Value = types.Value;
 pub const GlobalsRwLock = struct {
     /// Bit 31 = writer holds/wants the lock; low 31 bits = active readers.
     state: std.atomic.Value(u32) = .init(0),
+    /// Generation of the globals map this lock guards: bumped by every
+    /// rebinding that can invalidate a per-function global cache
+    /// (`Function.cache_version` is compared against it). It lives on the
+    /// lock rather than on the VM because the lock is the one object
+    /// `VM.initForThread` shares by pointer with every SRFI-18 child: a
+    /// per-VM counter meant a child's caches were invalidated only by the
+    /// child's own rebindings, so after the root redefined a global the
+    /// child kept serving the old binding -- and kept a `guard_builtin`
+    /// on its fast path after the root redefined the builtin (kaappi#2483).
+    /// Read through `VM.globalVersion`, advanced through
+    /// `VM.bumpGlobalVersion`; see those for the ordering rules.
+    version: std.atomic.Value(u32) = .init(0),
 
     const WRITER: u32 = 0x8000_0000;
 

--- a/src/kaappi_lsp.zig
+++ b/src/kaappi_lsp.zig
@@ -871,7 +871,7 @@ fn pruneImportedGlobals(vm: *vm_mod.VM, allocator: std.mem.Allocator) void {
     }
     if (to_remove.items.len == 0) return;
     for (to_remove.items) |k| _ = vm.globals.remove(k);
-    vm.global_version +%= 1;
+    _ = vm.bumpGlobalVersion();
 }
 
 // Convert a `file://` URI to a native filesystem path in `buf`, percent-decoding

--- a/src/runtime_exports.zig
+++ b/src/runtime_exports.zig
@@ -123,7 +123,7 @@ pub export fn kaappi_set_global(vm: ?*vm_mod.VM, name_ptr: [*]const u8, name_len
         // fallback, say) that cached this global — including the pristine
         // primitive a guard_builtin compares against (kaappi#2469) — must
         // not keep serving the old value.
-        v.global_version +%= 1;
+        _ = v.bumpGlobalVersion();
     } else {
         _ = platform.write(2, "set!: unbound variable '", 24);
         _ = platform.write(2, name_ptr, len);

--- a/src/tests_core_eval.zig
+++ b/src/tests_core_eval.zig
@@ -849,8 +849,9 @@ test "bootstrap stubs fail loudly without vm_bootstrap.install (#1375)" {
 // re-stamp); the two call opcodes did not.
 //
 // Asserting the stamp rather than timing keeps this deterministic. Child
-// SRFI-18 VMs masked the bug: initForThread leaves global_version at 0, which
-// happens to match the un-stamped default.
+// SRFI-18 VMs masked the bug at the time: initForThread left the child's own
+// (then per-VM) global_version at 0, which happened to match the un-stamped
+// default. The counter is shared with the root since kaappi#2483.
 test "call_global stamps cache_version so its inline cache can hit" {
     var ctx: th.TestContext = undefined;
     try ctx.init();
@@ -865,10 +866,10 @@ test "call_global stamps cache_version so its inline cache can hit" {
 
     // The cache must exist and be valid for this VM, or it can never hit.
     try std.testing.expect(func.global_cache != null);
-    try std.testing.expectEqual(ctx.vm.global_version, func.cache_version);
-    // global_version is non-zero in a real VM: that is precisely why an
+    try std.testing.expectEqual(ctx.vm.globalVersion(), func.cache_version);
+    // The global version is non-zero in a real VM: that is precisely why an
     // un-stamped (default 0) cache_version could never match.
-    try std.testing.expect(ctx.vm.global_version != 0);
+    try std.testing.expect(ctx.vm.globalVersion() != 0);
 }
 
 // The heal must clear the whole cache before re-stamping (issue #812's rule),

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -1127,3 +1127,63 @@ test "kaappi#2473: thread-start! unwinds extra_roots when the spawn setup fails"
     // leaves one extra entry, which stays for the life of the GC.
     try std.testing.expectEqual(before, gc.extra_roots.items.len);
 }
+
+// kaappi#2483: the globals generation counter was a per-VM field, and
+// VM.initForThread neither copied nor shared it, so a child thread's
+// per-function global caches were invalidated only by the child's OWN
+// rebindings. After the root redefined a global, a child that had already
+// cached it kept calling the old binding -- and, since kaappi#2469, a child's
+// guard_builtin kept its fast path after the root redefined the builtin,
+// because its cached value still compared equal to the pristine primitive.
+// The counter now lives on the GlobalsRwLock the child shares by pointer.
+//
+// The handoff is fully ordered through a mutex and two condition variables
+// shared as globals (the supported route for sync primitives), so the child
+// provably fills its caches BEFORE the root rebinds and re-reads AFTER. Every
+// wait carries a timeout, so a lost wakeup fails the test instead of hanging
+// it. Without the fix the child returns (first 3 first 3).
+test "child thread sees the root's rebinding of a cached global and a guarded builtin (#2483)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // OS threads are unregistered on wasm (thread-start! is native-only)
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    _ = try vm.eval("(define m (make-mutex))");
+    _ = try vm.eval("(define cv-cached (make-condition-variable))");
+    _ = try vm.eval("(define cv-rebound (make-condition-variable))");
+    _ = try vm.eval("(define (f) 'first)");
+    _ = try vm.eval(
+        \\(define (child)
+        \\  ;; call_global caches f; guard_builtin caches the pristine apply.
+        \\  (let ((f-before (f))
+        \\        (apply-before (apply + (list 1 2))))
+        \\    (mutex-lock! m)
+        \\    (condition-variable-signal! cv-cached)
+        \\    ;; Atomically release m and wait for the root's rebinding.
+        \\    (mutex-unlock! m cv-rebound 60)
+        \\    (list f-before apply-before (f) (apply + (list 1 2)))))
+    );
+    _ = try vm.eval("(define t (make-thread child))");
+    _ = try vm.eval("(mutex-lock! m)");
+    _ = try vm.eval("(thread-start! t)");
+    // Blocks until the child has filled its caches; the child cannot signal
+    // before it holds m, which this wait is what releases.
+    _ = try vm.eval("(mutex-unlock! m cv-cached 60)");
+    // Reacquire m: the child releases it only by entering its own wait, so
+    // once this returns the child is parked on cv-rebound.
+    _ = try vm.eval("(mutex-lock! m)");
+    _ = try vm.eval("(define (f) 'second)");
+    _ = try vm.eval("(define (apply proc args) 'user-apply)");
+    _ = try vm.eval("(condition-variable-signal! cv-rebound)");
+    _ = try vm.eval("(mutex-unlock! m)");
+    const result = try vm.eval(
+        \\(let ((r (thread-join! t 60 'join-timeout)))
+        \\  (if (equal? r '(first 3 second user-apply))
+        \\      'ok
+        \\      (string->symbol
+        \\        (let ((p (open-output-string))) (write r p) (get-output-string p)))))
+    );
+    try std.testing.expect(types.isSymbol(result));
+    try std.testing.expectEqualStrings("ok", types.symbolName(result));
+}

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -399,6 +399,10 @@ pub const VM = struct {
     ///     every map read;
     ///   - the owner thread reads lock-free: it is the only thread expected
     ///     to structurally mutate the map, so its own reads cannot race.
+    /// The map's generation counter (`GlobalsRwLock.version`, read via
+    /// `globalVersion`) rides on the same shared lock object, so every
+    /// thread's per-function global caches are invalidated by every
+    /// thread's rebindings (kaappi#2483).
     /// Known gap: a child that defines globals via `eval` takes the exclusive
     /// lock (protecting other children), but the owner's lock-free reads can
     /// still race such writes — same limitation PR #968 documented for child
@@ -553,7 +557,6 @@ pub const VM = struct {
     watches: [16]WatchEntry = undefined,
     watch_count: usize = 0,
     inspect_frame: usize = 0,
-    global_version: u32 = 0,
     profile_mode: bool = false,
     coverage_mode: bool = false,
     coverage_xml_path: ?[]const u8 = null,
@@ -1333,7 +1336,7 @@ pub const VM = struct {
 
     /// Insert/overwrite a globals binding under the exclusive lock, so a
     /// concurrent child-thread reader never observes a rehash in progress.
-    /// Does not bump global_version — use defineGlobal for definition
+    /// Does not bump the global version — use defineGlobal for definition
     /// semantics.
     pub fn globalsPut(self: *VM, name: []const u8, value: Value) !void {
         self.globals_lock.lock();
@@ -1342,8 +1345,32 @@ pub const VM = struct {
     }
 
     pub fn defineGlobal(self: *VM, name: []const u8, value: Value) !void {
-        try self.globalsPut(name, value);
-        self.global_version +%= 1;
+        self.globals_lock.lock();
+        defer self.globals_lock.unlock();
+        try self.globals.put(name, value);
+        _ = self.bumpGlobalVersion();
+    }
+
+    /// The generation of the shared globals map (`GlobalsRwLock.version`,
+    /// kaappi#2483) — one counter for the root and every child VM chained to
+    /// its map. A per-function global cache is valid only while its
+    /// `cache_version` equals this. Callers that go on to read the map and
+    /// fill a cache must snapshot this ONCE, before the read, and stamp the
+    /// snapshot: stamping a fresh load taken after the read would re-bless
+    /// a value another thread has rebound in between.
+    pub inline fn globalVersion(self: *const VM) u32 {
+        return self.globals_lock.version.load(.acquire);
+    }
+
+    /// Advance the shared generation after a rebinding, returning the new
+    /// value. A writer that then re-validates its own cache slot must stamp
+    /// exactly this value (not a fresh `globalVersion`): a concurrent
+    /// rebinding by another thread may already have moved the counter past
+    /// it, and stamping the later value would bless the writer's slot
+    /// against a map it no longer matches. Call it inside the same locked
+    /// region as the store, so the store and its bump are ordered together.
+    pub inline fn bumpGlobalVersion(self: *VM) u32 {
+        return self.globals_lock.version.fetchAdd(1, .acq_rel) +% 1;
     }
 
     // -- Exception handling --

--- a/src/vm_bootstrap.zig
+++ b/src/vm_bootstrap.zig
@@ -62,7 +62,7 @@ pub fn install(vm: *VM) VMError!void {
             _ = vm.globals.remove(name);
         }
     }
-    vm.global_version +%= 1;
+    _ = vm.bumpGlobalVersion();
 }
 
 /// One definition, with the failure reported by index instead of as a bare

--- a/src/vm_dispatch.zig
+++ b/src/vm_dispatch.zig
@@ -320,15 +320,19 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     // barrier, so this order is as safe as barrier-first.
                     self.gc.envStoreBarrier(func.env_val, val);
                 }
+                // kaappi#2483: the version is shared with every child VM, so
+                // bump it inside the locked region that made the store, and
+                // stamp the cache below with the value THIS bump produced —
+                // see VM.bumpGlobalVersion.
+                const new_version: ?u32 = if (ptr != null and func.env == null) self.bumpGlobalVersion() else null;
                 self.unlockGlobalsShared();
                 if (ptr == null) {
                     self.setErrorDetail("set!: unbound variable '{s}'", .{name});
                     return VMError.UndefinedVariable;
                 }
-                if (func.env == null) {
-                    self.global_version +%= 1;
+                if (new_version) |nv| {
                     if (func.global_cache) |cache| {
-                        // Bumping global_version invalidates every function's
+                        // Bumping the version invalidates every function's
                         // cache, including this one's other entries. Clear the
                         // whole cache before revalidating the written slot —
                         // stamping cache_version without the memset would
@@ -336,7 +340,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                         // serving them stale (issue #812). Mirrors get_global.
                         @memset(cache, types.VOID);
                         if (sym_idx < cache.len) cache[sym_idx] = val;
-                        func.cache_version = self.global_version;
+                        func.cache_version = nv;
                         // #1961 (review): same orphaned-slot hazard as
                         // get_global's cache fill.
                         self.gc.writeBarrier(&func.header, val);
@@ -367,27 +371,31 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const root_vm = self.root_vm orelse self;
                     if (types.toObject(val).owner != root_vm.gc.id) return raiseCrossHeapStoreVM(self, "define");
                 }
+                var new_version: ?u32 = null;
                 if (env == self.globals) {
                     // Structural mutation of the shared globals map: may
                     // rehash, so it must exclude child-thread readers.
                     self.globals_lock.lock();
                     defer self.globals_lock.unlock();
                     env.put(name, val) catch return VMError.OutOfMemory;
+                    // kaappi#2483: bump under the same exclusive lock as
+                    // the put, and stamp the cache below with this bump's
+                    // own value — see set_global / VM.bumpGlobalVersion.
+                    if (func.env == null) new_version = self.bumpGlobalVersion();
                 } else {
                     env.put(name, val) catch return VMError.OutOfMemory;
                     // #1961: same rule as set_global, via the shared helper
                     // (envStoreBarrier) so the exclusion lives once.
                     self.gc.envStoreBarrier(func.env_val, val);
                 }
-                if (func.env == null) {
-                    self.global_version +%= 1;
+                if (new_version) |nv| {
                     if (func.global_cache) |cache| {
                         // See set_global: clear the whole cache before
                         // revalidating so unrelated stale entries aren't
                         // re-blessed by the version stamp (issue #812).
                         @memset(cache, types.VOID);
                         if (sym_idx < cache.len) cache[sym_idx] = val;
-                        func.cache_version = self.global_version;
+                        func.cache_version = nv;
                         // #1961 (review): same orphaned-slot hazard as
                         // get_global's cache fill.
                         self.gc.writeBarrier(&func.header, val);
@@ -989,15 +997,18 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const base: u32 = try toBase(base_wide);
 
                 if (the_func.env == null) {
+                    // kaappi#2483: one snapshot before the map read stamps
+                    // every fill below — see VM.globalVersion.
+                    const gv = self.globalVersion();
                     if (the_func.global_cache) |cache| {
-                        if (the_func.cache_version == self.global_version and
+                        if (the_func.cache_version == gv and
                             sym_idx < cache.len and cache[sym_idx] != types.VOID)
                         {
                             self.registers[base] = cache[sym_idx];
                         } else {
-                            if (the_func.cache_version != self.global_version) {
+                            if (the_func.cache_version != gv) {
                                 @memset(cache, types.VOID);
-                                the_func.cache_version = self.global_version;
+                                the_func.cache_version = gv;
                             }
                             const sym = try constantAt(self, the_func, sym_idx);
                             if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
@@ -1005,8 +1016,8 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             const val = lookupGlobalLocked(self, the_func, name) orelse return raiseUndefinedVariable(self, name);
                             self.registers[base] = val;
                             // #1812: don't cache a def_env_binding_prefix
-                            // resolution — see the get_global handler's own
-                            // comment on why self.global_version can't be
+                            // resolution — see lookupGlobalCached's own
+                            // comment on why the global version can't be
                             // trusted to invalidate it.
                             if ((types.isClosure(val) or types.isNativeFn(val)) and
                                 vm_mod.globals_mod.parseDefEnvBindingSymbolName(name) == null)
@@ -1040,7 +1051,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             @memset(cache, types.VOID);
                             cache[sym_idx] = val;
                             the_func.global_cache = cache;
-                            the_func.cache_version = self.global_version;
+                            the_func.cache_version = gv;
                             // #1961 (review): fresh caches too — the function
                             // can already be promoted by its first global op.
                             self.gc.writeBarrier(&the_func.header, val);
@@ -1108,9 +1119,12 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                 const abs_base: u32 = try toBase(abs_base_wide);
 
                 var callee: Value = types.VOID;
+                // kaappi#2483: one snapshot before the map read stamps every
+                // fill below — see VM.globalVersion.
+                const gv = self.globalVersion();
                 if (func.env == null) {
                     if (func.global_cache) |cache| {
-                        if (func.cache_version == self.global_version and
+                        if (func.cache_version == gv and
                             sym_idx < cache.len and cache[sym_idx] != types.VOID)
                         {
                             callee = cache[sym_idx];
@@ -1123,15 +1137,15 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                     const name = types.symbolName(sym);
                     callee = lookupGlobalLocked(self, func, name) orelse return raiseUndefinedVariable(self, name);
                     // #1812: don't cache a def_env_binding_prefix resolution
-                    // — see get_global's own comment on why self.global_version
-                    // can't be trusted to invalidate it.
+                    // — see lookupGlobalCached's own comment on why the global
+                    // version can't be trusted to invalidate it.
                     if (func.env == null and (types.isClosure(callee) or types.isNativeFn(callee)) and
                         vm_mod.globals_mod.parseDefEnvBindingSymbolName(name) == null)
                     {
                         if (func.global_cache) |cache| {
-                            if (func.cache_version != self.global_version) {
+                            if (func.cache_version != gv) {
                                 @memset(cache, types.VOID);
-                                func.cache_version = self.global_version;
+                                func.cache_version = gv;
                             }
                             if (sym_idx < cache.len) cache[sym_idx] = callee;
                         } else {
@@ -1141,7 +1155,7 @@ pub fn runUntil(self: *VM, target_frame_count: usize, target_wind_count: usize) 
                             @memset(cache, types.VOID);
                             cache[sym_idx] = callee;
                             func.global_cache = cache;
-                            func.cache_version = self.global_version;
+                            func.cache_version = gv;
                         }
                         // #1961 (review): same orphaned-slot hazard as
                         // get_global's cache fill.

--- a/src/vm_dispatch_helpers.zig
+++ b/src/vm_dispatch_helpers.zig
@@ -364,19 +364,24 @@ inline fn resolveBaseBindingLocked(self: *VM, env: *std.StringHashMap(Value), ba
 /// performs, shared with `guard_builtin` (kaappi#2469). A cache entry is
 /// only ever a closure or native procedure resolved through the ordinary
 /// (non-def-env, #1812) route, and the whole cache is dropped whenever
-/// `global_version` moves, so a stale procedure can never be served after a
-/// rebinding (#812). Raises the undefined-variable error for an unbound name.
+/// the shared global version moves, so a stale procedure can never be
+/// served after a rebinding (#812) — by this thread or any other
+/// (kaappi#2483). Raises the undefined-variable error for an unbound name.
 pub fn lookupGlobalCached(self: *VM, func: *types.Function, sym_idx: u16) VMError!Value {
+    // One snapshot, taken before the map read, stamps every cache fill
+    // below: see VM.globalVersion for why a fresh load after the read would
+    // re-bless a value another thread has since rebound.
+    const gv = self.globalVersion();
     if (func.env == null) {
         if (func.global_cache) |cache| {
-            if (func.cache_version == self.global_version and
+            if (func.cache_version == gv and
                 sym_idx < cache.len and cache[sym_idx] != types.VOID)
             {
                 return cache[sym_idx];
             }
-            if (func.cache_version != self.global_version) {
+            if (func.cache_version != gv) {
                 @memset(cache, types.VOID);
-                func.cache_version = self.global_version;
+                func.cache_version = gv;
             }
         }
     }
@@ -384,7 +389,7 @@ pub fn lookupGlobalCached(self: *VM, func: *types.Function, sym_idx: u16) VMErro
     if (!types.isSymbol(sym)) return VMError.InvalidBytecode;
     const name = types.symbolName(sym);
     // #1812: skip caching a def_env_binding_prefix reference — its
-    // resolution isn't invalidated by self.global_version (a library's own
+    // resolution isn't invalidated by the global version (a library's own
     // internal set! on its def_env doesn't bump it, since that mutation's
     // func.env isn't null), so caching it under that version could go stale.
     const def_env_parts = vm_mod.globals_mod.parseDefEnvBindingSymbolName(name);
@@ -400,7 +405,7 @@ pub fn lookupGlobalCached(self: *VM, func: *types.Function, sym_idx: u16) VMErro
             @memset(cache, types.VOID);
             cache[sym_idx] = val;
             func.global_cache = cache;
-            func.cache_version = self.global_version;
+            func.cache_version = gv;
         }
         // #1961 (review): the cached value is root-marked right now (it is
         // also in the globals map), but a later rebinding by another

--- a/src/vm_imports.zig
+++ b/src/vm_imports.zig
@@ -49,6 +49,11 @@ fn importBinding(vm: *VM, target: *std.StringHashMap(Value), name: []const u8, v
         vm.globals_lock.lock();
         defer vm.globals_lock.unlock();
         target.put(name, val) catch return error.OutOfMemory;
+        // Bumped inside the same locked region as the put (the rule on
+        // VM.bumpGlobalVersion, kaappi#2483). A transformer put never
+        // strands a cached value — a cache entry is only ever a closure or
+        // native procedure — so it deliberately does not bump.
+        if (!types.isTransformer(val)) _ = vm.bumpGlobalVersion();
     } else {
         target.put(name, val) catch return error.OutOfMemory;
     }
@@ -62,10 +67,6 @@ fn importBinding(vm: *VM, target: *std.StringHashMap(Value), name: []const u8, v
             defer visited.deinit();
             try copyTransformerFreeRefs(vm, target, tx, &visited, 0);
         }
-        return;
-    }
-    if (target == vm.globals) {
-        _ = vm.bumpGlobalVersion();
     }
 }
 

--- a/src/vm_imports.zig
+++ b/src/vm_imports.zig
@@ -65,7 +65,7 @@ fn importBinding(vm: *VM, target: *std.StringHashMap(Value), name: []const u8, v
         return;
     }
     if (target == vm.globals) {
-        vm.global_version +%= 1;
+        _ = vm.bumpGlobalVersion();
     }
 }
 
@@ -160,9 +160,9 @@ fn copyOneDefEnvBinding(
                     vm.globals_lock.unlock();
                     return error.OutOfMemory;
                 };
+                _ = vm.bumpGlobalVersion();
             }
             vm.globals_lock.unlock();
-            if (missing) vm.global_version +%= 1;
         }
     } else if (!target.contains(fname)) {
         target.put(fname, fval) catch return error.OutOfMemory;

--- a/tests/scheme/srfi/srfi18-global-cache-2483.scm
+++ b/tests/scheme/srfi/srfi18-global-cache-2483.scm
@@ -1,0 +1,73 @@
+;; Regression test for kaappi#2483: a child OS thread's per-function global
+;; caches must be invalidated by the ROOT's rebindings, not only by its own.
+;;
+;; The globals generation counter used to be a per-VM field that
+;; VM.initForThread neither copied nor shared, so a child that had cached a
+;; global kept calling the old binding after the root redefined it -- and a
+;; guard_builtin (kaappi#2469) kept its fast path after the root redefined the
+;; builtin, because the cached value still matched the pristine primitive.
+;;
+;; The handoff is ordered through a mutex and two condition variables shared
+;; as globals (the supported way to share sync primitives across OS threads):
+;; the child provably fills its caches BEFORE the root rebinds and re-reads
+;; AFTER. Every wait has a timeout so a lost wakeup fails instead of hanging.
+
+(import (scheme base) (scheme write) (scheme process-context) (srfi 18))
+
+(define pass 0)
+(define fail 0)
+
+(define (check name got expected)
+  (if (equal? got expected)
+      (set! pass (+ pass 1))
+      (begin
+        (set! fail (+ fail 1))
+        (display "FAIL: ") (display name)
+        (display " expected ") (write expected)
+        (display " got ") (write got)
+        (newline))))
+
+(define m (make-mutex))
+(define cv-cached (make-condition-variable))
+(define cv-rebound (make-condition-variable))
+
+(define (f) 'first)
+
+(define (child)
+  ;; call_global caches f; guard_builtin caches the pristine apply.
+  (let ((f-before (f))
+        (apply-before (apply + (list 1 2))))
+    (mutex-lock! m)
+    (condition-variable-signal! cv-cached)
+    ;; Atomically release m and wait for the root's rebinding.
+    (mutex-unlock! m cv-rebound 60)
+    (list f-before apply-before (f) (apply + (list 1 2)))))
+
+(define t (make-thread child))
+
+(let ()
+  (mutex-lock! m)
+  (thread-start! t)
+  ;; Blocks until the child has filled its caches: the child cannot signal
+  ;; before it holds m, which this wait is what releases.
+  (check "root woke for the child's cached signal (not a timeout)"
+    (mutex-unlock! m cv-cached 60) #t))
+
+;; The child has cached both bindings and is now parked on (or about to park
+;; on) cv-rebound; it re-reads only after the signal below.
+(define (f) 'second)
+(define (apply proc args) 'user-apply)
+
+(let ()
+  ;; Reacquire m: the child releases it only by entering its own wait, so
+  ;; once this returns the child is enqueued on cv-rebound -- no lost wakeup.
+  (mutex-lock! m)
+  (condition-variable-signal! cv-rebound)
+  (mutex-unlock! m)
+  (check "child re-reads a global rebound by the root (call_global) and a builtin rebound by the root (guard_builtin)"
+    (thread-join! t 60 'join-timeout)
+    '(first 3 second user-apply)))
+
+(display pass) (display " passed, ") (display fail) (display " failed")
+(newline)
+(when (> fail 0) (exit 1))


### PR DESCRIPTION
## Summary

`VM.global_version` was a per-VM field that `VM.initForThread` neither copied nor shared, while the globals map itself is shared by pointer (kaappi#2129). Every per-function global cache (`get_global`, `call_global`/`tail_call_global`, and since #2469 `guard_builtin`, all via `lookupGlobalCached`) was invalidated only by its **own** VM's rebindings. So a child thread that had cached a global kept calling the old binding after the root redefined it, and a child's `guard_builtin` silently stayed on its superinstruction fast path after the root redefined `apply`.

**Fix:** the generation counter now lives on the `GlobalsRwLock` — the one object every VM chained to the map already holds by pointer — as an atomic `version`, read through `VM.globalVersion()` and advanced through `VM.bumpGlobalVersion()`. The per-VM field is gone.

Two ordering rules make the shared counter sound across threads (documented on the two methods and in `docs/dev/thread-value-sharing.md`):

- **Writers** (`set_global`, `define_global`, `defineGlobal`, import merges) bump inside the locked region that made the store, and re-validate their own cache slot with the value **that bump returned** — a fresh load could already reflect another thread's later rebinding and would bless a slot the map no longer matches.
- **Readers** (`lookupGlobalCached`, `call_global`, `tail_call_global`) snapshot the version **once, before** the map read, and stamp the snapshot. Previously the fresh-cache paths stamped a load taken *after* the read.

## Test plan

- [x] New Zig unit test in `src/tests_srfi18.zig`: a child OS thread caches a user procedure and the pristine `apply` (via `guard_builtin`), a mutex/condition-variable handoff (shared as globals, the supported route) guarantees the root rebinds both only afterwards, and the child re-reads only after the signal. Every wait has a timeout so a lost wakeup fails rather than hangs.
- [x] New Scheme suite file `tests/scheme/srfi/srfi18-global-cache-2483.scm` with the same handoff. Run against the pre-fix `main` binary it fails with exactly the stale result: `expected (first 3 second user-apply) got (first 3 first 3)`. With this branch: `2 passed, 0 failed`.
- [x] `zig build test`: 1913 pass, 21 skip, 0 fail (+ 88 thottam tests).
- [x] `srfi18.scm`, `srfi18-cross-thread-wait.scm`, `srfi18-sharing-model.scm`, `thread-notifier-waits-2395.scm` all pass with the fixed binary.
- [x] `zig build -Dtarget=x86_64-windows` and `zig build wasm` succeed; `zig fmt --check` and `markdownlint-cli2` clean.

Closes #2483

🤖 Generated with [Claude Code](https://claude.com/claude-code)
