### PR TITLE
CI: run the riscv64 unit suite as capped chunks so a hang names its chunk (#2488)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,8 +555,7 @@ jobs:
     # what localise; the job cap below only backstops several chunks
     # overrunning at once, and is sized so a single hung chunk hits ITS cap
     # first (setup + build + two healthy chunks + the hung one's cap stays
-    # inside it). Expected healthy total: ~35m (the two extra test-binary
-    # compiles cost a few minutes).
+    # inside it). Measured healthy total: 35m on the first chunked run.
     timeout-minutes: 55
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -578,11 +577,14 @@ jobs:
         run: zig build -Dtarget=riscv64-linux
 
       # Three chunks, not one step: see the job comment and the script's
-      # header. Natively the process and concurrency chunks take ~15s each
-      # and the rest ~7m; under QEMU the whole suite was 23-28m, so the
-      # per-step caps below are each well above the chunk's healthy share.
-      # A chunk that hangs is cancelled by its own step's cap, and the step
-      # name in the job log is the localisation kaappi#2488 asks for.
+      # header. Measured under QEMU on the first chunked run (job
+      # 33674064049): process 1.9m, concurrency 3.3m, rest 25.8m, each
+      # including its own test-binary compile. The caps below leave the
+      # rest chunk ~10m over its measured time (the pre-chunk unit step
+      # varied 23-28m run to run) while still firing well before the hung
+      # runs' 41-43m. A chunk that hangs is cancelled by its own step's
+      # cap, and the step name in the job log is the localisation
+      # kaappi#2488 asks for.
       - name: Unit tests, process chunk (riscv64 via QEMU)
         timeout-minutes: 12
         run: bash tools/run-unit-test-chunk.sh process -Dtarget=riscv64-linux
@@ -592,7 +594,7 @@ jobs:
         run: bash tools/run-unit-test-chunk.sh concurrency -Dtarget=riscv64-linux
 
       - name: Unit tests, rest chunk (riscv64 via QEMU)
-        timeout-minutes: 32
+        timeout-minutes: 36
         run: bash tools/run-unit-test-chunk.sh rest -Dtarget=riscv64-linux
 
       - name: R7RS test suite (riscv64 via QEMU)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,13 +549,16 @@ jobs:
     # the unit-test step at 41-43m -- 15m past the slowest success -- with
     # the `unit-tests` binary alive: a hang, not a slow tail (kaappi#2488).
     # That step printed nothing until it finished, so the log said nothing
-    # about which test. The unit suite therefore runs as three chunks
+    # about which test. The unit suite therefore runs as chunks
     # (tools/run-unit-test-chunk.sh), each its own step with its own
     # `timeout-minutes`, so the next hang names its chunk. The step caps are
     # what localise; the job cap below only backstops several chunks
     # overrunning at once, and is sized so a single hung chunk hits ITS cap
-    # first (setup + build + two healthy chunks + the hung one's cap stays
-    # inside it). Measured healthy total: 35m on the first chunked run.
+    # first (setup + build + every other chunk healthy + the hung one's cap
+    # stays inside it). The first three-way split measured 35m healthy and
+    # localised the first recurrence to its `rest` chunk (1646 tests); the
+    # eight-way split below cuts that remainder along its QEMU-sensitive
+    # seams at the price of five more test-binary compiles (~1.5m each).
     timeout-minutes: 55
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -576,15 +579,18 @@ jobs:
       - name: Build (cross-compile for riscv64)
         run: zig build -Dtarget=riscv64-linux
 
-      # Three chunks, not one step: see the job comment and the script's
-      # header. Measured under QEMU on the first chunked run (job
-      # 33674064049): process 1.9m, concurrency 3.3m, rest 25.8m, each
-      # including its own test-binary compile. The caps below leave the
-      # rest chunk ~10m over its measured time (the pre-chunk unit step
-      # varied 23-28m run to run) while still firing well before the hung
-      # runs' 41-43m. A chunk that hangs is cancelled by its own step's
-      # cap, and the step name in the job log is the localisation
-      # kaappi#2488 asks for.
+      # Chunks, not one step: see the job comment and the script's header.
+      # Measured under QEMU on the three-way split (jobs 33674064049 and
+      # 100407731878): process 1.4-1.9m, concurrency 3.3-5.4m, the old
+      # 1646-test rest 25.8m healthy and hung once at its 36m cap -- each
+      # figure including the chunk's own test-binary compile. The five
+      # chunks carved out of that remainder measured natively io 11s,
+      # fuzz 1m, gc 9s, native 2s (skips on this tier), tooling and the new
+      # rest ~3m; the QEMU factor on the old rest was ~3.3x on top of
+      # ~1.5m of compile, which is what the caps below are sized from, with
+      # roughly 2x headroom each. A chunk that hangs is cancelled by its
+      # own step's cap, and the step name in the job log is the
+      # localisation kaappi#2488 asks for.
       - name: Unit tests, process chunk (riscv64 via QEMU)
         timeout-minutes: 12
         run: bash tools/run-unit-test-chunk.sh process -Dtarget=riscv64-linux
@@ -593,8 +599,28 @@ jobs:
         timeout-minutes: 12
         run: bash tools/run-unit-test-chunk.sh concurrency -Dtarget=riscv64-linux
 
+      - name: Unit tests, io chunk (riscv64 via QEMU)
+        timeout-minutes: 12
+        run: bash tools/run-unit-test-chunk.sh io -Dtarget=riscv64-linux
+
+      - name: Unit tests, fuzz chunk (riscv64 via QEMU)
+        timeout-minutes: 15
+        run: bash tools/run-unit-test-chunk.sh fuzz -Dtarget=riscv64-linux
+
+      - name: Unit tests, gc chunk (riscv64 via QEMU)
+        timeout-minutes: 10
+        run: bash tools/run-unit-test-chunk.sh gc -Dtarget=riscv64-linux
+
+      - name: Unit tests, native chunk (riscv64 via QEMU)
+        timeout-minutes: 8
+        run: bash tools/run-unit-test-chunk.sh native -Dtarget=riscv64-linux
+
+      - name: Unit tests, tooling chunk (riscv64 via QEMU)
+        timeout-minutes: 12
+        run: bash tools/run-unit-test-chunk.sh tooling -Dtarget=riscv64-linux
+
       - name: Unit tests, rest chunk (riscv64 via QEMU)
-        timeout-minutes: 36
+        timeout-minutes: 24
         run: bash tools/run-unit-test-chunk.sh rest -Dtarget=riscv64-linux
 
       - name: R7RS test suite (riscv64 via QEMU)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,12 +539,25 @@ jobs:
     needs: format
     if: needs.format.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
-    # QEMU user-mode overhead puts this leg at 16-27m on main, close enough
-    # to 30m that ~1 in 15 runs is killed mid-suite on timing alone and reads
-    # as a failure in gh pr checks (kaappi#2458). KEP-0022 adds to it: every
-    # child a process test spawns is a whole /bin/sh emulated through binfmt,
-    # so this job pays a multiple of what those tests cost natively.
-    timeout-minutes: 45
+    # QEMU user-mode overhead puts this leg at 27-32m on main (kaappi#2458
+    # raised the cap from 30 to 45 when it was 16-27m and ~1 in 15 runs was
+    # killed on timing alone). KEP-0022 adds to it: every child a process
+    # test spawns is a whole /bin/sh emulated through binfmt, so this job
+    # pays a multiple of what those tests cost natively.
+    #
+    # Since 2026-09-02 about 1 run in 4 is killed at the cap while STILL in
+    # the unit-test step at 41-43m -- 15m past the slowest success -- with
+    # the `unit-tests` binary alive: a hang, not a slow tail (kaappi#2488).
+    # That step printed nothing until it finished, so the log said nothing
+    # about which test. The unit suite therefore runs as three chunks
+    # (tools/run-unit-test-chunk.sh), each its own step with its own
+    # `timeout-minutes`, so the next hang names its chunk. The step caps are
+    # what localise; the job cap below only backstops several chunks
+    # overrunning at once, and is sized so a single hung chunk hits ITS cap
+    # first (setup + build + two healthy chunks + the hung one's cap stays
+    # inside it). Expected healthy total: ~35m (the two extra test-binary
+    # compiles cost a few minutes).
+    timeout-minutes: 55
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -564,8 +577,23 @@ jobs:
       - name: Build (cross-compile for riscv64)
         run: zig build -Dtarget=riscv64-linux
 
-      - name: Unit tests (riscv64 via QEMU)
-        run: zig build test -Dtarget=riscv64-linux
+      # Three chunks, not one step: see the job comment and the script's
+      # header. Natively the process and concurrency chunks take ~15s each
+      # and the rest ~7m; under QEMU the whole suite was 23-28m, so the
+      # per-step caps below are each well above the chunk's healthy share.
+      # A chunk that hangs is cancelled by its own step's cap, and the step
+      # name in the job log is the localisation kaappi#2488 asks for.
+      - name: Unit tests, process chunk (riscv64 via QEMU)
+        timeout-minutes: 12
+        run: bash tools/run-unit-test-chunk.sh process -Dtarget=riscv64-linux
+
+      - name: Unit tests, concurrency chunk (riscv64 via QEMU)
+        timeout-minutes: 12
+        run: bash tools/run-unit-test-chunk.sh concurrency -Dtarget=riscv64-linux
+
+      - name: Unit tests, rest chunk (riscv64 via QEMU)
+        timeout-minutes: 32
+        run: bash tools/run-unit-test-chunk.sh rest -Dtarget=riscv64-linux
 
       - name: R7RS test suite (riscv64 via QEMU)
         run: bash tools/run-r7rs-suite.sh zig-out/bin/kaappi

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -679,7 +679,7 @@ matrix covers:
 | `test` | Ubuntu (x86, ARM), macOS | Unit tests, `run-all.sh`, robustness, sandbox, thottam integration, SRFI final-status guard |
 | `gc-stress` | Ubuntu | Unit suite under `-Dgc-stress=true` |
 | `gc-stress-scheme` | Ubuntu | Scheme suites under `-Dgc-stress=true` |
-| `riscv64-test` | Ubuntu (QEMU) | Cross-compiled unit tests + R7RS suite. The unit suite runs as three chunks (`tools/run-unit-test-chunk.sh`: process, concurrency, rest), each its own step with its own cap, so a hang under emulation names its chunk (kaappi#2488) |
+| `riscv64-test` | Ubuntu (QEMU) | Cross-compiled unit tests + R7RS suite. The unit suite runs as eight chunks (`tools/run-unit-test-chunk.sh`: process, concurrency, io, fuzz, gc, native, tooling, and a derived rest), each its own step with its own cap, so a hang under emulation names its chunk (kaappi#2488) |
 | `s390x-test` | Ubuntu (QEMU) | Big-endian leg — the byte-order canary (kaappi#1654) |
 | `ppc64le-test` | Ubuntu (QEMU) | Cross-compiled unit tests + R7RS suite |
 | `freebsd-test`, `openbsd-test`, `netbsd-test` | Ubuntu (VM action) | Per-BSD build + tests; see the matching `docs/dev/<os>.md` |

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -679,7 +679,7 @@ matrix covers:
 | `test` | Ubuntu (x86, ARM), macOS | Unit tests, `run-all.sh`, robustness, sandbox, thottam integration, SRFI final-status guard |
 | `gc-stress` | Ubuntu | Unit suite under `-Dgc-stress=true` |
 | `gc-stress-scheme` | Ubuntu | Scheme suites under `-Dgc-stress=true` |
-| `riscv64-test` | Ubuntu (QEMU) | Cross-compiled unit tests + R7RS suite |
+| `riscv64-test` | Ubuntu (QEMU) | Cross-compiled unit tests + R7RS suite. The unit suite runs as three chunks (`tools/run-unit-test-chunk.sh`: process, concurrency, rest), each its own step with its own cap, so a hang under emulation names its chunk (kaappi#2488) |
 | `s390x-test` | Ubuntu (QEMU) | Big-endian leg — the byte-order canary (kaappi#1654) |
 | `ppc64le-test` | Ubuntu (QEMU) | Cross-compiled unit tests + R7RS suite |
 | `freebsd-test`, `openbsd-test`, `netbsd-test` | Ubuntu (VM action) | Per-BSD build + tests; see the matching `docs/dev/<os>.md` |

--- a/tools/run-unit-test-chunk.sh
+++ b/tools/run-unit-test-chunk.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Run one named chunk of the Zig unit suite, so a hang names its chunk.
+#
+#     bash tools/run-unit-test-chunk.sh <process|concurrency|rest> [zig build args...]
+#     bash tools/run-unit-test-chunk.sh --list <chunk>      # print the filters, run nothing
+#
+# WHY THIS EXISTS. `riscv64-test` runs the whole unit suite under QEMU
+# user-mode as ONE `zig build test` step that prints nothing until it
+# finishes. When a test hangs there, the only evidence is a 45-minute log
+# with a single line in it and an `unit-tests` orphan at the end (kaappi#2488
+# -- roughly one run in four since 2026-09-02). Splitting the suite into a
+# few chunks, each its own workflow step with its own `timeout-minutes`,
+# makes the next hang say WHICH chunk it was in. Chunking is a diagnostic,
+# not a fix; the chunks exist to be narrowed, not to grow.
+#
+# HOW THE CHUNKS ARE CUT. `-Dtest-filter` is a substring match on a test's
+# qualified name, `<file basename>.test.<title>` (build.zig; repeatable).
+# Anchoring every filter as `<basename>.test.` selects exactly the tests
+# declared in that file: `ffi.test.` also matches `tests_ffi.test.…`, but a
+# test is included ONCE however many filters match it (the filter prunes
+# `builtin.test_functions` at compile time), so overlap costs nothing and
+# every filter is emitted unconditionally.
+#
+#   process      the KEP-0022 subprocess tests: every child they spawn is a
+#                whole /bin/sh emulated through binfmt on the QEMU legs
+#   concurrency  fibers, reactor, scheduler, channels, SRFI-18 threads --
+#                the parking and timing paths
+#   rest         EVERY OTHER `src/*.zig` file that declares a `test "…"`,
+#                derived from the tree, so a new test file lands here
+#                automatically and cannot be silently dropped
+#
+# Two things keep the split honest. A name in the explicit lists that matches
+# no file FAILS the run (a list cannot rot into a silent no-op -- the same
+# rule `KAAPPI_GC_STRESS_SKIP` follows). And every chunk asserts it ran more
+# tests than the unnamed `test { _ = @import(…); }` reference blocks, which
+# a filtered build keeps regardless of filter (five of them in the unit
+# binary today; they are why three chunk totals sum to the unfiltered total
+# plus ten). A chunk whose filters matched nothing therefore fails instead
+# of passing vacuously.
+#
+# The `thottam-tests` binary takes the same filters (build.zig hands both
+# test steps the same list): it runs its full 88 in `rest`, whose derived
+# list includes the thottam files, and only its own unnamed block elsewhere.
+#
+# Works for any target: pass `-Dtarget=riscv64-linux` (or nothing, for the
+# host) after the chunk name. Exit status is `zig build test`'s, or 2 for a
+# misuse this script detected itself.
+
+set -u
+set -o pipefail
+
+PROCESS_FILES="tests_process tests_process_run tests_process_win"
+CONCURRENCY_FILES="tests_fibers tests_reactor tests_reactor_parity tests_scheduler
+                   tests_shared_channel tests_shared_channel_rendezvous tests_srfi18
+                   tests_waitforfd"
+
+usage() {
+    echo "usage: $0 [--list] <process|concurrency|rest> [zig build args...]" >&2
+    exit 2
+}
+
+list_only=0
+if [ "${1:-}" = "--list" ]; then
+    list_only=1
+    shift
+fi
+chunk="${1:-}"
+[ -n "$chunk" ] || usage
+shift
+
+# Resolve paths against the repo root so the script works from any cwd.
+cd "$(dirname "$0")/.." || exit 2
+
+# Every explicitly listed name must be a real test file, or the list has
+# rotted and the chunk would quietly shrink.
+for name in $PROCESS_FILES $CONCURRENCY_FILES; do
+    if [ ! -f "src/$name.zig" ]; then
+        echo "$0: '$name' names no src/$name.zig -- update the chunk lists" >&2
+        exit 2
+    fi
+done
+
+in_list() { # in_list <name> <list...>
+    local needle="$1"; shift
+    local n
+    for n in "$@"; do [ "$n" = "$needle" ] && return 0; done
+    return 1
+}
+
+case "$chunk" in
+    process)     names="$PROCESS_FILES" ;;
+    concurrency) names="$CONCURRENCY_FILES" ;;
+    rest)
+        names=""
+        for f in src/*.zig; do
+            n="$(basename "$f" .zig)"
+            # shellcheck disable=SC2086
+            in_list "$n" $PROCESS_FILES $CONCURRENCY_FILES && continue
+            grep -q '^test "' "$f" || continue
+            names="$names $n"
+        done
+        ;;
+    *) usage ;;
+esac
+
+filters=()
+for n in $names; do filters+=("-Dtest-filter=$n.test."); done
+
+if [ "$list_only" = 1 ]; then
+    printf '%s\n' "${filters[@]}"
+    exit 0
+fi
+
+# The floor a chunk must clear: the unnamed reference blocks are in every
+# filtered binary, so a chunk that matched nothing still reports that many.
+floor="$(grep -l '^test {' src/*.zig | wc -l | tr -d ' ')"
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+echo "== unit-test chunk '$chunk': ${#filters[@]} filter(s), extra args: $*"
+zig build test "${filters[@]}" "$@" --summary all 2>&1 | tee "$log"
+status=${PIPESTATUS[0]}
+[ "$status" = 0 ] || exit "$status"
+
+# `--summary all` prints one line per test binary, e.g.
+#   +- run test unit-tests 54 pass, 12 skip (66 total) 15s MaxRSS:1G
+total="$(sed -n 's/.*run test unit-tests .*(\([0-9][0-9]*\) total).*/\1/p' "$log" | head -1)"
+if [ -z "$total" ]; then
+    echo "$0: could not find the unit-tests total in the build summary" >&2
+    exit 2
+fi
+if [ "$total" -le "$floor" ]; then
+    echo "$0: chunk '$chunk' ran only $total test(s), no more than the $floor unnamed reference block(s) -- its filters matched nothing" >&2
+    exit 2
+fi
+echo "== unit-test chunk '$chunk': $total tests (floor $floor)"

--- a/tools/run-unit-test-chunk.sh
+++ b/tools/run-unit-test-chunk.sh
@@ -19,28 +19,53 @@
 # declared in that file: `ffi.test.` also matches `tests_ffi.test.…`, but a
 # test is included ONCE however many filters match it (the filter prunes
 # `builtin.test_functions` at compile time), so overlap costs nothing and
-# every filter is emitted unconditionally.
+# every filter is emitted unconditionally. The one consequence across
+# chunks: a listed file whose basename ENDS with an unlisted file's basename
+# also runs in `rest` (`native_compiler` ends with `compiler`, so its five
+# tests run in both `native` and `rest`). That is a few seconds of
+# duplicated work, never a dropped test, and the exact per-chunk counts are
+# in the PR that introduced each chunk.
 #
 #   process      the KEP-0022 subprocess tests: every child they spawn is a
 #                whole /bin/sh emulated through binfmt on the QEMU legs
 #   concurrency  fibers, reactor, scheduler, channels, SRFI-18 threads --
 #                the parking and timing paths
+#   io           ports and the reactor-driven reads behind them: file and
+#                string ports, transcoded ports (SRFI 181), the incremental
+#                reader, the filesystem primitives (SRFI 170)
+#   fuzz         the fuzz generators and their wall-clock/instruction-bounded
+#                harness (#1573 was this family flaking under QEMU)
+#   gc           the collector: tracing, runtime stress, root-boundary OOM
+#                sweeps, deep copy, and the robustness edge-case suite
+#   native       the LLVM native tier (skips almost entirely on the
+#                interpreter-tier QEMU legs, so this chunk is cheap there)
+#   tooling      the CLI surface and its subcommands (check, fmt, doctor,
+#                explain, features, the `kaappi test` runner -- whose worker
+#                processes are emulated children on the QEMU legs), the
+#                bytecode/library caches, the REPL, and thottam (this is
+#                where the `thottam-tests` binary runs its full suite)
 #   rest         EVERY OTHER `src/*.zig` file that declares a `test "…"`,
 #                derived from the tree, so a new test file lands here
 #                automatically and cannot be silently dropped
+#
+# The first split (process / concurrency / rest) localised kaappi#2488's
+# first recurrence to `rest`, which was 1646 tests wide; the io / fuzz / gc /
+# native chunks are the second cut, along the seams in that remainder with
+# QEMU-sensitive behaviour. Add a chunk by adding a list and a case below;
+# `rest` shrinks by itself because it is derived from what is NOT listed.
 #
 # Two things keep the split honest. A name in the explicit lists that matches
 # no file FAILS the run (a list cannot rot into a silent no-op -- the same
 # rule `KAAPPI_GC_STRESS_SKIP` follows). And every chunk asserts it ran more
 # tests than the unnamed `test { _ = @import(…); }` reference blocks, which
 # a filtered build keeps regardless of filter (five of them in the unit
-# binary today; they are why three chunk totals sum to the unfiltered total
-# plus ten). A chunk whose filters matched nothing therefore fails instead
-# of passing vacuously.
+# binary today; they are why N chunk totals sum to the unfiltered total
+# plus 5*(N-1), before the duplicate noted above). A chunk whose filters
+# matched nothing therefore fails instead of passing vacuously.
 #
 # The `thottam-tests` binary takes the same filters (build.zig hands both
-# test steps the same list): it runs its full 88 in `rest`, whose derived
-# list includes the thottam files, and only its own unnamed block elsewhere.
+# test steps the same list): it runs its full 88 in `tooling`, which lists
+# the thottam files, and only its own unnamed block in every other chunk.
 #
 # Works for any target: pass `-Dtarget=riscv64-linux` (or nothing, for the
 # host) after the chunk name. Exit status is `zig build test`'s, or 2 for a
@@ -53,9 +78,26 @@ PROCESS_FILES="tests_process tests_process_run tests_process_win"
 CONCURRENCY_FILES="tests_fibers tests_reactor tests_reactor_parity tests_scheduler
                    tests_shared_channel tests_shared_channel_rendezvous tests_srfi18
                    tests_waitforfd"
+IO_FILES="tests_io tests_port_io tests_random_port tests_srfi181
+          tests_reader_incremental tests_filesystem primitives_io"
+FUZZ_FILES="tests_fuzz fuzz_gen fuzz_gen_native fuzz_gen_portable"
+GC_FILES="tests_gc_tracing tests_gc_runtime_stress tests_gc_root_boundary
+          tests_deepcopy tests_robustness memory"
+NATIVE_FILES="tests_native tests_native_dispatch tests_native_gate
+              native_compiler llvm_emit"
+TOOLING_FILES="cli cli_spec completions config check_lint tests_check doctor
+               explain features fmt tests_fmt kaappi_paths lsp_diagnostic
+               test_runner test_selection timings crash repl disassembler
+               tests_diagnostics bytecode_file cache tests_bytecode_cache
+               tests_vm_library_cache thottam thottam_fs thottam_proc
+               thottam_semver thottam_state tests_thottam"
+# Every explicitly listed file, for the `rest` derivation and the existence
+# check. Extend this when adding a list.
+LISTED_FILES="$PROCESS_FILES $CONCURRENCY_FILES $IO_FILES $FUZZ_FILES $GC_FILES $NATIVE_FILES $TOOLING_FILES"
+CHUNK_NAMES="process|concurrency|io|fuzz|gc|native|tooling|rest"
 
 usage() {
-    echo "usage: $0 [--list] <process|concurrency|rest> [zig build args...]" >&2
+    echo "usage: $0 [--list] <$CHUNK_NAMES> [zig build args...]" >&2
     exit 2
 }
 
@@ -73,7 +115,7 @@ cd "$(dirname "$0")/.." || exit 2
 
 # Every explicitly listed name must be a real test file, or the list has
 # rotted and the chunk would quietly shrink.
-for name in $PROCESS_FILES $CONCURRENCY_FILES; do
+for name in $LISTED_FILES; do
     if [ ! -f "src/$name.zig" ]; then
         echo "$0: '$name' names no src/$name.zig -- update the chunk lists" >&2
         exit 2
@@ -90,12 +132,17 @@ in_list() { # in_list <name> <list...>
 case "$chunk" in
     process)     names="$PROCESS_FILES" ;;
     concurrency) names="$CONCURRENCY_FILES" ;;
+    io)          names="$IO_FILES" ;;
+    fuzz)        names="$FUZZ_FILES" ;;
+    gc)          names="$GC_FILES" ;;
+    native)      names="$NATIVE_FILES" ;;
+    tooling)     names="$TOOLING_FILES" ;;
     rest)
         names=""
         for f in src/*.zig; do
             n="$(basename "$f" .zig)"
             # shellcheck disable=SC2086
-            in_list "$n" $PROCESS_FILES $CONCURRENCY_FILES && continue
+            in_list "$n" $LISTED_FILES && continue
             grep -q '^test "' "$f" || continue
             names="$names $n"
         done


### PR DESCRIPTION
## Summary

`riscv64-test` is cancelled at its 45-minute cap in roughly one run in four since 2026-09-02 ([#2488](https://github.com/kaappi/kaappi/issues/2488)). Every cancelled run was still inside the single "Unit tests (riscv64 via QEMU)" step at 41–43 minutes with the `unit-tests` binary alive; every success finishes that step in 23–28 minutes. Nothing lands in between, so this is a hang, not the slow tail #2458 fixed by raising the cap — and the step printed nothing until it finished, so the log never said which test.

This PR does not raise the cap again (that would only make the same red arrive later). It splits the unit suite into chunks, each its own step with its own `timeout-minutes`, so a hang is cancelled by its chunk's cap and the step name localises it.

**It already worked once.** The first version of this PR (three chunks) hung on its own re-run: process and concurrency passed, the 1646-test `rest` chunk hit its cap with the binary orphaned ([details on the issue](https://github.com/kaappi/kaappi/issues/2488#issuecomment-5516350236)). That ruled out the two suspects the issue named, so the second commit cuts `rest` along its QEMU-sensitive seams:

| step | what | native | step cap |
|---|---|---|---|
| process | `tests_process*` — KEP-0022 subprocess tests, whose children are whole emulated `/bin/sh` processes under binfmt | 15s (66) | 12m |
| concurrency | fibers, reactor, scheduler, channels, SRFI-18, waitforfd | 15s (231) | 12m |
| io | file/string/transcoded ports (SRFI 181), incremental reader, filesystem (SRFI 170) | 11s (150) | 12m |
| fuzz | the fuzz generators and their bounded harness (#1573's family) | 1m (26) | 15m |
| gc | tracing, runtime stress, root-boundary OOM sweeps, deep copy, robustness | 9s (220) | 10m |
| native | the LLVM tier — skips almost entirely on this interpreter-tier leg | 2s (141) | 8m |
| tooling | CLI subcommands, the `kaappi test` runner (emulated worker children), caches, REPL, thottam (the `thottam-tests` binary runs its full 88 here) | 17s (301) | 12m |
| rest | every other `src/*.zig` that declares a `test "…"`, **derived from the tree** so a new test file lands here automatically | 1m (840) | 24m |

New script `tools/run-unit-test-chunk.sh <chunk> [zig build args]` builds the filter list, runs `zig build test --summary all`, and asserts the chunk actually ran tests. It works for any target (`-Dtarget=riscv64-linux` in CI, nothing for the host). Adding a chunk is one list and one `case`; `rest` shrinks by itself.

**Why the cut is exact.** `-Dtest-filter` is a substring match on the qualified name `<basename>.test.<title>`, the filter prunes `builtin.test_functions` at compile time, and a test is included once however many filters match it. Verified by dumping the binary's test list: every test-bearing file is either fully in the unit binary or fully absent from it. Chunk totals sum to the unfiltered count plus the unnamed `test { _ = @import(…); }` reference blocks every filtered binary keeps (counted once per chunk), plus one documented cross-chunk duplicate inherent to substring filters: `native_compiler` ends with `compiler`, so its five tests also run in `rest`.

**Guards against rot.** A name in the explicit lists that matches no file fails the run (the `KAAPPI_GC_STRESS_SKIP` rule), and a chunk that ran no more tests than the unnamed reference blocks fails instead of passing vacuously.

**Job cap.** Moves from 45 to 55 only as a backstop for several chunks overrunning at once; it is sized so a single hung chunk hits its own step cap first. The extra test-binary compiles cost ~1.5m each under cross-compilation.

## Test plan

- [x] `shellcheck` and `bash -n` clean; `--list` prints 3 / 8 / 7 / 4 / 6 / 5 / 30 / 42 filters; a bad chunk name exits 2 with usage; works from another cwd.
- [x] All eight chunks run natively through the script, all green, floor check reports 7 each; totals as in the table.
- [x] `ci.yml` parses (pyyaml) with the eight steps and caps above; markdownlint clean on `docs/dev/testing.md`.
- [x] Three-way version on CI (job 33674064049): process 1.9m / concurrency 3.3m / rest 25.8m, totals matching native, job green at 35.1m.
- [x] Three-way version caught the real hang (job 100407731878): process and concurrency passed, rest cancelled at its cap — the localisation this PR exists for.
- [ ] Eight-way version on CI: all eight chunk steps visible and green, healthy total well under the 55m cap.

Refs #2488

🤖 Generated with [Claude Code](https://claude.com/claude-code)
