### PR TITLE
CI: bound each emulated unit test with --test-timeout so a hang names its test (#2488)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,14 +600,16 @@ jobs:
       # on top, so a hung test is killed and NAMED by `zig build` while the
       # step is still alive (a step cap that fires first would lose the
       # name again). Measured healthy times on the eight-way split under
-      # QEMU (run 33684320694): process 1.8m, concurrency 3.3m, io 2.1m,
-      # fuzz 6.0m, gc 2.9m, native 1.7m, tooling 2.1m, rest 6.9m.
+      # QEMU, two runs (33684320694 and PR #2491's), slowest of each:
+      # process 1.8m, concurrency 7.0m (3.3m on the other run -- the
+      # timing-sensitive chunk varies most with runner load), io 2.1m,
+      # fuzz 6.0m, gc 6.1m (2.9m), native 1.7m, tooling 2.1m, rest 6.9m.
       - name: Unit tests, process chunk (riscv64 via QEMU)
         timeout-minutes: 14
         run: bash tools/run-unit-test-chunk.sh process -Dtarget=riscv64-linux
 
       - name: Unit tests, concurrency chunk (riscv64 via QEMU)
-        timeout-minutes: 16
+        timeout-minutes: 20
         run: bash tools/run-unit-test-chunk.sh concurrency -Dtarget=riscv64-linux
 
       - name: Unit tests, io chunk (riscv64 via QEMU)
@@ -619,7 +621,7 @@ jobs:
         run: bash tools/run-unit-test-chunk.sh fuzz -Dtarget=riscv64-linux
 
       - name: Unit tests, gc chunk (riscv64 via QEMU)
-        timeout-minutes: 15
+        timeout-minutes: 18
         run: bash tools/run-unit-test-chunk.sh gc -Dtarget=riscv64-linux
 
       - name: Unit tests, native chunk (riscv64 via QEMU)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,14 +551,22 @@ jobs:
     # That step printed nothing until it finished, so the log said nothing
     # about which test. The unit suite therefore runs as chunks
     # (tools/run-unit-test-chunk.sh), each its own step with its own
-    # `timeout-minutes`, so the next hang names its chunk. The step caps are
-    # what localise; the job cap below only backstops several chunks
-    # overrunning at once, and is sized so a single hung chunk hits ITS cap
-    # first (setup + build + every other chunk healthy + the hung one's cap
-    # stays inside it). The first three-way split measured 35m healthy and
-    # localised the first recurrence to its `rest` chunk (1646 tests); the
-    # eight-way split below cuts that remainder along its QEMU-sensitive
-    # seams at the price of five more test-binary compiles (~1.5m each).
+    # `timeout-minutes`, so the next hang names its chunk. The first
+    # three-way split measured 35m healthy and localised the first
+    # recurrence to its `rest` chunk (1646 tests); the eight-way split below
+    # cuts that remainder along its QEMU-sensitive seams at the price of
+    # five more test-binary compiles (~1.5m each).
+    #
+    # The chunk script also passes `zig build test --test-timeout` (8m by
+    # default; see its header). That is what localises to a TEST: the build
+    # runner otherwise waits forever for a test's result, and with the bound
+    # it kills the overrunning test, prints its name, and carries on with
+    # the rest of the chunk, so the log ends with a named failure and a full
+    # verdict for every other test instead of a cancel. For that to happen
+    # the step must outlive the per-test bound, so every step cap below is
+    # its healthy time plus the 8m bound plus margin -- the cap is now the
+    # backstop, not the localiser. The job cap backstops the same way: setup
+    # + build + every chunk healthy (30m) + one hung test (8m) stays inside.
     timeout-minutes: 55
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -588,35 +596,38 @@ jobs:
       # fuzz 1m, gc 9s, native 2s (skips on this tier), tooling and the new
       # rest ~3m; the QEMU factor on the old rest was ~3.3x on top of
       # ~1.5m of compile, which is what the caps below are sized from, with
-      # roughly 2x headroom each. A chunk that hangs is cancelled by its
-      # own step's cap, and the step name in the job log is the
-      # localisation kaappi#2488 asks for.
+      # roughly 2x headroom each -- and then the script's 8m per-test bound
+      # on top, so a hung test is killed and NAMED by `zig build` while the
+      # step is still alive (a step cap that fires first would lose the
+      # name again). Measured healthy times on the eight-way split under
+      # QEMU (run 33684320694): process 1.8m, concurrency 3.3m, io 2.1m,
+      # fuzz 6.0m, gc 2.9m, native 1.7m, tooling 2.1m, rest 6.9m.
       - name: Unit tests, process chunk (riscv64 via QEMU)
-        timeout-minutes: 12
+        timeout-minutes: 14
         run: bash tools/run-unit-test-chunk.sh process -Dtarget=riscv64-linux
 
       - name: Unit tests, concurrency chunk (riscv64 via QEMU)
-        timeout-minutes: 12
+        timeout-minutes: 16
         run: bash tools/run-unit-test-chunk.sh concurrency -Dtarget=riscv64-linux
 
       - name: Unit tests, io chunk (riscv64 via QEMU)
-        timeout-minutes: 12
+        timeout-minutes: 14
         run: bash tools/run-unit-test-chunk.sh io -Dtarget=riscv64-linux
 
       - name: Unit tests, fuzz chunk (riscv64 via QEMU)
-        timeout-minutes: 15
+        timeout-minutes: 20
         run: bash tools/run-unit-test-chunk.sh fuzz -Dtarget=riscv64-linux
 
       - name: Unit tests, gc chunk (riscv64 via QEMU)
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: bash tools/run-unit-test-chunk.sh gc -Dtarget=riscv64-linux
 
       - name: Unit tests, native chunk (riscv64 via QEMU)
-        timeout-minutes: 8
+        timeout-minutes: 12
         run: bash tools/run-unit-test-chunk.sh native -Dtarget=riscv64-linux
 
       - name: Unit tests, tooling chunk (riscv64 via QEMU)
-        timeout-minutes: 12
+        timeout-minutes: 14
         run: bash tools/run-unit-test-chunk.sh tooling -Dtarget=riscv64-linux
 
       - name: Unit tests, rest chunk (riscv64 via QEMU)
@@ -662,8 +673,12 @@ jobs:
       - name: Build (cross-compile for s390x)
         run: zig build -Dtarget=s390x-linux
 
+      # Same per-test bound as the riscv64 chunks (kaappi#2488): a test that
+      # hangs under emulation is killed and named after 8m, and the rest of
+      # the suite still reports, instead of the step going silent until the
+      # job cap. This leg's whole unit step is ~10m healthy.
       - name: Unit tests (s390x via QEMU)
-        run: zig build test -Dtarget=s390x-linux
+        run: zig build test -Dtarget=s390x-linux --test-timeout 8m
 
       - name: R7RS test suite (s390x via QEMU)
         run: bash tools/run-r7rs-suite.sh zig-out/bin/kaappi
@@ -706,8 +721,10 @@ jobs:
       - name: Build (cross-compile for ppc64le)
         run: zig build -Dtarget=powerpc64le-linux
 
+      # Per-test bound as on the s390x and riscv64 legs (kaappi#2488); this
+      # unit step is ~4m healthy.
       - name: Unit tests (ppc64le via QEMU)
-        run: zig build test -Dtarget=powerpc64le-linux
+        run: zig build test -Dtarget=powerpc64le-linux --test-timeout 8m
 
       - name: R7RS test suite (ppc64le via QEMU)
         run: bash tools/run-r7rs-suite.sh zig-out/bin/kaappi

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -679,9 +679,9 @@ matrix covers:
 | `test` | Ubuntu (x86, ARM), macOS | Unit tests, `run-all.sh`, robustness, sandbox, thottam integration, SRFI final-status guard |
 | `gc-stress` | Ubuntu | Unit suite under `-Dgc-stress=true` |
 | `gc-stress-scheme` | Ubuntu | Scheme suites under `-Dgc-stress=true` |
-| `riscv64-test` | Ubuntu (QEMU) | Cross-compiled unit tests + R7RS suite. The unit suite runs as eight chunks (`tools/run-unit-test-chunk.sh`: process, concurrency, io, fuzz, gc, native, tooling, and a derived rest), each its own step with its own cap, so a hang under emulation names its chunk (kaappi#2488) |
-| `s390x-test` | Ubuntu (QEMU) | Big-endian leg — the byte-order canary (kaappi#1654) |
-| `ppc64le-test` | Ubuntu (QEMU) | Cross-compiled unit tests + R7RS suite |
+| `riscv64-test` | Ubuntu (QEMU) | Cross-compiled unit tests + R7RS suite. The unit suite runs as eight chunks (`tools/run-unit-test-chunk.sh`: process, concurrency, io, fuzz, gc, native, tooling, and a derived rest), each its own step with its own cap, and the script passes `zig build test --test-timeout 8m`, so a hang under emulation is killed and named per test while the rest of the chunk still reports (kaappi#2488) |
+| `s390x-test` | Ubuntu (QEMU) | Big-endian leg — the byte-order canary (kaappi#1654); same `--test-timeout 8m` |
+| `ppc64le-test` | Ubuntu (QEMU) | Cross-compiled unit tests + R7RS suite; same `--test-timeout 8m` |
 | `freebsd-test`, `openbsd-test`, `netbsd-test` | Ubuntu (VM action) | Per-BSD build + tests; see the matching `docs/dev/<os>.md` |
 | `windows-cross` | Ubuntu | Cross-compile check for both Windows targets |
 | `windows-arm-test` | Windows 11 ARM | Native build + tests |

--- a/tools/run-unit-test-chunk.sh
+++ b/tools/run-unit-test-chunk.sh
@@ -3,6 +3,7 @@
 #
 #     bash tools/run-unit-test-chunk.sh <process|concurrency|rest> [zig build args...]
 #     bash tools/run-unit-test-chunk.sh --list <chunk>      # print the filters, run nothing
+#     KAAPPI_TEST_TIMEOUT=90s bash tools/run-unit-test-chunk.sh <chunk>   # per-test bound
 #
 # WHY THIS EXISTS. `riscv64-test` runs the whole unit suite under QEMU
 # user-mode as ONE `zig build test` step that prints nothing until it
@@ -12,6 +13,28 @@
 # few chunks, each its own workflow step with its own `timeout-minutes`,
 # makes the next hang say WHICH chunk it was in. Chunking is a diagnostic,
 # not a fix; the chunks exist to be narrowed, not to grow.
+#
+# THE PER-TEST TIMEOUT. `zig build test` talks to the test binary over the
+# binary's stdin/stdout (`--listen=-`): it asks for one test at a time and,
+# by default, waits for that test's result FOREVER -- which is the whole
+# 43-minute silence above. Zig 0.16's `--test-timeout <duration>` bounds
+# that wait per test: a test that overruns it is reported by NAME
+# ("'<file>.test.<title>' timed out after 8m"), its process is killed, and
+# the runner respawns the binary and carries on from the next test, so one
+# hang costs the timeout, names its test, and still leaves every other
+# test's verdict in the log. The same bound covers the other way a run can
+# go silent: a test that writes to fd 1 corrupts the IPC stream (the build
+# runner reads the stray bytes as a message header and waits for a body
+# that never comes), and the runner now gives up on that test too instead
+# of on the whole step. The chunks stay: the timeout localises to a test
+# only once the step is allowed to outlive it, so every step cap in the
+# workflow is sized as its healthy time plus this timeout plus margin.
+#
+# $KAAPPI_TEST_TIMEOUT overrides the bound (a Zig duration such as 8m or
+# 90s). The default is sized from the slowest chunk under QEMU: the fuzz
+# chunk's 20 tests (the fixed-seed generator gates among them) take about
+# 4.5m TOGETHER, so no single test is anywhere near 8m, and under emulation
+# a legitimately slow test must never be mistaken for a hang.
 #
 # HOW THE CHUNKS ARE CUT. `-Dtest-filter` is a substring match on a test's
 # qualified name, `<file basename>.test.<title>` (build.zig; repeatable).
@@ -165,8 +188,10 @@ floor="$(grep -l '^test {' src/*.zig | wc -l | tr -d ' ')"
 log="$(mktemp)"
 trap 'rm -f "$log"' EXIT
 
-echo "== unit-test chunk '$chunk': ${#filters[@]} filter(s), extra args: $*"
-zig build test "${filters[@]}" "$@" --summary all 2>&1 | tee "$log"
+test_timeout="${KAAPPI_TEST_TIMEOUT:-8m}"
+
+echo "== unit-test chunk '$chunk': ${#filters[@]} filter(s), per-test timeout $test_timeout, extra args: $*"
+zig build test "${filters[@]}" "$@" --test-timeout "$test_timeout" --summary all 2>&1 | tee "$log"
 status=${PIPESTATUS[0]}
 [ "$status" = 0 ] || exit "$status"
 


### PR DESCRIPTION
Follow-up to #2490 for #2488 (the intermittent riscv64 hang). Does not close the issue: the hang itself is still open; this makes the next recurrence name the **test**, not just the chunk.

## Why

The eight-way chunking narrows a hang to a step, but a hung step still ends as a silent cancel. `zig build test` drives the test binary over its stdin/stdout (`--listen=-`), asks for one test at a time, and by default waits for that test's result **forever** — that is the whole 43-minute silence in the cancelled runs. Chunking further would mean a step per file.

## What

- **`tools/run-unit-test-chunk.sh` passes `zig build test --test-timeout 8m`** (`$KAAPPI_TEST_TIMEOUT` overrides). Zig 0.16 reports a test that overruns the bound by name (`'<file>.test.<title>' timed out after 8m`), kills its process, respawns the binary and continues from the next test — so one hang costs eight minutes, names its test, and every other test still gets a verdict.
- **Step caps grow** so the per-test bound fires before the step cap does (a step cap firing first would lose the name again). Each cap is the measured healthy time from run 33684320694 plus the 8m bound plus margin; the 55m job cap still holds setup + build + all chunks healthy (30m) + one hung test (8m).
- **s390x and ppc64le get the same flag** — they run the suite as one unfiltered step under QEMU and share the failure mode.
- `docs/dev/testing.md` CI table updated.

The same bound also covers the other way this protocol goes silent: a test that writes to fd 1 corrupts the IPC stream (the runner parses stray bytes as a message header and waits for a body that never comes). That is now a named per-test timeout instead of a step cancel.

## Verified

- Natively, `KAAPPI_TEST_TIMEOUT=40ms bash tools/run-unit-test-chunk.sh gc` reports `167 pass, 6 skip, 47 timeout`, one `error: '<test>' timed out after 40ms` line per test, and exits 1; `bash tools/run-unit-test-chunk.sh native` with the default passes (141 tests).
- `bash -n`, shellcheck, YAML load, and markdownlint are clean.
- Sizing: the fuzz chunk's 20 tests take ~4.5m *together* under QEMU, so no single test is near 8m.

## Still open

The hang has not recurred since #2490 landed (2 main runs + 2 PR runs green). A local repro loop of the old 1646-test rest chunk under a podman riscv64 container has completed 2 of 16 passes so far without a hang; if it catches one, the fix follows separately with the test named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
