### PR TITLE
Add -Dtest-strip and use it on the macOS CI leg, where per-allocation stack capture grew the unit binary to 44 GB (#2489)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,9 +249,22 @@ jobs:
           # (healthy runs sit at 18–24 min). timeout is an include-only key
           # that merges into this existing os+optimize combination without
           # renaming its required check.
+          #
+          # test_args: the unit binaries are stripped on this leg only
+          # (kaappi#2489). `std.testing.allocator` captures a stack trace per
+          # allocation, and on aarch64-macOS Zig 0.16 unwinds it through the
+          # Mach-O DWARF path whose scratch lives in a never-freed arena: the
+          # unit binary's footprint reached 44 GB by the end of the suite,
+          # the runner's 3 GB swap filled 11-13 min in, and the kernel's "no
+          # paging space" action SIGKILLed it ("'<test>' terminated with
+          # signal KILL", a different victim each time). Stripping the test
+          # module turns that capture off: same 1913 pass / 21 skip, ~20 s
+          # instead of ~10 min, 91 MB instead of 44 GB. The Linux legs keep
+          # symbolized traces; they run the suite in under a minute anyway.
           - os: macos-latest
             optimize: ReleaseSafe
             timeout: 50
+            test_args: -Dtest-strip=true
           - os: ubuntu-latest
             optimize: ReleaseFast
 
@@ -295,7 +308,7 @@ jobs:
       # the gc-stress job below is read against (its skip count differs).
       - name: Unit tests (leak detection via std.testing.allocator)
         if: env.DOCS_ONLY != 'true'
-        run: zig build test -Doptimize=${{ matrix.optimize }} --summary all
+        run: zig build test -Doptimize=${{ matrix.optimize }} ${{ matrix.test_args }} --summary all
 
       - name: Scheme suites
         if: env.DOCS_ONLY != 'true'

--- a/build.zig
+++ b/build.zig
@@ -50,6 +50,24 @@ pub fn build(b: *std.Build) void {
 
     const test_filters = b.option([]const []const u8, "test-filter", "Only run unit tests whose names match the filter (repeatable)") orelse &.{};
 
+    // Strip the TEST binaries only (kaappi#2489). `std.testing.allocator`
+    // captures a 10-frame stack trace on every allocation, and on
+    // aarch64-macOS Zig 0.16 walks it with the Mach-O DWARF unwinder, whose
+    // scratch comes from std.debug's process-lifetime arena: the unit
+    // binary's footprint grows ~100 MB/s to ~44 GB over the suite, which a
+    // 7 GB CI runner answers with a kernel "no paging space" SIGKILL, and
+    // the unwinding itself makes the suite ~20x slower there (7 min vs 20 s
+    // locally; Linux runs the same suite in 47 s). `allow_stack_tracing`
+    // defaults to `!strip_debug_info`, and the test binary's root is Zig's
+    // own test runner (it owns `std_options`), so stripping the test module
+    // is the one lever this build has. Cost: a panic or a leak report in the
+    // test binary prints addresses, not symbolized frames -- hence opt-in;
+    // the macOS CI leg passes it, and local runs can when a trace is not
+    // what they are after. Test-only: `-Dstrip` still governs the shipped
+    // binaries, and the kcov coverage modules keep their DWARF regardless.
+    const test_strip = b.option(bool, "test-strip", "Strip the unit-test binaries: no symbolized traces, but ~20x faster and bounded memory on macOS (kaappi#2489)") orelse false;
+    const test_strip_opt: ?bool = if (test_strip) true else null;
+
     // A cross-compiled test binary runs under an emulator: CI cross-compiles to
     // riscv64-linux and runs the unit tests under QEMU user-mode (~10-30x slower
     // than native). The fuzz generator "programs evaluate without error" gates in
@@ -453,6 +471,7 @@ pub fn build(b: *std.Build) void {
         // Match the wasm executable's own threading model (see `main_mod`
         // above): wasm32-wasi without wasi-threads is single-threaded.
         .single_threaded = if (is_wasm_target) true else null,
+        .strip = test_strip_opt,
     });
     const unit_tests = b.addTest(.{
         .name = "unit-tests",
@@ -482,6 +501,7 @@ pub fn build(b: *std.Build) void {
         .root = "src/thottam.zig",
         .target = target,
         .optimize = optimize,
+        .strip = test_strip_opt,
     });
     const thottam_tests = b.addTest(.{
         .name = "thottam-tests",

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -85,7 +85,21 @@ zig build test 2>&1 | head                # Quick check for failures
 zig build test -Dtest-filter=tests_io     # Only tests whose names match
 zig build test -Dtest-filter="eval quote" # Substring match on test names
 zig build test -Dgc-stress=true           # Collection on every allocation
+zig build test -Dtest-strip=true          # macOS: ~20x faster, bounded memory; no symbolized traces
 ```
+
+`-Dtest-strip=true` strips the *test* binaries only. It exists for
+aarch64-macOS, where `std.testing.allocator`'s per-allocation stack capture
+goes through Zig 0.16's Mach-O DWARF unwinder and its never-freed scratch
+arena: the unit binary's footprint grows to ~44 GB over the suite and the run
+takes ~7–10 minutes, against 20 s and 91 MB stripped (kaappi#2489 — the CI
+macOS leg was being SIGKILLed by the kernel when the runner's swap filled).
+Stripping turns the capture off (`allow_stack_tracing` defaults to
+`!strip_debug_info`; the test binary's root is Zig's test runner, so it
+cannot be set from `main.zig`). The cost is that a panic or a leak report in
+the test binary prints raw addresses, so leave it off when you need a trace.
+The macOS CI leg passes it; Linux runs the same suite in under a minute
+without it.
 
 Individual test files cannot be run in isolation -- `zig build test` runs all
 tests discovered through the import graph from `main.zig`. Use


### PR DESCRIPTION
Fixes the macOS ReleaseSafe SIGKILL of #2489 (does not close it until a run or two confirms; the upstream Zig leak stays open regardless).

## Root cause (measured; full chain on #2489)

- Kernel log on the runner: `memorystatus: triggering no paging space action` → `killing largest compressed process unit-tests [7227] 43913 MB`. 7 GB runner, 3 GB swap cap.
- Every region still mapped at process exit (leak detection green) was allocated by `std.debug.captureCurrentStackTrace` from `std.testing.allocator`'s per-allocation trace capture, via the Mach-O DWARF unwinder, whose rule computation allocates from `std.debug.getDebugInfoAllocator` — a process-lifetime arena. Footprint grows ~100 MB/s to **44 GB** by the last test. Linux (ELF path) runs the same suite in 47 s / 97 MB.
- `allow_stack_tracing` gates the capture and defaults to `!strip_debug_info`; the test binary's root is Zig's test runner (owns `std_options`), so it cannot be set from `main.zig` — verified, no effect. Stripping the test module is the lever.

## What this does

- **`build.zig`**: new `-Dtest-strip=[bool]` (default off). Sets `strip = true` on the unit-test and thottam-test modules only; `-Dstrip` still governs shipped binaries; kcov modules untouched.
- **`ci.yml`**: the `macos-latest` matrix entry gains `test_args: -Dtest-strip=true`, spliced into the unit-test step. Linux legs unchanged (they keep symbolized traces and are already fast).
- **`docs/dev/testing.md`**: documents the flag and the trade-off (a panic or leak report in the test binary prints raw addresses).

## Measured

| | unit suite | MaxRSS | footprint at exit (36 numeric tests) |
|---|---|---|---|
| default | 7 m local / 10 m CI | 2 GB (44 GB footprint) | 2546 MB |
| `-Dtest-strip=true` | **21 s** | **91 MB** | 2 MB |

Same 1913 pass / 21 skip / 88 thottam. Default build verified unchanged on a filtered run; YAML and markdownlint clean. Expect the macOS leg's unit step to drop from ~10 min to well under a minute.

Related: #2493 (the failure-only diagnostics that captured the kernel line; can be dropped once this is in), #2464 / #2485 (a different, libmalloc-side retention in the shipped binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
