### PR TITLE
CI: fail openbsd-test fast when pkg_add cannot install bash (#2492)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -873,7 +873,19 @@ jobs:
           copyback: false
           # bash: run-all.sh; python3 + git: the errors/ and test-runner/
           # suites validate JSON output and build throwaway git repos.
-          prepare: pkg_add -I bash python%3 git
+          # Retried with a post-install probe rather than pkg_add's exit
+          # status: on a mirror blip pkg_add prints "Can't find bash" and
+          # still exits 0 (kaappi#2492), so the netbsd-style `pkg_add &&
+          # break` would break on the first attempt having installed
+          # nothing. The trailing check turns a fully failed install into a
+          # prepare-step failure before any suite runs.
+          prepare: |
+            for i in 1 2 3; do
+              pkg_add -I bash python%3 git || true
+              command -v bash >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 && command -v git >/dev/null 2>&1 && break
+              sleep 20
+            done
+            command -v bash >/dev/null 2>&1 || { echo "openbsd-test: pkg_add could not install bash after 3 attempts"; exit 1; }
           run: |
             set -e
             # OpenBSD's default login class caps the main-thread stack at 4 MiB
@@ -886,6 +898,11 @@ jobs:
             ./unit-tests-openbsd
             ./thottam-tests-openbsd
             cc -shared -fPIC tests/scheme/ffi/fixtures/u64test.c -o tests/scheme/ffi/fixtures/libu64test.so
+            # Backstop for the prepare probe above: if bash is still missing,
+            # fail here with the cause named, not minutes later as
+            # `sh: bash: not found` after every suite has passed (kaappi#2492).
+            # 127 is the code the missing-bash invocation would produce anyway.
+            command -v bash >/dev/null 2>&1 || { echo "openbsd-test: bash missing — pkg_add prepare failed"; exit 127; }
             bash tests/scheme/run-all.sh
 
   netbsd-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -877,15 +877,18 @@ jobs:
           # status: on a mirror blip pkg_add prints "Can't find bash" and
           # still exits 0 (kaappi#2492), so the netbsd-style `pkg_add &&
           # break` would break on the first attempt having installed
-          # nothing. The trailing check turns a fully failed install into a
-          # prepare-step failure before any suite runs.
+          # nothing. The trailing check turns a failed or partial install
+          # into a prepare-step failure before any suite runs.
           prepare: |
             for i in 1 2 3; do
               pkg_add -I bash python%3 git || true
               command -v bash >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 && command -v git >/dev/null 2>&1 && break
-              sleep 20
+              if [ "$i" -lt 3 ]; then sleep 20; fi
             done
-            command -v bash >/dev/null 2>&1 || { echo "openbsd-test: pkg_add could not install bash after 3 attempts"; exit 1; }
+            if ! command -v bash >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1 || ! command -v git >/dev/null 2>&1; then
+              echo "openbsd-test: pkg_add could not install all required tools after 3 attempts"
+              exit 1
+            fi
           run: |
             set -e
             # OpenBSD's default login class caps the main-thread stack at 4 MiB


### PR DESCRIPTION
## What

Makes the `openbsd-test` job fail at the right time with the right message when the OpenBSD package mirror eats the `pkg_add`, instead of running every suite green and dying minutes later with `sh: bash: not found`.

Closes #2492

## Why

The attempt-1 log of run 33707916882 (PR #2485, 2026-09-03 ~02:40Z) shows the mechanism precisely:

- `pkg_add -I bash python%3 git` printed `Can't find bash` / `Can't find git` **but exited 0**, so the vm action's prepare step looked successful and the job continued.
- All 1938 unit tests then ran green, and the job failed only at `bash tests/scheme/run-all.sh` with `sh: bash: not found` → `ssh exited with code 127` — a red that misattributed a package-install problem to the test run and spent ~2 VM minutes on suites that could never finish.

The same job passed on main at 00:49Z and on rerun, so this was a transient mirror blip, **not** the 7.9 package-set rotation — no `release:` bump (and `docs/dev/openbsd.md` untouched).

## The fix

**1. Retry the prepare** (`prepare:` is now a block, mirroring the netbsd job's retry, which exists for the same class of transience):

```sh
for i in 1 2 3; do
  pkg_add -I bash python%3 git || true
  command -v bash >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 && command -v git >/dev/null 2>&1 && break
  sleep 20
done
command -v bash >/dev/null 2>&1 || { echo "openbsd-test: pkg_add could not install bash after 3 attempts"; exit 1; }
```

One deliberate deviation from a verbatim copy of the netbsd loop (`pkg_add ... && break`): the loop decides success by **probing for the installed binaries**, not pkg_add's exit status. The observed failure mode exits 0 while installing nothing, so an exit-code-based `&& break` would break on the first attempt having installed nothing — the retry would never fire for exactly the failure it exists for. The trailing check (netbsd's block ends with the same shape, for clang) fails the prepare step once the retry budget is spent.

**2. Guard where bash is invoked** — immediately before `bash tests/scheme/run-all.sh` in the run script:

```sh
command -v bash >/dev/null 2>&1 || { echo "openbsd-test: bash missing — pkg_add prepare failed"; exit 127; }
```

The guard lives in the run script, not inside `tests/scheme/run-all.sh`, because that script *is* executed by bash — a guard there is unreachable precisely when bash is absent. 127 is the code the missing-bash invocation would have produced anyway; only the message changes.

python3/git get no run-script guard: their absences were never the confusing case — `tests/scheme/errors/*.sh` and `tests/scheme/test-runner/*.sh` already self-guard (`command -v python3` / `command -v git`) with loud, correctly-attributed messages, so `run-all.sh` itself is left untouched.

## Verification

CI-config change — there is no Zig regression test for it; the standalone demonstrations below are the verification:

- YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`), scripts extracted back out of the workflow for the demos below (so they exercise exactly what shipped, not a retyped copy).
- Standalone harness with a fake `pkg_add` reproducing the observed exit-0 "Can't find" behavior:
  - healthy mirror → loop breaks on attempt 1, prepare exit 0
  - transient (fails twice, exits 0 each time) → retried, installs on attempt 3, prepare exit 0
  - persistent failure → 3 attempts, then `pkg_add could not install bash after 3 attempts`, prepare exit 1 (job fails at the prepare step, before any test runs)
- Guard line, run standalone: with bash on PATH → silent exit 0; without bash → the message above and exit 127.