### PR TITLE
Document Zig's No LLM/No AI policy for upstream contributions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -516,12 +516,13 @@ query that finds every open issue with none *or* more than one priority label.
 ## Upstream Zig: no LLM / no AI
 
 Kaappi is written in Zig, so we routinely touch the Zig ecosystem. Zig enforces
-a **Strict No LLM / No AI Policy**, and we respect it in full in Zig's community
-spaces (tracker on Codeberg, GitHub mirror, Ziggit, forums): nothing an LLM
-produced or touched goes upstream — issues, PRs, comments, edits, translations,
-or LLM-found bugs — and don't discuss chatbot/LLM use there. The boundary is the
-destination: this restricts *contributions to Zig*, not AI-assisted work on
-Kaappi's own Zig code. **`docs/dev/zig-upstream-policy.md`** is the full note.
+a **Strict No LLM / No AI Policy** in the spaces its CoC governs (the `ziglang`
+org on Codeberg, the `#zig` Libera.chat IRC, the Zig Zulip — GitHub is *not*
+among them), and we respect it in full: nothing an LLM produced or touched goes
+upstream — issues, PRs, comments, edits, translations, or LLM-found bugs — and
+don't discuss chatbot/LLM use there. The boundary is the destination: this
+restricts *contributions to Zig*, not AI-assisted work on Kaappi's own Zig code.
+**`docs/dev/zig-upstream-policy.md`** is the full note.
 
 ## Claude Code harness
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -513,6 +513,16 @@ issue up *within* its level, not a level of its own.
 boundary rules, severity-vs-priority, and the triage commands, including the
 query that finds every open issue with none *or* more than one priority label.
 
+## Upstream Zig: no LLM / no AI
+
+Kaappi is written in Zig, so we routinely touch the Zig ecosystem. Zig enforces
+a **Strict No LLM / No AI Policy**, and we respect it in full in Zig's community
+spaces (tracker on Codeberg, GitHub mirror, Ziggit, forums): nothing an LLM
+produced or touched goes upstream — issues, PRs, comments, edits, translations,
+or LLM-found bugs — and don't discuss chatbot/LLM use there. The boundary is the
+destination: this restricts *contributions to Zig*, not AI-assisted work on
+Kaappi's own Zig code. **`docs/dev/zig-upstream-policy.md`** is the full note.
+
 ## Claude Code harness
 
 Hooks, permissions, path-scoped rules, and skills that enforce the conventions

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -91,6 +91,7 @@ investigations.
 | Document | Contents |
 |----------|----------|
 | [ecosystem-library-bar.md](ecosystem-library-bar.md) | Quality bar for `kaappi-*` packages (applies ecosystem-wide, not just this repo) |
+| [zig-upstream-policy.md](zig-upstream-policy.md) | Zig's Strict No LLM / No AI policy and how we respect it when acting in Zig community spaces — the boundary vs. AI-assisted work on this repo |
 | [github-issues.md](github-issues.md) | Issue tracker: the four label axes, the priority rubric (what separates critical from high), severity-vs-priority, the one-priority-per-open-issue invariant |
 | [srfi-exclusions.md](srfi-exclusions.md) | The 30 SRFIs deliberately not implemented, one section each, with the reason |
 | [srfi-status-check.md](srfi-status-check.md) | The CI guard that fails if a shipped SRFI is `draft` or `withdrawn` in the canonical registry — and how the counts are re-derived from the binary |

--- a/docs/dev/zig-upstream-policy.md
+++ b/docs/dev/zig-upstream-policy.md
@@ -1,0 +1,41 @@
+# Upstream Zig: No LLM / No AI
+
+Kaappi is written in Zig, so contributors routinely touch the Zig ecosystem —
+filing compiler or standard-library bugs, reading the tracker, following
+discussions. The Zig project enforces a **Strict No LLM / No AI Policy**, and
+we respect it in full whenever we act in a Zig community space.
+
+Canonical source:
+<https://ziglang.org/code-of-conduct/#strict-no-llm-no-ai-policy>
+
+## What the policy forbids
+
+In Zig's own spaces — its issue tracker (hosted on Codeberg), the GitHub
+mirror, Ziggit, and the forums — the policy forbids:
+
+- LLM-generated content, whether code or prose;
+- paraphrasing LLM-generated content;
+- LLMs for editing, including fixing spelling or grammar;
+- LLMs for translation (posting in your native language and letting readers
+  translate is welcome; running it through a chatbot is not);
+- sharing the results of LLM brainstorming, even when you write the prose;
+- LLMs for finding bugs;
+- talking about your use of chatbot/LLM services.
+
+## What this means for Kaappi contributors
+
+- **Nothing an LLM produced or touched goes upstream.** Issues, pull requests,
+  comments, and forum posts to Zig must be entirely your own — including edits
+  and translations.
+- **LLM-found Zig bugs are not filed by the LLM.** If AI-assisted work on
+  Kaappi turns up a likely Zig compiler or `std` bug, any upstream report must
+  be your own independent investigation and your own words.
+- **Don't discuss LLM/chatbot use in Zig spaces.**
+
+## The boundary
+
+This policy governs **contributions to Zig and its community**. It places no
+restriction on AI-assisted work on *this* repository — Kaappi's own Zig code,
+tests, and docs — which is our code under our own conventions (see
+[claude-code-harness.md](claude-code-harness.md)). The line is the destination:
+our repo, fine; Zig's spaces, off-limits.

--- a/docs/dev/zig-upstream-policy.md
+++ b/docs/dev/zig-upstream-policy.md
@@ -10,8 +10,10 @@ Canonical source:
 
 ## What the policy forbids
 
-In Zig's own spaces — its issue tracker (hosted on Codeberg), the GitHub
-mirror, Ziggit, and the forums — the policy forbids:
+The Code of Conduct names the spaces it governs: the `ziglang` organization on
+Codeberg (which now hosts the issue tracker), the `#zig` IRC channel on
+Libera.chat, and the Zig project development Zulip. GitHub is explicitly *not*
+among them. In those governed spaces the policy forbids:
 
 - LLM-generated content, whether code or prose;
 - paraphrasing LLM-generated content;
@@ -25,12 +27,17 @@ mirror, Ziggit, and the forums — the policy forbids:
 ## What this means for Kaappi contributors
 
 - **Nothing an LLM produced or touched goes upstream.** Issues, pull requests,
-  comments, and forum posts to Zig must be entirely your own — including edits
-  and translations.
+  and messages in the governed spaces must be entirely your own — including
+  edits and translations.
 - **LLM-found Zig bugs are not filed by the LLM.** If AI-assisted work on
   Kaappi turns up a likely Zig compiler or `std` bug, any upstream report must
   be your own independent investigation and your own words.
-- **Don't discuss LLM/chatbot use in Zig spaces.**
+- **Don't discuss LLM/chatbot use in the governed spaces.**
+
+Two of Zig's contribution venues sit *outside* the CoC's named spaces: the
+GitHub mirror and the community-run Ziggit forum. Zig's policy does not
+formally reach them — but as our own rule of good citizenship, we hold to the
+same practice there.
 
 ## The boundary
 


### PR DESCRIPTION
## What

Adds a small contributor-policy note recording Zig's [Strict No LLM / No AI Policy](https://ziglang.org/code-of-conduct/#strict-no-llm-no-ai-policy) and how we respect it, since Kaappi is written in Zig and contributors routinely act in Zig's community spaces (filing compiler/std bugs, reading the Codeberg tracker, following threads).

- **New:** `docs/dev/zig-upstream-policy.md` — the policy, its canonical CoC link, what it forbids in Zig spaces (LLM-generated/paraphrased content, LLM editing/translation, LLM-found bugs, discussing chatbot use), and the destination-based boundary.
- **Index:** registered in the Policy table of `docs/dev/README.md`.
- **Pointer:** a compact "Upstream Zig: no LLM / no AI" section in `CLAUDE.md` (inherited by the `AGENTS.md` symlink) so the rule is visible from the orientation map.

## Boundary

The policy governs **contributions to Zig and its community** — it places no restriction on AI-assisted work on *this* repo (Kaappi's own Zig code), which stays under our own conventions.

## Notes

Docs-only; no code changes. `npx markdownlint-cli2` passes clean across the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)