### PR TITLE
github-release: drop the hand-edited docs-site count step

### DIFF
--- a/.claude/skills/github-release/SKILL.md
+++ b/.claude/skills/github-release/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Cut a GitHub release for Kaappi — bumps version strings, writes the CHANGELOG.md section from the commit log, updates the downloads page, commits, tags, pushes, and verifies the release workflow. Use when the user asks to make a release, cut a release, publish a version, tag a release, ship a version, or prepare a release.
+description: Cut a GitHub release for Kaappi — bumps version strings, writes the CHANGELOG.md section from the commit log, refreshes the built-in procedure count, commits, tags, pushes, verifies the release and post-release workflows, and triggers the docs-site update. Use when the user asks to make a release, cut a release, publish a version, tag a release, ship a version, or prepare a release.
 ---
 
 # GitHub Release
@@ -152,18 +152,24 @@ Update the count in each match (README.md and CONFORMANCE.md are user-facing;
 entries untouched — they record what was true at the time. Include any changed
 files in the release commit (Step 7).
 
-**The docs site cites the count too, and it is a separate repo** — so it needs
-its own grep and its own commit, in `../kaappi.github.io`:
+**Do not touch the docs site's counts.** `mkdocs.yml`'s `builtin_count`,
+`srfi_count`, `srfi_builtin` and `srfi_portable` are bumped by Step 11's
+`update-wasm` workflow, which extracts them from `CONFORMANCE.md` *at the
+release tag* with these patterns:
 
-```bash
-grep -rn "built-in procedures\|standard libraries" ../kaappi.github.io/docs/ ../kaappi.github.io/overrides/
-```
+| Variable | Pattern matched in `CONFORMANCE.md` |
+|----------|-------------------------------------|
+| `builtin_count` | `[0-9]+ built-in procedures` |
+| `srfi_count` | `[0-9]+ SRFIs supported` |
+| `srfi_builtin` | `[0-9]+ built-in \(native Zig\)` |
+| `srfi_portable` | `[0-9]+ portable \(\.sld files\)` |
 
-Omitting this is not hypothetical: the site sat at **601** while the core repo
-was at 689, because Step 5 only ever grepped this repo. Pages that say "600+"
-rather than an exact figure are deliberate and need no edit — prefer that
-phrasing for prose pages, and reserve the exact count for
-`docs/conformance.md`, which mirrors `CONFORMANCE.md`.
+A hand edit in `../kaappi.github.io` is redundant and leaves a local diff
+that conflicts with the workflow's PR (v0.26.0 did exactly that and had to
+revert it). What *is* on this step: keep `CONFORMANCE.md`'s wording matching
+those four patterns — a no-match fails the workflow with
+`no match for <label>` — and prose pages on the site that say "600+" are
+deliberate and never need an exact figure.
 
 ## Step 6: Build verification
 
@@ -343,10 +349,25 @@ gh workflow run update-wasm.yml -R kaappi/kaappi.github.io -f tag=vX.Y.Z
 gh run watch -R kaappi/kaappi.github.io <run-id>
 ```
 
-This updates `/playground/`, `/tour/` (shared WASM binary), and the version
+This updates `/playground/`, `/tour/` (shared WASM binary), the version
 shown on `/download/`, `/guide/first-program/`, and `/guide/repl/` (all read
-from `kaappi_version` in `mkdocs.yml`). Verify at `kaappi-lang.org/playground/`
-and `kaappi-lang.org/download/` after it deploys.
+from `kaappi_version` in `mkdocs.yml`), and the four count variables Step 5
+describes, extracted from `CONFORMANCE.md` at the tag. The bump lands on
+`main` through a PR the workflow opens and auto-merges once DCO passes, tagged
+`docs-vX.Y.Z`; the workflow runs `mkdocs build --strict` and deploys itself,
+so expect no "CI & Deploy" run on `main` for that merge (a `GITHUB_TOKEN`
+merge triggers nothing) and a job-less failed run on the bot branch (it was
+deleted before the PR-triggered run could start). Neither is a problem.
+
+Verify after it deploys: `kaappi-lang.org/download/` shows the new version,
+`kaappi-lang.org/conformance/` shows the new procedure and SRFI counts, and
+the served `/wasm/kaappi.wasm` hashes to the release's `SHA256SUMS` entry.
+
+**One thing the workflow does not do:** the per-SRFI rows in
+`docs/guide/srfi-support.md` are hand-maintained. A release that adds a SRFI
+needs a row added by an ordinary PR to `kaappi/kaappi.github.io`, or the
+table undercounts the total the same page cites (v0.26.0 shipped 273 and 274
+with the table stopping at 271).
 
 ## Error recovery
 

--- a/docs/dev/claude-code-harness.md
+++ b/docs/dev/claude-code-harness.md
@@ -264,20 +264,32 @@ when working on the compiler or VM.
 
 ### `/github-release`
 
-Full release workflow with 10 steps and multiple confirmation gates:
+Full release workflow with 11 steps and multiple confirmation gates:
 
 1. Analyze changes since last tag, recommend semver bump.
 2. Generate release notes from `git log` since the previous tag — this is
    where `CHANGELOG.md` gets written; PRs never touch it.
 3. Update CHANGELOG.md (insert the new version section).
-4. Bump version in `main.zig`, `thottam.zig`, `build.zig.zon`, and the docs
-   site download page.
-5. Build verification (`zig build`).
-6. Commit and create annotated tag.
-7. Push (requires explicit confirmation — triggers CI release workflow).
-8. Verify release workflow (platform binaries, macOS signing, GitHub Release).
-9. Verify post-release acceptance tests.
-10. Update docs site (WASM binary, download page).
+4. Bump version in `build.zig.zon` (the single source; `main.zig` and
+   `thottam.zig` read it from `build_options`) and the workspace
+   `../CLAUDE.md` "Current release" line.
+5. Refresh the built-in procedure count in this repo's docs (README,
+   CONFORMANCE, CLAUDE.md, `docs/dev/`), diffing name sets against the last
+   tag so a literal-only grep cannot mask a constant-named spec. **Nothing in
+   the docs site is edited by hand** — its `builtin_count`/`srfi_*` values are
+   extracted from `CONFORMANCE.md` at the tag by Step 11's workflow, so the
+   only obligation here is keeping `CONFORMANCE.md`'s wording matching that
+   workflow's patterns.
+6. Build verification (`zig build`).
+7. Commit and create annotated tag.
+8. Push (requires explicit confirmation — triggers CI release workflow).
+9. Verify release workflow (platform binaries, macOS signing, GitHub Release).
+10. Run and verify post-release acceptance tests, plus manual smoke tests on
+    the aarch64 Windows/FreeBSD/OpenBSD/NetBSD reference VMs, which have no
+    CI acceptance leg.
+11. Trigger the docs site's `update-wasm` workflow, which fetches the released
+    WASM, bumps `kaappi_version` and the count variables, and deploys. The
+    per-SRFI rows in the site's `srfi-support.md` stay manual.
 
 Includes error recovery procedures for both pre-push and post-push failures.
 


### PR DESCRIPTION
## Why

`/github-release` Step 5 told the releaser to grep `../kaappi.github.io` and commit a new builtin count there. That has been wrong since the docs site's `update-wasm` workflow started extracting `builtin_count`, `srfi_count`, `srfi_builtin` and `srfi_portable` from `CONFORMANCE.md` at the release tag. A hand edit is redundant and leaves a local diff that conflicts with the PR the workflow opens; v0.26.0 followed the step as written and had to revert the edit mid-release.

## What

- **Step 5** replaces the docs-site grep with the four patterns the workflow matches, so the one real obligation, keeping `CONFORMANCE.md`'s wording matching them, is stated where the count is refreshed.
- **Step 11** now says the workflow bumps those counts, lands them via an auto-merging PR tagged `docs-vX.Y.Z`, and explains two artefacts a releaser will see and should not chase: a job-less failed "CI & Deploy" run on the deleted bot branch, and no CI run on `main` for the `GITHUB_TOKEN` merge (the strict build runs inside the workflow). It adds the conformance page and served-WASM checksum to the post-deploy checks, and records that the per-SRFI rows in `srfi-support.md` stay manual, which is how 273 and 274 shipped with the table stopping at 271.
- **Frontmatter** no longer claims the skill "updates the downloads page".
- **`docs/dev/claude-code-harness.md`**: the skill summary was stale independently (ten steps, a version bump touching `main.zig` and "the docs site download page", no count-refresh step). Brought in line with the skill's eleven steps, per CLAUDE.md's rule that harness changes update both.

Docs and harness only; no Zig or Scheme changes. markdownlint clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
