### PR TITLE
Return an exact complex from sqrt of a negative exact perfect square

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -570,24 +570,27 @@ fn sqrtFn(args: []const Value) PrimitiveError!Value {
         const i = i_sign * @sqrt((mag - re) / 2.0);
         return makeComplexOrReal(r, i);
     }
-    if (types.isBignum(args[0]) and !bignum_mod.isNegative(args[0])) {
+    if (types.isFixnum(args[0]) or types.isBignum(args[0]) or types.isRationalObj(args[0])) {
         const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-        const r = try isqrtNonNegative(gc, args[0]);
-        if (bignum_mod.isZero(r.rem)) return r.root;
-    }
-    if (types.isRationalObj(args[0])) {
-        const rat = types.toRational(args[0]);
-        if (!bignum_mod.isNegative(rat.numerator)) {
-            const gc = memory.gc_instance orelse return PrimitiveError.OutOfMemory;
-            const num_r = try isqrtNonNegative(gc, rat.numerator);
-            if (bignum_mod.isZero(num_r.rem)) {
-                var slot_root = gc.rootedSlot(num_r.root) catch return PrimitiveError.OutOfMemory;
-                defer slot_root.release();
-                const den_r = try isqrtNonNegative(gc, rat.denominator);
-                if (bignum_mod.isZero(den_r.rem)) {
-                    return arith.makeRationalReduced(gc, num_r.root, den_r.root);
-                }
+        // Exact argument: an exact perfect square (integer or rational,
+        // either sign) yields an exact root. R7RS 6.2.6 gives
+        // (sqrt -1) => +i, an EXACT complex under the section's own
+        // convention that exact notation denotes an exact number
+        // (kaappi#2503) -- so a negative perfect square becomes the exact
+        // complex 0+root*i rather than falling through to the f64 path.
+        const negative = if (types.isRationalObj(args[0]))
+            bignum_mod.isNegative(types.toRational(args[0]).numerator)
+        else
+            bignum_mod.isNegative(args[0]);
+        if (negative) {
+            const pos = try negateExact(gc, args[0]);
+            var slot_pos = gc.rootedSlot(pos) catch return PrimitiveError.OutOfMemory;
+            defer slot_pos.release();
+            if (try exactSqrt(gc, slot_pos.get())) |root| {
+                return gc.allocComplex(types.makeFixnum(0), root) catch return PrimitiveError.OutOfMemory;
             }
+        } else if (try exactSqrt(gc, args[0])) |root| {
+            return root;
         }
     }
     const f = try toF64(args[0]);
@@ -595,12 +598,41 @@ fn sqrtFn(args: []const Value) PrimitiveError!Value {
         const imag = @sqrt(-f);
         return makeComplexOrReal(0.0, imag);
     }
-    const result = @sqrt(f);
-    if (types.isFixnum(args[0])) {
-        const ri: i64 = @intFromFloat(result);
-        if (ri * ri == types.toFixnum(args[0])) return types.makeFixnum(ri);
+    return makeFlonumVal(@sqrt(f));
+}
+
+/// Negate an exact number (fixnum, bignum, or rational). The result is
+/// unrooted; callers must root it before allocating.
+fn negateExact(gc: *memory.GC, v: Value) PrimitiveError!Value {
+    if (types.isRationalObj(v)) {
+        const rat = types.toRational(v);
+        const neg_num = bignum_mod.negate(gc, rat.numerator) catch return PrimitiveError.OutOfMemory;
+        var slot = gc.rootedSlot(neg_num) catch return PrimitiveError.OutOfMemory;
+        defer slot.release();
+        return arith.makeRationalReduced(gc, slot.get(), rat.denominator);
     }
-    return makeFlonumVal(result);
+    return bignum_mod.negate(gc, v) catch return PrimitiveError.OutOfMemory;
+}
+
+/// Exact square root of a NON-NEGATIVE exact number, or null when the
+/// argument is not a perfect square (so the caller falls back to the inexact
+/// path). Integers use the shared exact-integer-sqrt helper; a rational is a
+/// perfect square iff numerator and denominator both are. The result is
+/// unrooted.
+fn exactSqrt(gc: *memory.GC, v: Value) PrimitiveError!?Value {
+    if (types.isRationalObj(v)) {
+        const rat = types.toRational(v);
+        const num_r = try isqrtNonNegative(gc, rat.numerator);
+        if (!bignum_mod.isZero(num_r.rem)) return null;
+        var slot_root = gc.rootedSlot(num_r.root) catch return PrimitiveError.OutOfMemory;
+        defer slot_root.release();
+        const den_r = try isqrtNonNegative(gc, rat.denominator);
+        if (!bignum_mod.isZero(den_r.rem)) return null;
+        return try arith.makeRationalReduced(gc, slot_root.get(), den_r.root);
+    }
+    const r = try isqrtNonNegative(gc, v);
+    if (!bignum_mod.isZero(r.rem)) return null;
+    return r.root;
 }
 
 const IsqrtResult = struct { root: Value, rem: Value };

--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -578,6 +578,12 @@ fn sqrtFn(args: []const Value) PrimitiveError!Value {
         // convention that exact notation denotes an exact number
         // (kaappi#2503) -- so a negative perfect square becomes the exact
         // complex 0+root*i rather than falling through to the f64 path.
+        // The rational arm is load-bearing, not cosmetic: bignum_mod.isNegative
+        // answers false for any Value that is not a fixnum or bignum, so a
+        // flattened isNegative(args[0]) would classify every negative rational
+        // as non-negative and hand exactSqrt a negative numerator -- where
+        // isqrtNonNegative evaluates @intFromFloat(@sqrt(-9.0)), a NaN, and
+        // panics in ReleaseSafe on plain (sqrt -9/4).
         const negative = if (types.isRationalObj(args[0]))
             bignum_mod.isNegative(types.toRational(args[0]).numerator)
         else
@@ -587,6 +593,11 @@ fn sqrtFn(args: []const Value) PrimitiveError!Value {
             var slot_pos = gc.rootedSlot(pos) catch return PrimitiveError.OutOfMemory;
             defer slot_pos.release();
             if (try exactSqrt(gc, slot_pos.get())) |root| {
+                // `root` is unrooted, and that is safe only because it goes
+                // STRAIGHT into allocComplex, which roots both arguments
+                // (rootArgs2) before maybeCollect. Anything allocating
+                // inserted between the exactSqrt call and this line must
+                // root it first.
                 return gc.allocComplex(types.makeFixnum(0), root) catch return PrimitiveError.OutOfMemory;
             }
         } else if (try exactSqrt(gc, args[0])) |root| {

--- a/tests/scheme/compliance/complex-exactness-2166-2167.scm
+++ b/tests/scheme/compliance/complex-exactness-2166-2167.scm
@@ -120,7 +120,7 @@
 (test-assert "expt exact zero exponent is 1" (eqv? (expt 1+2i 0) 1))
 (test-assert "negation exact round-trip" (eqv? (- (- z)) z))
 (test-assert "magnitude stays inexact (out of scope)" (inexact? (magnitude z)))
-(test-assert "sqrt of exact complex stays inexact (out of scope)" (inexact? (sqrt -4)))
+(test-assert "sqrt of a negative exact square is exact (kaappi#2503)" (eqv? (sqrt -4) +2i))
 
 ;; --- #2166 (full): make-rectangular never rounds ---------------------------
 

--- a/tests/scheme/compliance/sqrt-exact.scm
+++ b/tests/scheme/compliance/sqrt-exact.scm
@@ -40,9 +40,37 @@
 (test-assert "(sqrt 4.0) inexact" (inexact? (sqrt 4.0)))
 (test-equal "(sqrt 4.0)" 2.0 (sqrt 4.0))
 
-;; Negative exact rational -> complex (inexact) result, not an error
-(test-approximate "(sqrt -9/4) imag" 1.5 (imag-part (sqrt -9/4)) 1e-9)
-(test-approximate "(sqrt -9/4) real" 0.0 (real-part (sqrt -9/4)) 1e-9)
+;; Negative exact perfect squares -> exact complex (kaappi#2503).
+;; R7RS 6.2.6: (sqrt -1) => +i, exact under the section's own convention.
+(test-assert "(sqrt -1) is +i" (eqv? (sqrt -1) +i))
+(test-assert "(sqrt -1) exact" (exact? (sqrt -1)))
+(test-equal "(sqrt -1) real-part" 0 (real-part (sqrt -1)))
+(test-equal "(sqrt -1) imag-part" 1 (imag-part (sqrt -1)))
+(test-assert "(sqrt -4) is +2i" (eqv? (sqrt -4) +2i))
+(test-assert "(sqrt -9/4) is +3/2i" (eqv? (sqrt -9/4) (make-rectangular 0 3/2)))
+(test-assert "(sqrt -1/4) is +1/2i" (eqv? (sqrt -1/4) (make-rectangular 0 1/2)))
+(test-equal "(sqrt -4) imaginary part is non-negative" 2 (imag-part (sqrt -4)))
+(test-assert "negative bignum perfect square"
+  (eqv? (sqrt (- (* big big))) (make-rectangular 0 big)))
+(test-assert "negative rational with bignum denominator"
+  (eqv? (sqrt (/ -9 (* big big))) (make-rectangular 0 (/ 3 big))))
+(test-assert "most negative fixnum squares stay exact"
+  (eqv? (sqrt (- (* 140737488355328 140737488355328)))
+        (make-rectangular 0 140737488355328)))   ; 2^47
+(test-assert "(sqrt -1) squares back to -1" (eqv? (* (sqrt -1) (sqrt -1)) -1))
+(test-assert "(sqrt -1) is not eqv? to its inexact twin" (not (eqv? (sqrt -1) +1.0i)))
+
+;; Negative exact non-squares stay inexact complex, with the right sign
+(test-assert "(sqrt -2) inexact" (inexact? (sqrt -2)))
+(test-approximate "(sqrt -2) imag" 1.4142135623730951 (imag-part (sqrt -2)) 1e-12)
+(test-assert "(sqrt -2/3) inexact" (inexact? (sqrt -2/3)))
+(test-assert "(sqrt -9/2) inexact" (inexact? (sqrt -9/2)))
+
+;; Negative inexact arguments are unchanged
+(test-assert "(sqrt -1.0) inexact" (inexact? (sqrt -1.0)))
+(test-assert "(sqrt -1.0) is +1.0i" (eqv? (sqrt -1.0) +1.0i))
+(test-assert "(sqrt -4.0) is +2.0i" (eqv? (sqrt -4.0) +2.0i))
+(test-assert "(sqrt -0.0) is -0.0" (eqv? (sqrt -0.0) -0.0))
 
 ;; exact-integer-sqrt still works through the shared helper
 (test-equal "(exact-integer-sqrt 17)" '(4 1)


### PR DESCRIPTION
## Summary

R7RS §6.2.6 (errata-corrected PDF p. 38) gives `(sqrt -1) ⟹ +i`, exact under the section's stated convention that exact notation denotes an exact number. Kaappi returned inexact `+1.0i` for every negative exact argument, because the exact bignum/rational paths in `sqrtFn` were guarded by `!isNegative` and the fixnum perfect-square check ran only after the `f < 0.0` branch had returned.

This PR:

- Folds the three exact paths in `sqrtFn` into one `exactSqrt` helper (fixnum, bignum, rational; returns `null` for a non-square).
- For a negative exact argument, takes the exact root of its negation and returns `0+root*i` with an exact fixnum zero real part.
- Leaves negative non-squares on the inexact complex path and negative inexact arguments untouched.

| Expression | Before | After |
|---|---|---|
| `(sqrt -1)` | `+1.0i` | `+i` |
| `(eqv? (sqrt -1) +i)` | `#f` | `#t` |
| `(sqrt -9/4)` | `+1.5i` | `+3/2i` |
| `(* (sqrt -1) (sqrt -1))` | `-1.0+0.0i` | `-1` |
| `(sqrt -2)` | `+1.4142135623730951i` | unchanged |
| `(sqrt -1.0)` | `+1.0i` | unchanged |

## Tests

- `tests/scheme/compliance/sqrt-exact.scm`: negative fixnum, bignum, rational, the 2^47 fixnum boundary, non-squares staying inexact, inexact arguments unchanged (46 passes, was 33).
- `tests/scheme/compliance/complex-exactness-2166-2167.scm`: the "out of scope" `(inexact? (sqrt -4))` assertion flips to `(eqv? (sqrt -4) +2i)`.
- R7RS suite 1395/0, numeric unit tests 58/58, and `sqrt-exact.scm` green under a `-Dgc-stress=true` build.

Fixes #2503

🤖 Generated with [Claude Code](https://claude.com/claude-code)
