### PR TITLE
Stop exporting sqrt from (scheme base)

### DIFF
--- a/src/primitives_numeric.zig
+++ b/src/primitives_numeric.zig
@@ -94,7 +94,7 @@ pub const specs = [_]primitives.PrimSpec{
     .{ .name = "inexact", .func = &inexactFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "expt", .func = &exptFn, .arity = .{ .exact = 2 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_r5rs }) },
     .{ .name = "square", .func = &squareFn, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
-    .{ .name = "sqrt", .func = &sqrtFn, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_base, .scheme_inexact, .scheme_r5rs }) },
+    .{ .name = "sqrt", .func = &sqrtFn, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_inexact, .scheme_r5rs }) },
     .{ .name = "exact-integer-sqrt", .func = &exactIntegerSqrt, .arity = .{ .exact = 1 }, .libs = LS.initOne(.scheme_base) },
     .{ .name = "sin", .func = &sinFn, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_inexact, .scheme_r5rs }) },
     .{ .name = "cos", .func = &cosFn, .arity = .{ .exact = 1 }, .libs = LS.initMany(&.{ .scheme_inexact, .scheme_r5rs }) },

--- a/tests/scheme/compliance/complex-exactness-2166-2167.scm
+++ b/tests/scheme/compliance/complex-exactness-2166-2167.scm
@@ -17,7 +17,7 @@
 ;; These tests pin the full behavior, including the exact arithmetic the
 ;; interim slice deliberately left inexact.
 
-(import (scheme base) (scheme complex) (scheme write) (scheme process-context) (srfi 64) (srfi 69))
+(import (scheme base) (scheme complex) (scheme inexact) (scheme write) (scheme process-context) (srfi 64) (srfi 69))
 
 (define (write-to-string v)
   (let ((port (open-output-string)))

--- a/tests/scheme/compliance/r7rs-control-io-gaps.scm
+++ b/tests/scheme/compliance/r7rs-control-io-gaps.scm
@@ -5,7 +5,7 @@
 ;; guard/parameterize) are Phase 4B's unit, not covered here.
 ;; Spec references cite docs/errata-corrected-r7rs.pdf.
 
-(import (scheme base) (scheme write) (scheme read) (scheme eval) (scheme file)
+(import (scheme base) (scheme inexact) (scheme write) (scheme read) (scheme eval) (scheme file)
         (scheme time) (scheme char) (scheme process-context) (srfi 64))
 
 ;; Windows preserves case but names are case-insensitive ("Path"), so

--- a/tests/scheme/smoke/expt-negative-base-1725.scm
+++ b/tests/scheme/smoke/expt-negative-base-1725.scm
@@ -1,7 +1,7 @@
 ;; Regression test for #1725: expt doesn't promote to complex for a negative
 ;; real base combined with a non-integer real exponent.
 
-(import (scheme base) (scheme write) (scheme process-context) (srfi 64))
+(import (scheme base) (scheme inexact) (scheme write) (scheme process-context) (srfi 64))
 
 (test-begin "expt-negative-base-1725")
 

--- a/tests/scheme/smoke/lib2504/mathlib.sld
+++ b/tests/scheme/smoke/lib2504/mathlib.sld
@@ -1,0 +1,12 @@
+;; A library that defines and exports its own sqrt while importing only
+;; (scheme base). Legal under R7RS: sqrt is an inexact library procedure
+;; (§6.2.6), exported by (scheme inexact) and absent from (scheme base), so
+;; there is no redefinition of an imported binding here.
+(define-library (lib2504 mathlib)
+  (import (scheme base))
+  (export sqrt hypot-ish)
+  (begin
+    (define (sqrt x) (list 'lib-mine x))
+    ;; A same-library caller resolves to the library's own definition, not
+    ;; the built-in it never imported.
+    (define (hypot-ish a b) (sqrt (+ (* a a) (* b b))))))

--- a/tests/scheme/smoke/sqrt-user-library-2504.scm
+++ b/tests/scheme/smoke/sqrt-user-library-2504.scm
@@ -30,6 +30,13 @@
              (eq? (eval 'sqrt (environment '(scheme inexact)))
                   (eval 'sqrt (environment '(scheme r5rs)))))
 
+;; The other half of the change: a (scheme base) environment no longer
+;; resolves sqrt at all. Nothing else in the suite would notice the tag
+;; silently coming back — library and program bodies fall through to the
+;; globals map, so only a restricted environment can tell.
+(test-error "(scheme base) no longer resolves sqrt"
+            (eval 'sqrt (environment '(scheme base))))
+
 ;; (scheme base) keeps exact-integer-sqrt — that one really is a base export.
 (test-equal "(scheme base) exports exact-integer-sqrt"
             '(4 1) (eval '(call-with-values (lambda () (exact-integer-sqrt 17)) list)

--- a/tests/scheme/smoke/sqrt-user-library-2504.scm
+++ b/tests/scheme/smoke/sqrt-user-library-2504.scm
@@ -1,0 +1,49 @@
+;; Regression test for #2504: (scheme base) exported sqrt, which R7RS reserves
+;; to (scheme inexact) (§6.2.6; Appendix A lists exact-integer-sqrt, not sqrt,
+;; among the base exports). Since kaappi enforces R7RS 5.2 (importing one
+;; identifier from two libraries with different bindings is an error), a
+;; portable program that imported (scheme base) together with a user library
+;; exporting its own sqrt failed to load with KP2001 — the same collision
+;; class as #1856's %-prefixed base exports, with a name a math library is far
+;; more likely to define.
+;;
+;; The fixture library lives in lib2504/ and is found via the script's own
+;; directory on the library search path.
+(import (scheme base) (scheme write) (scheme process-context) (srfi 64)
+        (lib2504 mathlib))
+
+(test-begin "sqrt-user-library-2504")
+
+;; The program loads at all — this is the issue's own reproduction: with
+;; (scheme base) no longer exporting sqrt, the two imports do not collide.
+(test-equal "user sqrt is the user's" '(lib-mine 4) (sqrt 4))
+(test-equal "library-internal caller sees the library's sqrt"
+            '(lib-mine 25) (hypot-ish 3 4))
+
+;; The built-in is still reachable from the libraries R7RS and R5RS assign it
+;; to, and is the same procedure via both.
+(test-equal "(scheme inexact) exports sqrt"
+            2 (eval '(sqrt 4) (environment '(scheme inexact))))
+(test-equal "(scheme r5rs) exports sqrt"
+            3 (eval '(sqrt 9) (environment '(scheme r5rs))))
+(test-assert "inexact and r5rs sqrt are one binding"
+             (eq? (eval 'sqrt (environment '(scheme inexact)))
+                  (eval 'sqrt (environment '(scheme r5rs)))))
+
+;; (scheme base) keeps exact-integer-sqrt — that one really is a base export.
+(test-equal "(scheme base) exports exact-integer-sqrt"
+            '(4 1) (eval '(call-with-values (lambda () (exact-integer-sqrt 17)) list)
+                         (environment '(scheme base))))
+
+;; Renaming around the user library still reaches the built-in, so a program
+;; that wants both can have both.
+(test-equal "prefixed built-in alongside the user's"
+            '(2 (lib-mine 4))
+            (eval '(list (in:sqrt 4) (sqrt 4))
+                  (environment '(scheme base)
+                               '(prefix (scheme inexact) in:)
+                               '(lib2504 mathlib))))
+
+(let ((runner (test-runner-current)))
+  (test-end "sqrt-user-library-2504")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi231-official-transform.py
+++ b/tests/scheme/srfi/srfi231-official-transform.py
@@ -741,6 +741,19 @@ NEW_REPORT = ''';;; --- kaappi vendoring: known-divergence accounting ----------
 ;;; unchecked, which the spec text permits but the reference does not do.
 ;;; kaappi now always checks the user-visible getter/setter, so that
 ;;; divergence is resolved rather than documented.
+;;;
+;;; Entries 737-741 lived here until kaappi#2454. They arrived with
+;;; kaappi#2451: these five forms' getters capture a continuation and
+;;; re-invoke it after the copy has returned, which used to raise
+;;; "continuation cannot resume across a returned native call" and,
+;;; once #2452 removed that engine limit, reached a library divergence
+;;; instead -- %array-copy-impl (lib/srfi/231/views.sld) filled the
+;;; destination directly, so the re-entry overwrote the array the first
+;;; copy already returned. array-copy now collects the source's values
+;;; through a functional accumulator before the destination exists, so
+;;; the re-entry materializes its own array; array-append/stack/block/
+;;; decurry delegate to array-copy, which is why one change resolved
+;;; all five. That divergence is resolved rather than documented.
 (define divergent-tests 0)
 (define diverged-counts (make-vector 10000 0))
 (define known-divergences

--- a/tests/scheme/srfi/srfi231-official-transform.py
+++ b/tests/scheme/srfi/srfi231-official-transform.py
@@ -293,7 +293,7 @@ old_include = '''(begin
   (include "generic-arrays.scm"))'''
 new_include = '''(import (srfi 231) (srfi 27) (srfi 143) (srfi 4)
         (srfi 160 u64) (srfi 160 s64)
-        (scheme base) (scheme write) (scheme char) (scheme cxr)
+        (scheme base) (scheme inexact) (scheme write) (scheme char) (scheme cxr)
         (scheme file) (scheme read) (scheme lazy))'''
 assert old_include in src
 src = src.replace(old_include, new_include)

--- a/tests/scheme/srfi/srfi231-official.scm
+++ b/tests/scheme/srfi/srfi231-official.scm
@@ -66,7 +66,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 (import (srfi 231) (srfi 27) (srfi 143) (srfi 4)
         (srfi 160 u64) (srfi 160 s64)
-        (scheme base) (scheme write) (scheme char) (scheme cxr)
+        (scheme base) (scheme inexact) (scheme write) (scheme char) (scheme cxr)
         (scheme file) (scheme read) (scheme lazy)
         (scheme process-context))
 


### PR DESCRIPTION
Closes #2504

## What

Drop the `.scheme_base` tag from the `sqrt` spec entry in `src/primitives_numeric.zig`. R7RS §6.2.6 makes `sqrt` an inexact library procedure: `(scheme inexact)` exports it, `(scheme base)` does not (Appendix A lists `exact-integer-sqrt` among the base exports, not `sqrt`). It was the only `(scheme inexact)` procedure carrying the extra tag; the `(scheme r5rs)` tag stays.

## Why

Since v0.22.0 Kaappi enforces R7RS 5.2, so a portable, spec-legal program that imports `(scheme base)` next to a user library exporting its own `sqrt` failed to load with KP2001. Same collision class as #1856, with a name a math library is far more likely to define (kaappi-mpl works around it today).

## Behaviour change (`breaking`, non-standard extension)

- `(scheme inexact)` and `(scheme r5rs)` still export `sqrt`, and library/program bodies still resolve an unimported `sqrt` through the globals map. Code that just calls `sqrt` after importing only `(scheme base)` keeps running.
- `sqrt` is no longer visible in a restricted environment built from `(scheme base)` alone: `(eval '(sqrt 4) (environment '(scheme base)))` is now KP3001, as R7RS specifies.
- Any import selector naming `sqrt` out of `(scheme base)` — `only`, `except`, or `rename` — is now KP2001 ("not found in import set"), which R7RS 5.2 also specifies. kaappi-mpl has four such sites (three libraries and its test file), all workarounds for exactly this collision; kaappi/kaappi-mpl#3 removes them. That PR needs this change, so the nightly `pure-libs` group is red for kaappi-mpl between this merging and that merging, and kaappi-mpl's own CI (pinned to the latest release) is red for it until the next release.

## Tests

- New `tests/scheme/smoke/sqrt-user-library-2504.scm` + `lib2504/mathlib.sld`: loads a library exporting its own `sqrt` alongside `(scheme base)` (the issue's reproduction, KP2001 before this change), checks `(scheme inexact)`/`(scheme r5rs)` still hand out the same built-in, `(scheme base)` keeps `exact-integer-sqrt`, and a `prefix` import gives a program both.
- `(scheme inexact)` added to the four in-repo tests that reached `sqrt` through base alone (`expt-negative-base-1725`, `complex-exactness-2166-2167`, `r7rs-control-io-gaps`, `srfi231-official` and its generator script). The smoke test also pins that `(environment '(scheme base))` no longer resolves `sqrt`. The SRFI 231 generator now emits the #2461 known-divergence note it had drifted from, so regeneration is a no-op again.
- `zig build test`: 1918 pass, 21 skip. `tests/scheme/run-all.sh`: 2144 pass, 0 fail (R7RS suite 1395/1395). kaappi-mpl's suite with kaappi/kaappi-mpl#3 applied: 226/226 against this branch's binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)