### PR TITLE
Refresh the source line count in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Kaappi — R7RS Scheme in Zig
 
-Complete R7RS-small Scheme implementation. Zig 0.16, ~100k lines, 717 built-in
+Complete R7RS-small Scheme implementation. Zig 0.16, ~120k lines, 717 built-in
 procedures, 180 SRFIs.
 
 This file is the orientation map. Detail lives in `docs/dev/` — every section


### PR DESCRIPTION
`CLAUDE.md`'s orientation line has said `~100k lines` since ec875b3f
(2026-08-04) — a commit whose own subject was "correct the drift found
doing it". At that commit `src/*.zig` excluding `*tests*` measured
**99,064** lines, which pins the metric the figure was counting.

That same measure is now **118,294**, so the line understates the tree
by roughly 20%. Updated to `~120k`.

I deliberately kept the original metric (non-test `src/*.zig`) rather
than switching to the all-inclusive count, which is currently ~156k —
a swap would have made the new number incomparable to the one it
replaces and inflated the apparent jump.

No other `~100k` copy exists in the repo. The only other `100k` is
`docs/dev/llvm-backend.md:889` ("Tail-recursive loops (100k
iterations)"), a benchmark iteration count, left untouched.

Found while correcting stale SRFI counts (178/174/162 → 180/176/164,
which missed the v0.26.0 bump that added SRFI 273 and 274) in the
workspace-level `CLAUDE.md`, which lives outside any git repo and so is
not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)