### PR TITLE
Make char-ready? and u8-ready? report real fd readiness

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -166,6 +166,7 @@ its struct lives outside `types.zig` entirely with no `types.Fiber` re-export.
 | `bytecode_file.zig` | `.sbc` codec hub: shared format contract (magic, version, tags, limits), `BytecodeError`, `compilerHash`/`sourceHash`/`getSbcPath`, re-exports of the read/write halves |
 | `bytecode_file_write.zig` | Serializer: `Writer`, `writeConstant`, function collection, `writeFileWithTopLevel`/`writeFileWithBundle` |
 | `bytecode_file_read.zig` | Deserializer: `Reader`, `readConstant`, bytecode validation, `deserializeFromBuffer`, `readHeaderInfo`, `DeserializeResult`/`HeaderInfo` |
+| `port_readiness.zig` | Readiness oracles behind `char-ready?`/`u8-ready?` (kaappi#2511): byte-granular `portReadyNow` (u8-ready?), character-granular `charReadyNow` (char-ready? — a lone UTF-8 lead byte is not a ready character; the fd arm poll-gates a non-parking drain into the port's own buffers), the zero-timeout fd probe, and the custom/transcoded-port readiness contracts |
 | `disassembler.zig` | Bytecode disassembler for `(disassemble proc)` |
 | `isocline.zig` | Zig FFI wrapper for the vendored isocline line editor |
 | `main.zig` | Entry point, file execution, CLI flags, `pub const version`, `pub const panic` (the REPL loop lives in `repl.zig`) |

--- a/src/port_readiness.zig
+++ b/src/port_readiness.zig
@@ -1,0 +1,351 @@
+//! Port readiness oracles behind `char-ready?` and `u8-ready?` — kaappi#2511
+//! plus its PR review round (#2516).
+//!
+//! R7RS 6.13.1 hangs a hard guarantee on these predicates: "If char-ready?
+//! returns #t then the next read-char operation on the given port is
+//! guaranteed not to hang" (6.13.3 says the same of u8-ready?), and both must
+//! return #t at end of file (#1179). The pre-fix code returned #t
+//! unconditionally, so a poll-then-read drive loop on a subprocess pipe fell
+//! straight into the blocking read it was polling to avoid. Extracted from
+//! primitives_io.zig so the readiness layer has one cohesive home (the rest
+//! of that file stays put — it is a flat primitives file, which the repo's
+//! file-size policy explicitly exempts from the 1500-line cap).
+//!
+//! Two oracles live here because the two predicates promise different things:
+//!
+//! * `portReadyNow` — byte readiness (u8-ready? via primitives_bytevector).
+//!   One available byte, or an EOF/error that answers at once, is enough.
+//!
+//! * `charReadyNow` — character readiness (char-ready? via primitives_io).
+//!   A *complete* character must be available: a lone UTF-8 lead byte makes
+//!   the fd readable, but read-char would consume it and then block waiting
+//!   for the continuation — exactly the hang the #t guarantee forbids. The
+//!   predicate therefore drains whatever the fd holds *right now* into the
+//!   port's own software buffers (peek_byte/peek_extra/read_buf — the same
+//!   buffers every read drains, so nothing Scheme-visible is consumed or
+//!   reordered) and then checks buffered completeness. The drain never parks
+//!   (this is a synchronous predicate, not a scheduler operation): it only
+//!   reads when a zero-timeout poll just said data is there, and treats
+//!   would-block as a conservative #f — which R7RS permits, since only #t
+//!   carries the guarantee.
+//!
+//! Custom ports (SRFI 181) have no readiness contract: read! is arbitrary
+//! Scheme code with no non-blocking probe, so the only truthful answer
+//! without invoking it (a side effect a predicate must not have) is #f until
+//! a complete character is already buffered — and #t when the port is
+//! output-only, whose reads are EOF forever. Both oracles hold that line.
+//! Likewise a transcoded port's readiness is its wrapped port's *character*
+//! readiness under both predicates: the transcoded layer emits whole
+//! re-encoded characters, so a single buffered wrapped byte — byte-ready as
+//! it may be — cannot produce even one output byte without possibly
+//! blocking.
+//!
+//! WASM keeps the historical best-effort #t everywhere readiness cannot be
+//! queried (KEP-0001 Phase 4): wasmtime's poll_oneoff cannot serve a
+//! zero-timeout snapshot here, and draining on a host that cannot report
+//! readiness could block the only fiber.
+
+const std = @import("std");
+const platform = @import("platform.zig");
+const is_wasm = @import("builtin").os.tag == .wasi;
+const types = @import("types.zig");
+const memory = @import("memory.zig");
+const primitives_io = @import("primitives_io.zig");
+
+/// Byte-granular readiness oracle behind `u8-ready?` (primitives_bytevector).
+/// True iff the next read on `port` completes immediately, from a software
+/// buffer, an inexhaustible or at-EOF source, or an underlying fd that has a
+/// byte (or EOF/error) available right now.
+///
+/// Mirrors readOneByte's port-kind dispatch in the same order so the two can
+/// never disagree about which source serves the next byte:
+///
+///   peek_byte / peek_extra / read_buf   buffered bytes -> true
+///   random_gen                          inexhaustible -> true
+///   string port                         data or EOF, never blocks -> true
+///   custom port (SRFI 181)              no readiness contract for read!;
+///                                       true only when output-only (reads
+///                                       are EOF forever), else buffered
+///                                       bytes only (checked above)
+///   transcoded port (SRFI 181)          recursion on the wrapped port's
+///                                       *character* readiness — the port's
+///                                       own peek/read buffers checked above
+///                                       already hold any re-encoded
+///                                       leftovers
+///   fd                                  fdReadReadyNow: a zero-timeout
+///                                       poll of the fd itself, never a
+///                                       park
+pub fn portReadyNow(port: *types.Port) bool {
+    if (port.peek_byte != null or port.peek_extra_len > 0) return true;
+    if (port.read_buf_len > 0) return true;
+    if (port.random_gen != null) return true;
+    if (port.is_string_port) return true;
+    if (port.custom_backend) |cb| return cb.read_proc == types.FALSE;
+    if (port.transcode) |ts| {
+        const wrapped = types.toObject(ts.wrapped_port).as(types.Port);
+        return charReadyNow(wrapped);
+    }
+    return fdReadReadyNow(port.fd);
+}
+
+/// Character-granular readiness oracle behind `char-ready?`
+/// (primitives_io). True iff the next read-char answers immediately: a
+/// complete character (or an invalid lead byte, which read-char returns
+/// as-is) is already buffered, or the source can never block (string data,
+/// random bytes), or the fd can complete the character right now / is at
+/// EOF / is about to raise. False is always a *may* hang, never a promise.
+pub fn charReadyNow(port: *types.Port) bool {
+    if (bufferedCharComplete(port)) return true;
+    if (port.random_gen != null) return true;
+    // A string source never blocks; even a truncated UTF-8 tail answers at
+    // once (readUtf8Char returns the lead byte alone at EOF).
+    if (port.is_string_port) return true;
+    // Custom backend: documented contract above — ready only when buffered
+    // (checked first) or when read! is absent and reads are EOF forever.
+    if (port.custom_backend) |cb| return cb.read_proc == types.FALSE;
+    if (port.transcode) |ts| {
+        const wrapped = types.toObject(ts.wrapped_port).as(types.Port);
+        return charReadyNow(wrapped);
+    }
+    return switch (fdCharReadyNow(port)) {
+        .ready => true,
+        .would_block => false,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Software-buffer completeness
+// ---------------------------------------------------------------------------
+
+/// The next undelivered stream byte across the software buffers, in the
+/// order readOneByte drains them: peek_byte, then peek_extra, then the live
+/// span of read_buf.
+fn headByte(port: *types.Port) ?u8 {
+    if (port.peek_byte) |b| return b;
+    if (port.peek_extra_len > 0) return port.peek_extra[0];
+    if (port.read_buf) |rb| {
+        if (port.read_buf_len > 0) return rb[rb.len - port.read_buf_len];
+    }
+    return null;
+}
+
+fn bufferedByteCount(port: *types.Port) usize {
+    var n: usize = if (port.peek_byte != null) 1 else 0;
+    n += port.peek_extra_len;
+    n += port.read_buf_len;
+    return n;
+}
+
+/// Whether the software buffers hold a complete character: at least as many
+/// bytes as the head byte's UTF-8 sequence length. An invalid lead byte is
+/// "complete" — readUtf8Char returns it as a single Latin-1 character rather
+/// than waiting for continuations — and decodability need not be checked,
+/// since a decode failure also answers immediately (the Latin-1 fallback).
+fn bufferedCharComplete(port: *types.Port) bool {
+    const lead = headByte(port) orelse return false;
+    const seq_len = std.unicode.utf8ByteSequenceLength(lead) catch return true;
+    return bufferedByteCount(port) >= seq_len;
+}
+
+// ---------------------------------------------------------------------------
+// fd readiness
+// ---------------------------------------------------------------------------
+
+/// What one zero-timeout poll of an fd says about reading it right now.
+const FdReadSnapshot = struct {
+    /// The query itself failed; callers report ready (fdReadReadyNow's
+    /// standing rule: a wrong #f stalls a polling loop on data that arrived
+    /// between checks, while a spurious #t costs exactly one blocking read).
+    failed: bool,
+    /// A read returns at least one byte right now (POLLIN / oracle).
+    data: bool,
+    /// A read answers at once with EOF or an error instead: POLLHUP,
+    /// POLLERR, POLLNVAL on POSIX. Unknown (false) on Windows, whose
+    /// pipe/console oracles cannot distinguish it — there the conservative
+    /// loop below simply reports would-block instead.
+    closed_or_err: bool,
+};
+
+fn pollReadSnapshot(fd: platform.fd_t) FdReadSnapshot {
+    if (comptime platform.is_windows) {
+        // The reactor's own oracles (reactor_backends.arm() uses the same
+        // pair): PeekNamedPipe for pipe ends, a 0-timeout select() for
+        // sockets. Regular files and consoles have no cheap oracle, and a
+        // read on either way never blocks on data arrival — data.
+        switch (platform.fdKind(fd)) {
+            .socket => {
+                platform.ensureWinsock();
+                const sock = platform.sockFromFd(fd) orelse
+                    return .{ .failed = true, .data = false, .closed_or_err = false };
+                return .{ .failed = false, .data = platform.sockPollReady(sock, true, false).readable, .closed_or_err = false };
+            },
+            .pipe => return .{ .failed = false, .data = platform.pipePollReady(fd, true, false).readable, .closed_or_err = false },
+            .other => return .{ .failed = false, .data = true, .closed_or_err = false },
+        }
+    }
+    if (comptime is_wasm) {
+        // WASI has no poll(2) — std.posix.poll does not compile there
+        // (std.Io.Threaded's own have_poll excludes it), and KEP-0001
+        // Phase 4 keeps fd readiness best-effort on wasm hosts: the
+        // playground shim cannot report it at all. Preserve the
+        // historical #t rather than an always-#f no host could disprove.
+        return .{ .failed = false, .data = true, .closed_or_err = false };
+    }
+    var fds = [1]std.posix.pollfd{.{
+        .fd = fd,
+        .events = std.posix.POLL.IN,
+        .revents = 0,
+    }};
+    const n = std.posix.poll(&fds, 0) catch
+        return .{ .failed = true, .data = false, .closed_or_err = false };
+    if (n == 0) return .{ .failed = false, .data = false, .closed_or_err = false };
+    return .{
+        .failed = false,
+        .data = fds[0].revents & std.posix.POLL.IN != 0,
+        .closed_or_err = fds[0].revents & (std.posix.POLL.HUP |
+            std.posix.POLL.ERR | std.posix.POLL.NVAL) != 0,
+    };
+}
+
+/// Zero-timeout readability snapshot of a port's fd: true iff a read right
+/// now would return data, EOF, or an error rather than blocking. POLLHUP,
+/// POLLERR, and POLLNVAL count as ready — a pipe whose writer closed reads
+/// EOF immediately (R7RS's "at end of file, ready" case, kaappi#1179), an
+/// errored fd surfaces the error, not a hang, and poll only reports
+/// POLLNVAL for an fd a read would reject at once. Any query failure also
+/// reports ready: the wrong #f here stalls a polling drive loop on data
+/// that arrived between the buffer check and the fd, while a spurious #t
+/// costs exactly one blocking read — the pre-fix behavior everywhere.
+pub fn fdReadReadyNow(fd: platform.fd_t) bool {
+    const s = pollReadSnapshot(fd);
+    return s.failed or s.data or s.closed_or_err;
+}
+
+// ---------------------------------------------------------------------------
+// The character-completing drain (char-ready?'s fd arm)
+// ---------------------------------------------------------------------------
+
+const CharFdVerdict = enum { ready, would_block };
+
+/// Decides, without consuming Scheme-visible input, whether read-char on an
+/// fd-backed `port` answers immediately, given that the software buffers
+/// currently hold an incomplete character (or nothing at all).
+///
+/// The loop poll-gates every read: a read(2) only runs when the zero-timeout
+/// poll snapshot taken in the same iteration reported data, so a blocking fd
+/// is never read blind — the same discipline readOneByte's reactor path
+/// follows, minus the park (a predicate must not suspend the fiber; EAGAIN
+/// becomes a conservative would-block instead). Bytes read here are stashed
+/// into the port's software buffers and stay fully Scheme-visible: read_buf
+/// and the peek slots are the stream, not a copy of it, and every later read
+/// primitive drains them in order.
+///
+/// EOF and pending errors are "ready" even mid-sequence: readUtf8Char
+/// returns a truncated tail's lead byte alone rather than blocking, and an
+/// errored fd raises at once. Writes are deliberately NOT flushed first
+/// (readOneByte does, for request/response liveness): the flush can itself
+/// park, and any bytes drained here merely wait one read longer in read_buf
+/// — the next real read still flushes before touching the fd.
+fn fdCharReadyNow(port: *types.Port) CharFdVerdict {
+    // WASM: no poll oracle exists (see pollReadSnapshot); draining on a host
+    // that cannot report readiness could block the only fiber, so keep the
+    // best-effort #t instead (KEP-0001 Phase 4 degradation).
+    if (comptime is_wasm) return .ready;
+
+    // A character needs at most 4 bytes and every successful read returns at
+    // least one, so a handful of iterations suffices; the guard bounds a
+    // pathological writer that dribbles one byte per poll round.
+    var guard: usize = 0;
+    while (guard < 8) : (guard += 1) {
+        const snap = pollReadSnapshot(port.fd);
+        if (snap.failed) return .ready;
+        if (!snap.data) {
+            // Nothing readable right now. EOF/error pending still answers a
+            // read at once — ready even though the buffered character is
+            // incomplete. A quiet fd with the writer alive is the truthful #f.
+            return if (snap.closed_or_err) .ready else .would_block;
+        }
+        // How many more bytes would complete the head character? With no
+        // head byte yet, fetch one; with one, fetch exactly the remainder.
+        var needed: usize = 1;
+        if (headByte(port)) |h| {
+            const seq_len = std.unicode.utf8ByteSequenceLength(h) catch return .ready;
+            needed = seq_len - bufferedByteCount(port);
+        }
+        // Reserve any read_buf growth before reading: bytes pulled off the
+        // fd that cannot be kept are data loss, not a readiness answer, so
+        // on reservation failure answer would-block without reading at all.
+        if (!reserveReadBufTail(port, needed)) return .would_block;
+        var chunk: [4]u8 = undefined;
+        primitives_io.maybeSetNonblocking(port);
+        const rc = primitives_io.portFdRead(port, &chunk, needed);
+        if (rc > 0) {
+            const n: usize = @intCast(rc);
+            stashDrainedBytes(port, chunk[0..n]);
+            if (bufferedCharComplete(port)) return .ready;
+            continue; // short read mid-sequence: poll again for the rest
+        }
+        if (rc == 0) return .ready; // EOF behind (possibly partial) data
+        const e = platform.errno(rc);
+        if (e == .INTR) continue;
+        if (e == .AGAIN) return .would_block; // raced/spurious wakeup
+        return .ready; // a real error answers the next read immediately
+    }
+    return .would_block;
+}
+
+/// Ensures `extra` bytes can be appended behind read_buf's live span without
+/// a later allocation: true when the stash will land in the peek scratch
+/// instead (read_buf empty), when the slice's dead head space already has
+/// room (a compaction copy only), or after growing the slice now. False only
+/// when the growth allocation fails — the caller then reads nothing, so no
+/// byte is ever pulled off the fd and lost.
+fn reserveReadBufTail(port: *types.Port, extra: usize) bool {
+    if (extra == 0 or port.read_buf_len == 0) return true; // peek-scratch path
+    const gc = memory.gc_instance orelse return false;
+    const rb = port.read_buf orelse return false; // non-null while read_buf_len > 0
+    if (port.read_buf_len + extra <= rb.len) return true;
+    const live_len = port.read_buf_len;
+    const grown = gc.allocator.alloc(u8, live_len + extra) catch return false;
+    // Keep the live span the slice tail — the cursor rule every other
+    // read_buf user follows (consumption advances from the front by
+    // shrinking the count) — by copying it to grown's tail; the hole at
+    // grown's head is the reserved append room.
+    @memcpy(grown[extra..], rb[rb.len - live_len ..]);
+    gc.allocator.free(rb);
+    port.read_buf = grown;
+    return true;
+}
+
+/// Stashes a drain read's bytes at the end of the port's software buffers,
+/// preserving stream order (peek_byte, peek_extra, read_buf live span). The
+/// capacity invariant: the caller reads at most the bytes the head character
+/// still needs, an incomplete head occupies at most peek_byte plus 2 peek
+/// extras (3 extras would complete any sequence), so the 4-byte scratch
+/// always fits; the read_buf path was pre-reserved by reserveReadBufTail,
+/// and nothing between reserve and stash can run Scheme or switch fibers
+/// (no VM call, and the raw allocator does not collect), so the reservation
+/// cannot be invalidated in between.
+fn stashDrainedBytes(port: *types.Port, bytes: []const u8) void {
+    if (bytes.len == 0) return;
+    if (port.read_buf_len == 0) {
+        for (bytes) |b| {
+            if (port.peek_byte == null and port.peek_extra_len == 0) {
+                port.peek_byte = b;
+            } else {
+                port.peek_extra[port.peek_extra_len] = b;
+                port.peek_extra_len += 1;
+            }
+        }
+        return;
+    }
+    const rb = port.read_buf.?;
+    const live_len = port.read_buf_len;
+    std.debug.assert(live_len + bytes.len <= rb.len);
+    // Compact the live span to the front (it is currently the tail) and lay
+    // the new bytes down behind it, restoring the live-span-is-the-tail
+    // cursor rule with the concatenated span.
+    std.mem.copyForwards(u8, rb[0..live_len], rb[rb.len - live_len ..]);
+    @memcpy(rb[live_len..][0..bytes.len], bytes);
+    port.read_buf_len = live_len + bytes.len;
+}

--- a/src/primitives_bytevector.zig
+++ b/src/primitives_bytevector.zig
@@ -254,6 +254,7 @@ fn getOutputPort(args: []const Value, arg_idx: usize, proc_name: []const u8) Pri
 // same write buffer and reactor suspension points (KEP-0001 Phase 3).
 const portReadOneByte = primitives_io.readOneByte;
 const portWriteBytes = primitives_io.portWriteBytes;
+const portReadyNow = primitives_io.portReadyNow;
 
 fn readU8Fn(args: []const Value) PrimitiveError!Value {
     const port = try getInputPort(args, 0, "read-u8");
@@ -282,9 +283,12 @@ fn writeU8Fn(args: []const Value) PrimitiveError!Value {
 }
 
 fn u8ReadyP(args: []const Value) PrimitiveError!Value {
-    // For simplicity, always return #t (non-blocking check not worth the complexity)
-    _ = try getInputPort(args, 0, "u8-ready?");
-    return types.TRUE;
+    const port = try getInputPort(args, 0, "u8-ready?");
+    // Same oracle as char-ready? (kaappi#2511 — u8-ready? had the same
+    // unconditional-#t disease, one R7RS paragraph over in 6.13.3):
+    // buffered bytes / string sources / EOF are ready, an empty fd gets a
+    // zero-timeout poll. At EOF the answer is #t, per kaappi#1179.
+    return if (portReadyNow(port)) types.TRUE else types.FALSE;
 }
 
 fn readBytevectorFn(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_bytevector.zig
+++ b/src/primitives_bytevector.zig
@@ -254,7 +254,7 @@ fn getOutputPort(args: []const Value, arg_idx: usize, proc_name: []const u8) Pri
 // same write buffer and reactor suspension points (KEP-0001 Phase 3).
 const portReadOneByte = primitives_io.readOneByte;
 const portWriteBytes = primitives_io.portWriteBytes;
-const portReadyNow = primitives_io.portReadyNow;
+const portReadyNow = @import("port_readiness.zig").portReadyNow;
 
 fn readU8Fn(args: []const Value) PrimitiveError!Value {
     const port = try getInputPort(args, 0, "read-u8");

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -1896,11 +1896,101 @@ fn readLineFn(args: []const Value) PrimitiveError!Value {
     return gc.allocString(line_buf.items) catch return PrimitiveError.OutOfMemory;
 }
 
+/// R7RS 6.13.1 readiness oracle behind char-ready? (and u8-ready?, via
+/// primitives_bytevector) — kaappi#2511: true iff the next read on `port`
+/// completes immediately, from a software buffer, an inexhaustible or
+/// at-EOF source, or an underlying fd that has data (or EOF/error)
+/// available right now. False means a read would block, which is exactly
+/// the guarantee R7RS hangs on "if char-ready? returns #t then the next
+/// read-char is guaranteed not to hang" — the pre-fix code returned #t
+/// unconditionally, so a drive loop polling a subprocess pipe fell into
+/// the blocking read it was polling to avoid.
+///
+/// Mirrors readOneByte's port-kind dispatch in the same order so the two
+/// can never disagree about which source serves the next byte:
+///
+///   peek_byte / peek_extra / read_buf   buffered bytes -> true
+///   random_gen                          inexhaustible -> true
+///   string port                         data or EOF, never blocks -> true
+///   custom port (SRFI 181)              read! has no non-blocking probe;
+///                                       conservative true (previous
+///                                       behavior returned #t always)
+///   transcoded port (SRFI 181)          recursion on the wrapped port —
+///                                       the port's own peek/read buffers
+///                                       checked above already hold any
+///                                       re-encoded character leftovers
+///   fd                                  fdReadReadyNow: a zero-timeout
+///                                       poll of the fd itself, never a
+///                                       park — this is a synchronous
+///                                       predicate, not a scheduler
+///                                       operation (no waitPortFd)
+///
+/// Readiness is byte-granular: if only the lead bytes of a multi-byte
+/// character have arrived, this reports true while read-char may still
+/// park waiting for the rest. What read-char can promise is undecidable
+/// without consuming bytes; read-u8's guarantee is the strongest claim a
+/// non-destructive check can hold, and both predicates hold it.
+pub fn portReadyNow(port: *types.Port) bool {
+    if (port.peek_byte != null or port.peek_extra_len > 0) return true;
+    if (port.read_buf_len > 0) return true;
+    if (port.random_gen != null) return true;
+    if (port.is_string_port) return true;
+    if (port.custom_backend != null) return true;
+    if (port.transcode) |ts| {
+        const wrapped = types.toObject(ts.wrapped_port).as(types.Port);
+        return portReadyNow(wrapped);
+    }
+    return fdReadReadyNow(port.fd);
+}
+
+/// Zero-timeout readability snapshot of a port's fd: true iff a read right
+/// now would return data, EOF, or an error rather than blocking. POLLHUP,
+/// POLLERR, and POLLNVAL count as ready — a pipe whose writer closed reads
+/// EOF immediately (R7RS's "at end of file, ready" case, kaappi#1179), an
+/// errored fd surfaces the error, not a hang, and poll only reports
+/// POLLNVAL for an fd a read would reject at once. Any query failure also
+/// reports ready: the wrong #f here stalls a polling drive loop on data
+/// that arrived between the buffer check and the fd, while a spurious #t
+/// costs exactly one blocking read — the pre-fix behavior everywhere.
+fn fdReadReadyNow(fd: platform.fd_t) bool {
+    if (comptime platform.is_windows) {
+        // The reactor's own oracles (reactor_backends.arm() uses the same
+        // pair): PeekNamedPipe for pipe ends, a 0-timeout select() for
+        // sockets. Regular files and consoles have no cheap oracle, and a
+        // read on either way never blocks on data arrival — true.
+        switch (platform.fdKind(fd)) {
+            .socket => {
+                platform.ensureWinsock();
+                const sock = platform.sockFromFd(fd) orelse return true;
+                return platform.sockPollReady(sock, true, false).readable;
+            },
+            .pipe => return platform.pipePollReady(fd, true, false).readable,
+            .other => return true,
+        }
+    }
+    if (comptime is_wasm) {
+        // WASI has no poll(2) — std.posix.poll does not compile there
+        // (std.Io.Threaded's own have_poll excludes it), and KEP-0001
+        // Phase 4 keeps fd readiness best-effort on wasm hosts: the
+        // playground shim cannot report it at all. Preserve the
+        // historical #t rather than an always-#f no host could disprove.
+        return true;
+    }
+    var fds = [1]std.posix.pollfd{.{
+        .fd = fd,
+        .events = std.posix.POLL.IN,
+        .revents = 0,
+    }};
+    const n = std.posix.poll(&fds, 0) catch return true;
+    if (n == 0) return false;
+    const ready = std.posix.POLL.IN | std.posix.POLL.HUP |
+        std.posix.POLL.ERR | std.posix.POLL.NVAL;
+    return fds[0].revents & ready != 0;
+}
+
 fn charReadyP(args: []const Value) PrimitiveError!Value {
     const port = try getInputPort(args, 0, "char-ready?");
-    if (port.peek_byte != null or port.peek_extra_len > 0) return types.TRUE;
-    // For simplicity, always return #t (non-blocking check not worth the complexity)
-    return types.TRUE;
+    return if (portReadyNow(port)) types.TRUE else types.FALSE;
 }
 
 fn writeCharFn(args: []const Value) PrimitiveError!Value {

--- a/src/primitives_io.zig
+++ b/src/primitives_io.zig
@@ -10,6 +10,7 @@ const reader_mod = @import("reader.zig");
 const primitives_control = @import("primitives_control.zig");
 const fiber_mod = @import("fiber.zig");
 const reactor_mod = @import("reactor.zig");
+const port_readiness = @import("port_readiness.zig");
 const Value = types.Value;
 const NativeFn = types.NativeFn;
 const PrimitiveError = primitives.PrimitiveError;
@@ -248,7 +249,10 @@ pub fn maybeSetNonblocking(port: *types.Port) void {
 /// PeekNamedPipe gate that synthesizes EAGAIN (platform_win_pipe.zig; a
 /// sequential program's pipe port keeps plain blocking _read and its exact
 /// syscall profile). Same return/errno contract as platform.read.
-fn portFdRead(port: *types.Port, buf: [*]u8, len: usize) isize {
+///
+/// Pub for port_readiness.zig's character-completing drain, which reads only
+/// under a fresh zero-timeout poll of the fd — never blind, never parking.
+pub fn portFdRead(port: *types.Port, buf: [*]u8, len: usize) isize {
     if (comptime platform.is_windows) {
         if (port.fd_state.is_socket) return platform.sockRecv(port.fd, buf, len);
         if (port.fd_state.is_pipe and port.nonblocking) return platform.pipeRead(port.fd, buf, len);
@@ -1896,101 +1900,17 @@ fn readLineFn(args: []const Value) PrimitiveError!Value {
     return gc.allocString(line_buf.items) catch return PrimitiveError.OutOfMemory;
 }
 
-/// R7RS 6.13.1 readiness oracle behind char-ready? (and u8-ready?, via
-/// primitives_bytevector) — kaappi#2511: true iff the next read on `port`
-/// completes immediately, from a software buffer, an inexhaustible or
-/// at-EOF source, or an underlying fd that has data (or EOF/error)
-/// available right now. False means a read would block, which is exactly
-/// the guarantee R7RS hangs on "if char-ready? returns #t then the next
-/// read-char is guaranteed not to hang" — the pre-fix code returned #t
-/// unconditionally, so a drive loop polling a subprocess pipe fell into
-/// the blocking read it was polling to avoid.
-///
-/// Mirrors readOneByte's port-kind dispatch in the same order so the two
-/// can never disagree about which source serves the next byte:
-///
-///   peek_byte / peek_extra / read_buf   buffered bytes -> true
-///   random_gen                          inexhaustible -> true
-///   string port                         data or EOF, never blocks -> true
-///   custom port (SRFI 181)              read! has no non-blocking probe;
-///                                       conservative true (previous
-///                                       behavior returned #t always)
-///   transcoded port (SRFI 181)          recursion on the wrapped port —
-///                                       the port's own peek/read buffers
-///                                       checked above already hold any
-///                                       re-encoded character leftovers
-///   fd                                  fdReadReadyNow: a zero-timeout
-///                                       poll of the fd itself, never a
-///                                       park — this is a synchronous
-///                                       predicate, not a scheduler
-///                                       operation (no waitPortFd)
-///
-/// Readiness is byte-granular: if only the lead bytes of a multi-byte
-/// character have arrived, this reports true while read-char may still
-/// park waiting for the rest. What read-char can promise is undecidable
-/// without consuming bytes; read-u8's guarantee is the strongest claim a
-/// non-destructive check can hold, and both predicates hold it.
-pub fn portReadyNow(port: *types.Port) bool {
-    if (port.peek_byte != null or port.peek_extra_len > 0) return true;
-    if (port.read_buf_len > 0) return true;
-    if (port.random_gen != null) return true;
-    if (port.is_string_port) return true;
-    if (port.custom_backend != null) return true;
-    if (port.transcode) |ts| {
-        const wrapped = types.toObject(ts.wrapped_port).as(types.Port);
-        return portReadyNow(wrapped);
-    }
-    return fdReadReadyNow(port.fd);
-}
-
-/// Zero-timeout readability snapshot of a port's fd: true iff a read right
-/// now would return data, EOF, or an error rather than blocking. POLLHUP,
-/// POLLERR, and POLLNVAL count as ready — a pipe whose writer closed reads
-/// EOF immediately (R7RS's "at end of file, ready" case, kaappi#1179), an
-/// errored fd surfaces the error, not a hang, and poll only reports
-/// POLLNVAL for an fd a read would reject at once. Any query failure also
-/// reports ready: the wrong #f here stalls a polling drive loop on data
-/// that arrived between the buffer check and the fd, while a spurious #t
-/// costs exactly one blocking read — the pre-fix behavior everywhere.
-fn fdReadReadyNow(fd: platform.fd_t) bool {
-    if (comptime platform.is_windows) {
-        // The reactor's own oracles (reactor_backends.arm() uses the same
-        // pair): PeekNamedPipe for pipe ends, a 0-timeout select() for
-        // sockets. Regular files and consoles have no cheap oracle, and a
-        // read on either way never blocks on data arrival — true.
-        switch (platform.fdKind(fd)) {
-            .socket => {
-                platform.ensureWinsock();
-                const sock = platform.sockFromFd(fd) orelse return true;
-                return platform.sockPollReady(sock, true, false).readable;
-            },
-            .pipe => return platform.pipePollReady(fd, true, false).readable,
-            .other => return true,
-        }
-    }
-    if (comptime is_wasm) {
-        // WASI has no poll(2) — std.posix.poll does not compile there
-        // (std.Io.Threaded's own have_poll excludes it), and KEP-0001
-        // Phase 4 keeps fd readiness best-effort on wasm hosts: the
-        // playground shim cannot report it at all. Preserve the
-        // historical #t rather than an always-#f no host could disprove.
-        return true;
-    }
-    var fds = [1]std.posix.pollfd{.{
-        .fd = fd,
-        .events = std.posix.POLL.IN,
-        .revents = 0,
-    }};
-    const n = std.posix.poll(&fds, 0) catch return true;
-    if (n == 0) return false;
-    const ready = std.posix.POLL.IN | std.posix.POLL.HUP |
-        std.posix.POLL.ERR | std.posix.POLL.NVAL;
-    return fds[0].revents & ready != 0;
-}
-
+/// R7RS 6.13.1 readiness oracle behind char-ready? — kaappi#2511: char-ready?
+/// must return #t only when a *complete* character is available (or the port
+/// is at EOF / about to raise), so a lone UTF-8 lead byte on a live fd
+/// reports #f rather than letting read-char consume it and block for the
+/// continuation. The oracle, the zero-timeout fd probe, and the
+/// character-completing drain live in port_readiness.zig, alongside
+/// portReadyNow (the byte-granular twin u8-ready? uses via
+/// primitives_bytevector).
 fn charReadyP(args: []const Value) PrimitiveError!Value {
     const port = try getInputPort(args, 0, "char-ready?");
-    return if (portReadyNow(port)) types.TRUE else types.FALSE;
+    return if (port_readiness.charReadyNow(port)) types.TRUE else types.FALSE;
 }
 
 fn writeCharFn(args: []const Value) PrimitiveError!Value {

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -1033,14 +1033,16 @@ test "#1608: GC finalization of an abandoned pipe port with a full pipe drops th
 // with no sleeps: empty with the writer alive -> #f (the next read would
 // block — the exact case the filing repro hit), data -> #t, writer closed
 // -> #t (EOF answers immediately, R7RS 6.13.1/6.13.3's #1179 rule, now
-// held on the fd path too). The pair is a loopback socket pair on Windows
-// (the sockPollReady arm), a pipe on POSIX (poll(2)).
+// held on the fd path too). Both predicates get positive assertions at
+// data and at EOF, so an always-#f implementation fails too (#2516
+// review). The pair is a loopback socket pair on Windows (the
+// sockPollReady arm), a pipe on POSIX (poll(2)).
 test "char-ready? and u8-ready? report true pipe readiness (#2511)" {
     if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
-    var gc = memory.GC.init(std.testing.allocator);
-    defer gc.deinit();
-    var vm = try th.makeTestVM(&gc);
-    defer vm.deinit();
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
 
     const pipe = makePipe();
     _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
@@ -1052,14 +1054,123 @@ test "char-ready? and u8-ready? report true pipe readiness (#2511)" {
     try std.testing.expectEqual(types.FALSE, try vm.eval("(char-ready? rp)"));
     try std.testing.expectEqual(types.FALSE, try vm.eval("(u8-ready? rp)"));
 
-    // Data arrives: ready, and the read delivers it without blocking.
+    // Data arrives: both predicates ready, and the read delivers it without
+    // blocking.
     _ = try vm.eval("(begin (write-char #\\x wp) (flush-output-port wp))");
     try std.testing.expectEqual(types.TRUE, try vm.eval("(char-ready? rp)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(u8-ready? rp)"));
     try std.testing.expectEqual(types.makeChar('x'), try vm.eval("(read-char rp)"));
 
-    // Writer closed: at EOF the answer stays #t, and the read returns the
-    // eof-object at once.
+    // Writer closed: at EOF the answer stays #t for both — the eof read
+    // returns at once.
     _ = try vm.eval("(close-output-port wp)");
     try std.testing.expectEqual(types.TRUE, try vm.eval("(char-ready? rp)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(u8-ready? rp)"));
     try std.testing.expectEqual(types.TRUE, try vm.eval("(eof-object? (read-line rp))"));
+}
+
+// kaappi#2516 review: byte-granular readiness is not character readiness.
+// A pipe holding only byte 0xC3 (the UTF-8 lead byte of #\é) makes the fd
+// readable, so the pre-review char-ready? answered #t — and read-char then
+// consumed the lead byte and blocked for the continuation, the exact hang
+// R7RS 6.13.1's #t guarantee forbids. char-ready? must stay #f until the
+// character completes; u8-ready? keeps byte semantics and stays #t for the
+// lone byte. No sleeps needed: each write-u8 completes synchronously before
+// its assertion, so the intermediate state is deterministic.
+test "char-ready? is #f until a split multi-byte character completes (#2516 review)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    const pipe = makePipe();
+    _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    _ = try definePortGlobal(vm, "wp", pipe[1], false, true);
+
+    // The lead byte alone: u8-ready? #t (a byte IS ready), char-ready? #f
+    // (half a character is not). The pre-review code returned #t here —
+    // this is the assertion that fails without the completeness fix.
+    _ = try vm.eval("(begin (write-u8 195 wp) (flush-output-port wp))");
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(u8-ready? rp)"));
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(char-ready? rp)"));
+
+    // The continuation byte completes #\é (0xC3 0xA9) without anything
+    // having been consumed: the predicate's drain stashed the lead byte in
+    // the port's own buffers, so read-char now returns the whole character.
+    _ = try vm.eval("(begin (write-u8 169 wp) (flush-output-port wp))");
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(char-ready? rp)"));
+    try std.testing.expectEqual(types.makeChar(0xE9), try vm.eval("(read-char rp)"));
+}
+
+// kaappi#2516 review: a truncated tail at EOF is still "ready" — read-char
+// answers at once (readUtf8Char returns the lead byte alone rather than
+// blocking), so the completeness logic must treat a quiet-but-closed fd as
+// #t, and the read must deliver the Latin-1 fallback character.
+test "char-ready? at EOF behind a truncated UTF-8 sequence (#2516 review)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    const pipe = makePipe();
+    _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    _ = try definePortGlobal(vm, "wp", pipe[1], false, true);
+
+    _ = try vm.eval("(begin (write-u8 195 wp) (flush-output-port wp) (close-output-port wp))");
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(char-ready? rp)"));
+    // The truncated 0xC3 tail decodes as Latin-1 (#\xC3), then EOF.
+    try std.testing.expectEqual(types.makeChar(0xC3), try vm.eval("(read-char rp)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(char-ready? rp)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(eof-object? (read-char rp))"));
+}
+
+// kaappi#2516 review: a custom port's read! is arbitrary Scheme with no
+// readiness contract — one that delegates to an empty blocking pipe used to
+// get an unconditional #t, and the read-char after it blocked inside the
+// callback. The chosen semantics (documented in port_readiness.zig): ready
+// only when a complete character is already buffered, or when read! is
+// absent (reads are EOF forever); #f is the truthful answer otherwise,
+// because probing would mean invoking user code from a predicate.
+test "char-ready? on a custom port is #f until a character is buffered (#2516 review)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    const vm = ctx.vm;
+
+    const pipe = makePipe();
+    _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    _ = try definePortGlobal(vm, "wp", pipe[1], false, true);
+    _ = try vm.eval(
+        \\(define cp (make-custom-binary-input-port "cp"
+        \\  (lambda (bv start count)
+        \\    (read-bytevector! bv rp start (+ start 2)))
+        \\  #f #f #f))
+    );
+    // read! bounds its own range on purpose: kaappi's read-bytevector! fills
+    // the whole requested span or blocks, so a callback that forwarded the
+    // full 4096-byte count would drain the pipe and stall waiting for the
+    // rest — a real custom-port author must bound the burst the same way.
+
+    // Pipe empty: the custom port reports not-ready under both predicates
+    // (the pre-review unconditional #t failed here — this assertion fails
+    // without the fix).
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(char-ready? cp)"));
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(u8-ready? cp)"));
+
+    // Data arrives on the underlying pipe: still #f — read!'s readiness is
+    // unknowable without invoking it, and stays well-defined either way.
+    _ = try vm.eval("(begin (write-string \"ab\" wp) (flush-output-port wp))");
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(char-ready? cp)"));
+
+    // One read through the custom port pulls the burst into read_buf; the
+    // leftover 'b' is now buffered, so the predicates hold — and drain back
+    // to #f once the buffer empties.
+    try std.testing.expectEqual(types.makeChar('a'), try vm.eval("(read-char cp)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(char-ready? cp)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(u8-ready? cp)"));
+    try std.testing.expectEqual(types.makeChar('b'), try vm.eval("(read-char cp)"));
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(char-ready? cp)"));
 }

--- a/src/tests_port_io.zig
+++ b/src/tests_port_io.zig
@@ -1026,3 +1026,40 @@ test "#1608: GC finalization of an abandoned pipe port with a full pipe drops th
     // forever.
     gc.collect();
 }
+
+// kaappi#2511: char-ready?/u8-ready? must report a real readiness answer,
+// not the unconditional #t both predicates used to return. The fd oracle
+// is a zero-timeout poll, so the whole truth table of a pipe is checkable
+// with no sleeps: empty with the writer alive -> #f (the next read would
+// block — the exact case the filing repro hit), data -> #t, writer closed
+// -> #t (EOF answers immediately, R7RS 6.13.1/6.13.3's #1179 rule, now
+// held on the fd path too). The pair is a loopback socket pair on Windows
+// (the sockPollReady arm), a pipe on POSIX (poll(2)).
+test "char-ready? and u8-ready? report true pipe readiness (#2511)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // no constructible fd pairs on WASI p1 (kaappi#2153)
+    var gc = memory.GC.init(std.testing.allocator);
+    defer gc.deinit();
+    var vm = try th.makeTestVM(&gc);
+    defer vm.deinit();
+
+    const pipe = makePipe();
+    _ = try definePortGlobal(vm, "rp", pipe[0], true, false);
+    _ = try definePortGlobal(vm, "wp", pipe[1], false, true);
+
+    // Empty pipe, writer still holding the far end open. The old hardcoded
+    // #t failed exactly here, which is what let a poll-then-read drive
+    // loop fall into the blocking read it was polling to avoid.
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(char-ready? rp)"));
+    try std.testing.expectEqual(types.FALSE, try vm.eval("(u8-ready? rp)"));
+
+    // Data arrives: ready, and the read delivers it without blocking.
+    _ = try vm.eval("(begin (write-char #\\x wp) (flush-output-port wp))");
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(char-ready? rp)"));
+    try std.testing.expectEqual(types.makeChar('x'), try vm.eval("(read-char rp)"));
+
+    // Writer closed: at EOF the answer stays #t, and the read returns the
+    // eof-object at once.
+    _ = try vm.eval("(close-output-port wp)");
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(char-ready? rp)"));
+    try std.testing.expectEqual(types.TRUE, try vm.eval("(eof-object? (read-line rp))"));
+}

--- a/tests/scheme/compliance/bytevectors.scm
+++ b/tests/scheme/compliance/bytevectors.scm
@@ -54,7 +54,14 @@
   (test-equal "string->utf8" #u8(104 101 108 108 111) (string->utf8 "hello")))
 
 (test-group "binary I/O"
-  (test-assert "u8-ready? on stdin" (u8-ready?)))
+  ;; No-argument form: covers current-input-port resolution only. The
+  ;; readiness *value* is inherited from the invoking shell's stdin — EOF
+  ;; under `< /dev/null`, pending bytes on a pipe, nothing on a tty — so
+  ;; the only environment-independent claim is that it is a boolean
+  ;; (kaappi#2511 made both predicates truthful; the old hardcoded #t
+  ;; made this assertable, wrongly).
+  (test-assert "u8-ready? with no argument returns a boolean"
+    (boolean? (u8-ready?))))
 
 (define %test-fail-count (test-runner-fail-count (test-runner-current)))
 (test-end "bytevectors")

--- a/tests/scheme/process/char-ready-pipe-2511.scm
+++ b/tests/scheme/process/char-ready-pipe-2511.scm
@@ -8,12 +8,20 @@
 ;; zero timeout: buffered bytes / string sources / EOF are #t, an empty
 ;; fd with the writer alive is #f.
 ;;
+;; The #2516 review round added: char-ready? must hold the guarantee at
+;; *character* granularity (a lone UTF-8 lead byte is #f until its
+;; continuation arrives — byte-granular u8-ready? stays #t for it), custom
+;; ports are #f unless a character is buffered (read! has no readiness
+;; contract), and u8-ready? gets positive assertions at data and EOF so an
+;; always-#f oracle cannot pass.
+;;
 ;; The writer sleeps a generous 5s before echoing: no load spike can
 ;; shrink that below this test's own setup time, so the #f assertions
 ;; cannot flake. The blocking read and process-wait that follow absorb
 ;; the sleep exactly once.
 
-(import (scheme base) (scheme write) (scheme file) (scheme process-context) (srfi 64))
+(import (scheme base) (scheme write) (scheme file) (scheme process-context)
+        (scheme char) (srfi 64) (srfi 18))
 
 ;; Two gates, both before the first spawn-process reference (kaappi
 ;; compiles forms one at a time, so the later ones never compile either):
@@ -26,7 +34,7 @@
   (else))
 (cond-expand
   ((library (kaappi process))
-   (import (kaappi process)))
+   (import (kaappi process) (srfi 181)))
   (else (display "no (kaappi process) on this platform\n") (exit 0)))
 
 (test-begin "char-ready-pipe-2511")
@@ -35,19 +43,78 @@
 ;; then the data still arrives through a subsequent read. The wait comes
 ;; before the EOF assertions on purpose: it reaps the child, which is what
 ;; guarantees the pipe's write end is closed — between read-line returning
-;; "late" and the child's actual exit the writer is still alive, and #f
+;; "ate" and the child's actual exit the writer is still alive, and #f
 ;; would be the truthful answer there. After the reap, EOF is certain and
-;; reports ready (the kaappi#1179 rule on the fd path).
+;; reports ready (the kaappi#1179 rule on the fd path). u8-ready? is
+;; asserted positively both with data buffered and at EOF (#2516 review:
+;; the #f-only version of this test would pass against an always-#f
+;; oracle).
 (test-assert "predicates are #f on an empty pipe, #t once data or EOF arrives"
   (let* ((p (spawn-process (list "/bin/sh" "-c" "sleep 5; echo late")
                            'stdout: 'pipe))
          (out (process-stdout p)))
     (and (eq? #f (char-ready? out))
          (eq? #f (u8-ready? out))
-         (string=? "late" (read-line out))
+         (char=? #\l (read-char out))
+         (eq? #t (u8-ready? out))   ; "ate\n" is buffered behind the read
+         (eq? #t (char-ready? out)) ; ...and #\a is a complete character
+         (string=? "ate" (read-line out))
          (= 0 (process-wait p))
          (eq? #t (char-ready? out))
+         (eq? #t (u8-ready? out))   ; EOF answers at once
          (eof-object? (read-line out)))))
+
+;; kaappi#2516 review: the child writes only the UTF-8 lead byte 0xC3,
+;; waits 2s, then writes the continuation 0xA9 (together they are #\é).
+;; While the lead byte alone sits in the pipe, u8-ready? is #t (a byte IS
+;; ready) but char-ready? must be #f — read-char would consume the lead
+;; byte and then block for the continuation, the exact hang R7RS 6.13.1
+;; forbids a #t to lead into. The bounded poll first waits for the lead
+;; byte to land, so both mid-window assertions are deterministic.
+(test-assert "char-ready? stays #f while only a UTF-8 lead byte has arrived"
+  (let* ((p (spawn-process
+             (list "/bin/sh" "-c" "printf '\\303'; sleep 2; printf '\\251'")
+             'stdout: 'pipe))
+         (out (process-stdout p)))
+    (let loop ((i 0))
+      (when (and (eq? #f (u8-ready? out)) (< i 40))
+        (thread-sleep! 0.1)
+        (loop (+ i 1))))
+    (and (eq? #t (u8-ready? out))     ; the lead byte is one ready byte
+         (eq? #f (char-ready? out))   ; ...but half a character is not a ready char
+         (char=? #\é (read-char out)) ; blocks exactly until 0xA9 lands
+         (= 0 (process-wait p))
+         (eq? #t (char-ready? out))   ; EOF still ready
+         (eq? #t (u8-ready? out))
+         (eof-object? (read-char out)))))
+
+;; kaappi#2516 review: a custom port whose read! delegates to the pipe has
+;; no readiness contract — the pre-review #t let read-char block inside
+;; the callback. Chosen semantics (port_readiness.zig): #f unless a
+;; character is already buffered, or read! is absent; probing would mean
+;; invoking user code from a predicate. Data arriving on the underlying
+;; pipe changes nothing (still unknowable), a read through the custom port
+;; buffers the burst and turns the predicates #t, and at EOF the read
+;; answers eof-object at once.
+(test-assert "custom port readiness: #f until a character is buffered"
+  (let* ((p (spawn-process (list "/bin/sh" "-c" "sleep 5; echo late")
+                           'stdout: 'pipe))
+         (out (process-stdout p))
+         (cp (make-custom-binary-input-port
+              "cp"
+              (lambda (bv start count)
+                ;; Bounded on purpose: kaappi's read-bytevector! fills the
+                ;; whole requested span or blocks, so the callback must cap
+                ;; its own burst (a real custom-port author does the same).
+                (let ((n (read-bytevector! bv out start (+ start 1))))
+                  (if (eof-object? n) 0 n)))
+              #f #f #f)))
+    (and (eq? #f (char-ready? cp))
+         (eq? #f (u8-ready? cp))
+         (string=? "late" (read-line out)) ; data arrives on the pipe...
+         (eq? #f (char-ready? cp))         ; ...read!'s readiness is still unknowable
+         (= 0 (process-wait p))
+         (eof-object? (read-char cp)))))   ; and a read answers EOF at once
 
 ;; A regular file port: a read always has kernel data (or EOF) and never
 ;; blocks, so #t must hold — before the fix this was indistinguishable

--- a/tests/scheme/process/char-ready-pipe-2511.scm
+++ b/tests/scheme/process/char-ready-pipe-2511.scm
@@ -1,0 +1,73 @@
+;; char-ready? / u8-ready? on a subprocess pipe — kaappi#2511 regression.
+;;
+;; R7RS 6.13.1: "If char-ready? returns #t then the next read-char
+;; operation on the given port is guaranteed not to hang." Both predicates
+;; returned #t unconditionally, so a poll-then-read drive loop on a pipe
+;; with no data fell straight into the blocking read it was polling to
+;; avoid (2s in the filing repro). The fix polls the underlying fd with a
+;; zero timeout: buffered bytes / string sources / EOF are #t, an empty
+;; fd with the writer alive is #f.
+;;
+;; The writer sleeps a generous 5s before echoing: no load spike can
+;; shrink that below this test's own setup time, so the #f assertions
+;; cannot flake. The blocking read and process-wait that follow absorb
+;; the sleep exactly once.
+
+(import (scheme base) (scheme write) (scheme file) (scheme process-context) (srfi 64))
+
+;; Two gates, both before the first spawn-process reference (kaappi
+;; compiles forms one at a time, so the later ones never compile either):
+;; Windows has no /bin/sh child to spawn, and WASM has no subprocess
+;; support at all (the same gating as process-test.scm next to this).
+(cond-expand
+  (windows
+   (display "POSIX-only suite; pipe readiness is covered by src/tests_port_io.zig\n")
+   (exit 0))
+  (else))
+(cond-expand
+  ((library (kaappi process))
+   (import (kaappi process)))
+  (else (display "no (kaappi process) on this platform\n") (exit 0)))
+
+(test-begin "char-ready-pipe-2511")
+
+;; The filing repro's shape: nothing written yet -> both predicates #f,
+;; then the data still arrives through a subsequent read. The wait comes
+;; before the EOF assertions on purpose: it reaps the child, which is what
+;; guarantees the pipe's write end is closed — between read-line returning
+;; "late" and the child's actual exit the writer is still alive, and #f
+;; would be the truthful answer there. After the reap, EOF is certain and
+;; reports ready (the kaappi#1179 rule on the fd path).
+(test-assert "predicates are #f on an empty pipe, #t once data or EOF arrives"
+  (let* ((p (spawn-process (list "/bin/sh" "-c" "sleep 5; echo late")
+                           'stdout: 'pipe))
+         (out (process-stdout p)))
+    (and (eq? #f (char-ready? out))
+         (eq? #f (u8-ready? out))
+         (string=? "late" (read-line out))
+         (= 0 (process-wait p))
+         (eq? #t (char-ready? out))
+         (eof-object? (read-line out)))))
+
+;; A regular file port: a read always has kernel data (or EOF) and never
+;; blocks, so #t must hold — before the fix this was indistinguishable
+;; from the pipe's fake #t; now it is the truthful branch.
+(test-assert "char-ready? on a regular file port"
+  (let ((path (string-append (or (get-environment-variable "KAAPPI_HOME")
+                                 (get-environment-variable "TMPDIR")
+                                 "/tmp")
+                             "/kaappi-2511-ready.scm")))
+    (call-with-output-file path (lambda (port) (write-string "data" port)))
+    (let ((result
+           (call-with-input-file path
+             (lambda (port)
+               (and (eq? #t (char-ready? port))
+                    (string=? "data" (read-line port))
+                    ;; at EOF a file port stays ready
+                    (eq? #t (char-ready? port)))))))
+      (delete-file path)
+      result)))
+
+(let ((runner (test-runner-current)))
+  (test-end "char-ready-pipe-2511")
+  (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Closes #2511

## The bug

`char-ready?` returned `#t` unconditionally after its peeked-byte fast
path (the source comment said the non-blocking check was "not worth the
complexity"), so on a subprocess pipe with no data it claimed a read was
safe — and the very next `read-line` blocked for as long as the writer
stayed silent. That breaks R7RS 6.13.1's "if `char-ready?` returns `#t`
then the next `read-char` operation on the given port is guaranteed not
to hang", and removes the only non-blocking probe a Scheme drive loop
over a subprocess can use (the filing's case: mesthiri driving a
long-lived agent over newline-delimited JSON).

`u8-ready?` had the identical hardcoded-`#t` body — without even the
peek check — one spec paragraph over in R7RS 6.13.3. **It is fixed in
this PR with the same oracle.** As a side effect it finally gives
`u8-ready?` the "at EOF → `#t`" answer kaappi#1179 asked for on *fd*
ports (string/bytevector ports already had it).

## The fix

`char-ready?` now answers through `portReadyNow` (a new readiness
oracle in `src/primitives_io.zig`, `pub` so `primitives_bytevector` uses
it for `u8-ready?` too). It mirrors `readOneByte`'s port-kind dispatch
in the same order, so the two can never disagree about which source
serves the next byte:

| Port kind | Answer | Why |
|---|---|---|
| peeked byte / peek_extra / read_buf non-empty | `#t` | buffered bytes cost zero syscalls |
| SRFI-271 random port | `#t` | inexhaustible |
| string port (incl. bytevector input ports) | `#t` | data or EOF, never blocks (EOF-is-#t per #1179) |
| SRFI 181 custom port | `#t` (conservative) | a `read!` callback has no non-blocking probe; preserves the old answer |
| SRFI 181 transcoded port | recurse on wrapped port | the port's own peek/read buffers (checked first) hold re-encoded leftovers |
| real fd — POSIX | zero-timeout `poll(2)` | `POLLIN` = data; `POLLHUP`/`POLLERR`/`POLLNVAL` = EOF/error *now* (a read returns EOF or errors at once — the #1179 rule on the fd path); query failure degrades to `#t` so a racing drive loop can never be stalled by a lying `#f` |
| real fd — Windows pipe | `PeekNamedPipe` (`platform.pipePollReady`) | the reactor's own oracle (reactor_backends.arm) |
| real fd — Windows socket | 0-timeout `select` (`platform.sockPollReady`) | same |
| regular file / console | `#t` | a read never blocks on data arrival |
| WASI | `#t` (conservative) | no `poll(2)`; KEP-0001 Phase 4 keeps fd readiness best-effort on wasm hosts |

The fd check is a **synchronous snapshot, never a fiber park** — it goes
straight to the fd, not through `waitPortFd`, because this is a
predicate, not a scheduler operation.

Readiness is byte-granular: if only the lead bytes of a multi-byte
character have arrived, the answer is `#t` while `read-char` may still
park for the rest. `read-u8`'s guarantee is the strongest claim a
non-destructive check can hold; both predicates hold it.

One existing test was asserting the hardcoded value: `(test-assert
(u8-ready?))` on inherited stdin only passed because the answer was
`#t` no matter what — on a tty the truthful answer is `#f`. It now
asserts the environment-independent contract (`boolean?`), with the real
matrix covered by the new tests.

## Test evidence

- New `tests/scheme/process/char-ready-pipe-2511.scm` — the filing
  repro's shape with a generous 5s writer delay so a loaded CI machine
  cannot flake the `#f` assertion; asserts both predicates are `#f`
  before the data, the data is still readable, and (after `process-wait`
  makes EOF certain) `#t` at EOF and `read-line` → eof-object. Plus a
  regular-file-port case. **Verified failing on the pre-fix binary**
  (exit 1), passing after.
- New Zig unit test `char-ready? and u8-ready? report true pipe readiness
  (#2511)` in `src/tests_port_io.zig` — the empty/data/EOF truth table
  over a real fd pair with no sleeps (loopback socket pair on Windows,
  pipe on POSIX). **Verified failing on the pre-fix binary**, passing
  after.
- Repro from the issue: `#f` printed immediately (no 2s stall), then
  `read-line` → `"late"`; 3.0s total wall with a 3s writer sleep spent
  entirely in the blocking read/wait.
- Unchanged sanity matrix: string port `#t`, empty string/bytevector
  port `#t` (EOF), regular file `#t` before/at EOF, after `peek-char`
  `#t`.
- `zig build test` — green.
- `bash tools/run-r7rs-suite.sh` — 1395 pass, 0 fail.
- `bash tests/scheme/run-all.sh` — 750 Scheme files pass, 0 fail (2145
  total with the R7RS suite).
- Cross-compile gates: `zig build wasm`, `zig build test
  -Dtarget=wasm32-wasi`, `zig build -Dtarget=x86_64-windows`, `-Dtarget
  =x86_64-linux`, `-Dtarget=aarch64-linux-musl` — all build (per-OS arms
  verified).