### PR TITLE
Honor suppress_exit in emergency-exit so a test worker still emits

### DIFF
--- a/docs/dev/test-runner.md
+++ b/docs/dev/test-runner.md
@@ -95,9 +95,11 @@ Inside the worker (`src/toplevel_driver.zig` `runWorkerFile` →
 2. **Suppress `(exit)`.** The worker sets `vm.suppress_exit`, so a file's
    `(exit 1)` failure epilogue becomes a *recorded* no-op (`vm.exit_requested`
    / `vm.exit_code`) instead of terminating the worker before it can emit its
-   result. Because the call never happens, its *semantics* are reapplied when
-   the verdict is resolved — see [Verdicts](#verdicts-and-what-errored-means)
-   below.
+   result. `(emergency-exit …)` records through the same channel — a plain
+   `emergencyExitFn` used to kill the worker mid-file, and the orchestrator
+   reported the file as a missing result (kaappi#2521). Because the call never
+   happens, its *semantics* are reapplied when the verdict is resolved — see
+   [Verdicts](#verdicts-and-what-errored-means) below.
 3. **Run the file** via the normal `runFile` path (so the `.sbc` cache, imports,
    and error diagnostics all behave exactly as a plain run).
 4. **Emit one JSON object** for the file to `KAAPPI_TEST_EMIT`, built by walking
@@ -119,7 +121,8 @@ to a failure of a test. SRFI-64 catches ordinary test failures internally via
 
 Three inputs decide it (`resolveVerdict` in `src/test_runner.zig`): whether an
 uncaught read/compile/runtime error was reported at top level, what the file's
-suppressed `(exit)` asked for, and whether the SRFI-64 counters already show a
+suppressed `(exit)` — or `(emergency-exit …)`, the same channel since
+kaappi#2521 — asked for, and whether the SRFI-64 counters already show a
 failure.
 
 | The file… | `error` | Why |
@@ -361,7 +364,8 @@ a transcript diff between two runs stays meaningful at any job count.
 
 - `src/test_runner.zig` unit tests — JSON serialization round-trips, the
   SRFI-64 discovery gate, and the `suppress_exit` behaviour (the guard on the
-  `exitFn` change in `src/primitives_r7rs.zig`).
+  `exitFn` change in `src/primitives_r7rs.zig`; the `emergencyExitFn` twin of
+  that guard lives beside the primitive it protects).
 - `src/test_selection.zig` unit tests — import-spec unwrapping, the
   native-artifact classifier, lexical path canonicalisation, and the closure
   BFS over synthetic graphs (diamond deps, incomplete edges, cycles).
@@ -391,6 +395,12 @@ a transcript diff between two runs stays meaningful at any job count.
   bug class #2116 exists to forbid, and every file in the corpus that can print
   `FAIL` also exits nonzero when it does — which is why all ten fixtures still
   agree. If `kaappi test` ever grows the same net, the asymmetry closes.
+- `tests/scheme/test-runner/emergency-exit.sh` — `(emergency-exit …)` under a
+  worker honors `suppress_exit` (kaappi#2521): each of three fixtures (a green
+  suite exiting 0, a failing suite exiting 1, a bare unexplained exit 1) runs
+  through a plain `kaappi <file>` and `kaappi test`, which must agree and land
+  on the expected verdict, with the counts on the transcript and no
+  "worker produced no result".
 - `tests/scheme/test-runner/changed.sh` — `--changed`/`--list-affected` over a
   throwaway git repo with a known dependency shape: diamond import, `include`,
   a `(load …)` escape hatch, native-artifact and unknown-revision full-run

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -170,14 +170,26 @@ fn exitFn(args: []const Value) PrimitiveError!Value {
 }
 
 fn emergencyExitFn(args: []const Value) PrimitiveError!Value {
+    const code = exitCode(args);
+    if (vm_mod.vm_instance) |vm| {
+        // `kaappi test` worker: same suppression contract as `exit` (kaappi#2521).
+        // Terminating here would kill the worker before it emits its one JSON
+        // result, so the orchestrator reports the file as "worker produced no
+        // result" — losing the counts the file already collected. Record the
+        // request and return instead: the raw code, before the #2512 upgrade
+        // below, so the worker's `resolveVerdict` weighs what the file actually
+        // asked for, exactly as it does a suppressed `(exit N)`.
+        if (vm.suppress_exit) {
+            vm.exit_requested = true;
+            vm.exit_code = code;
+            return types.VOID;
+        }
+    }
     // Same #2512 rule as `exit`: an emergency exit from a run that already
     // reported an uncaught top-level error may not mask it with an explicit
     // 0. Skipping the cleanup — `exit`'s dynamic winds and port flush — is
-    // the emergency part; skipping the run's verdict is not. Deliberately
-    // still no `suppress_exit` consultation: emergency-exit terminating a
-    // `kaappi test` worker before it can emit its result is a pre-existing
-    // gap, filed separately (kaappi#2521), not something to half-fix here.
-    std.process.exit(effectiveExitCode(exitCode(args), toplevel_driver.script_had_error));
+    // the emergency part; skipping the run's verdict is not.
+    std.process.exit(effectiveExitCode(code, toplevel_driver.script_had_error));
 }
 
 fn getEnvVar(args: []const Value) PrimitiveError!Value {
@@ -591,4 +603,24 @@ test "effectiveExitCode: a reported script error upgrades (exit 0) only (#2512)"
     try std.testing.expectEqual(@as(u8, 1), effectiveExitCode(1, true));
     try std.testing.expectEqual(@as(u8, 5), effectiveExitCode(5, true));
     try std.testing.expectEqual(@as(u8, 255), effectiveExitCode(255, true));
+}
+
+// The emergency-exit twin of the suppress_exit test in test_runner.zig
+// (kaappi#2521): under suppression the call records its code instead of
+// terminating the process, so a `kaappi test` worker still reaches its
+// result-emission step. Guards the emergencyExitFn change above.
+test "suppress_exit turns (emergency-exit) into a recorded no-op, VM stays usable" {
+    const th = @import("testing_helpers.zig");
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    ctx.vm.suppress_exit = true;
+    const r = try ctx.vm.eval("(import (scheme process-context)) (emergency-exit 7)");
+    try std.testing.expectEqual(types.VOID, r);
+    try std.testing.expect(ctx.vm.exit_requested);
+    try std.testing.expectEqual(@as(u8, 7), ctx.vm.exit_code);
+
+    const after = try ctx.vm.eval("(+ 1 2)");
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(after));
 }

--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -22,8 +22,8 @@
 //! Subprocess isolation is deliberate, not incidental: a file that loops,
 //! segfaults, leaks a thread, or calls `(exit 1)` in its failure epilogue can
 //! neither corrupt the run nor bleed into another file's results. The worker
-//! sets `vm.suppress_exit` so that a file's `(exit)` cannot rob it of the
-//! chance to emit its result.
+//! sets `vm.suppress_exit` so that a file's `(exit)` or `(emergency-exit …)`
+//! cannot rob it of the chance to emit its result (kaappi#2521).
 
 const std = @import("std");
 const platform = @import("platform.zig");

--- a/src/toplevel_driver.zig
+++ b/src/toplevel_driver.zig
@@ -884,10 +884,10 @@ pub fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
 
 /// `kaappi test` worker path: install the collecting SRFI-64 runner, run the
 /// file, then emit its one JSON result object. `suppress_exit` lets a file's
-/// `(exit 1)` epilogue be recorded instead of terminating the worker before it
-/// reports. The worker always exits 0 — the orchestrator reads pass/fail from
-/// the emitted JSON, not from this process's status (a missing/empty result is
-/// what signals a crash).
+/// `(exit 1)` — or `(emergency-exit …)`, kaappi#2521 — epilogue be recorded
+/// instead of terminating the worker before it reports. The worker always
+/// exits 0 — the orchestrator reads pass/fail from the emitted JSON, not from
+/// this process's status (a missing/empty result is what signals a crash).
 pub fn runWorkerFile(vm: *vm_mod.VM, fp: []const u8, emit_path: []const u8) !void {
     vm.suppress_exit = true;
     test_runner.installCollector(vm) catch {

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -564,10 +564,11 @@ pub const VM = struct {
     profile_time_stack: [256]ProfileTimeEntry = undefined,
     profile_time_depth: usize = 0,
     sandbox_mode: bool = false,
-    /// Set by the `kaappi test` worker path: when true, `(exit code)` records
-    /// the request and returns instead of terminating the process, so the
-    /// worker always reaches its result-emission step even when a test file's
-    /// SRFI-64 epilogue calls `(exit 1)` on failure. `exit_requested`/
+    /// Set by the `kaappi test` worker path: when true, `(exit code)` and
+    /// `(emergency-exit code)` record the request and return instead of
+    /// terminating the process, so the worker always reaches its
+    /// result-emission step even when a test file's SRFI-64 epilogue calls
+    /// `(exit 1)` on failure. `exit_requested`/
     /// `exit_code` capture the last such request. No effect on normal runs.
     suppress_exit: bool = false,
     exit_requested: bool = false,

--- a/tests/scheme/test-runner/emergency-exit.sh
+++ b/tests/scheme/test-runner/emergency-exit.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# kaappi#2521 — `(emergency-exit ...)` must honor the `kaappi test` worker's
+# suppress_exit contract.
+#
+# `exit` consults `vm.suppress_exit`, so a worker turns a file's `(exit 1)`
+# failure epilogue into a recorded no-op and still emits its one JSON result.
+# `emergency-exit` did not — it called std.process.exit directly, killing the
+# worker before it could emit, and the orchestrator reported
+# `ERROR <file> (worker produced no result)`, losing every SRFI-64 count the
+# file had already collected. A passing suite ending in `(emergency-exit 0)`
+# was red under `kaappi test` and green under `tests/scheme/run-all.sh`.
+#
+# Now `emergency-exit` records the request the same way `exit` does, so a
+# requested emergency exit code weighs into the file's verdict exactly like a
+# requested `(exit N)` — the worker reaches emitResult and the verdict rules
+# certified by runner-agreement.sh apply unchanged.
+#
+# Each fixture runs BOTH ways, as in runner-agreement.sh: a plain
+# `kaappi <file>` (whose exit status is what run-all.sh reads) and
+# `kaappi test <file>`; the two must agree AND land on the expected verdict.
+
+set -euo pipefail
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+KAAPPI="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+PASS=0
+FAIL=0
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+export KAAPPI_HOME="$WORK/home"
+mkdir -p "$KAAPPI_HOME"
+# Run from the temp dir: a plain `kaappi <file>` run's SRFI-64 runner drops a
+# `<suite>.log` in the cwd. Keep those out of the repo.
+cd "$WORK"
+
+# --- the two runners' verdict rules (as in runner-agreement.sh) --------------
+
+verdict_run_all() {
+    local file="$1" status=0
+    "$KAAPPI" "$file" > "$WORK/out.txt" 2>&1 || status=$?
+    if [[ $status -ne 0 ]]; then
+        echo "FAIL"
+    else
+        echo "PASS"
+    fi
+}
+
+# `kaappi test`'s rule, read off its own exit status — nonzero iff a test
+# failed, unexpectedly passed, or a file errored.
+verdict_kaappi_test() {
+    local file="$1" status=0
+    "$KAAPPI" test "$file" > "$WORK/kt.txt" 2>&1 || status=$?
+    if [[ $status -ne 0 ]]; then echo "FAIL"; else echo "PASS"; fi
+}
+
+# Both runners must agree, and both must reach `expected`. Requiring only
+# agreement would be satisfied by two runners that are wrong together.
+assert_agree() {
+    local label="$1" file="$2" expected="$3"
+    local a b
+    a=$(verdict_run_all "$file")
+    b=$(verdict_kaappi_test "$file")
+    if [[ "$a" == "$b" && "$a" == "$expected" ]]; then
+        echo "PASS: $label ($expected in both runners)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — run-all.sh=$a kaappi-test=$b, expected $expected in both"
+        sed 's/^/      | /' "$WORK/kt.txt"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Assert a substring is present in the last `kaappi test` transcript. Uses a
+# here-string, never a pipe into grep -q (see tests/scheme/CLAUDE.md).
+assert_kt_mentions() {
+    local label="$1" needle="$2"
+    local body
+    body=$(cat "$WORK/kt.txt")
+    if grep -qF "$needle" <<< "$body"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — transcript does not mention '$needle'"
+        sed 's/^/      | /' "$WORK/kt.txt"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# The absence twin: the crash flavor this script exists to bury.
+assert_kt_lacks() {
+    local label="$1" needle="$2"
+    local body
+    body=$(cat "$WORK/kt.txt")
+    if grep -qF "$needle" <<< "$body"; then
+        echo "FAIL: $label — transcript mentions '$needle'"
+        sed 's/^/      | /' "$WORK/kt.txt"
+        FAIL=$((FAIL + 1))
+    else
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# --- fixtures ---------------------------------------------------------------
+
+# A wholly green suite ending in (emergency-exit 0): a plain run exits 0, and
+# the worker must reach emitResult with its counts, not die mid-file. This is
+# the exact shape that used to report `worker produced no result` (#2521).
+cat > ee-pass.scm <<'EOF'
+(import (scheme base) (scheme process-context) (srfi 64))
+(test-begin "ee-pass")
+(test-equal "an ordinary passing assertion" 1 1)
+(test-end "ee-pass")
+(emergency-exit 0)
+EOF
+
+# The failure-epilogue shape: a failing assertion plus (emergency-exit 1). The
+# nonzero request is redundant with the counts, so `kaappi test` must report a
+# FAIL carrying the assertion detail, not an opaque file error.
+cat > ee-fail-epilogue.scm <<'EOF'
+(import (scheme base) (scheme process-context) (srfi 64))
+(test-begin "ee-fail-epilogue")
+(test-equal "a genuinely failing assertion" 1 2)
+(test-end "ee-fail-epilogue")
+(emergency-exit 1)
+EOF
+
+# A bare (emergency-exit 1) with nothing in the counts to explain it: a plain
+# run exits 1, so the file's own verdict is the only signal there is and it
+# must not be discarded — or crash-flavored into a missing result.
+cat > ee-bare.scm <<'EOF'
+(import (scheme base) (scheme process-context) (srfi 64))
+(test-begin "ee-bare")
+(test-equal "an ordinary passing assertion" 1 1)
+(test-end "ee-bare")
+(emergency-exit 1)
+EOF
+
+# --- the matrix -------------------------------------------------------------
+
+assert_agree "(emergency-exit 0) over a passing suite stays green in both runners (#2521)" ee-pass.scm PASS
+assert_kt_mentions "the passing suite's counts survive the suppressed emergency exit" "(1 tests"
+assert_kt_lacks "a suppressed emergency exit is not a missing worker result" "worker produced no result"
+
+assert_agree "(emergency-exit 1) over a failing suite is a failure in both runners" ee-fail-epilogue.scm FAIL
+assert_kt_mentions "the failing assertion keeps its detail" "a genuinely failing assertion"
+assert_kt_lacks "the failure epilogue is not a missing worker result" "worker produced no result"
+
+assert_agree "a bare (emergency-exit 1) with nothing failing is a failure in both runners" ee-bare.scm FAIL
+assert_kt_mentions "the file's own verdict is on the transcript, not lost to a crash" \
+    "file requested a nonzero exit with no failing test to explain it"
+
+echo ""
+echo "emergency-exit: $PASS pass, $FAIL fail"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Closes #2521

## The bug

`exit` consults `vm.suppress_exit`, so a `kaappi test` worker turns a file's `(exit 1)` failure epilogue into a recorded no-op and still reaches `emitResult` — the documented worker contract (docs/dev/test-runner.md): the worker always emits exactly one JSON object. `emergency-exit` did not — `emergencyExitFn` called `std.process.exit` directly, killing the worker subprocess before it wrote its `KAAPPI_TEST_EMIT` result. The orchestrator then reported:

```
ERROR file.scm  (worker produced no result)
```

losing every SRFI-64 count the file had already collected. A passing suite ending in `(emergency-exit 0)` was red under `kaappi test` and green under `tests/scheme/run-all.sh` — exactly the two-runner disagreement `runner-agreement.sh` exists to forbid (kaappi#1903). Reproduced on a684eeb3.

## The fix

`emergencyExitFn` (src/primitives_r7rs.zig) now consults `vm.suppress_exit` the same way `exitFn` does:

- **Under suppression** (a `kaappi test` worker): record the request (`vm.exit_requested` / `vm.exit_code` — the *raw* code, before the kaappi#2512 upgrade, so the worker's `resolveVerdict` weighs what the file actually asked for) and return `VOID`, keeping the VM usable so the worker reaches `emitResult`. A requested emergency exit code therefore influences the file's verdict exactly like a requested `(exit N)` does today.
- **Outside suppression**: unchanged — a real `std.process.exit` through `effectiveExitCode` (still honoring a reported script error per #2512), still skipping dynamic-wind cleanup and the port flush; that skip is emergency-exit's own contract (R7RS 6.14). Verified: a plain run of `(emergency-exit 3)` inside `dynamic-wind` exits 3 immediately, without running the after-thunk.

`src/test_runner.zig` and `src/toplevel_driver.zig` got only in-place comment rewraps (both are near/over the 1500-line cap); the diff stays in `src/primitives_r7rs.zig` plus docs and tests.

## Test evidence

- New unit test beside the primitive, `suppress_exit turns (emergency-exit) into a recorded no-op, VM stays usable` (src/primitives_r7rs.zig — the twin of the `exitFn` guard in test_runner.zig, placed there because test_runner.zig is already over the cap).
  - Without the fix: `zig build test -Dtest-filter="emergency-exit"` → build fails, "1 crashed" (the primitive killed the test binary).
  - With the fix: passes, and the full `zig build test` is green (exit 0).
- New end-to-end test `tests/scheme/test-runner/emergency-exit.sh` (picked up by `tests/scheme/run-all.sh`'s "Test runner" suite): three fixtures — a green suite ending `(emergency-exit 0)`, a failing suite ending `(emergency-exit 1)`, a bare unexplained `(emergency-exit 1)` — each run through a plain `kaappi <file>` and `kaappi test`, requiring both verdict agreement and the expected verdict, surviving counts on the transcript, and no "worker produced no result".
  - Without the fix: 2 pass, 6 fail (the transcripts show `ERROR ee-pass.scm (worker produced no result)`).
  - With the fix: 8 pass, 0 fail.
- Original repro after the fix: `kaappi test pass.scm` (passing SRFI-64 suite + `(emergency-exit 0)`) now prints `PASS ... (1 tests, 0 skipped, 1ms)` and exits 0; a bare `(emergency-exit 1)` yields `error: true` with the note `file requested a nonzero exit with no failing test to explain it` — the same verdict a suppressed `(exit 1)` gets.

## Docs

`docs/dev/test-runner.md` updated where it documents the suppression step (worker walkthrough step 2), the verdict inputs, and the test inventory.