### PR TITLE
Name the differing compiler-key component in bundle rejection

### DIFF
--- a/docs/dev/cache.md
+++ b/docs/dev/cache.md
@@ -101,11 +101,20 @@ embedded bundle can say *which* of the three compiler-key components differed
 (`renderForeignBuildDiagnostic` in `src/bytecode_file_read.zig`, re-exported by
 `src/bytecode_file.zig`; for a cross-target bundle the build id matches on both
 sides, so it cannot carry the diagnosis alone). Older headers lack the last two
-fields and read them back as absent:
-the reader accepts `MIN_READ_VERSION..VERSION` (v13 files load and classify
-unchanged — a bump that only *adds* header fields never invalidates a cache),
-and anything older reads back as a miss. A format bump that changes the entry
-*layout* still invalidates every older entry.
+fields and read them back as absent: the reader accepts
+`MIN_READ_VERSION..VERSION`, and anything older reads back as a miss.
+
+That read window is narrower than it looks. Loading still requires the
+compiler hash to match, and the hash folds in the version string and the build
+id — so the only v13 entry that can *hit* under the v14 reader is one written
+at the same commit and tree state, in practice a dirty build on the author's
+own machine; for every released or per-commit binary a v13 entry is a miss
+either way. What the window actually buys: a v13 embedded bundle still
+classifies as a foreign build (and gets the "not recorded" advice rather than
+"invalid"), `cache status` still parses v13 entries, and the checked-in
+fuzz-seed fixture did not need regenerating. A format bump that changes the
+entry *layout* must raise `MIN_READ_VERSION` (see the `VERSION` doc-comment)
+and so invalidates every older entry.
 
 ## Location
 

--- a/docs/dev/cache.md
+++ b/docs/dev/cache.md
@@ -94,9 +94,18 @@ case above is different in kind — the key genuinely matches — which is why i
 needs the manual step.
 
 The header also records, purely for `cache status` to display, the **producing
-build id** and the **source path** (see `src/bytecode_file.zig`, format
-`VERSION`). Bumping the on-disk format `VERSION` invalidates every older entry —
-a version mismatch reads back as a miss.
+build id** and the **source path**, and since format v14
+([#2514](https://github.com/kaappi/kaappi/issues/2514)) the producing binary's
+**compile target** and **version string** too — the last two so a rejected
+embedded bundle can say *which* of the three compiler-key components differed
+(`renderForeignBuildDiagnostic` in `src/bytecode_file_read.zig`, re-exported by
+`src/bytecode_file.zig`; for a cross-target bundle the build id matches on both
+sides, so it cannot carry the diagnosis alone). Older headers lack the last two
+fields and read them back as absent:
+the reader accepts `MIN_READ_VERSION..VERSION` (v13 files load and classify
+unchanged — a bump that only *adds* header fields never invalidates a cache),
+and anything older reads back as a miss. A format bump that changes the entry
+*layout* still invalidates every older entry.
 
 ## Location
 

--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -54,6 +54,13 @@ pub const MAGIC = [4]u8{ 'K', 'P', 'B', 'C' };
 /// order), and library entries carry transformer, event, include and
 /// dependency sections. v12 (kaappi#2166): TAG_COMPLEX payload changed from
 /// two f64s + two exactness bytes to two nested component constants.
+///
+/// Bumping rule: a bump that changes the entry *tail* (anything after the
+/// header strings) must raise `MIN_READ_VERSION` to the new value — nothing
+/// else stops the reader from parsing an older tail under the new layout. A
+/// bump that only appends header fields may leave `MIN_READ_VERSION` alone,
+/// provided the readers gate the new fields on `ver >=` a named threshold
+/// like `TARGET_FIELDS_SINCE`.
 pub const VERSION: u16 = 14;
 /// Oldest header version this binary reads. v13 files lack the target and
 /// version strings but share v14's tail layout (entry kind, slots, sections),
@@ -61,6 +68,14 @@ pub const VERSION: u16 = 14;
 /// diagnostics must not claim equality of an unrecorded component. Anything
 /// older is rejected as before: a version mismatch reads as a plain miss.
 pub const MIN_READ_VERSION: u16 = 13;
+/// First format version whose header carries the compile target and version
+/// strings after the source path (kaappi#2514). Both readers gate those two
+/// reads on it; a header below it reads them back as null.
+pub const TARGET_FIELDS_SINCE: u16 = 14;
+comptime {
+    std.debug.assert(MIN_READ_VERSION <= VERSION);
+    std.debug.assert(MIN_READ_VERSION <= TARGET_FIELDS_SINCE and TARGET_FIELDS_SINCE <= VERSION);
+}
 pub const MAX_FUNCTIONS: u32 = 16_384;
 pub const MAX_TOP_LEVEL_FUNCTIONS: u32 = 4_096;
 pub const MAX_CODE_BYTES: u32 = 4_194_304;
@@ -979,8 +994,9 @@ test "classifyEmbeddedRejection: cross-target bundle names the target (kaappi#25
     try std.testing.expect(!std.mem.eql(u8, other_target, compile_target_id));
 
     // A v14 header produced by a binary for `other_target` at this very
-    // version and build id. The literal 14 pins the format this test targets;
-    // the reader must keep accepting it across future bumps.
+    // version and build id. The literal 14 pins the format this fixture is
+    // written in; when MIN_READ_VERSION passes 14, rewrite the fixture in the
+    // new format rather than the assertion.
     var w = Writer{ .buf = .empty };
     defer w.buf.deinit(allocator);
     const foreign_key = compilerHashFor(main.version, build_options.git_build_id, other_target);

--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -42,13 +42,25 @@ pub const MAGIC = [4]u8{ 'K', 'P', 'B', 'C' };
 // runtime errors can report `file:line:col`. A version mismatch makes
 // `readFileWithTopLevel` return null, so older `.sbc` caches are ignored and
 // silently recompiled — no stale-cache hazard.
-/// Format version. v13 (kaappi#1888): the header carries an entry-kind byte
-/// after the source path (program / bundle / library), program entries carry a
-/// positional slot section (compiled function vs. declaration source text, in
-/// top-level order), and library entries carry transformer, event, include and
-/// dependency sections. v12 (kaappi#2166): TAG_COMPLEX payload changed from two
-/// f64s + two exactness bytes to two nested component constants.
-pub const VERSION: u16 = 13;
+/// Format version. v14 (kaappi#2514): the header carries the producing
+/// binary's compile target (`compile_target_id`) and release version string
+/// after the source path, so a rejected embedded bundle can name *which*
+/// component of the compiler key differed — for release binaries built from
+/// one clean checkout the build id is identical across targets and the target
+/// is the only differing input, which the old diagnostic never reported.
+/// v13 (kaappi#1888): the header carries an entry-kind byte after the source
+/// path (program / bundle / library), program entries carry a positional slot
+/// section (compiled function vs. declaration source text, in top-level
+/// order), and library entries carry transformer, event, include and
+/// dependency sections. v12 (kaappi#2166): TAG_COMPLEX payload changed from
+/// two f64s + two exactness bytes to two nested component constants.
+pub const VERSION: u16 = 14;
+/// Oldest header version this binary reads. v13 files lack the target and
+/// version strings but share v14's tail layout (entry kind, slots, sections),
+/// so they still load and classify — the new fields read back as null and
+/// diagnostics must not claim equality of an unrecorded component. Anything
+/// older is rejected as before: a version mismatch reads as a plain miss.
+pub const MIN_READ_VERSION: u16 = 13;
 pub const MAX_FUNCTIONS: u32 = 16_384;
 pub const MAX_TOP_LEVEL_FUNCTIONS: u32 = 4_096;
 pub const MAX_CODE_BYTES: u32 = 4_194_304;
@@ -170,6 +182,8 @@ pub const writeFileWithLibrary = write.writeFileWithLibrary;
 pub const DeserializeResult = read.DeserializeResult;
 pub const freeDeserializeResult = read.freeDeserializeResult;
 pub const HeaderInfo = read.HeaderInfo;
+pub const BuildIdentity = read.BuildIdentity;
+pub const renderForeignBuildDiagnostic = read.renderForeignBuildDiagnostic;
 pub const deserializeFromBuffer = read.deserializeFromBuffer;
 pub const readFromBuffer = read.readFromBuffer;
 pub const readFileWithTopLevel = read.readFileWithTopLevel;
@@ -916,6 +930,8 @@ test "classifyEmbeddedRejection: foreign build id is distinguished from corrupt"
     try foreign.writeU64(allocator, foreign_key);
     try foreign.writeStr(allocator, "0000000-other-build");
     try foreign.writeStr(allocator, "prog.scm");
+    try foreign.writeStr(allocator, compile_target_id); // v14 target
+    try foreign.writeStr(allocator, main.version); // v14 version
     try foreign.writeU32(allocator, 1);
     try foreign.writeU32(allocator, 1);
 
@@ -949,7 +965,191 @@ test "classifyEmbeddedRejection: foreign build id is distinguished from corrupt"
     try std.testing.expect(classifyEmbeddedRejection(data) == .invalid);
 }
 
-test "readHeaderInfo round-trips build id and source path" {
+test "classifyEmbeddedRejection: cross-target bundle names the target (kaappi#2514)" {
+    // The release-matrix case: all release binaries come from one clean
+    // checkout, so version and build id are IDENTICAL across targets and the
+    // target is the only differing compiler-key input. The old message printed
+    // the matching build id on both sides and advised a pointless rebuild.
+    const allocator = std.testing.allocator;
+    var gc = GC.init(allocator);
+    defer gc.deinit();
+
+    // A target guaranteed different from this binary's on every host.
+    const other_target = "fakearch-fakeos-none;r7rs;fake";
+    try std.testing.expect(!std.mem.eql(u8, other_target, compile_target_id));
+
+    // A v14 header produced by a binary for `other_target` at this very
+    // version and build id. The literal 14 pins the format this test targets;
+    // the reader must keep accepting it across future bumps.
+    var w = Writer{ .buf = .empty };
+    defer w.buf.deinit(allocator);
+    const foreign_key = compilerHashFor(main.version, build_options.git_build_id, other_target);
+    try std.testing.expect(foreign_key != compilerHash()); // precondition
+    try w.writeBytes(allocator, &MAGIC);
+    try w.writeU16(allocator, 14);
+    try w.writeU64(allocator, 0x5EED);
+    try w.writeU64(allocator, foreign_key);
+    try w.writeStr(allocator, build_options.git_build_id);
+    try w.writeStr(allocator, "prog.scm");
+    try w.writeStr(allocator, other_target);
+    try w.writeStr(allocator, main.version);
+
+    // Still a foreign-build rejection, and the loader really refuses it.
+    try std.testing.expect(classifyEmbeddedRejection(w.buf.items) == .foreign_build);
+    try std.testing.expect(try deserializeFromBuffer(&gc, w.buf.items, 0x5EED) == null);
+
+    // The header exposes the target, and the diagnostic names it with the
+    // fix that applies: recompile for THIS target, not "rebuild from source".
+    const info = readHeaderInfo(w.buf.items) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(other_target, info.target.?);
+    try std.testing.expectEqualStrings(main.version, info.version.?);
+    const msg = try renderForeignBuildDiagnostic(allocator, info, .{
+        .version = main.version,
+        .build_id = build_options.git_build_id,
+        .target = compile_target_id,
+    });
+    defer allocator.free(msg);
+    try std.testing.expect(std.mem.indexOf(u8, msg, other_target) != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, compile_target_id) != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "The target differs") != null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        msg,
+        "recompile the .sbc with a kaappi built for this target",
+    ) != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "The build id differs") == null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "The version differs") == null);
+}
+
+test "renderForeignBuildDiagnostic: advice matches the differing component (kaappi#2514)" {
+    const allocator = std.testing.allocator;
+    const this_build = BuildIdentity{
+        .version = main.version,
+        .build_id = build_options.git_build_id,
+        .target = compile_target_id,
+    };
+
+    // Stale bundle (kaappi#1930's case): build id differs → rebuild advice.
+    const stale = try renderForeignBuildDiagnostic(allocator, .{
+        .source_hash = 1,
+        .compiler_hash = 2,
+        .build_id = "0000000-old",
+        .source_path = "prog.scm",
+        .target = compile_target_id,
+        .version = main.version,
+        .current_build = false,
+    }, this_build);
+    defer allocator.free(stale);
+    try std.testing.expect(std.mem.indexOf(u8, stale, "The build id differs") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stale, "rebuild the bundle from current source") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stale, "The target differs") == null);
+
+    // Version differs → rebuild advice, and the versions are both printed.
+    const old_version = try renderForeignBuildDiagnostic(allocator, .{
+        .source_hash = 1,
+        .compiler_hash = 2,
+        .build_id = build_options.git_build_id,
+        .source_path = "prog.scm",
+        .target = compile_target_id,
+        .version = "0.0.1-ancient",
+        .current_build = false,
+    }, this_build);
+    defer allocator.free(old_version);
+    try std.testing.expect(std.mem.indexOf(u8, old_version, "The version differs") != null);
+    try std.testing.expect(std.mem.indexOf(u8, old_version, "0.0.1-ancient") != null);
+    try std.testing.expect(std.mem.indexOf(u8, old_version, "The target differs") == null);
+
+    // Pre-v14 header: target/version unrecorded (null) and everything recorded
+    // matches. The diagnostic must NOT claim a component differs — it never
+    // read one — and says the differing component is not recorded instead.
+    const legacy = try renderForeignBuildDiagnostic(allocator, .{
+        .source_hash = 1,
+        .compiler_hash = 2,
+        .build_id = build_options.git_build_id,
+        .source_path = "prog.scm",
+        .target = null,
+        .version = null,
+        .current_build = false,
+    }, this_build);
+    defer allocator.free(legacy);
+    try std.testing.expect(std.mem.indexOf(u8, legacy, "not recorded") != null);
+    try std.testing.expect(std.mem.indexOf(u8, legacy, "The target differs") == null);
+    try std.testing.expect(std.mem.indexOf(u8, legacy, "The build id differs") == null);
+    try std.testing.expect(std.mem.indexOf(u8, legacy, "The version differs") == null);
+}
+
+test "pre-v14 .sbc still classifies and loads (kaappi#2514)" {
+    // Backward compatibility: headers written before the target/version fields
+    // exist must keep parsing (for classification and `cache status`) and keep
+    // loading (a v13 cache entry with a current compiler hash is a hit), since
+    // v13 shares v14's tail layout.
+    const allocator = std.testing.allocator;
+    var gc = GC.init(allocator);
+    defer gc.deinit();
+
+    // A v13 header from a different build of the same target: classifies as a
+    // foreign build with the new fields reading back as null.
+    var w = Writer{ .buf = .empty };
+    defer w.buf.deinit(allocator);
+    const other_build_key = compilerHashFor(main.version, "0000000-other-build", compile_target_id);
+    try w.writeBytes(allocator, &MAGIC);
+    try w.writeU16(allocator, 13);
+    try w.writeU64(allocator, 0x5EED);
+    try w.writeU64(allocator, other_build_key);
+    try w.writeStr(allocator, "0000000-other-build");
+    try w.writeStr(allocator, "prog.scm");
+    // v13: no target or version strings follow the source path.
+
+    try std.testing.expect(classifyEmbeddedRejection(w.buf.items) == .foreign_build);
+    const info = readHeaderInfo(w.buf.items) orelse return error.TestUnexpectedResult;
+    try std.testing.expect(info.target == null);
+    try std.testing.expect(info.version == null);
+
+    // A complete v13 program entry written by THIS build (current compiler
+    // hash) loads: one return-only function, one replay slot, empty sections.
+    var old = Writer{ .buf = .empty };
+    defer old.buf.deinit(allocator);
+    try old.writeBytes(allocator, &MAGIC);
+    try old.writeU16(allocator, 13);
+    try old.writeU64(allocator, 0x1D0C);
+    try old.writeU64(allocator, compilerHash());
+    try old.writeStr(allocator, build_options.git_build_id);
+    try old.writeStr(allocator, "old.scm");
+    try old.writeU8(allocator, ENTRY_PROGRAM);
+    try old.writeU32(allocator, 1); // func_count
+    try old.writeU32(allocator, 1); // top_level_count
+    // Function 0: return-only body, like the classify fixture above.
+    try old.writeU8(allocator, 0); // arity
+    try old.writeU16(allocator, 1); // locals_count
+    try old.writeU16(allocator, 0); // upvalue_count
+    try old.writeU8(allocator, 0); // is_variadic
+    try old.writeU16(allocator, 0); // name_len
+    try old.writeU32(allocator, 3); // code_len
+    try old.writeU8(allocator, @intFromEnum(types.OpCode.@"return"));
+    try old.writeU8(allocator, 0);
+    try old.writeU8(allocator, 0);
+    try old.writeU32(allocator, 0); // const_count
+    try old.writeU32(allocator, 0); // source_line
+    try old.writeU32(allocator, 0); // line_table count
+    // Program slots: one function slot.
+    try old.writeU32(allocator, 1);
+    try old.writeU8(allocator, SLOT_FUNCTION);
+    try old.writeU32(allocator, 0);
+    // Empty include/dependency/bundled/preamble sections.
+    try old.writeU32(allocator, 0);
+    try old.writeU32(allocator, 0);
+    try old.writeU32(allocator, 0);
+    try old.writeU32(allocator, 0);
+
+    var loaded = (try deserializeFromBuffer(&gc, old.buf.items, 0x1D0C)) orelse
+        return error.TestUnexpectedResult;
+    defer freeDeserializeResult(allocator, &loaded);
+    try std.testing.expectEqual(@as(u32, 1), loaded.top_level_count);
+    try std.testing.expectEqual(@as(usize, 1), loaded.funcs.len);
+    try std.testing.expect(loaded.slots != null);
+}
+
+test "readHeaderInfo round-trips build id, source path, target and version" {
     if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     const allocator = std.testing.allocator;
     var gc = GC.init(allocator);
@@ -974,6 +1174,9 @@ test "readHeaderInfo round-trips build id and source path" {
     try std.testing.expectEqual(@as(u64, 0xABCD), info.source_hash);
     try std.testing.expectEqualStrings(build_options.git_build_id, info.build_id);
     try std.testing.expectEqualStrings("/home/u/prog.scm", info.source_path);
+    // v14 (kaappi#2514): the other two compiler-key components round-trip too.
+    try std.testing.expectEqualStrings(compile_target_id, info.target.?);
+    try std.testing.expectEqualStrings(main.version, info.version.?);
     // Written by this very binary, so it reads back as the current build.
     try std.testing.expect(info.current_build);
 }
@@ -993,6 +1196,9 @@ test "bytecode validation rejects oversized function count header" {
     try w.writeU64(allocator, compilerHash());
     try w.writeStr(allocator, "unknown"); // build id
     try w.writeStr(allocator, "test.scm"); // source path
+    try w.writeStr(allocator, compile_target_id); // v14 target
+    try w.writeStr(allocator, main.version); // v14 version
+    try w.writeU8(allocator, ENTRY_PROGRAM);
     try w.writeU32(allocator, @as(u32, @intCast(MAX_FUNCTIONS + 1)));
     try w.writeU32(allocator, 1);
 
@@ -1179,6 +1385,9 @@ test "bytecode validation rejects invalid opcode" {
     try w.writeU64(allocator, compilerHash());
     try w.writeStr(allocator, "unknown"); // build id
     try w.writeStr(allocator, "test.scm"); // source path
+    try w.writeStr(allocator, compile_target_id); // v14 target
+    try w.writeStr(allocator, main.version); // v14 version
+    try w.writeU8(allocator, ENTRY_PROGRAM);
     try w.writeU32(allocator, 1); // function count
     try w.writeU32(allocator, 1); // top-level count
 

--- a/src/bytecode_file_read.zig
+++ b/src/bytecode_file_read.zig
@@ -581,7 +581,7 @@ fn deserializeFromBufferImpl(gc: *GC, data: []const u8, expected_hash: ?u64) Byt
     // v14 (kaappi#2514): the producing binary's compile target and version
     // string follow. Read to advance the cursor; a v13 entry stops after the
     // source path and shares this tail layout, so it loads unchanged.
-    if (ver >= 14) {
+    if (ver >= bf.TARGET_FIELDS_SINCE) {
         _ = r.readStr() catch return null;
         _ = r.readStr() catch return null;
     }
@@ -1065,7 +1065,7 @@ pub fn readHeaderInfo(data: []const u8) ?HeaderInfo {
     const source_path = r.readStr() catch return null;
     var target: ?[]const u8 = null;
     var version_str: ?[]const u8 = null;
-    if (ver >= 14) {
+    if (ver >= bf.TARGET_FIELDS_SINCE) {
         target = r.readStr() catch return null;
         version_str = r.readStr() catch return null;
     }
@@ -1152,10 +1152,12 @@ pub fn renderForeignBuildDiagnostic(
     );
     if (!version_differs and !build_id_differs and !target_differs) {
         if (bundle.version == null or bundle.target == null) {
-            // Pre-v14 header: the differing input is one this header never
-            // wrote down (target/version), or two dirty builds sharing one
-            // build id. Name the likely cause without claiming equality of a
-            // component that was never read.
+            // Pre-v14 header: the build id matched, so the differing input is
+            // one this header never wrote down — target or version. (Two
+            // dirty builds at one commit do NOT land here: they share all
+            // three hash inputs and load each other's entries silently,
+            // kaappi#1516.) Name the likely cause without claiming equality
+            // of a component that was never read.
             try w.print(
                 "The differing component is not recorded in this .sbc (older header " ++
                     "format). If it was compiled for a different target, recompile " ++

--- a/src/bytecode_file_read.zig
+++ b/src/bytecode_file_read.zig
@@ -563,7 +563,7 @@ fn deserializeFromBufferImpl(gc: *GC, data: []const u8, expected_hash: ?u64) Byt
     if (!std.mem.eql(u8, magic, &bf.MAGIC)) return null;
 
     const ver = r.readU16() catch return null;
-    if (ver != bf.VERSION) return null;
+    if (ver < bf.MIN_READ_VERSION or ver > bf.VERSION) return null;
 
     const file_hash = r.readU64() catch return null;
     if (expected_hash) |eh| {
@@ -578,6 +578,13 @@ fn deserializeFromBufferImpl(gc: *GC, data: []const u8, expected_hash: ?u64) Byt
     // status`). A truncated header here is a corrupt cache — treat as a miss.
     _ = r.readStr() catch return null;
     _ = r.readStr() catch return null;
+    // v14 (kaappi#2514): the producing binary's compile target and version
+    // string follow. Read to advance the cursor; a v13 entry stops after the
+    // source path and shares this tail layout, so it loads unchanged.
+    if (ver >= 14) {
+        _ = r.readStr() catch return null;
+        _ = r.readStr() catch return null;
+    }
 
     // Entry kind (v13): selects the tail layout.
     const entry_kind = r.readU8() catch return null;
@@ -1028,6 +1035,12 @@ pub const HeaderInfo = struct {
     compiler_hash: u64,
     build_id: []const u8,
     source_path: []const u8,
+    /// The producing binary's compile target (`bf.compile_target_id`), or null
+    /// for a pre-v14 header that did not record it (kaappi#2514).
+    target: ?[]const u8 = null,
+    /// The producing binary's release version string (e.g. "0.26.1" — not the
+    /// on-disk format VERSION), or null for a pre-v14 header.
+    version: ?[]const u8 = null,
     /// True when this entry was produced by the running binary — i.e. a plain
     /// run of its source would hit (given the source is unchanged).
     current_build: bool,
@@ -1035,26 +1048,133 @@ pub const HeaderInfo = struct {
 
 /// Parse just the header of a `.sbc` buffer for reporting, without
 /// deserializing any functions. Returns null when the buffer is not a
-/// current-format Kaappi cache file (bad magic, or a version this binary can't
-/// parse) — `cache status` shows such files by size only. Unlike the load path
-/// this does *not* reject on a compiler-hash mismatch: reporting stale entries
-/// from other builds is the whole point.
+/// readable-format Kaappi cache file (bad magic, or a version outside
+/// `MIN_READ_VERSION..VERSION`) — `cache status` shows such files by size
+/// only. Unlike the load path this does *not* reject on a compiler-hash
+/// mismatch: reporting stale entries from other builds is the whole point.
 pub fn readHeaderInfo(data: []const u8) ?HeaderInfo {
     if (data.len < 22) return null;
     var r = Reader{ .data = data, .pos = 0 };
     const magic = r.readBytes(4) catch return null;
     if (!std.mem.eql(u8, magic, &bf.MAGIC)) return null;
     const ver = r.readU16() catch return null;
-    if (ver != bf.VERSION) return null;
+    if (ver < bf.MIN_READ_VERSION or ver > bf.VERSION) return null;
     const source_hash_val = r.readU64() catch return null;
     const compiler_hash_val = r.readU64() catch return null;
     const build_id = r.readStr() catch return null;
     const source_path = r.readStr() catch return null;
+    var target: ?[]const u8 = null;
+    var version_str: ?[]const u8 = null;
+    if (ver >= 14) {
+        target = r.readStr() catch return null;
+        version_str = r.readStr() catch return null;
+    }
     return .{
         .source_hash = source_hash_val,
         .compiler_hash = compiler_hash_val,
         .build_id = build_id,
         .source_path = source_path,
+        .target = target,
+        .version = version_str,
         .current_build = compiler_hash_val == bf.compilerHash(),
     };
+}
+
+// ---------------------------------------------------------------------------
+// Foreign-build diagnostic rendering (kaappi#2514)
+// ---------------------------------------------------------------------------
+
+/// One side of a `.foreign_build` comparison: the three inputs of
+/// `bf.compilerHashFor`. The binary's identity is passed in explicitly (rather
+/// than read from `main.version`/`build_options` inside) so tests can render
+/// against a hypothetical other-target binary.
+pub const BuildIdentity = struct {
+    version: []const u8,
+    build_id: []const u8,
+    target: []const u8,
+};
+
+/// The placeholder printed for a component a pre-v14 header does not record.
+/// Rendering it as absent (rather than guessing) keeps the diagnostic from
+/// claiming equality of a component it never read.
+const unrecorded = "?";
+
+/// Render the fatal diagnostic for a `.foreign_build` rejection of an embedded
+/// `.sbc` (kaappi#2514). Both sides show all three components of the compiler
+/// identity — version, build id, target — because the case that motivated this
+/// has two of the three *equal*: release binaries are built from one clean
+/// checkout, so a cross-target bundle reports a matching build id twice while
+/// refusing, which reads as a kaappi bug. Each differing component gets an
+/// advice line naming the fix that actually applies:
+///
+///   * target   → recompile the .sbc with a kaappi built for this target;
+///   * version or build id → the bundle is stale; rebuild it from current
+///     source (kaappi#1930's original case, unchanged advice).
+///
+/// A component the header does not record (pre-v14) prints as `?` and is never
+/// claimed equal or different; if nothing recorded differs, the fallback
+/// advice says so instead of naming a component it cannot see. Pure in its
+/// inputs so the wording is unit-testable without a VM.
+pub fn renderForeignBuildDiagnostic(
+    allocator: std.mem.Allocator,
+    bundle: HeaderInfo,
+    binary: BuildIdentity,
+) ![]u8 {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    errdefer aw.deinit();
+    const w = &aw.writer;
+
+    try w.print("fatal: embedded bytecode was produced by a different build\n", .{});
+    try w.print("  bundle:  {s}  {s}  {s}\n", .{
+        bundle.version orelse unrecorded,
+        bundle.build_id,
+        bundle.target orelse unrecorded,
+    });
+    try w.print("  binary:  {s}  {s}  {s}\n", .{ binary.version, binary.build_id, binary.target });
+
+    const version_differs = bundle.version != null and
+        !std.mem.eql(u8, bundle.version.?, binary.version);
+    const build_id_differs = !std.mem.eql(u8, bundle.build_id, binary.build_id);
+    const target_differs = bundle.target != null and
+        !std.mem.eql(u8, bundle.target.?, binary.target);
+
+    if (version_differs) try w.print(
+        "The version differs: rebuild the bundle from current source.\n",
+        .{},
+    );
+    if (build_id_differs) try w.print(
+        "The build id differs: rebuild the bundle from current source.\n",
+        .{},
+    );
+    if (target_differs) try w.print(
+        "The target differs: recompile the .sbc with a kaappi built for this target.\n",
+        .{},
+    );
+    if (!version_differs and !build_id_differs and !target_differs) {
+        if (bundle.version == null or bundle.target == null) {
+            // Pre-v14 header: the differing input is one this header never
+            // wrote down (target/version), or two dirty builds sharing one
+            // build id. Name the likely cause without claiming equality of a
+            // component that was never read.
+            try w.print(
+                "The differing component is not recorded in this .sbc (older header " ++
+                    "format). If it was compiled for a different target, recompile " ++
+                    "the .sbc with a kaappi built for this target; otherwise rebuild " ++
+                    "the bundle from current source.\n",
+                .{},
+            );
+        } else {
+            // Every component is recorded and matches, yet the compiler hash
+            // differs — not reachable through the writer (the hash is a pure
+            // function of these three), so at most a collision. Keep the
+            // advice generic rather than naming a component.
+            try w.print(
+                "The compiler build differs though every recorded component matches; " ++
+                    "rebuild the bundle from current source.\n",
+                .{},
+            );
+        }
+    }
+
+    return aw.toOwnedSlice();
 }

--- a/src/bytecode_file_write.zig
+++ b/src/bytecode_file_write.zig
@@ -404,6 +404,14 @@ fn writeFuncsSection(
     // rejected on load regardless of what these strings say.
     try w.writeStr(allocator, build_options.git_build_id);
     try w.writeStr(allocator, source_path);
+    // v14 (kaappi#2514): the other two inputs of `compilerHash`, recorded so a
+    // rejected embedded bundle can say *which* component differed. Release
+    // binaries are built from one clean checkout, so for a cross-target bundle
+    // the build id is identical on both sides and the target is the only
+    // differing input — without these strings the diagnostic could not name
+    // it. Same deal as the build id: informational, never load-gating.
+    try w.writeStr(allocator, bf.compile_target_id);
+    try w.writeStr(allocator, build_options.version);
     // v13 (kaappi#1888): the entry kind selects the tail layout — program
     // slots, bundle sections, or the library sections.
     try w.writeU8(allocator, entry_kind);

--- a/src/main.zig
+++ b/src/main.zig
@@ -337,12 +337,25 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
             // "wrong version or format".
             switch (bytecode_file.classifyEmbeddedRejection(bytecode_data)) {
                 .foreign_build => {
-                    const info = bytecode_file.readHeaderInfo(bytecode_data).?;
-                    writeStderr("fatal: embedded bytecode was produced by a different build (build id ");
-                    writeStderr(info.build_id);
-                    writeStderr("); this binary is ");
-                    writeStderr(build_options.git_build_id);
-                    writeStderr(". Rebuild the bundle from current source.\n");
+                    // kaappi#2514: print all three components of the compiler
+                    // identity on both sides and advice for the one that
+                    // differs — for a cross-target bundle the build id matches
+                    // (release binaries come from one clean checkout) and the
+                    // old build-id-only message read as a kaappi bug.
+                    if (bytecode_file.readHeaderInfo(bytecode_data)) |info| {
+                        if (bytecode_file.renderForeignBuildDiagnostic(allocator, info, .{
+                            .version = version,
+                            .build_id = build_options.git_build_id,
+                            .target = bytecode_file.compile_target_id,
+                        })) |msg| {
+                            writeStderr(msg);
+                            allocator.free(msg);
+                        } else |_| {
+                            writeStderr("fatal: embedded bytecode was produced by a different build\n");
+                        }
+                    } else {
+                        writeStderr("fatal: embedded bytecode was produced by a different build\n");
+                    }
                 },
                 .invalid => writeStderr("fatal: invalid embedded bytecode (wrong version or format)\n"),
             }

--- a/src/tests_endian.zig
+++ b/src/tests_endian.zig
@@ -197,12 +197,21 @@ test "endian: readHeaderInfo decodes a hand-assembled little-endian header" {
     try buf.appendSlice(allocator, "id");
     try appendLeU16(&buf, allocator, 6);
     try buf.appendSlice(allocator, "a.scm\x00"[0..6]);
+    // v14 (kaappi#2514): compile target and version strings after the source
+    // path. Literals, like every other field here — the reader accepts any
+    // string. Strings carry no byte order; only their u16 lengths do.
+    try appendLeU16(&buf, allocator, 3);
+    try buf.appendSlice(allocator, "tgt");
+    try appendLeU16(&buf, allocator, 3);
+    try buf.appendSlice(allocator, "9.9");
 
     const info = bf.readHeaderInfo(buf.items) orelse
         return error.HeaderRejected;
     try std.testing.expectEqual(@as(u64, 0x0102030405060708), info.source_hash);
     try std.testing.expectEqual(@as(u64, 0x1122334455667788), info.compiler_hash);
     try std.testing.expectEqualStrings("id", info.build_id);
+    try std.testing.expectEqualStrings("tgt", info.target.?);
+    try std.testing.expectEqualStrings("9.9", info.version.?);
 }
 
 test "endian: readHeaderInfo rejects a big-endian-spelled version field" {
@@ -475,6 +484,13 @@ fn goldenHeader(
     try list.appendSlice(allocator, build_id);
     try appendLe(list, allocator, 2, GOLDEN_SOURCE_PATH.len);
     try list.appendSlice(allocator, GOLDEN_SOURCE_PATH);
+    // v14 (kaappi#2514): the compile target and version strings after the
+    // source path. The writer stamps the real ones, so the fixture does too —
+    // strings carry no byte order, only their u16 lengths do.
+    try appendLe(list, allocator, 2, bf.compile_target_id.len);
+    try list.appendSlice(allocator, bf.compile_target_id);
+    try appendLe(list, allocator, 2, build_options.version.len);
+    try list.appendSlice(allocator, build_options.version);
     // v13 (kaappi#1888): the entry-kind byte after the source path — a
     // program entry (0), whose replay slot section GOLDEN_BODY carries.
     try list.append(allocator, bf.ENTRY_PROGRAM);

--- a/src/tests_endian.zig
+++ b/src/tests_endian.zig
@@ -221,16 +221,18 @@ test "endian: readHeaderInfo rejects a big-endian-spelled version field" {
     // honouring it -- and on a big-endian host that is precisely the bug
     // this file exists to catch.
     comptime {
-        // The control is only discriminating while VERSION's two bytes
-        // differ. At VERSION 10 (0x000A) they do. A future bump to a value
-        // like 0x0101 would make the swap invisible and this test vacuous,
-        // so fail the build then rather than keep a green no-op.
-        const lo: u8 = @truncate(bf.VERSION);
-        const hi: u8 = @truncate(bf.VERSION >> 8);
-        if (lo == hi) @compileError(
-            "bytecode_file.VERSION's two bytes are equal, so byte-swapping it " ++
-                "is undetectable and this endianness control asserts nothing. " ++
-                "Pick a different discriminating field, or a VERSION whose bytes differ.",
+        // The control is only discriminating while the byte-swapped VERSION
+        // falls OUTSIDE the reader's accepted window MIN_READ_VERSION..VERSION
+        // (kaappi#2514). Two bytes that are equal (0x0101) swap to themselves;
+        // a wider window could also admit a swapped value that differs — either
+        // way the swap would be accepted and this test a green no-op, so fail
+        // the build then. At VERSION 14 (0x000E) the swap is 0x0E00 = 3584.
+        const swapped: u16 = @byteSwap(bf.VERSION);
+        if (swapped >= bf.MIN_READ_VERSION and swapped <= bf.VERSION) @compileError(
+            "byte-swapping bytecode_file.VERSION yields a value inside the " ++
+                "MIN_READ_VERSION..VERSION read window, so this endianness control " ++
+                "asserts nothing. Pick a different discriminating field, or a " ++
+                "VERSION whose byte-swap falls outside the window.",
         );
     }
     const allocator = std.testing.allocator;

--- a/src/tests_fuzz.zig
+++ b/src/tests_fuzz.zig
@@ -105,8 +105,12 @@ const eval_corpus = [_][]const u8{
 // ---------------------------------------------------------------------------
 // Bytecode loader fixture
 //
-// A small valid .sbc checked in at src/testdata/fuzz-seed.sbc. Regenerate it
-// after a bytecode format VERSION bump (the sanity test below will fail):
+// A small valid .sbc checked in at src/testdata/fuzz-seed.sbc. Its header is
+// format v13; the reader accepts MIN_READ_VERSION..VERSION, so a VERSION bump
+// that leaves the tail layout alone does not invalidate it — it keeps loading
+// (and keeps exercising the pre-v14 read path, where the header's target and
+// version strings are absent). Regenerate it only when that window or the
+// entry layout changes (the sanity test below will fail):
 //
 //   zig build && zig-out/bin/kaappi --compile src/testdata/fuzz-seed.scm \
 //     -o src/testdata/fuzz-seed.sbc

--- a/src/toplevel_driver.zig
+++ b/src/toplevel_driver.zig
@@ -645,9 +645,10 @@ pub fn runFile(vm: *vm_mod.VM, path: []const u8) !void {
                 // re-dispatched through handleTopLevelForm — in the exact
                 // top-level order, so an `import` between two defines stays
                 // between them (no preamble hoisting, the #2200 reorder class).
-                // Older-format entries are unreachable: the VERSION check
-                // rejects them, and the kind/slots check above is what admits a
-                // replayable entry.
+                // Pre-v13 entries are unreachable: the MIN_READ_VERSION check
+                // rejects them. v13 and v14 share this tail layout (the v14
+                // bump only added two header strings, kaappi#2514), and the
+                // kind/slots check above is what admits a replayable entry.
                 {
                     for (loaded.slots.?) |slot| {
                         switch (slot) {


### PR DESCRIPTION
Closes #2514

## The problem

When a bundled standalone refuses its embedded `.sbc` because it was built for a **different target**, the fatal diagnostic printed the build id on both sides — identical, because all release binaries come from one clean checkout — and still refused, advising "Rebuild the bundle from current source". The bundle *is* from current source; the real fix is recompiling the `.sbc` with a kaappi built for the embedding binary's target. The target is one of the three inputs of `compilerHashFor` (version, build id, target) and the only one the message never named.

## The fix

- **Format v14**: the `.sbc` header records the producing binary's compile target (`compile_target_id`, the exact string `compilerHashFor` hashes) and release version string after the source path. Purely informational, never load-gating — same contract as the v10 build id.
- **`HeaderInfo`** carries `target: ?[]const u8` and `version: ?[]const u8` (null for pre-v14 headers).
- **`renderForeignBuildDiagnostic`** (in `bytecode_file_read.zig`, re-exported by the hub; pure in its inputs) prints all three components for both sides and one advice line per differing component:
  - target differs → "The target differs: recompile the .sbc with a kaappi built for this target."
  - version or build id differs → the kaappi#1930 stale-bundle advice, unchanged.
  - nothing recorded differs (pre-v14 header) → says the differing component is not recorded, prints `?` for the unrecorded components, and never claims equality of a component it never read.
- `main.zig`'s `.foreign_build` arm renders through it.

New message, cross-target case (end-to-end via `-Dbundle`):

```
fatal: embedded bytecode was produced by a different build
  bundle:  0.26.1  a684eeb3-dirty  aarch64-linux-none;r7rs;kaappi;…
  binary:  0.26.1  a684eeb3-dirty  aarch64-macos-none;r7rs;kaappi;…
The target differs: recompile the .sbc with a kaappi built for this target.
```

## Backward compatibility

The reader now accepts `MIN_READ_VERSION..VERSION` (13..14) instead of exactly `VERSION`. A v13 file merely lacks the two new strings and shares v14's tail layout, so it still **loads** (cache safety is unchanged — the v13 compiler hash already folded version, build id and target), still classifies as `.foreign_build` when foreign, and reads the new fields back as null. v12 and older are rejected exactly as before. The checked-in v13 fuzz-seed fixture therefore still loads through its comptime compiler-hash patch and was not regenerated.

## Tests

- `classifyEmbeddedRejection: cross-target bundle names the target` — a v14 header at this version + build id but a different target classifies as `.foreign_build`, the loader refuses it, and the rendered diagnostic names the target with the recompile advice (and not the stale-bundle one).
- `renderForeignBuildDiagnostic: advice matches the differing component` — build-id, version, and pre-v14-unknown cases each get the right advice; the legacy case never claims a component differs.
- `pre-v14 .sbc still classifies and loads` — a v13 header classifies with `target`/`version` reading back null, and a complete v13 program entry with a current compiler hash still deserializes.
- Extended: the kaappi#2155 area tests, the `readHeaderInfo` round-trip (now asserts target + version), the golden-byte endian fixtures, and the hand-assembled header fixtures (now well-formed v14).
- Sabotage-checked: breaking one assertion in the cross-target test fails the suite, so the tests execute, not skip.

Evidence: `zig build test` — **unit-tests 1933 pass, 21 skip, 0 fail; thottam-tests 88 pass**. End-to-end: forged cross-target bundle prints the message above and exits 1; the un-forged same-target bundle prints its program output and exits 0.