### PR TITLE
State what suppress_exit does not reproduce for emergency-exit

### DIFF
--- a/docs/dev/test-runner.md
+++ b/docs/dev/test-runner.md
@@ -97,9 +97,16 @@ Inside the worker (`src/toplevel_driver.zig` `runWorkerFile` →
    / `vm.exit_code`) instead of terminating the worker before it can emit its
    result. `(emergency-exit …)` records through the same channel — a plain
    `emergencyExitFn` used to kill the worker mid-file, and the orchestrator
-   reported the file as a missing result (kaappi#2521). Because the call never
-   happens, its *semantics* are reapplied when the verdict is resolved — see
-   [Verdicts](#verdicts-and-what-errored-means) below.
+   reported the file as a missing result (kaappi#2521). Because the process
+   does not actually terminate, the request's *semantics* — the exit code —
+   are reapplied when the verdict is resolved; see
+   [Verdicts](#verdicts-and-what-errored-means) below. What suppression does
+   not reproduce is the non-return: the call returns, so the file's remaining
+   forms still run, and for `(emergency-exit …)` the `dynamic-wind`
+   after-thunks a plain run would skip do run. Both are accepted
+   worker-vs-plain divergences — a worker that must reach `emitResult` cannot
+   honor "skip everything" — and `runner-agreement.sh` covers the shapes that
+   matter.
 3. **Run the file** via the normal `runFile` path (so the `.sbc` cache, imports,
    and error diagnostics all behave exactly as a plain run).
 4. **Emit one JSON object** for the file to `KAAPPI_TEST_EMIT`, built by walking

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -179,6 +179,15 @@ fn emergencyExitFn(args: []const Value) PrimitiveError!Value {
         // request and return instead: the raw code, before the #2512 upgrade
         // below, so the worker's `resolveVerdict` weighs what the file actually
         // asked for, exactly as it does a suppressed `(exit N)`.
+        //
+        // Returning is a deliberate departure from R7RS 6.14: control leaves
+        // any enclosing `dynamic-wind` extent normally, so the after-thunks a
+        // real emergency-exit skips DO run under suppression, and the file's
+        // remaining forms run too. A worker that must reach `emitResult`
+        // cannot honor "skip everything"; this is an accepted worker-vs-plain
+        // divergence (the same class `exit` has for forms after the call),
+        // not a bug to fix here. The plain-run contract is unchanged below
+        // and guarded by tests/scheme/errors/exit-wind.sh.
         if (vm.suppress_exit) {
             vm.exit_requested = true;
             vm.exit_code = code;


### PR DESCRIPTION
Follow-up to #2523, carrying the two non-blocking doc comments from its review.

## Why

Both the `emergencyExitFn` comment and the worker walkthrough in `docs/dev/test-runner.md` said the suppressed call "never happens". The call does happen; only the termination doesn't, and the parts of emergency-exit's R7RS 6.14 contract that depend on not returning are lost under a worker:

- the file's remaining forms still run (already true for `exit`), and
- control leaves any enclosing `dynamic-wind` extent normally, so the after-thunks a plain `(emergency-exit …)` skips **do** run.

Reproduced on the merged head:

```scheme
(import (scheme base) (scheme process-context) (srfi 64))
(test-begin "wind")
(dynamic-wind (lambda () #f)
  (lambda () (emergency-exit 0))
  (lambda () (test-assert "after-thunk ran" #f)))
(test-end "wind")
```

Plain run: exit 0, after-thunk skipped. `kaappi test`: `FAIL wind.scm (1/1 failed) - after-thunk ran: got #f`.

This is an accepted worker-vs-plain divergence — a worker that must reach `emitResult` cannot honor "skip everything" — not something to fix. Both sites now say so explicitly, so the R7RS 6.14 note just below the suppression block doesn't read as a contradiction someone should resolve by skipping the winds again.

## What changed

- `src/primitives_r7rs.zig`: a paragraph in the `emergencyExitFn` suppression comment.
- `docs/dev/test-runner.md`: worker walkthrough step 2 rewritten to say what is reapplied (the exit code, via the verdict) and what is not reproduced (the non-return).

Comments and docs only; no behaviour change. `zig fmt --check` and markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
