### PR TITLE
Honor suppress_exit from a SRFI-18 child thread and record it on the root

### DIFF
--- a/docs/dev/test-runner.md
+++ b/docs/dev/test-runner.md
@@ -122,8 +122,10 @@ to a failure of a test. SRFI-64 catches ordinary test failures internally via
 Three inputs decide it (`resolveVerdict` in `src/test_runner.zig`): whether an
 uncaught read/compile/runtime error was reported at top level, what the file's
 suppressed `(exit)` — or `(emergency-exit …)`, the same channel since
-kaappi#2521 — asked for, and whether the SRFI-64 counters already show a
-failure.
+kaappi#2521, and from a SRFI-18 child thread as much as from the main one
+since kaappi#2525: the flag is inherited by every child VM and the request
+is recorded on the root VM, the only one the worker reads — asked for, and
+whether the SRFI-64 counters already show a failure.
 
 | The file… | `error` | Why |
 |---|---|---|
@@ -401,6 +403,11 @@ a transcript diff between two runs stays meaningful at any job count.
   through a plain `kaappi <file>` and `kaappi test`, which must agree and land
   on the expected verdict, with the counts on the transcript and no
   "worker produced no result".
+- `tests/scheme/test-runner/thread-exit.sh` — `(exit …)` and
+  `(emergency-exit …)` made from a SRFI-18 child thread honor the worker's
+  `suppress_exit` and land on the root VM (kaappi#2525): a green suite whose
+  thread exits 0 stays green in both runners with its counts intact, and a
+  thread's unexplained exit 1 is the file's verdict in both.
 - `tests/scheme/test-runner/changed.sh` — `--changed`/`--list-affected` over a
   throwaway git repo with a known dependency shape: diamond import, `include`,
   a `(load …)` escape hatch, native-artifact and unknown-revision full-run

--- a/src/primitives_r7rs.zig
+++ b/src/primitives_r7rs.zig
@@ -130,6 +130,20 @@ pub fn effectiveExitCode(explicit: u8, script_had_error: bool) u8 {
     return if (explicit == 0 and script_had_error) 1 else explicit;
 }
 
+/// Record a suppressed `(exit)`/`(emergency-exit)` request where the
+/// `kaappi test` worker's `emitResult` will read it: on the ROOT VM. A
+/// SRFI-18 child thread runs on its own VM (`vm_instance` is threadlocal),
+/// and a request recorded there was never read — before kaappi#2525 the
+/// child did not even inherit `suppress_exit`, so its `(exit 0)` killed the
+/// worker outright. Atomic stores, code first: the root may be building its
+/// result while an unjoined child is still running, and a reader that sees
+/// `exit_requested` must not see a stale code.
+fn recordSuppressedExit(vm: *vm_mod.VM, code: u8) void {
+    const root = vm.root_vm orelse vm;
+    @atomicStore(u8, &root.exit_code, code, .monotonic);
+    @atomicStore(bool, &root.exit_requested, true, .release);
+}
+
 fn exitFn(args: []const Value) PrimitiveError!Value {
     var code = exitCode(args);
     if (vm_mod.vm_instance) |vm| {
@@ -138,8 +152,7 @@ fn exitFn(args: []const Value) PrimitiveError!Value {
         // epilogue calls `(exit 1)` only on failure; suppressing it lets the
         // worker report that failure structurally instead of losing the run.
         if (vm.suppress_exit) {
-            vm.exit_requested = true;
-            vm.exit_code = code;
+            recordSuppressedExit(vm, code);
             return types.VOID;
         }
         // The flag wins over an explicit `(exit 0)` (kaappi#2512). Consulted
@@ -180,8 +193,7 @@ fn emergencyExitFn(args: []const Value) PrimitiveError!Value {
         // below, so the worker's `resolveVerdict` weighs what the file actually
         // asked for, exactly as it does a suppressed `(exit N)`.
         if (vm.suppress_exit) {
-            vm.exit_requested = true;
-            vm.exit_code = code;
+            recordSuppressedExit(vm, code);
             return types.VOID;
         }
     }
@@ -620,6 +632,41 @@ test "suppress_exit turns (emergency-exit) into a recorded no-op, VM stays usabl
     try std.testing.expectEqual(types.VOID, r);
     try std.testing.expect(ctx.vm.exit_requested);
     try std.testing.expectEqual(@as(u8, 7), ctx.vm.exit_code);
+
+    const after = try ctx.vm.eval("(+ 1 2)");
+    try std.testing.expectEqual(@as(i64, 3), types.toFixnum(after));
+}
+
+// kaappi#2525: the worker's suppression must reach a SRFI-18 child thread —
+// `vm_instance` is threadlocal, so the child consults ITS VM's flag — and the
+// request must land on the root VM, the only one `emitResult` reads. Without
+// the fix this test does not fail, it dies: the child's `(exit 5)` is a real
+// std.process.exit of the test binary.
+test "suppress_exit reaches a SRFI-18 child thread and records on the root VM (#2525)" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // OS threads are unregistered on wasm (thread-start! is native-only)
+    const th = @import("testing_helpers.zig");
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+
+    ctx.vm.suppress_exit = true;
+    const r = try ctx.vm.eval(
+        \\(import (scheme process-context) (srfi 18))
+        \\(thread-join! (thread-start! (make-thread (lambda () (exit 5) 'after-exit))))
+    );
+    // The child's thunk ran on past the suppressed call, exactly as the main
+    // thread's would, and the join returned its value.
+    try std.testing.expect(types.isSymbol(r));
+    try std.testing.expectEqualStrings("after-exit", types.symbolName(r));
+    try std.testing.expect(ctx.vm.exit_requested);
+    try std.testing.expectEqual(@as(u8, 5), ctx.vm.exit_code);
+
+    // emergency-exit takes the same route.
+    ctx.vm.exit_requested = false;
+    ctx.vm.exit_code = 0;
+    _ = try ctx.vm.eval("(thread-join! (thread-start! (make-thread (lambda () (emergency-exit 6)))))");
+    try std.testing.expect(ctx.vm.exit_requested);
+    try std.testing.expectEqual(@as(u8, 6), ctx.vm.exit_code);
 
     const after = try ctx.vm.eval("(+ 1 2)");
     try std.testing.expectEqual(@as(i64, 3), types.toFixnum(after));

--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -244,10 +244,13 @@ fn buildFileJson(w: *std.Io.Writer, vm: *VM, file_path: []const u8, toplevel_err
     }
     const tests = pass + fail + xpass + xfail + skip;
 
+    // Acquire pairs with the release store in `recordSuppressedExit`: a
+    // SRFI-18 child the file never joined may still be running (kaappi#2525).
+    const exit_requested = @atomicLoad(bool, &vm.exit_requested, .acquire);
     const verdict = resolveVerdict(
         toplevel_error,
-        vm.exit_requested,
-        vm.exit_code,
+        exit_requested,
+        @atomicLoad(u8, &vm.exit_code, .monotonic),
         fail > 0 or xpass > 0,
     );
 

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -568,8 +568,14 @@ pub const VM = struct {
     /// `(emergency-exit code)` record the request and return instead of
     /// terminating the process, so the worker always reaches its
     /// result-emission step even when a test file's SRFI-64 epilogue calls
-    /// `(exit 1)` on failure. `exit_requested`/
-    /// `exit_code` capture the last such request. No effect on normal runs.
+    /// `(exit 1)` on failure. Inherited by every SRFI-18 child VM
+    /// (`initForThread`), because a child's `(exit)` is the same
+    /// `std.process.exit` and killed the worker just the same (kaappi#2525).
+    /// `exit_requested`/`exit_code` capture the last such request — always
+    /// on the ROOT VM, whichever thread made it, since the root is the only
+    /// VM the worker's `emitResult` reads; a child records through
+    /// `root_vm`, with atomic stores because the root may be emitting while
+    /// an unjoined child is still running. No effect on normal runs.
     suppress_exit: bool = false,
     exit_requested: bool = false,
     exit_code: u8 = 0,
@@ -839,6 +845,11 @@ pub const VM = struct {
             // tables and for the shared maps, and a grandchild's parent join
             // frees the middle VM/GC underneath it (#2129).
             .root_vm = parent.root_vm orelse parent,
+            // A `kaappi test` worker's suppression must reach every thread:
+            // a child's `(exit …)` is the same std.process.exit and used to
+            // kill the worker before it emitted (kaappi#2525). The request
+            // itself is recorded on the root (see `suppress_exit`).
+            .suppress_exit = parent.suppress_exit,
             // Shared reference, not a copy: SRFI 59/193 want a thread's
             // `program-vicinity`/`script-file` to still answer for the
             // top-level script, not #f. Never freed by the child -- see the

--- a/tests/scheme/test-runner/thread-exit.sh
+++ b/tests/scheme/test-runner/thread-exit.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# kaappi#2525 — `(exit …)` / `(emergency-exit …)` from a SRFI-18 child thread
+# must honor the `kaappi test` worker's suppress_exit contract too.
+#
+# `vm_instance` is threadlocal, so a child thread's `exit` consults ITS VM's
+# flag. `VM.initForThread` did not inherit `suppress_exit`, so a thread's
+# `(exit 0)` was a real std.process.exit: the worker died before emitting its
+# one JSON result and the orchestrator reported
+# `ERROR <file> (worker produced no result)` — the same crash-flavoured
+# outcome kaappi#2521 removed for the main thread — losing every SRFI-64
+# count the file had collected. A plain `kaappi <file>` exited 0, so the two
+# runners disagreed (kaappi#1903).
+#
+# Now the flag is inherited and the request lands on the ROOT VM (the only
+# one the worker's emitResult reads), so a thread's requested exit code
+# weighs into the verdict exactly like a main-thread `(exit N)`.
+#
+# Each fixture runs BOTH ways, as in runner-agreement.sh: a plain
+# `kaappi <file>` (whose exit status is what run-all.sh reads) and
+# `kaappi test <file>`; the two must agree AND land on the expected verdict.
+
+set -euo pipefail
+
+KAAPPI="${KAAPPI:-zig-out/bin/kaappi}"
+KAAPPI="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")"
+PASS=0
+FAIL=0
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+export KAAPPI_HOME="$WORK/home"
+mkdir -p "$KAAPPI_HOME"
+# Run from the temp dir: a plain `kaappi <file>` run's SRFI-64 runner drops a
+# `<suite>.log` in the cwd. Keep those out of the repo.
+cd "$WORK"
+
+# --- the two runners' verdict rules (as in runner-agreement.sh) --------------
+
+verdict_run_all() {
+    local file="$1" status=0
+    "$KAAPPI" "$file" > "$WORK/out.txt" 2>&1 || status=$?
+    if [[ $status -ne 0 ]]; then echo "FAIL"; else echo "PASS"; fi
+}
+
+verdict_kaappi_test() {
+    local file="$1" status=0
+    "$KAAPPI" test "$file" > "$WORK/kt.txt" 2>&1 || status=$?
+    if [[ $status -ne 0 ]]; then echo "FAIL"; else echo "PASS"; fi
+}
+
+# Both runners must agree, and both must reach `expected`. Requiring only
+# agreement would be satisfied by two runners that are wrong together.
+assert_agree() {
+    local label="$1" file="$2" expected="$3"
+    local a b
+    a=$(verdict_run_all "$file")
+    b=$(verdict_kaappi_test "$file")
+    if [[ "$a" == "$b" && "$a" == "$expected" ]]; then
+        echo "PASS: $label ($expected in both runners)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — run-all.sh=$a kaappi-test=$b, expected $expected in both"
+        sed 's/^/      | /' "$WORK/kt.txt"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Assert a substring is present in the last `kaappi test` transcript. Uses a
+# here-string, never a pipe into grep -q (see tests/scheme/CLAUDE.md).
+assert_kt_mentions() {
+    local label="$1" needle="$2"
+    local body
+    body=$(cat "$WORK/kt.txt")
+    if grep -qF "$needle" <<< "$body"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — transcript does not mention '$needle'"
+        sed 's/^/      | /' "$WORK/kt.txt"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# The absence twin: the crash flavour this script exists to bury.
+assert_kt_lacks() {
+    local label="$1" needle="$2"
+    local body
+    body=$(cat "$WORK/kt.txt")
+    if grep -qF "$needle" <<< "$body"; then
+        echo "FAIL: $label — transcript mentions '$needle'"
+        sed 's/^/      | /' "$WORK/kt.txt"
+        FAIL=$((FAIL + 1))
+    else
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# --- fixtures ---------------------------------------------------------------
+
+# A green suite whose joined child thread calls (exit 0): a plain run exits 0
+# (the thread's exit IS the process exit), and the worker must reach
+# emitResult with its counts. This is the exact shape that reported
+# `worker produced no result` (#2525).
+cat > te-pass.scm <<'SCM'
+(import (scheme base) (scheme process-context) (srfi 18) (srfi 64))
+(test-begin "te-pass")
+(test-equal "an ordinary passing assertion" 1 1)
+(thread-join! (thread-start! (make-thread (lambda () (exit 0)))))
+(test-end "te-pass")
+SCM
+
+# Same, via emergency-exit.
+cat > te-emergency-pass.scm <<'SCM'
+(import (scheme base) (scheme process-context) (srfi 18) (srfi 64))
+(test-begin "te-emergency-pass")
+(test-equal "an ordinary passing assertion" 1 1)
+(thread-join! (thread-start! (make-thread (lambda () (emergency-exit 0)))))
+(test-end "te-emergency-pass")
+SCM
+
+# A thread's bare (exit 1) with nothing in the counts to explain it: a plain
+# run exits 1, so the request must reach the ROOT VM's record — a request
+# left on the child VM is one the worker never reads, and the file would
+# come back green under `kaappi test`.
+cat > te-bare.scm <<'SCM'
+(import (scheme base) (scheme process-context) (srfi 18) (srfi 64))
+(test-begin "te-bare")
+(test-equal "an ordinary passing assertion" 1 1)
+(thread-join! (thread-start! (make-thread (lambda () (exit 1)))))
+(test-end "te-bare")
+SCM
+
+# --- the matrix -------------------------------------------------------------
+
+assert_agree "a child thread's (exit 0) over a passing suite stays green in both runners (#2525)" te-pass.scm PASS
+assert_kt_mentions "the passing suite's counts survive the thread's suppressed exit" "(1 tests"
+assert_kt_lacks "a thread's suppressed exit is not a missing worker result" "worker produced no result"
+
+assert_agree "a child thread's (emergency-exit 0) over a passing suite stays green in both runners" te-emergency-pass.scm PASS
+assert_kt_lacks "a thread's suppressed emergency exit is not a missing worker result" "worker produced no result"
+
+assert_agree "a child thread's bare (exit 1) with nothing failing is a failure in both runners" te-bare.scm FAIL
+assert_kt_mentions "the thread's request reached the root VM's verdict, not a child's unread record" \
+    "file requested a nonzero exit with no failing test to explain it"
+
+echo ""
+echo "thread-exit: $PASS pass, $FAIL fail"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Closes #2525

## The bug

A `kaappi test` worker sets `vm.suppress_exit` so a file's `(exit …)` — and since #2523 `(emergency-exit …)` — becomes a recorded no-op and the worker still emits its one JSON result. That only covered the main thread. `vm_instance` is threadlocal, so a SRFI-18 child thread consults **its** VM's flag, and `VM.initForThread` never copied `suppress_exit`. A thread's `(exit 0)` was a real `std.process.exit`: the worker died before writing `KAAPPI_TEST_EMIT` and the orchestrator reported

```
ERROR thr.scm  (worker produced no result)
```

losing every SRFI-64 count the file had collected. A plain `kaappi thr.scm` exited 0, so the two runners disagreed (kaappi#1903). Reproduced on main with a `thread-join!`'d `(make-thread (lambda () (exit 0)))`; identical for `emergency-exit`.

## The fix

Two halves, both needed:

- **`initForThread` inherits `suppress_exit`** (`src/vm.zig`), so the child's call returns instead of terminating.
- **The request is recorded on the root VM**, not the calling thread's. A child VM's own `exit_requested`/`exit_code` live on a struct the worker's `emitResult` never reads — inheriting the flag alone would have turned a thread's unexplained `(exit 1)` into a green file. `recordSuppressedExit` (`src/primitives_r7rs.zig`, now shared by `exitFn` and `emergencyExitFn`) writes through `root_vm` with atomic stores (code first, then the flag with release); `buildFileJson` reads with acquire, since the root may be building its result while a child the file never joined is still running.

Outside a worker nothing changes: a thread's exit still terminates the process.

`src/test_runner.zig` is already over the 1500-line cap; its change is the two atomic loads plus a comment (+3 net).

## Test evidence

- **Unit test** beside the primitive: `suppress_exit reaches a SRFI-18 child thread and records on the root VM (#2525)`. Starts a thread calling `(exit 5)` under suppression, checks the join returns the thunk's value and the root VM's record reads 5; repeats via `(emergency-exit 6)`; VM still usable. Without the fix this test does not fail, it kills the test binary.
- **`tests/scheme/test-runner/thread-exit.sh`** (picked up by `run-all.sh`'s "Test runner" suite): three fixtures — a green suite whose joined thread calls `(exit 0)`, the same via `(emergency-exit 0)`, and a thread's bare `(exit 1)` with nothing failing — each run through a plain `kaappi <file>` and `kaappi test`, requiring agreement and the expected verdict, surviving counts, and no "worker produced no result". The bare-exit fixture is the one that proves the root-VM recording: a child-side record would leave it green.
  - Without the fix (base binary from a684eeb3, and the pre-fix build of this branch): 1 pass, 6 fail.
  - With the fix: 7 pass, 0 fail.
- Full `zig build test`: 1932 pass, 21 skip. `emergency-exit.sh`, `runner-agreement.sh`, `errors/exit-wind.sh`, `errors/exit-code.sh` unchanged and green.

## Docs

`docs/dev/test-runner.md`: the verdict-inputs paragraph now says the suppressed request may come from any thread, and the test inventory lists the new script. Independent of #2526 (which rewrites the worker-walkthrough paragraph); this PR deliberately doesn't touch those lines, so the two merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
