### PR TITLE
Default -Dbundle builds to the portable baseline CPU

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,11 +35,12 @@ Bundle builds (`-Dbundle`/`-Dbundle-src`) additionally default to the portable
 **baseline CPU model** rather than the build host's exact CPU (kaappi#2515):
 a standalone binary is a thing you ship, and a host-tuned one can SIGILL on
 another machine of the same architecture — which reads as a VM bug, not a
-build-flags bug. Plain `zig build` stays host-tuned. An explicit `-Dcpu=<model>`
-(including `-Dcpu=native`) is always respected, and `-Dbundle-cpu-native` opts
-a bundle build back into host tuning. The CPU model is not part of the bytecode
-compiler key, so an `.sbc` produced by a host-tuned kaappi still embeds in a
-baseline bundler built from the same tree.
+build-flags bug. Plain `zig build` stays host-tuned. An explicit
+`-Dcpu=<model>` is always respected — `-Dcpu=native` is the opt-out that
+restores host tuning for a binary that really will only run on the machine
+that built it. The CPU model is not part of the bytecode compiler key, so an
+`.sbc` produced by a host-tuned kaappi still embeds in a baseline bundler
+built from the same tree.
 
 ### Build-time limits
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,16 @@ overflow auto-promotes to bignum). Debug is ~500x slower for allocation- and
 continuation-heavy workloads — only use it when debugging
 (`-Doptimize=Debug`). For maximum throughput: `-Doptimize=ReleaseFast`.
 
+Bundle builds (`-Dbundle`/`-Dbundle-src`) additionally default to the portable
+**baseline CPU model** rather than the build host's exact CPU (kaappi#2515):
+a standalone binary is a thing you ship, and a host-tuned one can SIGILL on
+another machine of the same architecture — which reads as a VM bug, not a
+build-flags bug. Plain `zig build` stays host-tuned. An explicit `-Dcpu=<model>`
+(including `-Dcpu=native`) is always respected, and `-Dbundle-cpu-native` opts
+a bundle build back into host tuning. The CPU model is not part of the bytecode
+compiler key, so an `.sbc` produced by a host-tuned kaappi still embeds in a
+baseline bundler built from the same tree.
+
 ### Build-time limits
 
 | Option | Default | Grows to |

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ symbols, and **multi-line input** with automatic paren balancing.
 
 - **180 SRFIs** — 12 built-in, 164 as portable `.sld` libraries, plus SRFI 261 portable library references (`(srfi srfi-1)`, `(srfi lists-1)`) resolved in the importer and SRFI 226/160/211 as sub-libraries only (full list in [CONFORMANCE.md](CONFORMANCE.md))
 - **Native binaries** — `kaappi compile program.scm -o program` compiles Scheme to a native executable via LLVM, with self-tail-calls compiled as loops ([details](docs/dev/llvm-backend.md))
-- **Standalone bundles** — `zig build -Dbundle-src=program.scm` embeds bytecode + libraries in a single executable
+- **Standalone bundles** — `zig build -Dbundle-src=program.scm` embeds bytecode + libraries in a single executable, tuned to the portable baseline CPU so it runs on other machines of the same architecture (`-Dbundle-cpu-native` restores host tuning)
 - **C FFI** — call shared libraries from Scheme via `(kaappi ffi)`; 18 marshalled types, callbacks for passing Scheme procedures to C
 - **Concurrency** — green threads with channels via `(kaappi fibers)`, plus real OS threads via SRFI-18
 - **Stepping debugger** — breakpoints (with conditions), watch expressions, step/next/step-out, frame navigation, locals — all from the REPL

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ symbols, and **multi-line input** with automatic paren balancing.
 
 - **180 SRFIs** — 12 built-in, 164 as portable `.sld` libraries, plus SRFI 261 portable library references (`(srfi srfi-1)`, `(srfi lists-1)`) resolved in the importer and SRFI 226/160/211 as sub-libraries only (full list in [CONFORMANCE.md](CONFORMANCE.md))
 - **Native binaries** — `kaappi compile program.scm -o program` compiles Scheme to a native executable via LLVM, with self-tail-calls compiled as loops ([details](docs/dev/llvm-backend.md))
-- **Standalone bundles** — `zig build -Dbundle-src=program.scm` embeds bytecode + libraries in a single executable, tuned to the portable baseline CPU so it runs on other machines of the same architecture (`-Dbundle-cpu-native` restores host tuning)
+- **Standalone bundles** — `zig build -Dbundle-src=program.scm` embeds bytecode + libraries in a single executable, tuned to the portable baseline CPU so it runs on other machines of the same architecture (`-Dcpu=native` restores host tuning)
 - **C FFI** — call shared libraries from Scheme via `(kaappi ffi)`; 18 marshalled types, callbacks for passing Scheme procedures to C
 - **Concurrency** — green threads with channels via `(kaappi fibers)`, plus real OS threads via SRFI-18
 - **Stepping debugger** — breakpoints (with conditions), watch expressions, step/next/step-out, frame navigation, locals — all from the REPL

--- a/build.zig
+++ b/build.zig
@@ -2,7 +2,46 @@ const std = @import("std");
 const zon = @import("build.zig.zon");
 
 pub fn build(b: *std.Build) void {
-    const target = b.standardTargetOptions(.{});
+    // Standard -Dtarget/-Dcpu/-Dofmt/-Ddynamic-linker, parsed to a query but
+    // NOT yet resolved: the bundle path below may retune the CPU model first
+    // (kaappi#2515). Same option registration `standardTargetOptions` performs,
+    // so the non-bundle path below resolves to exactly what it always did.
+    const target_query = b.standardTargetOptionsQueryOnly(.{});
+
+    // Standalone binary: embed compiled bytecode via -Dbundle=path/to/program.sbc.
+    // Bundled builds default to the portable baseline CPU (kaappi#2515): a
+    // standalone binary is a thing you *ship*, and `zig build` with no -Dtarget
+    // otherwise tunes for the build host's exact CPU model, so the binary can
+    // SIGILL on another machine of the same architecture — which presents as a
+    // VM bug, not a build-flags bug. -Dbundle-cpu-native opts back into host
+    // tuning for a binary that really will only ever run here.
+    const bundle = b.option([]const u8, "bundle", "Path to .sbc bytecode file to embed for standalone binary (defaults to the portable baseline CPU so it runs on other machines of the same arch; -Dbundle-cpu-native restores host tuning)");
+    // Single-step: compile and embed in one build
+    const bundle_src = b.option([]const u8, "bundle-src", "Path to .scm source file to compile and embed for standalone binary (defaults to the portable baseline CPU so it runs on other machines of the same arch; -Dbundle-cpu-native restores host tuning)");
+    const bundle_cpu_native = b.option(bool, "bundle-cpu-native", "Tune a -Dbundle/-Dbundle-src binary for this machine's exact CPU model instead of the portable baseline default (kaappi#2515); such a binary can SIGILL on other machines of the same architecture") orelse false;
+
+    // kaappi#2515: when bundling, retune the query to the baseline CPU model
+    // unless the user named a CPU themselves. `.determined_by_arch_os` is the
+    // "user didn't say" state — Zig resolves it to the *host* model when no
+    // -Dtarget was given (that is the bug) and to baseline for an explicit
+    // -Dtarget, so pinning it to `.baseline` makes both spellings land on
+    // baseline while `-Dcpu=<model>`/`-Dcpu=native` (`.explicit`/`.native`) and
+    // `-Dcpu=baseline` are left exactly as passed. This tunes every artifact of
+    // a bundling configure (the embedded binary, its build-time
+    // kaappi-compiler, and the always-installed thottam/kaappi-lsp) — one
+    // configure, one target. Plain `zig build` without bundle options is
+    // untouched and stays host-tuned: that binary stays on the machine that
+    // built it. The CPU model is not part of the bytecode compiler key
+    // (`bytecode_file.compile_target_id` hashes arch/os/abi + cond-expand
+    // features only), so a baseline bundler still accepts an .sbc produced by
+    // a host-tuned kaappi from the same tree.
+    const bundling = bundle != null or bundle_src != null;
+    var effective_query = target_query;
+    if (bundling and !bundle_cpu_native and target_query.cpu_model == .determined_by_arch_os) {
+        effective_query.cpu_model = .baseline;
+    }
+    const target = b.resolveTargetQuery(effective_query);
+
     // Default to ReleaseSafe rather than Debug: the interpreter exists to *run*
     // Scheme programs, and Debug is ~500x slower for allocation/continuation-
     // heavy workloads. ReleaseSafe matches ReleaseFast in throughput here while
@@ -14,11 +53,6 @@ pub fn build(b: *std.Build) void {
         "Prioritize performance, safety, or binary size (default: ReleaseSafe)",
     );
     const optimize = optimize_opt orelse .ReleaseSafe;
-
-    // Standalone binary: embed compiled bytecode via -Dbundle=path/to/program.sbc
-    const bundle = b.option([]const u8, "bundle", "Path to .sbc bytecode file to embed for standalone binary");
-    // Single-step: compile and embed in one build
-    const bundle_src = b.option([]const u8, "bundle-src", "Path to .scm source file to compile and embed for standalone binary");
 
     const do_strip = b.option(bool, "strip", "Strip debug info from binaries (for release builds)") orelse false;
     const strip: ?bool = if (do_strip) true else null;

--- a/build.zig
+++ b/build.zig
@@ -13,12 +13,11 @@ pub fn build(b: *std.Build) void {
     // standalone binary is a thing you *ship*, and `zig build` with no -Dtarget
     // otherwise tunes for the build host's exact CPU model, so the binary can
     // SIGILL on another machine of the same architecture — which presents as a
-    // VM bug, not a build-flags bug. -Dbundle-cpu-native opts back into host
-    // tuning for a binary that really will only ever run here.
-    const bundle = b.option([]const u8, "bundle", "Path to .sbc bytecode file to embed for standalone binary (defaults to the portable baseline CPU so it runs on other machines of the same arch; -Dbundle-cpu-native restores host tuning)");
+    // VM bug, not a build-flags bug. -Dcpu=native opts back into host tuning
+    // for a binary that really will only ever run here.
+    const bundle = b.option([]const u8, "bundle", "Path to .sbc bytecode file to embed for standalone binary (defaults to the portable baseline CPU so it runs on other machines of the same arch; -Dcpu=native restores host tuning)");
     // Single-step: compile and embed in one build
-    const bundle_src = b.option([]const u8, "bundle-src", "Path to .scm source file to compile and embed for standalone binary (defaults to the portable baseline CPU so it runs on other machines of the same arch; -Dbundle-cpu-native restores host tuning)");
-    const bundle_cpu_native = b.option(bool, "bundle-cpu-native", "Tune a -Dbundle/-Dbundle-src binary for this machine's exact CPU model instead of the portable baseline default (kaappi#2515); such a binary can SIGILL on other machines of the same architecture") orelse false;
+    const bundle_src = b.option([]const u8, "bundle-src", "Path to .scm source file to compile and embed for standalone binary (defaults to the portable baseline CPU so it runs on other machines of the same arch; -Dcpu=native restores host tuning)");
 
     // kaappi#2515: when bundling, retune the query to the baseline CPU model
     // unless the user named a CPU themselves. `.determined_by_arch_os` is the
@@ -26,10 +25,15 @@ pub fn build(b: *std.Build) void {
     // -Dtarget was given (that is the bug) and to baseline for an explicit
     // -Dtarget, so pinning it to `.baseline` makes both spellings land on
     // baseline while `-Dcpu=<model>`/`-Dcpu=native` (`.explicit`/`.native`) and
-    // `-Dcpu=baseline` are left exactly as passed. This tunes every artifact of
-    // a bundling configure (the embedded binary, its build-time
-    // kaappi-compiler, and the always-installed thottam/kaappi-lsp) — one
-    // configure, one target. Plain `zig build` without bundle options is
+    // `-Dcpu=baseline` are left exactly as passed. The opt-out is Zig's own
+    // `-Dcpu=native` rather than a bundle-only flag: it is the pre-fix tuning
+    // bit for bit (`detectNativeCpuAndFeatures`, the same call the unpinned
+    // query makes) and, unlike a flag that merely skipped this pin, it also
+    // delivers host tuning under an explicit `-Dtarget`, where an unpinned
+    // `.determined_by_arch_os` query would resolve to baseline. This tunes
+    // every artifact of a bundling configure (the embedded binary, its
+    // build-time kaappi-compiler, and the always-installed thottam/kaappi-lsp)
+    // — one configure, one target. Plain `zig build` without bundle options is
     // untouched and stays host-tuned: that binary stays on the machine that
     // built it. The CPU model is not part of the bytecode compiler key
     // (`bytecode_file.compile_target_id` hashes arch/os/abi + cond-expand
@@ -37,7 +41,7 @@ pub fn build(b: *std.Build) void {
     // a host-tuned kaappi from the same tree.
     const bundling = bundle != null or bundle_src != null;
     var effective_query = target_query;
-    if (bundling and !bundle_cpu_native and target_query.cpu_model == .determined_by_arch_os) {
+    if (bundling and target_query.cpu_model == .determined_by_arch_os) {
         effective_query.cpu_model = .baseline;
     }
     const target = b.resolveTargetQuery(effective_query);

--- a/docs/dev/cache.md
+++ b/docs/dev/cache.md
@@ -87,6 +87,14 @@ through explicit conversions, pinned against committed golden bytes in
 `src/tests_endian.zig` (audit v2 Phase 7D) so a swap on either side — or on
 both — fails on every host.
 
+The **CPU model** is not part of it either: `compile_target_id` hashes the
+arch/os/abi triple plus `platform_features`, and none of those move when the
+same target is tuned for baseline instead of the host's exact CPU. That is
+what lets a `-Dbundle=` bundler — baseline by default since kaappi#2515, so
+the standalone binary runs on other machines of the same architecture —
+embed an `.sbc` produced by a plain host-tuned `kaappi --compile` from the
+same tree, which is the documented two-command bundle flow.
+
 A *filename* collision is self-correcting, never a wrong result: even if two
 different source paths hashed to the same cache filename, the stored source
 hash would not match, so the load misses and recompiles. The dirty-build-id

--- a/docs/dev/test-runner.md
+++ b/docs/dev/test-runner.md
@@ -371,7 +371,7 @@ Three things make that safe and worthwhile (kaappi#1926):
   stays host-tuned. That asymmetry is deliberate and free — the embedded
   bytecode already puts the bundler on its own cache key, and the CPU model
   is not part of the `.sbc` compiler hash (see [cache.md](cache.md)) — but it
-  means no script may pass `-Dbundle-cpu-native` (or a host-naming
+  means no script may pass `-Dcpu=native` (or any host-naming
   `-Dcpu=<model>`) to a `-Dbundle=` build: it would fork the shared cache key
   *and* reintroduce the portability bug the default exists to prevent.
 

--- a/docs/dev/test-runner.md
+++ b/docs/dev/test-runner.md
@@ -364,6 +364,17 @@ Three things make that safe and worthwhile (kaappi#1926):
   that ordinary runner variance decided it, failing a *required* check about
   one run in fourteen. Keep the count of full builds per script at one.
 
+  The same one-key discipline applies to the CPU: since kaappi#2515 every
+  `-Dbundle=` build resolves the portable **baseline** CPU model by default
+  (a bundled binary is shipped, and a host-tuned one SIGILLs on other
+  machines of the same arch), while `fixture_interpreter`'s plain `zig build`
+  stays host-tuned. That asymmetry is deliberate and free — the embedded
+  bytecode already puts the bundler on its own cache key, and the CPU model
+  is not part of the `.sbc` compiler hash (see [cache.md](cache.md)) — but it
+  means no script may pass `-Dbundle-cpu-native` (or a host-naming
+  `-Dcpu=<model>`) to a `-Dbundle=` build: it would fork the shared cache key
+  *and* reintroduce the portability bug the default exists to prevent.
+
 Dispatch inside a suite is longest-first — scripts that shell out to a full
 `zig build -D…`, or to either shared builder, go first, found by grep rather
 than a hand-kept list of names. Reporting still walks the glob-sorted order, so

--- a/tests/scheme/compile/bundle-cpu-baseline-2515.sh
+++ b/tests/scheme/compile/bundle-cpu-baseline-2515.sh
@@ -3,8 +3,10 @@
 # host's exact CPU model, so a standalone binary built that way — the
 # documented way to ship a Kaappi program — could SIGILL on another machine
 # of the same architecture. The fix: -Dbundle/-Dbundle-src builds resolve the
-# portable baseline CPU model by default; -Dbundle-cpu-native opts back into
-# host tuning for a binary that really will only run here; an explicit
+# portable baseline CPU model by default; -Dcpu=native (Zig's own spelling —
+# bit for bit the pre-fix tuning, and unlike a skip-the-pin flag it also
+# delivers host tuning under an explicit -Dtarget) opts back into host tuning
+# for a binary that really will only run here; any other explicit
 # -Dcpu=<model> is always respected.
 #
 # Build-system defaults have no Scheme-visible surface and the binary carries
@@ -14,8 +16,8 @@
 # assertion fails without the fix on every host whose CPU model differs from
 # the baseline (CI's x86_64 legs, Apple Silicon above M1) and passes trivially
 # where host == baseline, because the bug cannot manifest there. The opt-out
-# is checked the same way: when host != baseline, the -Dbundle-cpu-native
-# build must differ from the default. A tiny zig probe — the technique from
+# is checked the same way: when host != baseline, the -Dcpu=native build must
+# differ from the default. A tiny zig probe — the technique from
 # the issue itself — names the two models so the script knows which world it
 # is in instead of guessing.
 #
@@ -24,7 +26,7 @@
 # model is not part of the compiler hash, which is exactly why a baseline
 # bundler may embed a host-tuned compiler's .sbc), and the default bundle
 # build is the shared one, so only the -Dcpu=baseline twin (a cache hit under
-# the fix) and the -Dbundle-cpu-native variant (one cold build) are new.
+# the fix) and the -Dcpu=native variant (one cold build) are new.
 #
 # Usage: bash tests/scheme/compile/bundle-cpu-baseline-2515.sh [path-to-kaappi]
 # (the kaappi path is accepted for suite uniformity and unused: every binary
@@ -106,7 +108,7 @@ build_variant() { # <name> <extra zig build flags...>
     return "$rc"
 }
 build_variant baseline -Dcpu=baseline
-build_variant native -Dbundle-cpu-native
+build_variant native -Dcpu=native
 
 # --- assertion 1: the default IS the baseline build ------------------------
 # Without the fix (host-tuned default) these differ wherever host != baseline.
@@ -121,7 +123,7 @@ fi
 # comparison is vacuous and the bug this guards cannot manifest.
 if [ "$HOST_MODEL" != "$BASE_MODEL" ]; then
     if cmp -s "$DEFAULT_BIN" "$DIR/native-kaappi"; then
-        echo "FAIL: -Dbundle-cpu-native did not restore host CPU tuning" >&2
+        echo "FAIL: -Dcpu=native did not restore host CPU tuning" >&2
         echo "      (host=$HOST_MODEL baseline=$BASE_MODEL, builds identical)" >&2
         exit 1
     fi
@@ -140,4 +142,4 @@ if ! grep -q '^703: Hello, world! #t$' <<< "$OUTPUT"; then
     exit 1
 fi
 
-echo "PASS: -Dbundle defaults to the baseline CPU ($BASE_MODEL; host is $HOST_MODEL); -Dbundle-cpu-native restores host tuning"
+echo "PASS: -Dbundle defaults to the baseline CPU ($BASE_MODEL; host is $HOST_MODEL); -Dcpu=native restores host tuning"

--- a/tests/scheme/compile/bundle-cpu-baseline-2515.sh
+++ b/tests/scheme/compile/bundle-cpu-baseline-2515.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Regression test for #2515: `zig build` with no -Dtarget tunes for the build
+# host's exact CPU model, so a standalone binary built that way — the
+# documented way to ship a Kaappi program — could SIGILL on another machine
+# of the same architecture. The fix: -Dbundle/-Dbundle-src builds resolve the
+# portable baseline CPU model by default; -Dbundle-cpu-native opts back into
+# host tuning for a binary that really will only run here; an explicit
+# -Dcpu=<model> is always respected.
+#
+# Build-system defaults have no Scheme-visible surface and the binary carries
+# no CPU-model tag (the bytecode compiler key hashes arch/os/abi only), so the
+# observable is differential: Zig builds are reproducible, so the default
+# bundle build must be byte-identical to an explicit -Dcpu=baseline one. That
+# assertion fails without the fix on every host whose CPU model differs from
+# the baseline (CI's x86_64 legs, Apple Silicon above M1) and passes trivially
+# where host == baseline, because the bug cannot manifest there. The opt-out
+# is checked the same way: when host != baseline, the -Dbundle-cpu-native
+# build must differ from the default. A tiny zig probe — the technique from
+# the issue itself — names the two models so the script knows which world it
+# is in instead of guessing.
+#
+# Build discipline follows bundle_fixture_binary (kaappi#1930/#1926): the
+# .sbc comes from the shared plain interpreter (host-tuned is fine — the CPU
+# model is not part of the compiler hash, which is exactly why a baseline
+# bundler may embed a host-tuned compiler's .sbc), and the default bundle
+# build is the shared one, so only the -Dcpu=baseline twin (a cache hit under
+# the fix) and the -Dbundle-cpu-native variant (one cold build) are new.
+#
+# Usage: bash tests/scheme/compile/bundle-cpu-baseline-2515.sh [path-to-kaappi]
+# (the kaappi path is accepted for suite uniformity and unused: every binary
+# here is built from current source, like every -Dbundle test.)
+
+set -euo pipefail
+
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+skip_without_zig "rebuilds the interpreter with -Dbundle on this machine"
+
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+OUT="$REPO_DIR/.zig-cache/kaappi-test-fixtures"
+SBC="$OUT/bundle-replay.sbc"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+# The binary under test: default flags, i.e. what a downstream user typing
+# `zig build -Dbundle=program.sbc` gets. bundle_fixture_binary compiles the
+# .sbc with the shared plain interpreter and builds the default bundle.
+DEFAULT_BIN="$DIR/default-kaappi"
+bundle_fixture_binary "$REPO_DIR" "$DEFAULT_BIN"
+
+# --- probe: name the host and baseline CPU models (the issue's technique) --
+# A three-line native zig program prints what the two CPU selections resolve
+# to on this machine (e.g. host=apple_m3 baseline=apple_m1 on an M3 Mac).
+cat > "$DIR/cpu-probe.zig" <<'EOF'
+const std = @import("std");
+const builtin = @import("builtin");
+pub fn main() !void {
+    const baseline = std.Target.Cpu.baseline(builtin.cpu.arch, builtin.os);
+    std.debug.print("host={s}\nbaseline={s}\n", .{ builtin.cpu.model.name, baseline.model.name });
+}
+EOF
+PROBE_LOG="$DIR/probe.log"
+if ! (cd "$DIR" && zig build-exe cpu-probe.zig) > "$PROBE_LOG" 2>&1; then
+    echo "FAIL: could not build the CPU-model probe" >&2
+    cat "$PROBE_LOG" >&2
+    exit 1
+fi
+# std.debug.print writes to stderr, so fold it into the capture.
+PROBE_OUT="$(cd "$DIR" && ./cpu-probe 2>&1)"
+HOST_MODEL="$(sed -n 's/^host=//p' <<< "$PROBE_OUT")"
+BASE_MODEL="$(sed -n 's/^baseline=//p' <<< "$PROBE_OUT")"
+if [ -z "$HOST_MODEL" ] || [ -z "$BASE_MODEL" ]; then
+    echo "FAIL: CPU-model probe printed no models:" >&2
+    printf '%s\n' "$PROBE_OUT" >&2
+    exit 1
+fi
+
+# --- the two bundle variants the assertions need --------------------------
+# Same .sbc, same -Doptimize, one flag apart. Under the fix the baseline twin
+# is a Zig cache hit of the default build (identical resolved target), so it
+# costs nothing; the native variant is the one cold build this script adds.
+build_variant() { # <name> <extra zig build flags...>
+    local name="$1"
+    shift
+    local log rc
+    log=$(mktemp)
+    build_lock "$REPO_DIR" bundle-cpu-2515
+    rc=0
+    (
+        cd "$REPO_DIR" &&
+            zig build -Dbundle="$SBC" -Doptimize=ReleaseSafe "$@" \
+                --prefix "$DIR/prefix-$name" &&
+            cp "$DIR/prefix-$name/bin/kaappi" "$DIR/$name-kaappi"
+    ) > "$log" 2>&1 || rc=$?
+    build_unlock "$REPO_DIR" bundle-cpu-2515
+    if [ "$rc" -ne 0 ]; then
+        echo "FAIL: could not build the '$name' bundle variant" >&2
+        cat "$log" >&2
+    fi
+    rm -f "$log"
+    return "$rc"
+}
+build_variant baseline -Dcpu=baseline
+build_variant native -Dbundle-cpu-native
+
+# --- assertion 1: the default IS the baseline build ------------------------
+# Without the fix (host-tuned default) these differ wherever host != baseline.
+if ! cmp -s "$DEFAULT_BIN" "$DIR/baseline-kaappi"; then
+    echo "FAIL: default -Dbundle build is not the -Dcpu=baseline build —" >&2
+    echo "      the portable-baseline default (#2515) regressed" >&2
+    exit 1
+fi
+
+# --- assertion 2: the opt-out restores host tuning -------------------------
+# Only meaningful where the two tunings differ; where host == baseline the
+# comparison is vacuous and the bug this guards cannot manifest.
+if [ "$HOST_MODEL" != "$BASE_MODEL" ]; then
+    if cmp -s "$DEFAULT_BIN" "$DIR/native-kaappi"; then
+        echo "FAIL: -Dbundle-cpu-native did not restore host CPU tuning" >&2
+        echo "      (host=$HOST_MODEL baseline=$BASE_MODEL, builds identical)" >&2
+        exit 1
+    fi
+else
+    echo "note: host CPU model == baseline ($HOST_MODEL); the opt-out comparison is vacuous here" >&2
+fi
+
+# --- assertion 3: the baseline binary still runs ---------------------------
+# Baseline is a subset of the host's features, so the shipped default must
+# execute right where it was built — and the .sbc inside it came from a
+# host-tuned compiler, which the compiler key permits (see cache.md).
+OUTPUT="$("$DEFAULT_BIN" 2>&1)" || true
+if ! grep -q '^703: Hello, world! #t$' <<< "$OUTPUT"; then
+    echo "FAIL: default (baseline) bundled binary does not run its program" >&2
+    echo "full output: $OUTPUT" >&2
+    exit 1
+fi
+
+echo "PASS: -Dbundle defaults to the baseline CPU ($BASE_MODEL; host is $HOST_MODEL); -Dbundle-cpu-native restores host tuning"


### PR DESCRIPTION
## Summary

`zig build` with no `-Dtarget` tunes for the **build host's exact CPU model**, so a standalone binary built with `-Dbundle=`/`-Dbundle-src=` — the documented way to ship a Kaappi program — could SIGILL on another machine of the same architecture, which presents as a VM bug rather than a build-flags bug (#2515). Published kaappi binaries are unaffected (the release workflow always passes `-Dtarget`); this hits downstream users of the standalone-binary feature.

This implements the issue's preferred resolution (option 3): **bundle builds default to the portable baseline CPU model**; plain `zig build` without bundle options stays host-tuned.

- `-Dbundle=` / `-Dbundle-src=` (with or without an explicit `-Dtarget=`) resolve `.cpu_model = .baseline` when the user did not name a CPU. An explicit `-Dtarget` arch/os/abi is preserved verbatim (Zig already defaults explicit targets to baseline without `-Dcpu`, so pinning is a no-op there).
- `-Dcpu=<model>` (including `-Dcpu=baseline`) is always respected. **`-Dcpu=native` is the opt-out** that restores host tuning for a binary that really will only run on the machine that built it — Zig's own spelling rather than a bundle-only flag, per review: it is the pre-fix tuning bit for bit (`.native` → the same `detectNativeCpuAndFeatures` call the unpinned query makes) and, unlike a flag that merely skipped the pin, it also delivers host tuning under an explicit `-Dtarget=`.
- Both `-Dbundle` build-option help strings state the default and the `-Dcpu=native` opt-out, so `zig build --help` communicates it.
- The CPU model is **not** part of the bytecode compiler key (`bytecode_file.compile_target_id` hashes arch/os/abi + `cond-expand` features only), so an `.sbc` produced by a host-tuned `kaappi --compile` still embeds in a baseline bundler from the same tree — the documented two-command bundle flow keeps working, and the #2514 foreign-build diagnostics never fire over a CPU difference.

Closes #2515

## Scope / follow-up

This PR fixes the **bundle** path only. The same hazard lives in the runtime archive: the `lib` step builds `libkaappi_rt.a` with the same host-tuned `target`, so a source-built `kaappi compile app.scm -o app` ships a host-tuned VM/GC inside every native executable (released archives are baseline — release.yml passes `-Dtarget`). That gap is tracked in #2531 rather than extended into this PR; `Closes #2515` above is not meant to close that hazard class.

## Verification

CPU models on this machine (the issue's probe technique — host is an Apple M3, baseline for aarch64-macos is apple_m1):

```
$ zig build-exe probe.zig && ./probe        # prints builtin.cpu.model vs Target.Cpu.baseline
host cpu model: apple_m3
baseline cpu model: apple_m1
```

Differential proof (Zig builds are reproducible within one build-graph state, so equal inputs ⇒ byte-identical binaries):

```
zig build -Dbundle=hello.sbc --prefix P-default            # no flags
zig build -Dbundle=hello.sbc -Dcpu=baseline --prefix P-baseline
zig build -Dbundle=hello.sbc -Dcpu=native --prefix P-native
zig build -Dcpu=baseline --prefix P-plain-baseline          # plain, no bundle

cmp P-default/bin/kaappi P-baseline/bin/kaappi     -> IDENTICAL  (default IS baseline)
cmp P-default/bin/kaappi P-native/bin/kaappi       -> DIFFER, ~144 KB of bytes (host tuning restored)
cmp zig-out/bin/kaappi P-plain-baseline/bin/kaappi -> DIFFER     (plain build stays host-tuned)
```

All bundled binaries run correctly (`hello from a bundled binary`, exit 0), including the default one whose `.sbc` was produced by the host-tuned plain binary — the compiler-key compatibility property above. `zig build -Dbundle-src=hello.scm` (single-step) also builds and runs.

Existing bundle flows (re-run after the review round, commit 45e92e09):

```
tests/scheme/compile/bundle-cpu-baseline-2515.sh    PASS
tests/scheme/compile/bundle-args-2010.sh            PASS
tests/scheme/compile/srfi-241-202-bundle-2391.sh    PASS
tests/scheme/compile/compile-preamble-gc-700.sh     exit 0
tests/scheme/compile/compile-import-error-703.sh    exit 0
tests/scheme/compile/compile-define-values-order-2200.sh    PASS (3/3)
tests/scheme/compile/compile-toplevel-side-effects-2156.sh  PASS (12/12)
tests/scheme/compile/native-external-library-import-1743.sh PASS
tests/scheme/cache/build-id-untracked-2097.sh       SKIP (77): its own pristine-tree
   premise does not hold in a dirty worktree; runs on a clean CI checkout
zig build test                                       exit 0 (macOS)
```

`zig fmt --check build.zig` clean; `npx markdownlint-cli2` 0 issues.

## Regression test

`tests/scheme/compile/bundle-cpu-baseline-2515.sh` — a build-system default has no Scheme-visible surface and the binary carries no CPU-model tag, so the test is differential: the default bundle binary must be byte-identical to an explicit `-Dcpu=baseline` one (fails without the fix wherever host ≠ baseline — CI's x86_64 legs, Apple Silicon above M1 — and is vacuously true where host = baseline, where the bug cannot manifest), and must differ from a `-Dcpu=native` one wherever the two tunings differ, detected with the issue's own CPU-model probe so the script knows which world it is in. Verified both ways after the review round: PASS with the fix; against pre-fix `build.zig` it exits 1 at the core assertion (`default -Dbundle build is not the -Dcpu=baseline build`).

## Follow-up

- #2531 tracks the `libkaappi_rt.a` / `kaappi compile` half of the hazard (see Scope above).
- The end-user standalone-binary guide lives in kaappi/kaappi.github.io (out of scope here by design) and needs a matching note there that bundles default to the baseline CPU and that `-Dcpu=native` is the opt-out.

🤖 This PR was prepared with ZCode assistance.
