### PR TITLE
Show the interpreter oracle's stderr on unexpected failure

### DIFF
--- a/tests/scheme/CLAUDE.md
+++ b/tests/scheme/CLAUDE.md
@@ -245,6 +245,17 @@ compared: the VM echoes a bare top-level expression's value and a native binary
 does not, the VM continues past a top-level error while a native binary exits
 at the first, and a procedure prints as `#<procedure name>` vs `#<procedure>`.
 
+**Pass the errfile, and show it only on the unexpected-failure branch.**
+`interp_stdout` takes an optional fourth argument — a file to capture the
+interpreter's stderr into — and `show_interp_stderr` prints it. Every oracle
+caller passes one (under its own mktemp workdir, never inside the repo tree)
+and calls `show_interp_stderr` in its FAIL branches. When an oracle run
+aborts, its piped stdout is lost to block buffering, so that captured stderr
+— a Zig panic trace, an allocator leak report — is the one datum that says
+why it died; dropping it left a one-off CI abort unlocalizable (kaappi#2532).
+This breaks no parity rule: the tier-difference ban is on *comparing*
+diagnostic text across tiers, and the capture is shown, never asserted on.
+
 Keep the golden string too, as a second assertion against the *interpreter* —
 it documents intent and still catches a bug both tiers share. What it must not
 be is the only thing between a miscompilation and a green run: kaappi#2092 was

--- a/tests/scheme/compile/bundle-args-2010.sh
+++ b/tests/scheme/compile/bundle-args-2010.sh
@@ -44,11 +44,16 @@ FAIL=0
 # golden on purpose: bundled (command-line) intentionally differs from direct
 # source execution (no script path, kaappi#2010).
 interp_status=0
-interp_out="$(interp_stdout "$KAAPPI_ABS" "$FIXTURE" "$FIXTURE/main.scm")" || interp_status=$?
+# The errfile goes under $DIR, never the fixture tree: interp_stdout would
+# happily write it in the workdir, and a stray file inside the repo changes
+# the build id baked into every .sbc.
+interp_err="$DIR/interp-oracle.err"
+interp_out="$(interp_stdout "$KAAPPI_ABS" "$FIXTURE" "$FIXTURE/main.scm" "$interp_err")" || interp_status=$?
 bundle_status=0
 bundle_out="$("$BUNDLE_BIN" 2>&1)" || bundle_status=$?
 if ! assert_tiers_agree "bundled vs interpreter (no args)" \
     "$interp_out" "$interp_status" "$bundle_out" "$bundle_status"; then
+    show_interp_stderr "$interp_err"
     exit 1
 fi
 

--- a/tests/scheme/compile/bundle-args-2010.sh
+++ b/tests/scheme/compile/bundle-args-2010.sh
@@ -44,9 +44,10 @@ FAIL=0
 # golden on purpose: bundled (command-line) intentionally differs from direct
 # source execution (no script path, kaappi#2010).
 interp_status=0
-# The errfile goes under $DIR, never the fixture tree: interp_stdout would
-# happily write it in the workdir, and a stray file inside the repo changes
-# the build id baked into every .sbc.
+# The errfile goes under $DIR, never the fixture tree: interp_stdout applies
+# the redirect before its cd, so a relative path would land in the script's
+# own cwd (the repo root under run-all.sh) — and a stray file inside the
+# repo changes the build id baked into every .sbc.
 interp_err="$DIR/interp-oracle.err"
 interp_out="$(interp_stdout "$KAAPPI_ABS" "$FIXTURE" "$FIXTURE/main.scm" "$interp_err")" || interp_status=$?
 bundle_status=0

--- a/tests/scheme/compile/compile-define-values-order-2200.sh
+++ b/tests/scheme/compile/compile-define-values-order-2200.sh
@@ -102,12 +102,14 @@ EXPECTED="(1 2)
 
 echo "=== interpreter (the tier oracle) ==="
 interp_status=0
-interp_out="$(interp_stdout "$KAAPPI_ABS" "$WORK" "$WORK/prog.scm")" || interp_status=$?
+interp_err="$WORK/prog.interp.err"
+interp_out="$(interp_stdout "$KAAPPI_ABS" "$WORK" "$WORK/prog.scm" "$interp_err")" || interp_status=$?
 if [ "$interp_out" == "$EXPECTED" ] && [ "$interp_status" -eq 0 ]; then
     ok "interpreted run prints (1 2) then 30 and exits 0"
 else
     bad "interpreted run prints (1 2) then 30 and exits 0" \
         "stdout: $interp_out" "exit: $interp_status"
+    show_interp_stderr "$interp_err"
 fi
 
 echo "=== standalone binary matches the interpreter ==="

--- a/tests/scheme/compile/compile-toplevel-side-effects-2156.sh
+++ b/tests/scheme/compile/compile-toplevel-side-effects-2156.sh
@@ -145,7 +145,8 @@ SCM
 # wrong artifact and a green run. This program has no bare top-level expression
 # and no top-level error, so none of the three by-design tier differences apply.
 interp_status=0
-interp_out="$(interp_stdout "$KAAPPI_ABS" "$WORK" "$WORK/prog.scm")" || interp_status=$?
+interp_err="$WORK/prog.interp.err"
+interp_out="$(interp_stdout "$KAAPPI_ABS" "$WORK" "$WORK/prog.scm" "$interp_err")" || interp_status=$?
 
 if [ "$interp_out" == "one
 two
@@ -154,6 +155,7 @@ three
     ok "interpreted run has the expected output"
 else
     bad "interpreted run has the expected output" "actual: $interp_out"
+    show_interp_stderr "$interp_err"
 fi
 # The interpreted run consumed the victim; restore it for the compiled run.
 echo hi > "$VICTIM"

--- a/tests/scheme/compile/compile-toplevel-side-effects-2156.sh
+++ b/tests/scheme/compile/compile-toplevel-side-effects-2156.sh
@@ -187,6 +187,10 @@ if assert_tiers_agree "standalone binary vs interpreter" \
     ok "the standalone binary agrees with the interpreter on stdout and exit status"
 else
     FAIL=$((FAIL + 1))
+    # The disagreement can be the interpreter's fault alone — an exit-time
+    # abort after stdout was flushed leaves the oracle's stdout check green
+    # and surfaces only here, as a status mismatch.
+    show_interp_stderr "$interp_err"
 fi
 
 if [ ! -f "$VICTIM" ]; then

--- a/tests/scheme/compile/native-bootstrap-callbacks-1376.sh
+++ b/tests/scheme/compile/native-bootstrap-callbacks-1376.sh
@@ -42,14 +42,16 @@ check_both() {
     local src="$1" expected="$2" label="$3"
     local bin="$DIR/${label}.bin"
 
-    local interp_out interp_status=0
-    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src")" || interp_status=$?
+    local interp_out interp_status=0 interp_err="$DIR/${label}.interp.err"
+    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src" "$interp_err")" || interp_status=$?
     if [[ $interp_status -ne 0 ]]; then
         echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        show_interp_stderr "$interp_err"
         exit 1
     fi
     if [[ "$interp_out" != "$expected" ]]; then
         echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        show_interp_stderr "$interp_err"
         exit 1
     fi
 

--- a/tests/scheme/compile/native-gc-roots-1034.sh
+++ b/tests/scheme/compile/native-gc-roots-1034.sh
@@ -42,14 +42,16 @@ check_both() {
     local src="$1" expected="$2" label="$3"
     local bin="$DIR/${label}.bin"
 
-    local interp_out interp_status=0
-    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src")" || interp_status=$?
+    local interp_out interp_status=0 interp_err="$DIR/${label}.interp.err"
+    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src" "$interp_err")" || interp_status=$?
     if [[ $interp_status -ne 0 ]]; then
         echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        show_interp_stderr "$interp_err"
         exit 1
     fi
     if [[ "$interp_out" != "$expected" ]]; then
         echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        show_interp_stderr "$interp_err"
         exit 1
     fi
 

--- a/tests/scheme/compile/native-let-tail-root-leak-1585.sh
+++ b/tests/scheme/compile/native-let-tail-root-leak-1585.sh
@@ -56,15 +56,17 @@ check() {
 
     printf '%s' "$src" > "$DIR/$name.scm"
 
-    local interp_out interp_status=0
-    interp_out=$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$DIR/$name.scm") || interp_status=$?
+    local interp_out interp_status=0 interp_err="$DIR/$name.interp.err"
+    interp_out=$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$DIR/$name.scm" "$interp_err") || interp_status=$?
     if [[ $interp_status -ne 0 ]]; then
         echo "FAIL: $name — interpreter exited $interp_status (output: '$interp_out')" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi
     if [[ "$interp_out" != "$expect_out" ]]; then
         echo "FAIL: $name — interpreter expected '$expect_out', got '$interp_out'" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi

--- a/tests/scheme/compile/native-lexical-scope-fold-2117-2118.sh
+++ b/tests/scheme/compile/native-lexical-scope-fold-2117-2118.sh
@@ -70,12 +70,13 @@ check_suite() {
     local bin="$DIR/$name.bin"
     n=$((n + 1))
 
-    local interp_raw interp_out interp_status=0
-    interp_raw="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src")" || interp_status=$?
+    local interp_raw interp_out interp_status=0 interp_err="$DIR/$name.interp.err"
+    interp_raw="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src" "$interp_err")" || interp_status=$?
     interp_out="$(printf '%s\n' "$interp_raw" | strip_echo)"
     if [[ $interp_status -ne 0 ]]; then
         echo "FAIL: $name — interpreter exited $interp_status:" >&2
         printf '%s\n' "$interp_raw" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi
@@ -86,6 +87,7 @@ check_suite() {
     if [[ "$interp_out" != *"$sentinel"* ]]; then
         echo "FAIL: $name — interpreter output missing '$sentinel':" >&2
         printf '%s\n' "$interp_out" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi
@@ -115,15 +117,17 @@ check_both() {
     n=$((n + 1))
     printf '%s\n' "$src_text" > "$src"
 
-    local interp_out interp_status=0
-    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src")" || interp_status=$?
+    local interp_out interp_status=0 interp_err="$DIR/$label.interp.err"
+    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src" "$interp_err")" || interp_status=$?
     if [[ $interp_status -ne 0 ]]; then
         echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi
     if [[ "$interp_out" != "$expected" ]]; then
         echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi

--- a/tests/scheme/compile/native-macro-set-tracking-2212.sh
+++ b/tests/scheme/compile/native-macro-set-tracking-2212.sh
@@ -45,15 +45,17 @@ check() {
 
     printf '%s' "$src" > "$DIR/$name.scm"
 
-    local interp_out interp_status=0
-    interp_out=$(interp_stdout "$KAAPPI_ABS" "$DIR" "$name.scm") || interp_status=$?
+    local interp_out interp_status=0 interp_err="$DIR/$name.interp.err"
+    interp_out=$(interp_stdout "$KAAPPI_ABS" "$DIR" "$name.scm" "$interp_err") || interp_status=$?
     if [[ "$interp_out" != "$expect_out" ]]; then
         echo "FAIL: $name — interpreter stdout '$interp_out' != expected '$expect_out'" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi
     if [[ "$interp_status" -ne "$expect_status" ]]; then
         echo "FAIL: $name — interpreter exit $interp_status != expected $expect_status" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi

--- a/tests/scheme/compile/native-nested-closure-1410.sh
+++ b/tests/scheme/compile/native-nested-closure-1410.sh
@@ -42,14 +42,16 @@ check_both() {
     local label="$1" expected="$2"
     local src="$DIR/${label}.scm" bin="$DIR/${label}.bin"
 
-    local interp_out interp_status=0
-    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src")" || interp_status=$?
+    local interp_out interp_status=0 interp_err="$DIR/${label}.interp.err"
+    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src" "$interp_err")" || interp_status=$?
     if [[ $interp_status -ne 0 ]]; then
         echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        show_interp_stderr "$interp_err"
         exit 1
     fi
     if [[ "$interp_out" != "$expected" ]]; then
         echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        show_interp_stderr "$interp_err"
         exit 1
     fi
 

--- a/tests/scheme/compile/native-param-shadow-fold-790.sh
+++ b/tests/scheme/compile/native-param-shadow-fold-790.sh
@@ -48,14 +48,16 @@ check_both() {
     local src="$1" expected="$2" label="$3"
     local bin="$DIR/${label}.bin"
 
-    local interp_out interp_status=0
-    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src")" || interp_status=$?
+    local interp_out interp_status=0 interp_err="$DIR/${label}.interp.err"
+    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src" "$interp_err")" || interp_status=$?
     if [[ $interp_status -ne 0 ]]; then
         echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        show_interp_stderr "$interp_err"
         exit 1
     fi
     if [[ "$interp_out" != "$expected" ]]; then
         echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        show_interp_stderr "$interp_err"
         exit 1
     fi
 

--- a/tests/scheme/compile/native-rebind-stale-call-822.sh
+++ b/tests/scheme/compile/native-rebind-stale-call-822.sh
@@ -43,15 +43,17 @@ check() {
 
     printf '%s' "$src" > "$DIR/$name.scm"
 
-    local interp_out interp_status=0
-    interp_out=$(interp_stdout "$KAAPPI_ABS" "$DIR" "$name.scm") || interp_status=$?
+    local interp_out interp_status=0 interp_err="$DIR/$name.interp.err"
+    interp_out=$(interp_stdout "$KAAPPI_ABS" "$DIR" "$name.scm" "$interp_err") || interp_status=$?
     if [[ "$interp_out" != "$expect_out" ]]; then
         echo "FAIL: $name — interpreter stdout '$interp_out' != expected '$expect_out'" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi
     if [[ "$interp_status" -ne "$expect_status" ]]; then
         echo "FAIL: $name — interpreter exit $interp_status != expected $expect_status" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi

--- a/tests/scheme/compile/native-set-capture-divergence-1422.sh
+++ b/tests/scheme/compile/native-set-capture-divergence-1422.sh
@@ -50,15 +50,17 @@ check() {
 
     printf '%s' "$src" > "$DIR/$name.scm"
 
-    local interp_out interp_status=0
-    interp_out=$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$DIR/$name.scm") || interp_status=$?
+    local interp_out interp_status=0 interp_err="$DIR/$name.interp.err"
+    interp_out=$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$DIR/$name.scm" "$interp_err") || interp_status=$?
     if [[ $interp_status -ne 0 ]]; then
         echo "FAIL: $name — interpreter exited $interp_status (output: '$interp_out')" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi
     if [[ "$interp_out" != "$expect_out" ]]; then
         echo "FAIL: $name — interpreter expected '$expect_out', got '$interp_out'" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi

--- a/tests/scheme/compile/native-set-global-child-thread-2487.sh
+++ b/tests/scheme/compile/native-set-global-child-thread-2487.sh
@@ -100,11 +100,16 @@ else
 fi
 
 # The oracle: the same program through the interpreter — set_global bumps no
-# stale caches, the final value is the child's last store.
+# stale caches, the final value is the child's last store. stderr is captured
+# so that a recurrence of the one-off abort this script once hit on a Debug
+# CI leg (kaappi#2532) shows its panic text instead of dying exit-134-with-
+# no-evidence: an aborting process loses its piped stdout to block buffering.
 interp_status=0
-interp_out=$(interp_stdout "$KAAPPI_ABS" "$DIR" "$name.scm") || interp_status=$?
+interp_err="$DIR/$name.interp.err"
+interp_out=$(interp_stdout "$KAAPPI_ABS" "$DIR" "$name.scm" "$interp_err") || interp_status=$?
 if [[ "$interp_out" != "200000" || "$interp_status" -ne 0 ]]; then
     echo "FAIL: $name — interpreter stdout '$interp_out' exit $interp_status, expected '200000' exit 0" >&2
+    show_interp_stderr "$interp_err"
     exit 1
 fi
 
@@ -141,9 +146,11 @@ cat > "$DIR/$xname.scm" << 'EOF'
 EOF
 
 xi_status=0
-xi_out=$(interp_stdout "$KAAPPI_ABS" "$DIR" "$xname.scm") || xi_status=$?
+xi_err="$DIR/$xname.interp.err"
+xi_out=$(interp_stdout "$KAAPPI_ABS" "$DIR" "$xname.scm" "$xi_err") || xi_status=$?
 if [[ "$xi_out" != "#<procedure h>" || "$xi_status" -ne 1 ]]; then
     echo "FAIL: $xname — interpreter stdout '$xi_out' exit $xi_status, expected '#<procedure h>' exit 1 (refused store, binding unchanged)" >&2
+    show_interp_stderr "$xi_err"
     exit 1
 fi
 

--- a/tests/scheme/compile/native-toplevel-continuation-resume-2119.sh
+++ b/tests/scheme/compile/native-toplevel-continuation-resume-2119.sh
@@ -52,14 +52,16 @@ check_both() {
     local src="$1" expected="$2" label="$3"
     local bin="$DIR/${label}.bin"
 
-    local interp_out interp_status=0
-    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src")" || interp_status=$?
+    local interp_out interp_status=0 interp_err="$DIR/${label}.interp.err"
+    interp_out="$(interp_stdout "$KAAPPI_ABS" "$REPO_DIR" "$src" "$interp_err")" || interp_status=$?
     if [[ $interp_status -ne 0 ]]; then
         echo "FAIL: $label — interpreter exited $interp_status (output: '$interp_out')" >&2
+        show_interp_stderr "$interp_err"
         exit 1
     fi
     if [[ "$interp_out" != "$expected" ]]; then
         echo "FAIL: $label — interpreter expected '$expected', got '$interp_out'" >&2
+        show_interp_stderr "$interp_err"
         exit 1
     fi
 

--- a/tests/scheme/compile/native-truncated-scan-fallback-2404.sh
+++ b/tests/scheme/compile/native-truncated-scan-fallback-2404.sh
@@ -48,15 +48,17 @@ check() {
 
     printf '%s' "$src" > "$DIR/$name.scm"
 
-    local interp_out interp_status=0
-    interp_out=$(interp_stdout "$KAAPPI_ABS" "$DIR" "$name.scm") || interp_status=$?
+    local interp_out interp_status=0 interp_err="$DIR/$name.interp.err"
+    interp_out=$(interp_stdout "$KAAPPI_ABS" "$DIR" "$name.scm" "$interp_err") || interp_status=$?
     if [[ "$interp_out" != "$expect_out" ]]; then
         echo "FAIL: $name — interpreter stdout '$interp_out' != expected '$expect_out'" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi
     if [[ "$interp_status" -ne "$expect_status" ]]; then
         echo "FAIL: $name — interpreter exit $interp_status != expected $expect_status" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi

--- a/tests/scheme/compile/set-define-lexical-scope-819.sh
+++ b/tests/scheme/compile/set-define-lexical-scope-819.sh
@@ -47,15 +47,17 @@ check() {
 
     printf '%s' "$src" > "$DIR/$name.scm"
 
-    local interp_out interp_status=0
-    interp_out=$(interp_stdout "$KAAPPI_ABS" "$DIR" "$name.scm") || interp_status=$?
+    local interp_out interp_status=0 interp_err="$DIR/$name.interp.err"
+    interp_out=$(interp_stdout "$KAAPPI_ABS" "$DIR" "$name.scm" "$interp_err") || interp_status=$?
     if [[ "$interp_out" != "$expect_out" ]]; then
         echo "FAIL: $name — interpreter stdout '$interp_out' != expected '$expect_out'" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi
     if [[ "$interp_status" -ne "$expect_status" ]]; then
         echo "FAIL: $name — interpreter exit $interp_status != expected $expect_status" >&2
+        show_interp_stderr "$interp_err"
         fail=1
         return
     fi

--- a/tests/scheme/shell-common.sh
+++ b/tests/scheme/shell-common.sh
@@ -124,14 +124,35 @@ skip_on_debug_build() {
 #   3. A procedure value prints as `#<procedure name>` in the VM and
 #      `#<procedure>` natively.
 #
-# interp_stdout <kaappi> <workdir> <src>: run <src> through the interpreter
-# from <workdir>, print its stdout, and return its own exit status. stderr is
-# dropped deliberately: the two tiers' diagnostics differ in framing by design
-# (the VM prefixes file:line and a source excerpt, the native runtime does
-# not), so a script asserting on a diagnostic's text does that separately,
-# against whichever tier it means.
+# interp_stdout <kaappi> <workdir> <src> [<errfile>]: run <src> through the
+# interpreter from <workdir>, print its stdout, and return its own exit
+# status. stderr goes to <errfile> when given, /dev/null otherwise.
+#
+# An oracle caller should pass an errfile — under its own mktemp workdir,
+# never inside the repo tree (a dirty tree changes the build id baked into
+# every .sbc, see the lock comment below) — and hand it to show_interp_stderr
+# on its unexpected-failure branch. An aborting interpreter loses its piped
+# stdout entirely (block buffering), so the captured stderr — a Zig panic
+# trace, an allocator leak report — is the one datum that says WHY it died,
+# and dropping it left a one-off CI abort unlocalizable (kaappi#2532).
+#
+# The tier-parity rationale is untouched by this: the two tiers' diagnostics
+# differ in framing by design (the VM prefixes file:line and a source
+# excerpt, the native runtime does not), so a script asserting on a
+# diagnostic's text does that separately, against whichever tier it means.
+# Capturing stderr to SHOW it on failure asserts nothing.
 interp_stdout() {
-    (cd "$2" && "$1" "$3" 2> /dev/null)
+    (cd "$2" && "$1" "$3") 2> "${4:-/dev/null}"
+}
+
+# show_interp_stderr <errfile>: print what interp_stdout captured, so a FAIL
+# branch carries the interpreter's own diagnostics into the CI log. No-op
+# when the file is empty or missing — the expected case on a green run, and
+# for a mismatch that is the native tier's fault alone.
+show_interp_stderr() {
+    [ -s "$1" ] || return 0
+    echo "--- interpreter stderr ---" >&2
+    cat "$1" >&2
 }
 
 # assert_tiers_agree <label> <interp-out> <interp-status> <native-out> <native-status>

--- a/tests/scheme/shell-common.sh
+++ b/tests/scheme/shell-common.sh
@@ -141,6 +141,15 @@ skip_on_debug_build() {
 # excerpt, the native runtime does not), so a script asserting on a
 # diagnostic's text does that separately, against whichever tier it means.
 # Capturing stderr to SHOW it on failure asserts nothing.
+#
+# The redirect sits on the subshell rather than on the kaappi command: it is
+# set up in the caller's directory (a relative errfile resolves against the
+# script's cwd, not the workdir interp_stdout cds into), and a failed `cd`'s
+# message lands in the errfile too. For errfile callers that is an
+# improvement — the FAIL branch shows it — but the 3-arg form now buries it
+# in /dev/null where it used to reach the script's stderr. Only the
+# kaappi#2532 self-test uses the 3-arg form; don't move the redirect back
+# inside the subshell to "fix" that.
 interp_stdout() {
     (cd "$2" && "$1" "$3") 2> "${4:-/dev/null}"
 }

--- a/tests/scheme/smoke/interp-oracle-stderr-2532.sh
+++ b/tests/scheme/smoke/interp-oracle-stderr-2532.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Regression test for kaappi#2532:
+#
+# interp_stdout (tests/scheme/shell-common.sh) discarded the interpreter's
+# stderr outright, so when a CI leg's oracle run aborted (exit 134, SIGABRT)
+# the harness had the exit status but not the panic text: stdout to a pipe is
+# block-buffered and its buffer is lost on abort, and stderr had gone to
+# /dev/null by design. The ubuntu-Debug recurrence could not be localized
+# between "abort in a race path" and "exit-time allocator report" purely for
+# want of that text.
+#
+# The fix: interp_stdout takes an optional errfile, and show_interp_stderr
+# prints it on the caller's unexpected-failure branch. This is a
+# deterministic simulation of the CI failure -- no real kaappi, no real
+# abort. A stub "interpreter" writes a marker to stderr, nothing to stdout,
+# and exits 134; the test asserts the stdout capture and exit-status
+# propagation are unchanged, that the stderr text lands in the errfile and is
+# surfaced by show_interp_stderr, and that a clean run stays silent.
+#
+# It tests the harness, not the interpreter: the oracle scripts in compile/
+# are the consumers, and their FAIL branches are what must carry the captured
+# stderr into the CI log.
+set -euo pipefail
+
+. "$(dirname "$0")/../shell-common.sh"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+# The aborting "interpreter": the CI failure's shape -- a panic line on
+# stderr, no stdout, exit 134.
+cat > "$DIR/aborting-kaappi" << 'EOF'
+#!/bin/sh
+echo "stub panic: simulated allocator/panic report" >&2
+exit 134
+EOF
+chmod +x "$DIR/aborting-kaappi"
+
+ERR="$DIR/oracle.interp.err"
+
+status=0
+out=$(interp_stdout "$DIR/aborting-kaappi" "$DIR" "prog.scm" "$ERR") || status=$?
+
+# The observable oracle facts are unchanged: empty stdout, status 134.
+if [ -n "$out" ]; then
+    echo "FAIL: interp_stdout leaked stderr text into stdout: '$out'" >&2
+    exit 1
+fi
+if [ "$status" -ne 134 ]; then
+    echo "FAIL: interp_stdout returned $status, expected 134" >&2
+    exit 1
+fi
+
+# The point of the fix: the stderr text survives in the errfile...
+if ! grep -q "stub panic" "$ERR"; then
+    echo "FAIL: interp_stdout dropped the interpreter's stderr (kaappi#2532)" >&2
+    exit 1
+fi
+# ...and show_interp_stderr surfaces it on the failure branch.
+shown=$(show_interp_stderr "$ERR" 2>&1)
+if ! grep -q "stub panic" <<< "$shown"; then
+    echo "FAIL: show_interp_stderr did not surface the captured stderr" >&2
+    show_interp_stderr "$ERR"
+    exit 1
+fi
+
+# A quiet run stays quiet, and the 3-arg form (no errfile) keeps working for
+# a caller that passes none.
+cat > "$DIR/quiet-kaappi" << 'EOF'
+#!/bin/sh
+echo "42"
+exit 0
+EOF
+chmod +x "$DIR/quiet-kaappi"
+
+status=0
+out=$(interp_stdout "$DIR/quiet-kaappi" "$DIR" "prog.scm") || status=$?
+if [ "$out" != "42" ] || [ "$status" -ne 0 ]; then
+    echo "FAIL: interp_stdout 3-arg form: stdout '$out' status $status" >&2
+    exit 1
+fi
+
+QERR="$DIR/quiet.interp.err"
+status=0
+out=$(interp_stdout "$DIR/quiet-kaappi" "$DIR" "prog.scm" "$QERR") || status=$?
+if [ "$out" != "42" ] || [ "$status" -ne 0 ]; then
+    echo "FAIL: interp_stdout with errfile: stdout '$out' status $status" >&2
+    exit 1
+fi
+if [ -s "$QERR" ]; then
+    echo "FAIL: a clean oracle run left a non-empty stderr capture" >&2
+    exit 1
+fi
+if [ -n "$(show_interp_stderr "$QERR" 2>&1)" ]; then
+    echo "FAIL: show_interp_stderr was noisy for an empty capture" >&2
+    exit 1
+fi
+
+echo "PASS: interp_stdout captures oracle stderr; show_interp_stderr surfaces it on failure"

--- a/tests/scheme/smoke/interp-oracle-stderr-2532.sh
+++ b/tests/scheme/smoke/interp-oracle-stderr-2532.sh
@@ -15,7 +15,9 @@
 # abort. A stub "interpreter" writes a marker to stderr, nothing to stdout,
 # and exits 134; the test asserts the stdout capture and exit-status
 # propagation are unchanged, that the stderr text lands in the errfile and is
-# surfaced by show_interp_stderr, and that a clean run stays silent.
+# surfaced by show_interp_stderr, that the 3-arg form still buries stderr
+# (with the NOISY stub, so a redirect regression cannot pass silently), and
+# that a clean run stays silent.
 #
 # It tests the harness, not the interpreter: the oracle scripts in compile/
 # are the consumers, and their FAIL branches are what must carry the captured
@@ -51,21 +53,36 @@ if [ "$status" -ne 134 ]; then
     exit 1
 fi
 
-# The point of the fix: the stderr text survives in the errfile...
-if ! grep -q "stub panic" "$ERR"; then
+# The point of the fix: the stderr text survives in the errfile... (-s keeps
+# the red path, where the old shell-common.sh never creates the file, down to
+# the one FAIL line that matters.)
+if ! grep -qs "stub panic" "$ERR"; then
     echo "FAIL: interp_stdout dropped the interpreter's stderr (kaappi#2532)" >&2
     exit 1
 fi
-# ...and show_interp_stderr surfaces it on the failure branch.
+# ...and show_interp_stderr surfaces it on the failure branch, under the
+# header that tells a merged CI log what the text is.
 shown=$(show_interp_stderr "$ERR" 2>&1)
-if ! grep -q "stub panic" <<< "$shown"; then
+if ! grep -qs "stub panic" <<< "$shown" \
+    || ! grep -qsF -- "--- interpreter stderr ---" <<< "$shown"; then
     echo "FAIL: show_interp_stderr did not surface the captured stderr" >&2
     show_interp_stderr "$ERR"
     exit 1
 fi
 
-# A quiet run stays quiet, and the 3-arg form (no errfile) keeps working for
-# a caller that passes none.
+# The 3-arg form must keep sending stderr to /dev/null. Prove it with the
+# NOISY stub -- a quiet one could not tell a redirect regression from
+# silence -- by capturing what reaches the CALLER's stderr: nothing may.
+leak="$DIR/three-arg.stderr"
+status=0
+out=$(interp_stdout "$DIR/aborting-kaappi" "$DIR" "prog.scm" 2> "$leak") || status=$?
+if [ -n "$out" ] || [ "$status" -ne 134 ] || [ -s "$leak" ]; then
+    echo "FAIL: 3-arg form must hide stderr: stdout '$out' status $status, leaked:" >&2
+    cat "$leak" >&2
+    exit 1
+fi
+
+# A quiet run stays quiet on both forms.
 cat > "$DIR/quiet-kaappi" << 'EOF'
 #!/bin/sh
 echo "42"


### PR DESCRIPTION
Closes #2532

## What

Implements the issue's "Catching a recurrence" prescription: when an interpreter oracle run in a compile script fails unexpectedly, its stderr — the one datum that can explain an abort — now lands in the CI log instead of `/dev/null`.

- `interp_stdout` (tests/scheme/shell-common.sh) takes an optional fourth argument, an errfile to capture the interpreter's stderr into; the default stays `/dev/null`.
- New `show_interp_stderr <errfile>` prints the capture with a `--- interpreter stderr ---` lead-in, and is a no-op when the file is empty — so a green run stays silent and a mismatch that is only the native tier's fault adds nothing.
- All 18 oracle call sites across the 16 compile scripts now pass an errfile (under each script's mktemp workdir, never inside the repo tree — a dirty tree changes the build id baked into `.sbc` files) and call `show_interp_stderr` on their interpreter-failure FAIL branches.
- `tests/scheme/smoke/interp-oracle-stderr-2532.sh` is a deterministic harness self-test (the `build-lock-orphan-2434.sh` shape, no real kaappi): a stub interpreter reproduces the CI failure's shape — panic line on stderr, no stdout, exit 134 — and the test asserts the capture and the showing, that the 3-arg form still buries stderr (proven with the noisy stub), and that quiet runs behave exactly as before.
- `tests/scheme/CLAUDE.md`'s oracle section documents the errfile convention.

## Why

Run 33958780190 aborted once in the interpreter oracle of `native-set-global-child-thread-2487.sh` (exit 134, empty stdout) and the two hypotheses — a residual race abort vs. an exit-time allocator report — were indistinguishable because `interp_stdout` dropped stderr by design. An aborting process loses its piped stdout to block buffering, so the captured stderr is the only thing that says *why* it died. If the failure recurs, the panic text now reaches the job log.

The tier-parity rule (never *compare* diagnostic text across tiers) is untouched: the text is shown on the failure branch, never asserted on.

## Verification

- Self-test verified both ways: red against `origin/main`'s `shell-common.sh` (a single clean FAIL line), green with the fix.
- End-to-end: pointing `native-macro-set-tracking-2212.sh` at a stub interpreter that aborts with exit 134 + panic text — every FAIL branch now carries `--- interpreter stderr ---` and the panic lines.
- All 16 touched compile scripts pass against a fresh ReleaseSafe build (run with an isolated `KAAPPI_HOME`, matching `run-all.sh`), plus `bash -n` on every touched script and `markdownlint-cli2` clean.

If the abort recurs on a Debug leg after this lands, file a fresh issue with the now-visible panic text — it should pick between the issue's two hypotheses directly.