### PR TITLE
Default zig build lib to the portable baseline CPU

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,13 @@ that built it. The CPU model is not part of the bytecode compiler key, so an
 `.sbc` produced by a host-tuned kaappi still embeds in a baseline bundler
 built from the same tree.
 
+The runtime archive `zig build lib` defaults to baseline for the same reason
+(kaappi#2531): `libkaappi_rt.a` ships inside every `kaappi compile` output,
+so a host-tuned archive put a host-tuned VM/GC in binaries that travel. The
+same `-Dcpu=native` opt-out applies. The dev binary built by the same
+configure stays host-tuned — only the artifact that gets linked into shipped
+programs is pinned.
+
 ### Build-time limits
 
 | Option | Default | Grows to |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,12 @@ built from the same tree.
 The runtime archive `zig build lib` defaults to baseline for the same reason
 (kaappi#2531): `libkaappi_rt.a` ships inside every `kaappi compile` output,
 so a host-tuned archive put a host-tuned VM/GC in binaries that travel. The
-same `-Dcpu=native` opt-out applies. The dev binary built by the same
-configure stays host-tuned — only the artifact that gets linked into shipped
-programs is pinned.
+same `-Dcpu=native` opt-out applies, and the native link routes pin the
+emitted program code to the same model (`-mcpu=baseline` for `zig cc`,
+which otherwise resolves the host CPU; clang/gcc already default to the
+generic model for the triple). The dev binary built by the same configure
+stays host-tuned *by default* — an explicit `-Dcpu=<model>` is respected
+everywhere.
 
 ### Build-time limits
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ symbols, and **multi-line input** with automatic paren balancing.
 ### Beyond the standard
 
 - **180 SRFIs** — 12 built-in, 164 as portable `.sld` libraries, plus SRFI 261 portable library references (`(srfi srfi-1)`, `(srfi lists-1)`) resolved in the importer and SRFI 226/160/211 as sub-libraries only (full list in [CONFORMANCE.md](CONFORMANCE.md))
-- **Native binaries** — `kaappi compile program.scm -o program` compiles Scheme to a native executable via LLVM, with self-tail-calls compiled as loops, linking a runtime archive tuned to the portable baseline CPU so the result runs on other machines of the same architecture ([details](docs/dev/llvm-backend.md))
+- **Native binaries** — `kaappi compile program.scm -o program` compiles Scheme to a native executable via LLVM, with self-tail-calls compiled as loops, tuned to the portable baseline CPU so the result runs on other machines of the same architecture ([details](docs/dev/llvm-backend.md))
 - **Standalone bundles** — `zig build -Dbundle-src=program.scm` embeds bytecode + libraries in a single executable, tuned to the portable baseline CPU so it runs on other machines of the same architecture (`-Dcpu=native` restores host tuning)
 - **C FFI** — call shared libraries from Scheme via `(kaappi ffi)`; 18 marshalled types, callbacks for passing Scheme procedures to C
 - **Concurrency** — green threads with channels via `(kaappi fibers)`, plus real OS threads via SRFI-18

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ symbols, and **multi-line input** with automatic paren balancing.
 ### Beyond the standard
 
 - **180 SRFIs** — 12 built-in, 164 as portable `.sld` libraries, plus SRFI 261 portable library references (`(srfi srfi-1)`, `(srfi lists-1)`) resolved in the importer and SRFI 226/160/211 as sub-libraries only (full list in [CONFORMANCE.md](CONFORMANCE.md))
-- **Native binaries** — `kaappi compile program.scm -o program` compiles Scheme to a native executable via LLVM, with self-tail-calls compiled as loops ([details](docs/dev/llvm-backend.md))
+- **Native binaries** — `kaappi compile program.scm -o program` compiles Scheme to a native executable via LLVM, with self-tail-calls compiled as loops, linking a runtime archive tuned to the portable baseline CPU so the result runs on other machines of the same architecture ([details](docs/dev/llvm-backend.md))
 - **Standalone bundles** — `zig build -Dbundle-src=program.scm` embeds bytecode + libraries in a single executable, tuned to the portable baseline CPU so it runs on other machines of the same architecture (`-Dcpu=native` restores host tuning)
 - **C FFI** — call shared libraries from Scheme via `(kaappi ffi)`; 18 marshalled types, callbacks for passing Scheme procedures to C
 - **Concurrency** — green threads with channels via `(kaappi fibers)`, plus real OS threads via SRFI-18

--- a/build.zig
+++ b/build.zig
@@ -335,6 +335,11 @@ pub fn build(b: *std.Build) void {
         // Optimize the emitted IR — the emitter relies on LLVM to clean up its
         // deliberately naive output; -O0 leaves it all in place (#1492).
         cc_run.addArg("-O2");
+        // `zig cc` with no -mcpu tunes for the build host (kaappi#2531): pin
+        // the emitted IR to the same resolved CPU model the runtime archive
+        // was built with, so `zig build native` output is portable by
+        // default and `-Dcpu=native` host-tunes the whole thing consistently.
+        cc_run.addArg(b.fmt("-mcpu={s}", .{lib_target.result.cpu.model.name}));
         cc_run.addFileArg(ll_output);
         cc_run.addArg("-o");
         const native_output = cc_run.addOutputFileArg("program");

--- a/build.zig
+++ b/build.zig
@@ -46,6 +46,28 @@ pub fn build(b: *std.Build) void {
     }
     const target = b.resolveTargetQuery(effective_query);
 
+    // kaappi#2531: the runtime archive gets the same pin *unconditionally*,
+    // not just when bundling. libkaappi_rt.a ships inside every executable
+    // `kaappi compile` emits — the other documented way to ship a Kaappi
+    // program — and the `lib` step used to build it from the same host-tuned
+    // `target` as the dev binary, so a source-built kaappi (no -Dtarget)
+    // produced `kaappi compile` output carrying a host-tuned VM/GC that
+    // SIGILLs on another machine of the same arch. Same pin, same opt-out:
+    // `.determined_by_arch_os → .baseline`, `-Dcpu=native` (or any explicit
+    // -Dcpu) respected verbatim, explicit -Dtarget already baseline so the
+    // release workflow's archives are bit-identical to before. Under a
+    // bundling configure the effective query is already pinned, so this is
+    // the same resolved target — one cache key, no forking. Everything a
+    // developer runs locally (zig build's REPL binary, tests, benches) keeps
+    // the host-tuned `target`: those artifacts stay on the machine that
+    // built them, and the A/B benchmark protocol in docs/dev/performance.md
+    // keeps its host-tuned baseline.
+    var lib_query = effective_query;
+    if (lib_query.cpu_model == .determined_by_arch_os) {
+        lib_query.cpu_model = .baseline;
+    }
+    const lib_target = b.resolveTargetQuery(lib_query);
+
     // Default to ReleaseSafe rather than Debug: the interpreter exists to *run*
     // Scheme programs, and Debug is ~500x slower for allocation/continuation-
     // heavy workloads. ReleaseSafe matches ReleaseFast in throughput here while
@@ -261,11 +283,15 @@ pub fn build(b: *std.Build) void {
     const run_step = b.step("run", "Run the Kaappi Scheme REPL");
     run_step.dependOn(&run_cmd.step);
 
-    // Runtime static library (for LLVM native backend)
-    const lib_step = b.step("lib", "Build libkaappi_rt.a (runtime for native backend)");
+    // Runtime static library (for LLVM native backend). Built from
+    // `lib_target` — baseline-pinned by default (kaappi#2531, see the query
+    // comment above): this archive is linked into every `kaappi compile`
+    // output, i.e. it is a thing users ship, while the dev binary built from
+    // `target` in the same configure stays host-tuned.
+    const lib_step = b.step("lib", "Build libkaappi_rt.a (runtime for native backend; defaults to the portable baseline CPU so kaappi-compile binaries run on other machines of the same arch — -Dcpu=native restores host tuning)");
     const lib_mod = kaappiModule(b, options_mod, .{
         .root = "src/runtime_exports.zig",
-        .target = target,
+        .target = lib_target,
         .optimize = optimize,
         .isocline = use_isocline,
         .embed = null_embed,

--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -80,10 +80,14 @@ NaN-boxed representation crosses C ABI trivially).
 ```bash
 zig build lib                                        # build libkaappi_rt.a
 kaappi --emit-llvm -o program.ll program.scm         # emit LLVM IR
-zig cc -w -O2 program.ll -o program \
+zig cc -w -O2 -mcpu=baseline program.ll -o program \
     -Lzig-out/lib -lkaappi_rt -lc -lm -lpthread      # link native binary
 ./program                                            # run
 ```
+
+(`zig cc` with no `-mcpu` tunes for the build host — see the baseline-CPU
+note above. This manual flow is also the escape hatch for hand-picking
+codegen the pinned routes don't offer.)
 
 ### Single-step build
 
@@ -96,19 +100,28 @@ zig build native -Dnative-src=program.scm            # all-in-one
 library references `__zig_probe_stack` and other Zig compiler-rt intrinsics
 that `clang` cannot resolve.
 
-**The archive defaults to the portable baseline CPU** (kaappi#2531):
-`libkaappi_rt.a` is linked into every binary `kaappi compile` emits, so it is
-a thing you ship, and without `-Dtarget` a host-tuned archive put a
-host-tuned VM/GC inside binaries that could SIGILL on another machine of the
-same architecture. `zig build lib` therefore resolves the baseline CPU model
-unless you name one — `-Dcpu=native` restores host tuning for archives that
-really will only be linked on the machine that built them. Released archives
-were never affected (the release workflow passes an explicit `-Dtarget`,
-which already meant baseline); only source builds. The dev binary from the
-same `zig build` configure stays host-tuned (kaappi#2529); only the archive
-is pinned. Note the emitted IR's own tuning comes from whichever C compiler
-links it — on the user's machine, with that compiler's default CPU — which
-is outside the build's control either way.
+**Everything `kaappi compile` ships defaults to the portable baseline CPU**
+(kaappi#2531). The runtime archive is one half: `libkaappi_rt.a` is linked
+into every binary the command emits, so it is a thing you ship, and without
+`-Dtarget` a host-tuned archive put a host-tuned VM/GC inside binaries that
+could SIGILL on another machine of the same architecture. `zig build lib`
+therefore resolves the baseline CPU model unless you name one —
+`-Dcpu=native` restores host tuning for artifacts that really will only run
+on the machine that built them. Released archives were never affected (the
+release workflow passes an explicit `-Dtarget`, which already meant
+baseline); only source builds.
+
+The program code is the other half, and the C compiler decides its default:
+`zig cc` with no `-mcpu` ends up on the *host* CPU (its effective
+`-target-cpu` is the detected model, byte-for-byte the `-mcpu=native` list),
+while clang and gcc default to the generic model for the target triple.
+Since `zig` is first in `kaappi compile`'s C-compiler search order, the
+`zig cc` route pins the emitted IR with `-mcpu=baseline`, matching the
+model of the archive it links against; `zig build native` does the same
+with its own resolved CPU model, so `-Dcpu=native` there host-tunes the
+whole output consistently. The dev binary built by the same `zig build`
+configure stays host-tuned by default (kaappi#2529) — an explicit
+`-Dcpu=<model>` is respected everywhere.
 
 ### Where `kaappi compile` looks for `libkaappi_rt.a`
 

--- a/docs/dev/llvm-backend.md
+++ b/docs/dev/llvm-backend.md
@@ -96,6 +96,20 @@ zig build native -Dnative-src=program.scm            # all-in-one
 library references `__zig_probe_stack` and other Zig compiler-rt intrinsics
 that `clang` cannot resolve.
 
+**The archive defaults to the portable baseline CPU** (kaappi#2531):
+`libkaappi_rt.a` is linked into every binary `kaappi compile` emits, so it is
+a thing you ship, and without `-Dtarget` a host-tuned archive put a
+host-tuned VM/GC inside binaries that could SIGILL on another machine of the
+same architecture. `zig build lib` therefore resolves the baseline CPU model
+unless you name one — `-Dcpu=native` restores host tuning for archives that
+really will only be linked on the machine that built them. Released archives
+were never affected (the release workflow passes an explicit `-Dtarget`,
+which already meant baseline); only source builds. The dev binary from the
+same `zig build` configure stays host-tuned (kaappi#2529); only the archive
+is pinned. Note the emitted IR's own tuning comes from whichever C compiler
+links it — on the user's machine, with that compiler's default CPU — which
+is outside the build's control either way.
+
 ### Where `kaappi compile` looks for `libkaappi_rt.a`
 
 In order: the `KAAPPI_LIB_DIR` environment variable, `<exe_dir>/../lib/`,

--- a/docs/dev/test-runner.md
+++ b/docs/dev/test-runner.md
@@ -368,17 +368,19 @@ Three things make that safe and worthwhile (kaappi#1926):
   `-Dbundle=` build resolves the portable **baseline** CPU model by default
   (a bundled binary is shipped, and a host-tuned one SIGILLs on other
   machines of the same arch), while `fixture_interpreter`'s plain `zig build`
-  stays host-tuned. That asymmetry is deliberate and free — the embedded
-  bytecode already puts the bundler on its own cache key, and the CPU model
-  is not part of the `.sbc` compiler hash (see [cache.md](cache.md)) — but it
-  means no script may pass `-Dcpu=native` (or any host-naming
-  `-Dcpu=<model>`) to a `-Dbundle=` build: it would fork the shared cache key
-  *and* reintroduce the portability bug the default exists to prevent. Since
-  kaappi#2531 the same holds for `zig build lib`: the runtime archive — the
-  one `ensure_runtime_lib` builds up front and every compile script links
-  against — also defaults to baseline (it ships inside `kaappi compile`
-  output), so no script may pass `-Dcpu=native` to it either, for both the
-  same reasons.
+  stays host-tuned; since kaappi#2531 the same holds for `zig build lib` —
+  the runtime archive `ensure_runtime_lib` builds up front and every compile
+  script links against ships inside `kaappi compile` output. That asymmetry
+  is deliberate and free — the embedded bytecode already puts the bundler on
+  its own cache key, and the CPU model is not part of the `.sbc` compiler
+  hash (see [cache.md](cache.md)) — so no script may pass a host-naming
+  `-Dcpu` to the shared builders, or to any build that installs into
+  `zig-out/`: it would fork the shared cache key *and* reintroduce the
+  portability bug the defaults exist to prevent. The sanctioned exception is
+  a differential probe that builds into a `--prefix` of its own, as the two
+  CPU-baseline regression scripts do with `-Dcpu=native`
+  (`bundle-cpu-baseline-2515.sh`, `lib-cpu-baseline-2531.sh`) — deliberately,
+  as their one cold build each.
 
 Dispatch inside a suite is longest-first — scripts that shell out to a full
 `zig build -D…`, or to either shared builder, go first, found by grep rather

--- a/docs/dev/test-runner.md
+++ b/docs/dev/test-runner.md
@@ -373,7 +373,12 @@ Three things make that safe and worthwhile (kaappi#1926):
   is not part of the `.sbc` compiler hash (see [cache.md](cache.md)) — but it
   means no script may pass `-Dcpu=native` (or any host-naming
   `-Dcpu=<model>`) to a `-Dbundle=` build: it would fork the shared cache key
-  *and* reintroduce the portability bug the default exists to prevent.
+  *and* reintroduce the portability bug the default exists to prevent. Since
+  kaappi#2531 the same holds for `zig build lib`: the runtime archive — the
+  one `ensure_runtime_lib` builds up front and every compile script links
+  against — also defaults to baseline (it ships inside `kaappi compile`
+  output), so no script may pass `-Dcpu=native` to it either, for both the
+  same reasons.
 
 Dispatch inside a suite is longest-first — scripts that shell out to a full
 `zig build -D…`, or to either shared builder, go first, found by grep rather

--- a/src/native_compiler.zig
+++ b/src/native_compiler.zig
@@ -686,7 +686,7 @@ test "checkLibDir looks for the platform-named runtime archive" {
 }
 
 fn tryLink(allocator: std.mem.Allocator, cc: []const u8, ll_path: []const u8, out_path: []const u8, lib_flag: []const u8, is_zig: bool) bool {
-    var argv_buf: [16]?[*:0]const u8 = .{null} ** 16;
+    var argv_buf: [20]?[*:0]const u8 = .{null} ** 20;
     var argc: usize = 0;
 
     const cc_z = allocator.dupeZ(u8, cc) catch return false;
@@ -712,6 +712,21 @@ fn tryLink(allocator: std.mem.Allocator, cc: []const u8, ll_path: []const u8, ou
     // (a hard verifier error still fails the compile regardless of -w). See #1492.
     argv_buf[argc] = "-O2";
     argc += 1;
+
+    if (is_zig) {
+        // `zig cc` with no -mcpu ends up on the *host* CPU (its effective
+        // -target-cpu is the detected model, byte-for-byte the -mcpu=native
+        // list), unlike clang/gcc, whose default for the triple is the
+        // generic model. zig is first in cc_search_order, so without this
+        // the program code kaappi compile ships would stay host-tuned even
+        // though the runtime archive it links is baseline-pinned
+        // (kaappi#2531) — the SIGILL hazard would survive on the preferred
+        // route. -mcpu=baseline matches the archive's default model; the
+        // manual three-step flow (docs/dev/llvm-backend.md) is the escape
+        // hatch for hand-picked codegen.
+        argv_buf[argc] = "-mcpu=baseline";
+        argc += 1;
+    }
 
     const ll_z = allocator.dupeZ(u8, ll_path) catch return false;
     defer allocator.free(ll_z);
@@ -765,7 +780,7 @@ fn tryLink(allocator: std.mem.Allocator, cc: []const u8, ll_path: []const u8, ou
 
     const link_ok = blk: {
         if (comptime platform.is_windows) {
-            var argv_slices: [16][]const u8 = undefined;
+            var argv_slices: [20][]const u8 = undefined;
             for (argv_buf[0..argc], 0..) |arg, i| argv_slices[i] = std.mem.sliceTo(arg.?, 0);
             const code = platform.winSpawnPassthrough(allocator, argv_slices[0..argc], null) catch break :blk false;
             break :blk code == 0;

--- a/tests/scheme/compile/bundle-cpu-baseline-2515.sh
+++ b/tests/scheme/compile/bundle-cpu-baseline-2515.sh
@@ -133,9 +133,15 @@ fi
 
 # --- assertion 3: the baseline binary still runs ---------------------------
 # Baseline is a subset of the host's features, so the shipped default must
-# execute right where it was built — and the .sbc inside it came from a
-# host-tuned compiler, which the compiler key permits (see cache.md).
-OUTPUT="$("$DEFAULT_BIN" 2>&1)" || true
+# execute right where it was built — and exit cleanly, since a teardown
+# crash after the expected line printed is exactly what this assertion
+# exists to catch. The .sbc inside it came from a host-tuned compiler,
+# which the compiler key permits (see cache.md).
+if ! OUTPUT="$("$DEFAULT_BIN" 2>&1)"; then
+    echo "FAIL: default (baseline) bundled binary exited unsuccessfully" >&2
+    echo "full output: $OUTPUT" >&2
+    exit 1
+fi
 if ! grep -q '^703: Hello, world! #t$' <<< "$OUTPUT"; then
     echo "FAIL: default (baseline) bundled binary does not run its program" >&2
     echo "full output: $OUTPUT" >&2

--- a/tests/scheme/compile/lib-cpu-baseline-2531.sh
+++ b/tests/scheme/compile/lib-cpu-baseline-2531.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Regression test for kaappi#2531: `zig build` with no -Dtarget tunes for the
+# build host's exact CPU model, and the `lib` step used to build
+# libkaappi_rt.a from that same host-tuned target — so every executable a
+# source-built `kaappi compile` emitted carried a host-tuned VM/GC and could
+# SIGILL on another machine of the same architecture (#2515's misdiagnosis
+# cost: it reads as a VM bug, not a build-flags bug). The fix, completing
+# #2529's bundle-path pin: the runtime archive resolves the portable baseline
+# CPU model by default; -Dcpu=native (Zig's own spelling — bit for bit the
+# pre-fix tuning) opts back into host tuning; any other explicit -Dcpu=<model>
+# is always respected. The dev binary from the same `zig build` configure
+# stays host-tuned — only the artifact that ships inside kaappi-compile
+# output is pinned.
+#
+# Build-system defaults have no Scheme-visible surface and the archive
+# carries no CPU-model tag, so the observable is differential, exactly as in
+# bundle-cpu-baseline-2515.sh: Zig builds are reproducible, so the default
+# `zig build lib` archive must be byte-identical to an explicit
+# `-Dcpu=baseline` one. That assertion fails without the fix on every host
+# whose CPU model differs from the baseline (CI's x86_64 legs, Apple Silicon
+# above M1) and passes trivially where host == baseline, because the bug
+# cannot manifest there. The opt-out is checked the same way: when
+# host != baseline, the -Dcpu=native archive must differ from the default.
+# A tiny zig probe — the technique from the #2515 issue itself — names the
+# two models so the script knows which world it is in instead of guessing.
+#
+# Build discipline (kaappi#1926/#1930): the default archive build shares
+# run-all.sh's own up-front `zig build lib` cache key exactly (same default
+# flags, and baseline == baseline under the fix), the -Dcpu=baseline twin is
+# a cache hit of it, and only the -Dcpu=native variant is one cold build.
+# The end-to-end link check compiles with the shared fixture interpreter
+# (host-tuned is fine — the interpreter only drives emission and linking)
+# against the default archive via KAAPPI_LIB_DIR, never zig-out's, so the
+# assertion is about THIS tree's default flags and not whatever archive
+# another script left installed.
+#
+# Usage: bash tests/scheme/compile/lib-cpu-baseline-2531.sh [path-to-kaappi]
+# (the kaappi path is accepted for suite uniformity and unused: the archive
+# under test is built from current source, like every compile-suite script.)
+
+set -euo pipefail
+
+# Native-compile regression tests rebuild the runtime archive (zig build lib)
+# or the interpreter itself on this machine; Windows ARM64 has no working
+# native Zig toolchain until the 0.17.0 bump (kaappi#1613), and CI's
+# windows-arm-test job deliberately installs none.
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+skip_without_zig "rebuilds libkaappi_rt.a with zig build lib on this machine"
+
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+RT_LIB="$(rt_lib_name)"
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+# --- probe: name the host and baseline CPU models (#2515's technique) ------
+# A three-line native zig program prints what the two CPU selections resolve
+# to on this machine (e.g. host=apple_m3 baseline=apple_m1 on an M3 Mac).
+cat > "$DIR/cpu-probe.zig" <<'EOF'
+const std = @import("std");
+const builtin = @import("builtin");
+pub fn main() !void {
+    const baseline = std.Target.Cpu.baseline(builtin.cpu.arch, builtin.os);
+    std.debug.print("host={s}\nbaseline={s}\n", .{ builtin.cpu.model.name, baseline.model.name });
+}
+EOF
+PROBE_LOG="$DIR/probe.log"
+if ! (cd "$DIR" && zig build-exe cpu-probe.zig) > "$PROBE_LOG" 2>&1; then
+    echo "FAIL: could not build the CPU-model probe" >&2
+    cat "$PROBE_LOG" >&2
+    exit 1
+fi
+# std.debug.print writes to stderr, so fold it into the capture.
+PROBE_OUT="$(cd "$DIR" && ./cpu-probe 2>&1)"
+HOST_MODEL="$(sed -n 's/^host=//p' <<< "$PROBE_OUT")"
+BASE_MODEL="$(sed -n 's/^baseline=//p' <<< "$PROBE_OUT")"
+if [ -z "$HOST_MODEL" ] || [ -z "$BASE_MODEL" ]; then
+    echo "FAIL: CPU-model probe printed no models:" >&2
+    printf '%s\n' "$PROBE_OUT" >&2
+    exit 1
+fi
+
+# --- the three archive variants the assertions need ------------------------
+# Same -Doptimize, one flag apart. Under the fix the baseline twin resolves
+# to the same target as the default build (a Zig cache hit), so it costs
+# nothing; the native variant is the one cold build this script adds.
+build_variant() { # <name> <extra zig build flags...>
+    local name="$1"
+    shift
+    local log rc
+    log=$(mktemp)
+    build_lock "$REPO_DIR" lib-cpu-2531
+    rc=0
+    (
+        cd "$REPO_DIR" &&
+            zig build lib -Doptimize=ReleaseSafe "$@" \
+                --prefix "$DIR/prefix-$name" &&
+            cp "$DIR/prefix-$name/lib/$RT_LIB" "$DIR/$name-$RT_LIB"
+    ) > "$log" 2>&1 || rc=$?
+    build_unlock "$REPO_DIR" lib-cpu-2531
+    if [ "$rc" -ne 0 ]; then
+        echo "FAIL: could not build the '$name' runtime-archive variant" >&2
+        cat "$log" >&2
+    fi
+    rm -f "$log"
+    return "$rc"
+}
+build_variant default
+build_variant baseline -Dcpu=baseline
+build_variant native -Dcpu=native
+
+# --- assertion 1: the default IS the baseline archive ----------------------
+# Without the fix (host-tuned default) these differ wherever host != baseline.
+if ! cmp -s "$DIR/default-$RT_LIB" "$DIR/baseline-$RT_LIB"; then
+    echo "FAIL: default zig build lib archive is not the -Dcpu=baseline one —" >&2
+    echo "      the portable-baseline default (kaappi#2531) regressed" >&2
+    exit 1
+fi
+
+# --- assertion 2: the opt-out restores host tuning -------------------------
+# Only meaningful where the two tunings differ; where host == baseline the
+# comparison is vacuous and the bug this guards cannot manifest.
+if [ "$HOST_MODEL" != "$BASE_MODEL" ]; then
+    if cmp -s "$DIR/default-$RT_LIB" "$DIR/native-$RT_LIB"; then
+        echo "FAIL: -Dcpu=native did not restore host CPU tuning" >&2
+        echo "      (host=$HOST_MODEL baseline=$BASE_MODEL, archives identical)" >&2
+        exit 1
+    fi
+else
+    echo "note: host CPU model == baseline ($HOST_MODEL); the opt-out comparison is vacuous here" >&2
+fi
+
+# --- assertion 3: kaappi-compile output linked against the default runs ----
+# Baseline is a subset of the host's features, so a program linked against
+# the default (baseline) archive must run right where it was built. This is
+# the issue's own scenario minus the second machine: the byte-identity
+# assertions above stand in for "the tuning actually moved".
+fixture_interpreter "$REPO_DIR" || {
+    echo "FAIL: could not build the fixture interpreter" >&2
+    exit 1
+}
+INTERP="$(fixture_interpreter_path "$REPO_DIR")"
+cat > "$DIR/prog.scm" <<'EOF'
+(display "2531: baseline archive links and runs") (newline)
+EOF
+COMPILE_LOG="$DIR/compile.log"
+if ! (cd "$DIR" && KAAPPI_LIB_DIR="$DIR/prefix-default/lib" \
+        "$INTERP" compile prog.scm -o prog) > "$COMPILE_LOG" 2>&1; then
+    echo "FAIL: kaappi compile against the default (baseline) archive failed" >&2
+    cat "$COMPILE_LOG" >&2
+    exit 1
+fi
+OUTPUT="$("$DIR/prog" 2>&1)" || true
+if [ "$OUTPUT" != "2531: baseline archive links and runs" ]; then
+    echo "FAIL: program linked against the default (baseline) archive did not run" >&2
+    echo "full output: $OUTPUT" >&2
+    cat "$COMPILE_LOG" >&2
+    exit 1
+fi
+
+echo "PASS: zig build lib defaults to the baseline CPU ($BASE_MODEL; host is $HOST_MODEL); -Dcpu=native restores host tuning"

--- a/tests/scheme/compile/lib-cpu-baseline-2531.sh
+++ b/tests/scheme/compile/lib-cpu-baseline-2531.sh
@@ -188,7 +188,12 @@ if ! grep -q -- '-mcpu=baseline' "$SHIM_LOG"; then
     exit 1
 fi
 
-OUTPUT="$(cd "$DIR" && ./prog 2>&1)"
+if ! OUTPUT="$(cd "$DIR" && ./prog 2>&1)"; then
+    echo "FAIL: program linked against the default (baseline) archive exited unsuccessfully" >&2
+    echo "full output: $OUTPUT" >&2
+    cat "$COMPILE_LOG" >&2
+    exit 1
+fi
 if [ "$OUTPUT" != "2531: baseline archive links and runs" ]; then
     echo "FAIL: program linked against the default (baseline) archive did not run" >&2
     echo "full output: $OUTPUT" >&2

--- a/tests/scheme/compile/lib-cpu-baseline-2531.sh
+++ b/tests/scheme/compile/lib-cpu-baseline-2531.sh
@@ -32,7 +32,13 @@
 # (host-tuned is fine — the interpreter only drives emission and linking)
 # against the default archive via KAAPPI_LIB_DIR, never zig-out's, so the
 # assertion is about THIS tree's default flags and not whatever archive
-# another script left installed.
+# another script left installed. The archive is only half of what
+# `kaappi compile` ships: on the preferred zig-cc link route the emitted IR
+# must be pinned with -mcpu=baseline too (`zig cc` with no -mcpu resolves
+# the host CPU, unlike clang/gcc's generic triple default), so a logging
+# `zig` shim placed first on PATH captures the exact argv the link step
+# handed the compiler — an externally observable assertion that runs on
+# every host, baseline or not.
 #
 # Usage: bash tests/scheme/compile/lib-cpu-baseline-2531.sh [path-to-kaappi]
 # (the kaappi path is accepted for suite uniformity and unused: the archive
@@ -133,9 +139,11 @@ fi
 
 # --- assertion 3: kaappi-compile output linked against the default runs ----
 # Baseline is a subset of the host's features, so a program linked against
-# the default (baseline) archive must run right where it was built. This is
-# the issue's own scenario minus the second machine: the byte-identity
-# assertions above stand in for "the tuning actually moved".
+# the default (baseline) archive must run right where it was built — and
+# exit cleanly, since a teardown crash after the expected line printed is
+# exactly what this assertion exists to catch. This is the issue's own
+# scenario minus the second machine: the byte-identity assertions above
+# stand in for "the tuning actually moved".
 fixture_interpreter "$REPO_DIR" || {
     echo "FAIL: could not build the fixture interpreter" >&2
     exit 1
@@ -144,14 +152,43 @@ INTERP="$(fixture_interpreter_path "$REPO_DIR")"
 cat > "$DIR/prog.scm" <<'EOF'
 (display "2531: baseline archive links and runs") (newline)
 EOF
+
+# --- assertion 4: the zig-cc link route pins -mcpu=baseline ----------------
+# A logging `zig` shim captures the exact argv `kaappi compile` hands the
+# compiler. The shim is transparent (it execs the real zig), so the binary
+# this one compile produces serves both this assertion and assertion 3.
+# Pre-fix the captured line has no -mcpu and zig cc tunes for the host;
+# unlike assertions 1/2 this check is meaningful on every host, because the
+# flag is passed unconditionally.
+REAL_ZIG="$(command -v zig)"
+export REAL_ZIG
+SHIM_LOG="$DIR/zig-argv.log"
+export SHIM_LOG
+mkdir -p "$DIR/shim-bin"
+cat > "$DIR/shim-bin/zig" <<'SHIM'
+#!/bin/bash
+printf '%s\n' "$*" >> "$SHIM_LOG"
+exec "${REAL_ZIG:?REAL_ZIG not set}" "$@"
+SHIM
+chmod +x "$DIR/shim-bin/zig"
+: > "$SHIM_LOG"
+
 COMPILE_LOG="$DIR/compile.log"
-if ! (cd "$DIR" && KAAPPI_LIB_DIR="$DIR/prefix-default/lib" \
+if ! (cd "$DIR" && PATH="$DIR/shim-bin:$PATH" KAAPPI_LIB_DIR="$DIR/prefix-default/lib" \
         "$INTERP" compile prog.scm -o prog) > "$COMPILE_LOG" 2>&1; then
     echo "FAIL: kaappi compile against the default (baseline) archive failed" >&2
     cat "$COMPILE_LOG" >&2
     exit 1
 fi
-OUTPUT="$("$DIR/prog" 2>&1)" || true
+if ! grep -q -- '-mcpu=baseline' "$SHIM_LOG"; then
+    echo "FAIL: the zig-cc link route did not pin -mcpu=baseline —" >&2
+    echo "      the program code kaappi compile ships stays host-tuned (kaappi#2531)" >&2
+    echo "argv captured by the shim:" >&2
+    cat "$SHIM_LOG" >&2
+    exit 1
+fi
+
+OUTPUT="$(cd "$DIR" && ./prog 2>&1)"
 if [ "$OUTPUT" != "2531: baseline archive links and runs" ]; then
     echo "FAIL: program linked against the default (baseline) archive did not run" >&2
     echo "full output: $OUTPUT" >&2
@@ -159,4 +196,4 @@ if [ "$OUTPUT" != "2531: baseline archive links and runs" ]; then
     exit 1
 fi
 
-echo "PASS: zig build lib defaults to the baseline CPU ($BASE_MODEL; host is $HOST_MODEL); -Dcpu=native restores host tuning"
+echo "PASS: zig build lib defaults to the baseline CPU ($BASE_MODEL; host is $HOST_MODEL); -Dcpu=native restores host tuning; the zig-cc link pins -mcpu=baseline"


### PR DESCRIPTION
Fixes #2531
Fixes #2536
Supersedes the runtime-archive half that #2529 deliberately left open when closing #2515.

## The bug

`zig build` with no `-Dtarget` tunes for the build host's exact CPU model, and the `lib` step built `libkaappi_rt.a` from that same host-tuned target. That archive is linked into **every executable `kaappi compile` emits** — the other documented way to ship a Kaappi program — so building kaappi from source on, say, an AVX-512 x86_64 host and running `kaappi compile app.scm -o app` shipped a host-tuned VM/GC inside `app`, which SIGILLs on another x86_64 machine and presents as a VM bug. Released archives were never affected (the release workflow passes an explicit `-Dtarget`, which already resolved baseline); only source builds — the same population #2515 targeted.

## The fix, part 1: the archive

The `lib` module now resolves its own target with the **same pin #2529 applies to bundles** (`.determined_by_arch_os → .baseline`), but unconditional rather than gated on `bundling`:

- Any explicit `-Dcpu=<model>` is respected verbatim; `-Dcpu=native` is the opt-out that restores the pre-fix tuning bit for bit.
- An explicit `-Dtarget` already meant baseline in Zig, so the release workflow's archives are **bit-identical to before**.
- Under a bundling configure the effective query is already pinned, so the lib and main targets are the same resolved target — one cache key, no forking.
- The dev side of the same configure is untouched: plain `zig build`'s REPL binary, the unit-test modules, and the benchmarks stay **host-tuned by default** (an explicit `-Dcpu` is respected everywhere); only the artifacts that ship are pinned.

## The fix, part 2: the program code (#2536)

The archive is only half of what `kaappi compile` ships. `zig` is first in the C-compiler search order, and `zig cc` with no `-mcpu` ends up on the **host** CPU (its effective `-target-cpu` is the detected model, byte-for-byte the `-mcpu=native` list — measured: default and `-mcpu=native` both resolve to `apple-m3`, `-mcpu=baseline` to `apple-m1`), while clang/gcc default to the generic model for the triple. So the SIGILL hazard survived on the preferred route even with a baseline archive.

`tryLink`'s `is_zig` branch now passes `-mcpu=baseline` (matching the archive's default model), and `zig build native` passes its own resolved CPU model, so `-Dcpu=native` there host-tunes the whole output consistently. No new opt-out flag: the manual three-step flow remains the escape hatch for hand-picked codegen (its documented example now includes `-mcpu=baseline`).

## Regression test

`tests/scheme/compile/lib-cpu-baseline-2531.sh` — the archive twin of `bundle-cpu-baseline-2515.sh`:

1. The default `zig build lib` archive must be byte-identical to an explicit `-Dcpu=baseline` one (fails without the fix wherever host ≠ baseline).
2. Where the CPU-model probe says host ≠ baseline, the `-Dcpu=native` archive must differ from the default.
3. A program compiled and linked against the default archive via `KAAPPI_LIB_DIR` runs **and exits 0** (a teardown crash after the expected output is exactly what this catches).
4. A logging `zig` shim first on PATH captures the exact argv the link step hands the compiler; the captured `zig cc` line must contain `-mcpu=baseline` — meaningful on **every** host, baseline or not, and verified to fail against pre-fix `native_compiler.zig`.

Verified on this M3 host (host=`apple_m3`, baseline=`apple_m1`): all four assertions pass with the fix and fail without it; `zig build test` and `bundle-cpu-baseline-2515.sh` (its exit-status check fixed too) pass; `zig build native -Dnative-src=` exercised end-to-end.

Docs: `AGENTS.md`/`CLAUDE.md`, `README.md`, `docs/dev/llvm-backend.md`, `docs/dev/test-runner.md` (the CPU one-key cache discipline now covers `zig build lib`, with the sanctioned `--prefix`ed differential-probe exception). The end-user native-compilation guide in kaappi/kaappi.github.io needs a matching follow-up, as #2529's did.
