### PR TITLE
Free completed-unjoined thread resources at process exit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,18 @@ jobs:
           # of the 300s default and flaked (kaappi#2232). Give the shell suites
           # the same "catch hangs, don't race the slowest legitimate build"
           # budget the per-file timeout above gives the .scm suites.
-          KAAPPI_SHELL_TEST_TIMEOUT: '600'
+          #
+          # bundle-cpu-baseline-2515 outgrew even the 600: on top of the
+          # fixture it builds TWO full -Doptimize=ReleaseSafe bundle variants
+          # (default vs baseline CPU -- deliberately separate cache keys,
+          # comparing them is the test's point), so its all-cold total sits at
+          # ~600s on the Debug leg and runner-load variance alone decides it:
+          # killed at 600s twice on PR #2538 (2026-09-06) where the identical
+          # script had passed inside the same budget on the PR's first commit
+          # the day's run before. Debug gets 900 -- a hang still dies three
+          # times over inside the 40m job cap -- and ReleaseSafe legs stay at
+          # 600, where this has not flaked.
+          KAAPPI_SHELL_TEST_TIMEOUT: ${{ matrix.optimize == 'Debug' && '900' || '600' }}
 
       - name: Sandbox escape tests
         if: env.DOCS_ONLY != 'true'

--- a/src/main.zig
+++ b/src/main.zig
@@ -196,6 +196,14 @@ fn mainImpl(init: std.process.Init.Minimal) !void {
     defer if (primitives_srfi18.hasLiveChildThreads()) {
         std.c._exit(if (toplevel_driver.script_had_error) 1 else 0);
     } else {
+        // kaappi#2537: with no live children, every entry left in the child
+        // registry belongs to a thread that completed but was never joined --
+        // its GC/VM were deliberately retained for a future thread-join! that
+        // can no longer happen. Free them here; otherwise a Debug build's
+        // leak-tracking allocator reports every object in those heaps at
+        // da.deinit() below, and symbolizing tens of thousands of stack
+        // traces blew the Debug CI leg's whole time budget.
+        _ = primitives_srfi18.freeUnjoinedExitedChildResources();
         vm.deinit();
         allocator.destroy(vm);
         gc.deinit();

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -125,9 +125,11 @@ const ChildThreadResources = struct {
 // Entries are freed when a thread is joined (freeChildResources called from
 // reapOsThread) or, when the join retires the entry because the thread still
 // has live descendants, by the last descendant's threadEntryFn defer once the
-// subtree drains (#2129). Threads that complete but are never joined leak
-// their child VM and GC — the result must survive until the parent copies it
-// out of its envelope, and automatic cleanup would race with that copy.
+// subtree drains (#2129). Threads that complete but are never joined keep
+// their child VM and GC until process exit -- the result must survive until
+// the parent copies it out of its envelope, and automatic cleanup would race
+// with that copy -- where the exit sweep frees them (kaappi#2537, called
+// from main.zig once no child thread is live).
 const ChildRegistry = struct {
     map: std.AutoHashMap(usize, ChildThreadResources),
     mutex: std.atomic.Mutex,
@@ -208,6 +210,22 @@ const ChildRegistry = struct {
             if (!entry.retired) return null;
         }
         if (self.map.fetchRemove(key)) |kv| return kv.value;
+        return null;
+    }
+
+    // kaappi#2537: pops one exited thread's entry, or null when none remains.
+    // The exit sweep (freeUnjoinedExitedChildResources) pops one at a time so
+    // freeChildResourcesEntry's real work -- two deinits plus frees -- runs
+    // outside the registry lock, same shape as the descendant-drain path.
+    fn removeAnyExited(self: *ChildRegistry) ?ChildThreadResources {
+        memory.spinLock(&self.mutex);
+        defer memory.spinUnlock(&self.mutex);
+        var it = self.map.iterator();
+        while (it.next()) |kv| {
+            if (kv.value_ptr.thread_exited) {
+                return self.map.fetchRemove(kv.key_ptr.*).?.value;
+            }
+        }
         return null;
     }
 };
@@ -1730,6 +1748,50 @@ fn freeChildResourcesEntry(res: ChildThreadResources, heir: ?*memory.GC) void {
     }
     res.child_gc.deinit();
     allocator.destroy(res.child_gc);
+}
+
+/// kaappi#2537: process-exit sweep of threads that completed but were never
+/// joined. The registry deliberately keeps such an entry alive -- its result
+/// envelope must survive until a future thread-join! copies it out -- but at
+/// exit there is no future join, and on a Debug build the retained child
+/// GC/VM surfaced as 29,366 DebugAllocator leak entries at da.deinit() for
+/// srfi18-join-spawn-grandchild-2129.scm, each symbolized through DWARF,
+/// which alone blew the Debug CI leg's whole 240s budget. Freeing here is
+/// what the exit path should have done all along: the same teardown a join
+/// performs, once it is certain no join will ever come.
+///
+/// Must only be called when no child thread is live -- main.zig's exit defer
+/// calls it in its hasLiveChildThreads() == false branch. That branch is what
+/// makes every remaining entry safe to free: a thread between its
+/// child_registry.put and threadEntryFn's markExited defer holds the live
+/// count throughout, so at count zero every entry in the map has exited. The
+/// thread_exited check stays as a floor anyway -- if a future ordering change
+/// ever breaks that invariant, skipping the entry degrades back to a leak
+/// report, never to freeing a running thread's GC/VM out from under it.
+///
+/// Returns how many entries were freed (unit-test seam).
+pub fn freeUnjoinedExitedChildResources() usize {
+    var freed: usize = 0;
+    while (child_registry.removeAnyExited()) |res| {
+        // A completed-unjoined thread's result/exception envelopes were never
+        // consumed by a join. They point into the child heap being freed, so
+        // there is nothing to copy out -- release them exactly as reapOsThread
+        // would have, then drop the entry.
+        switch (res.result) {
+            .envelope => |env| env.deinit(),
+            .none, .failed => {},
+        }
+        switch (res.exception) {
+            .envelope => |env| env.deinit(),
+            .none, .failed => {},
+        }
+        // Null heir, like the descendant-drain free: the process is
+        // quiescent, so there is no concurrent collection to protect and no
+        // parent that could still dereference this heap.
+        freeChildResourcesEntry(res, null);
+        freed += 1;
+    }
+    return freed;
 }
 
 fn threadJoinResult(target: *fiber_mod.Fiber) PrimitiveError!Value {

--- a/src/primitives_srfi18.zig
+++ b/src/primitives_srfi18.zig
@@ -217,6 +217,9 @@ const ChildRegistry = struct {
     // The exit sweep (freeUnjoinedExitedChildResources) pops one at a time so
     // freeChildResourcesEntry's real work -- two deinits plus frees -- runs
     // outside the registry lock, same shape as the descendant-drain path.
+    // Each pop rescans from the map's start, making a full sweep quadratic in
+    // the number of unjoined threads -- a non-issue at realistic counts, and
+    // the price of keeping the free outside the lock.
     fn removeAnyExited(self: *ChildRegistry) ?ChildThreadResources {
         memory.spinLock(&self.mutex);
         defer memory.spinUnlock(&self.mutex);

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -1128,6 +1128,37 @@ test "kaappi#2473: thread-start! unwinds extra_roots when the spawn setup fails"
     try std.testing.expectEqual(before, gc.extra_roots.items.len);
 }
 
+// kaappi#2537: a thread that completes but is never joined keeps its
+// child_registry entry -- its result envelope must survive a future join --
+// so at process exit a Debug build's leak-tracking allocator reported every
+// object in its GC/VM as a leak: 29,366 entries for
+// srfi18-join-spawn-grandchild-2129.scm, each symbolized through DWARF,
+// which alone blew the Debug CI leg's whole 240s budget. The exit sweep must
+// free exactly those entries. The testing allocator is the second detector:
+// the child GC/VM are allocated from the root GC's allocator, so an entry the
+// sweep skips fails ctx.deinit's leak check even if a stale entry from
+// another test masked the count.
+test "kaappi#2537: exit sweep frees a completed-unjoined thread's registry entry" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // thread-start! is unregistered on wasm
+    var ctx: th.TestContext = undefined;
+    try ctx.init();
+    defer ctx.deinit();
+    _ = try ctx.vm.eval("(define sweep-t (make-thread (lambda () 'swept)))");
+    _ = try ctx.vm.eval("(thread-start! sweep-t)");
+    // The sweep may only run once no child is live (main.zig calls it in the
+    // hasLiveChildThreads() == false branch). The live count is held from
+    // before the spawn until after the child's markExited defer, so false
+    // here means the entry exists and its thread has fully exited.
+    var spins: u32 = 0;
+    while (srfi18.hasLiveChildThreads()) : (spins += 1) {
+        if (spins >= 10_000) return error.ChildThreadNeverExited;
+        platform.sleepNs(std.time.ns_per_ms);
+    }
+    try std.testing.expect(srfi18.freeUnjoinedExitedChildResources() >= 1);
+    // Everything exited is gone after one pass; nothing can be freed twice.
+    try std.testing.expectEqual(@as(usize, 0), srfi18.freeUnjoinedExitedChildResources());
+}
+
 // kaappi#2483: the globals generation counter was a per-VM field, and
 // VM.initForThread neither copied nor shared it, so a child thread's
 // per-function global caches were invalidated only by the child's OWN

--- a/src/tests_srfi18.zig
+++ b/src/tests_srfi18.zig
@@ -1135,9 +1135,8 @@ test "kaappi#2473: thread-start! unwinds extra_roots when the spawn setup fails"
 // srfi18-join-spawn-grandchild-2129.scm, each symbolized through DWARF,
 // which alone blew the Debug CI leg's whole 240s budget. The exit sweep must
 // free exactly those entries. The testing allocator is the second detector:
-// the child GC/VM are allocated from the root GC's allocator, so an entry the
-// sweep skips fails ctx.deinit's leak check even if a stale entry from
-// another test masked the count.
+// the child GC/VM are allocated from the root GC's allocator, so an entry
+// the sweep skips fails ctx.deinit's leak check.
 test "kaappi#2537: exit sweep frees a completed-unjoined thread's registry entry" {
     if (comptime platform.is_wasm) return error.SkipZigTest; // thread-start! is unregistered on wasm
     var ctx: th.TestContext = undefined;
@@ -1154,7 +1153,10 @@ test "kaappi#2537: exit sweep frees a completed-unjoined thread's registry entry
         if (spins >= 10_000) return error.ChildThreadNeverExited;
         platform.sleepNs(std.time.ns_per_ms);
     }
-    try std.testing.expect(srfi18.freeUnjoinedExitedChildResources() >= 1);
+    // Exactly one: every other thread test in this file joins its thread, so
+    // the only entry is this test's. Equality surfaces a future test that
+    // starts leaving entries behind instead of absorbing it.
+    try std.testing.expectEqual(@as(usize, 1), srfi18.freeUnjoinedExitedChildResources());
     // Everything exited is gone after one pass; nothing can be freed twice.
     try std.testing.expectEqual(@as(usize, 0), srfi18.freeUnjoinedExitedChildResources());
 }

--- a/tests/scheme/srfi/srfi18-join-spawn-grandchild-2129.scm
+++ b/tests/scheme/srfi/srfi18-join-spawn-grandchild-2129.scm
@@ -64,18 +64,36 @@
 ;; whole run is a deref of the middle's retired -- not freed -- heap.
 ;; Allocating also interns symbols through the root's shared table (the
 ;; symbol-table half), so this exercises both halves at once.
+;;
+;; Each grandchild marks its own slot in BUSY-DONE when its allocation loop
+;; finishes, and the bounded wait before test-end below drains them. The
+;; unjoined shape stays -- that is the point of the test -- but the process
+;; no longer exits at a race-dependent moment relative to the grandchildren:
+;; before kaappi#2537, a run where the grandchildren finished just before the
+;; main thread reached the exit path left their heaps in the child registry
+;; (kept deliberately for a join that never comes) and the Debug build's
+;; leak report over 29k retained objects blew the CI leg's whole time budget.
+;; Waiting here makes the full completion path (and the exit sweep of the
+;; unjoined entries) deterministic on every run instead. The slots are
+;; one-element boxes, mutated with set-car! like GG-DONE below: a value a
+;; grandchild stores must be an immediate into a root-heap pair.
+(define busy-done (list (list #f) (list #f) (list #f) (list #f) (list #f) (list #f)))
+(define (busy-done-all?)
+  (let loop ((rest busy-done))
+    (or (null? rest) (and (car (car rest)) (loop (cdr rest))))))
 (define busy-failures 0)
 (let loop ((n 6))
   (when (> n 0)
-    (unless (eq? (run-shape
-                  (lambda ()
-                    (thread-sleep! 0.15)
-                    (let lp ((i 0) (acc '()))
-                      (if (< i 3000)
-                          (lp (+ i 1) (cons (string->symbol (string (integer->char (+ 97 (modulo i 26))))) acc))
-                          'g))))
-                 'plain)
-      (set! busy-failures (+ busy-failures 1)))
+    (let ((idx (- 6 n)))
+      (unless (eq? (run-shape
+                    (lambda ()
+                      (thread-sleep! 0.15)
+                      (let lp ((i 0) (acc '()))
+                        (if (< i 3000)
+                            (lp (+ i 1) (cons (string->symbol (string (integer->char (+ 97 (modulo i 26))))) acc))
+                            (begin (set-car! (list-ref busy-done idx) #t) 'g)))))
+                   'plain)
+        (set! busy-failures (+ busy-failures 1))))
     (loop (- n 1))))
 (test-equal "6 grandchildren keep allocating past the join (safepoints + symbol interning)"
   0 busy-failures)
@@ -129,6 +147,18 @@
   (let ((t (make-thread (lambda () 'plain))))
     (thread-start! t)
     (thread-join! t)))
+
+;; Bounded drain of the busy grandchildren (see BUSY-DONE above): poll until
+;; every grandchild's allocation loop has finished, so the process never
+;; exits while one is mid-loop. The bound exists only so a genuinely stuck
+;; grandchild fails by proceeding (the exit path handles live children
+;; cheaply) instead of hanging the leg; 60s is far beyond what the loops
+;; need even on a Debug build, and in practice the last flag is already set
+;; by the time we get here.
+(let drain ((polls 0))
+  (when (and (not (busy-done-all?)) (< polls 1200))
+    (thread-sleep! 0.05)
+    (drain (+ polls 1))))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi18-join-spawn-grandchild-2129")

--- a/tests/scheme/srfi/srfi18-join-spawn-grandchild-2129.scm
+++ b/tests/scheme/srfi/srfi18-join-spawn-grandchild-2129.scm
@@ -73,10 +73,14 @@
 ;; main thread reached the exit path left their heaps in the child registry
 ;; (kept deliberately for a join that never comes) and the Debug build's
 ;; leak report over 29k retained objects blew the CI leg's whole time budget.
-;; Waiting here makes the full completion path (and the exit sweep of the
-;; unjoined entries) deterministic on every run instead. The slots are
-;; one-element boxes, mutated with set-car! like GG-DONE below: a value a
-;; grandchild stores must be an immediate into a root-heap pair.
+;; Waiting here makes the grandchildren's full completion path (and the exit
+;; sweep of the unjoined entries) the expected course on every run. The flag
+;; is set before the grandchild's epilogue, so a small window remains where
+;; the exit defer still counts a live child and takes the _exit branch -- the
+;; guarantee is that either exit branch is cheap now, not that the outcome
+;; is deterministic. The slots are one-element boxes, mutated with set-car!
+;; like GG-DONE below: a value a grandchild stores must be an immediate into
+;; a root-heap pair.
 (define busy-done (list (list #f) (list #f) (list #f) (list #f) (list #f) (list #f)))
 (define (busy-done-all?)
   (let loop ((rest busy-done))
@@ -151,14 +155,17 @@
 ;; Bounded drain of the busy grandchildren (see BUSY-DONE above): poll until
 ;; every grandchild's allocation loop has finished, so the process never
 ;; exits while one is mid-loop. The bound exists only so a genuinely stuck
-;; grandchild fails by proceeding (the exit path handles live children
-;; cheaply) instead of hanging the leg; 60s is far beyond what the loops
-;; need even on a Debug build, and in practice the last flag is already set
-;; by the time we get here.
+;; grandchild cannot hang the leg; the test-assert below turns an expiry
+;; into a loud failure, and a grandchild still live at the (exit 1) that
+;; follows still leaves through the cheap _exit branch. Sixty seconds is far
+;; beyond what the loops need even on a Debug build, and in practice the
+;; last flag is already set by the time we get here.
 (let drain ((polls 0))
   (when (and (not (busy-done-all?)) (< polls 1200))
     (thread-sleep! 0.05)
     (drain (+ polls 1))))
+(test-assert "all six busy grandchildren finished their allocation loops"
+  (busy-done-all?))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi18-join-spawn-grandchild-2129")


### PR DESCRIPTION
Fixes #2537.

## Root cause

The issue's symptom is right but the mechanism is one step different. The Debug leak report comes from `da.deinit()`, which only runs on the **full-teardown** path — when `hasLiveChildThreads()` is false at the exit defer. So the failing run is the case where all six busy grandchildren had **finished (but were never joined)** before the main thread reached the exit path; the passing run 25 minutes earlier is the case where they were still alive and the `_exit` branch skipped teardown entirely.

Finished-but-unjoined threads keep their `child_registry` entry by design — the result envelope must survive a future `thread-join!` — so their child GC/VM are retained to process exit, and on a Debug build `da.deinit()` reports every object in those heaps (29,366 entries for this file, ~617k log lines once each is DWARF-symbolized). Whether teardown runs at all is the race; when it runs, the report alone blows the 240s budget.

I confirmed the mechanism on a pre-fix Debug binary: a single finished-but-unjoined grandchild with the same 3000-allocation loop produces 9,037 leak entries; the actual test file, made deterministic, produces 54,617 entries in ~2 minutes on this machine.

## The fix

**Engine (`primitives_srfi18.zig` + `main.zig`)** — the exit path's no-live-children branch now sweeps the registry (`freeUnjoinedExitedChildResources`): every entry still in the map belongs to a thread that has passed `threadEntryFn`'s `markExited` defer (the live-thread count is held from before the spawn until after it), so its resources are freed exactly as a join would have — unconsumed result/exception envelopes released, GC/VM deinited. Live children keep the `_exit` branch untouched, and the `thread_exited` check stays as a floor: if a future ordering change ever broke the invariant, the failure mode degrades back to a leak report, never to freeing a running thread's GC/VM.

**Test (`srfi18-join-spawn-grandchild-2129.scm`)** — the bounded drain the issue suggests, in the shape that actually helps: each busy grandchild marks its own slot (a root-heap box, `set-car!` with an immediate — the file's existing `gg-done` pattern) when its allocation loop finishes, and the main thread polls until all six are set before `test-end`, bounded at 60s so a genuinely stuck grandchild proceeds to the cheap `_exit` exit instead of hanging the leg. The unjoined shape stays; the process just no longer exits at a race-dependent moment relative to the grandchildren, which makes the completion path *and* the new sweep deterministic on every leg. (Draining alone, without the sweep, makes the Debug leg deterministically slow — verified — which is why the engine half is required.)

**Unit test (`tests_srfi18.zig`)** — a completed-unjoined thread's entry is freed by one sweep pass (second pass is a no-op), with the testing allocator's leak check as the second detector if any entry is ever skipped.

## Verification

| | pre-fix Debug | post-fix Debug | post-fix ReleaseSafe |
|---|---|---|---|
| test file, drained | 54,617 leak entries, 2:04 | 0 entries, **15s** | 0 entries, **0.9s** |
| assertions | 6/6 | 6/6 | 6/6 |

- `zig build test` — pass
- `bash tests/scheme/run-all.sh` — 756 scheme files + 1,395 R7RS tests, 0 fail
- `zig fmt --check` — clean