### PR TITLE
Make SRFI 231's accumulating non-! procedures call/cc safe

### DIFF
--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -922,8 +922,12 @@ from a functional accumulator — the official suite's own continuation cases
 (entries 737-741) passed over the scratch design — so the regression tests
 drive two continuations, each invoked twice. `array-copy` of a non-specialized
 source is therefore the reference's exact shape (reversed list, then a body
-filled by linear position); a specialized source takes the direct fill, also
-as in the reference, since no user code runs in its getter.
+filled by linear position). A specialized source takes the direct fill, as in
+the reference's `%!array-copy` — a deliberate, documented exception: a
+`make-storage-class` getter or a `specialized-array-share` mapping is user code
+that runs inside that fill and could capture a continuation, and neither the
+reference nor Kaappi defends it (the list path would cost 14× the peak memory
+on the common typed-array copy; the measurements are in `views.sld`).
 `specialized-array-reshape` uses a deliberate packed-check-based
 affine-detection simplification instead of the reference's full multi-group
 algorithm, verified identical on the spec's own worked examples. (`array-packed?`

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -908,6 +908,22 @@ pure aliases (verified by reading the reference implementation: both entry
 points wrap one shared helper differing only in whether inputs are eagerly
 pre-materialized before the fill, a distinction observable only under
 multi-shot-continuation re-entry, which the spec itself declares undefined).
+Every *accumulating* non-`!` procedure — `interval-fold-left`/`-right`,
+`array-fold-left`/`-right`, `array-reduce`, `array-every`, `array->list`, and
+the collection half of `array-copy` — threads its accumulator functionally
+through one shared walk (`%interval-fold` in `intervals.sld`), never a `set!`
+cell or a pre-sized scratch vector. The spec defines *call/cc safe* as written
+"in a way that does not modify the state of any data captured by a
+continuation" and intends every procedure without a trailing `!` to be that;
+both mutable shapes shipped here until the SRFI's author showed (kaappi#2539)
+that a second re-entry of a getter's continuation resumes over an earlier
+re-entry's overwrites. A single re-entry cannot distinguish a shared buffer
+from a functional accumulator — the official suite's own continuation cases
+(entries 737-741) passed over the scratch design — so the regression tests
+drive two continuations, each invoked twice. `array-copy` of a non-specialized
+source is therefore the reference's exact shape (reversed list, then a body
+filled by linear position); a specialized source takes the direct fill, also
+as in the reference, since no user code runs in its getter.
 `specialized-array-reshape` uses a deliberate packed-check-based
 affine-detection simplification instead of the reference's full multi-group
 algorithm, verified identical on the spec's own worked examples. (`array-packed?`

--- a/lib/srfi/231/assembly.sld
+++ b/lib/srfi/231/assembly.sld
@@ -33,15 +33,16 @@
 ;;; one of these four's `!` and non-`!` entry points are two one-line
 ;;; wrappers around one shared internal helper differing only in
 ;;; whether input arrays are eagerly materialized before the fill runs.
-;;; Since #2454 the shared path underneath (array-copy) collects the
-;;; source's values before the destination exists, so the aliases
-;;; inherit continuation-re-entry safety -- more than the spec asks of
-;;; the `!` variants (which may skip exactly that guarantee), never
-;;; less. The `!` twins do pay the same scratch cost as the non-! ones
-;;; (one pre-sized vector, N words -- the aliasing trades that memory
-;;; for one code path; splitting them apart to reclaim it would
-;;; re-diverge five fill loops for a cost the spec's `!` exemption
-;;; exists precisely to allow skipping).
+;;; The shared path underneath (array-copy) collects a non-specialized
+;;; source's values into a functionally accumulated list before the
+;;; destination exists (#2454, made genuinely call/cc safe in #2539),
+;;; so the aliases inherit continuation-re-entry safety -- more than
+;;; the spec asks of the `!` variants (which may skip exactly that
+;;; guarantee), never less. The `!` twins do pay the same collection
+;;; cost as the non-! ones (N live pairs during the copy -- the
+;;; aliasing trades that memory for one code path; splitting them apart
+;;; to reclaim it would re-diverge five fill loops for a cost the
+;;; spec's `!` exemption exists precisely to allow skipping).
 (define-library (srfi 231 assembly)
   (import (scheme base) (srfi 1)
           (srfi 231 misc) (srfi 231 intervals) (srfi 231 storage-classes)

--- a/lib/srfi/231/combinators.sld
+++ b/lib/srfi/231/combinators.sld
@@ -110,14 +110,19 @@
         (interval-for-each (lambda multi-index (apply f (map (lambda (a) (apply (array-unsafe-getter a) multi-index)) all)))
                             (array-domain array))))
 
+    ;; Every accumulator below is threaded through %interval-fold rather
+    ;; than a set! cell: these are non-! procedures, which the spec
+    ;; intends to be call/cc safe, and a shared cell hands a re-entered
+    ;; getter/operator continuation the LAST run's accumulation instead
+    ;; of its own -- see %interval-fold's comment in intervals.sld
+    ;; (kaappi#2539).
     (define (array-fold-left operator identity array . arrays)
       (%check-procedure! operator "array-fold-left")
-      (let ((all (cons array arrays)) (acc identity))
+      (let ((all (cons array arrays)))
         (%check-same-domain! all "array-fold-left")
-        (interval-for-each (lambda multi-index
-                              (set! acc (apply operator acc (map (lambda (a) (apply (array-unsafe-getter a) multi-index)) all))))
-                            (array-domain array))
-        acc))
+        (%interval-fold (lambda (multi-index acc)
+                          (apply operator acc (map (lambda (a) (apply (array-unsafe-getter a) multi-index)) all)))
+                        identity (array-domain array))))
 
     ;; Per spec, ALL f-evaluations complete before ANY operator
     ;; application -- collect per-index element-lists via cons during one
@@ -126,12 +131,12 @@
     ;; interval-fold-right's own already-verified technique.
     (define (array-fold-right operator identity array . arrays)
       (%check-procedure! operator "array-fold-right")
-      (let ((all (cons array arrays)) (results '()))
+      (let ((all (cons array arrays)))
         (%check-same-domain! all "array-fold-right")
-        (interval-for-each (lambda multi-index
-                              (set! results (cons (map (lambda (a) (apply (array-unsafe-getter a) multi-index)) all) results)))
-                            (array-domain array))
-        (let loop ((xs results) (acc identity))
+        (let loop ((xs (%interval-fold (lambda (multi-index acc)
+                                         (cons (map (lambda (a) (apply (array-unsafe-getter a) multi-index)) all) acc))
+                                       '() (array-domain array)))
+                   (acc identity))
           (if (null? xs) acc (loop (cdr xs) (apply operator (append (car xs) (list acc))))))))
 
     ;; No identity/seed -- a private sentinel distinguishes "no elements
@@ -146,12 +151,11 @@
       (unless (array? array) (error "array-reduce: not an array" array))
       (unless (procedure? operator) (error "array-reduce: not a procedure" operator))
       (when (array-empty? array) (error "array-reduce: cannot reduce an empty array" array))
-      (let ((acc %array-reduce-sentinel) (getter (array-unsafe-getter array)))
-        (interval-for-each (lambda multi-index
-                              (let ((val (apply getter multi-index)))
-                                (set! acc (if (eq? acc %array-reduce-sentinel) val (operator acc val)))))
-                            (array-domain array))
-        acc))
+      (let ((getter (array-unsafe-getter array)))
+        (%interval-fold (lambda (multi-index acc)
+                          (let ((val (apply getter multi-index)))
+                            (if (eq? acc %array-reduce-sentinel) val (operator acc val))))
+                        %array-reduce-sentinel (array-domain array))))
 
     ;; Short-circuits via call/cc on the first non-#f result, returning
     ;; that ACTUAL result (not just #t) -- matching the spec's own
@@ -172,15 +176,14 @@
     ;; returns the LAST nonfalse result, not just #t.
     (define (array-every predicate array . arrays)
       (%check-procedure! predicate "array-every")
-      (let ((all (cons array arrays)) (last-result #t))
+      (let ((all (cons array arrays)))
         (%check-same-domain! all "array-every")
         (call/cc
          (lambda (return)
-           (interval-for-each (lambda multi-index
-                                 (let ((r (apply predicate (map (lambda (a) (apply (array-unsafe-getter a) multi-index)) all))))
-                                   (if r (set! last-result r) (return #f))))
-                               (array-domain array))
-           last-result))))
+           (%interval-fold (lambda (multi-index last-result)
+                             (let ((r (apply predicate (map (lambda (a) (apply (array-unsafe-getter a) multi-index)) all))))
+                               (if r r (return #f))))
+                           #t (array-domain array))))))
 
     ;; --- products ---
 
@@ -217,10 +220,11 @@
 
     (define (array->list array)
       (unless (array? array) (error "array->list: not an array" array))
-      (let ((acc '()))
-        (interval-for-each (lambda multi-index (set! acc (cons (apply (array-unsafe-getter array) multi-index) acc)))
-                            (array-domain array))
-        (reverse acc)))
+      ;; `reverse`, never reverse!: a re-entered getter continuation still
+      ;; holds the prefix of the reversed list its own run built.
+      (let ((getter (array-unsafe-getter array)))
+        (reverse (%interval-fold (lambda (multi-index acc) (cons (apply getter multi-index) acc))
+                                 '() (array-domain array)))))
 
     (define (array->vector array) (list->vector (array->list array)))
 

--- a/lib/srfi/231/combinators.sld
+++ b/lib/srfi/231/combinators.sld
@@ -228,6 +228,13 @@
 
     (define (array->vector array) (list->vector (array->list array)))
 
+    ;; list->array and vector->array below still thread their position
+    ;; through a set! cell. That is safe ONLY because no user code runs
+    ;; inside the walk: the checker runs before the loop (#2448) and the
+    ;; setter is a fresh built-in-or-custom storage class's, called with
+    ;; already-checked values. Moving any user-callable call (the checker,
+    ;; an f applied per element) into the loop would reopen the
+    ;; shared-cell hazard %interval-fold exists to close (kaappi#2539).
     (define (list->array interval lst . opts)
       (unless (interval? interval) (error "list->array: not an interval" interval))
       (unless (list? lst) (error "list->array: not a list" lst))

--- a/lib/srfi/231/intervals.sld
+++ b/lib/srfi/231/intervals.sld
@@ -193,8 +193,10 @@
                       acc)))))
         (go 0 '() seed)))
 
+    ;; f's result is discarded, never threaded: interval-for-each is for
+    ;; effect, and f may return zero or several values.
     (define (interval-for-each f interval)
-      (%interval-fold (lambda (indices acc) (apply f indices)) #f interval)
+      (%interval-fold (lambda (indices acc) (apply f indices) acc) #f interval)
       (if #f #f))
 
     (define (interval-fold-left f operator identity interval)

--- a/lib/srfi/231/intervals.sld
+++ b/lib/srfi/231/intervals.sld
@@ -39,7 +39,11 @@
           interval= interval-subset? interval-contains-multi-index?
           interval-for-each interval-fold-left interval-fold-right
           interval-dilate interval-translate interval-permute interval-scale
-          interval-intersect interval-cartesian-product interval-projections)
+          interval-intersect interval-cartesian-product interval-projections
+          ;; internal: the functional lexicographic walk sibling files build
+          ;; their own accumulating procedures on (see its comment); not
+          ;; re-exported by the (srfi 231) hub, same as arrays.sld's %-helpers
+          %interval-fold)
   (begin
 
     (define-record-type <interval>
@@ -142,36 +146,60 @@
                 (and (<= (vector-ref lo i) (car xs)) (< (car xs) (vector-ref up i))
                      (loop (+ i 1) (cdr xs))))))))
 
-    ;; General d-dimensional nested traversal in lexicographic order. proc
-    ;; receives each multi-index as a LIST; public callers apply it to their
-    ;; own procedure via `apply` so f/operator see separate positional
-    ;; index arguments, matching the spec's convention everywhere. A
-    ;; zero-dimensional interval (both vectors empty) calls proc exactly
-    ;; once with '() -- a thunk call once `apply`-ed. Any axis with
-    ;; lo=hi contributes zero iterations, so an empty interval calls
-    ;; proc zero times overall, both matching spec exactly with no
-    ;; special-casing.
-    (define (%interval-for-each-indices lower upper proc)
-      (let ((d (vector-length lower)))
-        (define (go axis acc)
+    ;; General d-dimensional nested traversal in lexicographic order
+    ;; (first axis outermost), and the ONE walk every accumulating
+    ;; procedure in this package is built on. proc receives each
+    ;; multi-index as a fresh LIST plus the accumulator so far, and its
+    ;; result is the accumulator for the next multi-index; public callers
+    ;; apply the index list to their own procedure via `apply` so
+    ;; f/operator see separate positional index arguments, matching the
+    ;; spec's convention everywhere. A zero-dimensional interval (both
+    ;; vectors empty) calls proc exactly once with '() -- a thunk call
+    ;; once `apply`-ed. Any axis with lo=hi contributes zero iterations,
+    ;; so an empty interval calls proc zero times and returns seed, both
+    ;; matching spec exactly with no special-casing.
+    ;;
+    ;; The accumulator is threaded FUNCTIONALLY -- through the axis loops'
+    ;; own variables and the recursion's return value, never a set! cell
+    ;; -- and that threading is the whole call/cc-safety story for the
+    ;; non-! half of SRFI 231. The spec defines "call/cc safe" as written
+    ;; "in a way that does not modify the state of any data captured by a
+    ;; continuation" and intends every procedure without a trailing ! to
+    ;; be that (only array-set!/array-assign! and the five `!` bulk
+    ;; variants are exempt). A set! accumulator is exactly such state: a
+    ;; continuation captured inside f (or an array's getter) shares the
+    ;; cell with every other invocation of that continuation, so a
+    ;; re-entry resumes from wherever the LAST run left the cell rather
+    ;; than from what its own run had accumulated at capture time. One
+    ;; re-entry cannot tell the two apart -- it is the second re-entry,
+    ;; or a second continuation, that sees the first re-entry's
+    ;; overwrites (kaappi#2539, reported by the SRFI's author). With the
+    ;; accumulator held in the continuation's own frames, a re-entry sees
+    ;; precisely the accumulation its capture point had: an immutable
+    ;; list prefix, a fixnum, a folded value -- and consumers must keep
+    ;; it that way (never reverse! or otherwise mutate a list this walk
+    ;; built; a re-entry's continuation still holds a pointer into it).
+    (define (%interval-fold proc seed interval)
+      (let* ((lower (interval-lower-vec interval))
+             (upper (interval-upper-vec interval))
+             (d (vector-length lower)))
+        (define (go axis rev-index acc)
           (if (= axis d)
-              (proc (reverse acc))
+              (proc (reverse rev-index) acc)
               (let ((lo (vector-ref lower axis)) (hi (vector-ref upper axis)))
-                (let loop ((i lo))
-                  (when (< i hi)
-                    (go (+ axis 1) (cons i acc))
-                    (loop (+ i 1)))))))
-        (go 0 '())))
+                (let loop ((i lo) (acc acc))
+                  (if (< i hi)
+                      (loop (+ i 1) (go (+ axis 1) (cons i rev-index) acc))
+                      acc)))))
+        (go 0 '() seed)))
 
     (define (interval-for-each f interval)
-      (%interval-for-each-indices (interval-lower-vec interval) (interval-upper-vec interval)
-                                   (lambda (indices) (apply f indices))))
+      (%interval-fold (lambda (indices acc) (apply f indices)) #f interval)
+      (if #f #f))
 
     (define (interval-fold-left f operator identity interval)
-      (let ((acc identity))
-        (%interval-for-each-indices (interval-lower-vec interval) (interval-upper-vec interval)
-                                     (lambda (indices) (set! acc (operator acc (apply f indices)))))
-        acc))
+      (%interval-fold (lambda (indices acc) (operator acc (apply f indices)))
+                      identity interval))
 
     ;; Per spec, interval-fold-right must complete ALL f evaluations before
     ;; applying operator to any of them -- not just visit indices in
@@ -183,11 +211,10 @@
     ;; results (verified by hand-expansion against the spec's own
     ;; 0-dimensional formula, which falls out with no special-casing).
     (define (interval-fold-right f operator identity interval)
-      (let ((results '()))
-        (%interval-for-each-indices (interval-lower-vec interval) (interval-upper-vec interval)
-                                     (lambda (indices) (set! results (cons (apply f indices) results))))
-        (let loop ((xs results) (acc identity))
-          (if (null? xs) acc (loop (cdr xs) (operator (car xs) acc))))))
+      (let loop ((xs (%interval-fold (lambda (indices acc) (cons (apply f indices) acc))
+                                     '() interval))
+                 (acc identity))
+        (if (null? xs) acc (loop (cdr xs) (operator (car xs) acc)))))
 
     ;; vector-map stops at the shortest input on a length mismatch (R7RS,
     ;; matching `map`) rather than erroring, so a diffs/translation/scales/

--- a/lib/srfi/231/views.sld
+++ b/lib/srfi/231/views.sld
@@ -346,7 +346,15 @@
     ;; multi-index per element: a fresh destination's body IS the
     ;; lexicographic order (%make-lex-indexer), so it is filled by linear
     ;; position through the storage class's own setter, the shape the
-    ;; reference uses too.
+    ;; reference uses too. Measured, that trade is a net win in time: 20
+    ;; copies of a 1M-element non-specialized array took 73.5s here
+    ;; against 114.9s over the scratch design (PR #2540 review) -- the
+    ;; per-element indexer call the copy-out used to make cost more than
+    ;; the pairs it avoided. What the pairs DO cost is peak memory: a 1M
+    ;; u8 specialized source copied 6 times peaks at 176 MB RSS through
+    ;; the list against 12.5 MB through the direct fill (18.7s vs 33.3s),
+    ;; which is why the direct fill below stays for specialized sources
+    ;; rather than being retired for speed.
     ;;
     ;; A specialized SOURCE takes the direct fill, as in the reference
     ;; (%!array-copy): its getter is the storage class's, so no user

--- a/lib/srfi/231/views.sld
+++ b/lib/srfi/231/views.sld
@@ -309,50 +309,55 @@
     ;; call a true copy; otherwise omitted options fall back to
     ;; generic-storage-class/specialized-array-default-mutable?/-safe? --
     ;; confirmed via an explicit spec quote naming this exact asymmetry.
-    ;; array-copy must be safe under a getter that captures a
-    ;; continuation and re-invokes it after the copy returned (the whole
-    ;; documented difference from array-copy!): the re-entry gets a FRESH
-    ;; array, and the array the first call already returned never mutates
-    ;; under its holder. That requires collecting every source value
-    ;; BEFORE the destination exists, into a pre-sized scratch vector
-    ;; indexed by a position threaded FUNCTIONALLY through the walk --
-    ;; the threading is the safety mechanism (a set! position counter, or
-    ;; interval-fold-left/right, which use one, lets the re-entry keep
-    ;; counting on the first run's progress). The scratch itself is
-    ;; shared mutable state, deliberately: a re-entry resumes from the
-    ;; position captured at its capture point, so positions below it
-    ;; retain the first run's values and positions above are re-fetched
-    ;; -- observably identical to a functional cons accumulator, without
-    ;; that shape's cost (at 1M elements: 18.0M total pair allocations
-    ;; for a cons-list collector against 16.0M here, and its N live
-    ;; pairs gone; the churn that remains is the library apply shape
-    ;; every fill loop already shares -- kaappi#2464). A direct fill into
-    ;; a pre-allocated destination (the pre-#2454 shape, and what
-    ;; array-copy! still is -- the spec explicitly permits the `!`
-    ;; variant to skip exactly this guarantee) lets the resumed fill
-    ;; overwrite the already-returned array.
-    (define (%domain-walk lowers uppers leaf k)
-      ;; Walk the domain in lexicographic order (first axis outermost,
-      ;; matching %interval-for-each-indices in intervals.sld), calling
-      ;; (leaf index k) per multi-index with the index as a list, and
-      ;; threading the leaf's returned position functionally through the
-      ;; axis loops and the recursion. That threading is what makes a
-      ;; continuation captured inside a leaf re-run the walk from ITS
-      ;; captured position over ITS captured prefix, never the first
-      ;; run's. One helper serves both array-copy passes so they cannot
-      ;; drift out of order-agreement.
-      (letrec ((walk
-                (lambda (ls us rev-index k)
-                  (if (null? ls)
-                      (leaf (reverse rev-index) k)
-                      (let loop ((i (car ls)) (k k))
-                        (if (>= i (car us))
-                            k
-                            (loop (+ i 1)
-                                  (walk (cdr ls) (cdr us)
-                                        (cons i rev-index) k))))))))
-        (walk lowers uppers '() k)))
-
+    ;;
+    ;; array-copy must be call/cc safe -- the spec's term for "does not
+    ;; modify the state of any data captured by a continuation", the
+    ;; whole documented difference from array-copy!, whose getter
+    ;; continuations it is an error to invoke more than once. A getter
+    ;; that captures a continuation and re-invokes it after the copy
+    ;; returned must get a FRESH array, computed from the values ITS run
+    ;; had collected at the capture point, and the array the first call
+    ;; already returned must never mutate under its holder. Two shapes
+    ;; fail that, and both have shipped here:
+    ;;   * a direct fill into a pre-allocated destination (pre-#2454):
+    ;;     the resumed fill overwrites the already-returned array;
+    ;;   * collecting into a shared scratch vector before the destination
+    ;;     exists, with only the position threaded functionally
+    ;;     (#2454..#2539): one re-entry looks right, but the scratch is
+    ;;     one object shared by every continuation captured during the
+    ;;     collection, so a second re-entry -- or a second continuation
+    ;;     captured on the first run -- resumes over positions an earlier
+    ;;     re-entry has already overwritten and materializes ITS prefix.
+    ;;     The official suite's single-re-entry cases (737-741) cannot
+    ;;     see this; the SRFI's author's two-continuation, two-re-entry
+    ;;     case (kaappi#2539) can.
+    ;; Any partially filled structure that a *-set! procedure modifies
+    ;; is state a continuation captured mid-collection shares with every
+    ;; other invocation of it. So this is the reference implementation's
+    ;; shape exactly (%%generalized-array->specialized-array): collect
+    ;; the values into a reversed LIST through %interval-fold's
+    ;; functionally threaded accumulator, allocate the destination only
+    ;; afterwards, and fill its body from the list. The list's prefix is
+    ;; immutable, so a re-entry re-runs the collection over precisely
+    ;; the cells its own frames hold and allocates its own destination.
+    ;; The costs the scratch design was chosen to avoid (kaappi#2464) come
+    ;; back for this path -- N live pairs during the collection, one
+    ;; cons per element -- but the copy-out no longer regenerates a
+    ;; multi-index per element: a fresh destination's body IS the
+    ;; lexicographic order (%make-lex-indexer), so it is filled by linear
+    ;; position through the storage class's own setter, the shape the
+    ;; reference uses too.
+    ;;
+    ;; A specialized SOURCE takes the direct fill, as in the reference
+    ;; (%!array-copy): its getter is the storage class's, so no user
+    ;; code runs during the copy and nothing can capture a continuation
+    ;; in it. (A make-storage-class getter, or a specialized-array-share
+    ;; mapping, is user code that could -- the reference does not defend
+    ;; that either, and neither does this.) The storage-class setter on
+    ;; the copy-out is likewise user code for a custom storage class; a
+    ;; continuation captured THERE re-enters with the destination already
+    ;; allocated and rewrites the same collected values into it, the same
+    ;; residual exposure the reference's shape has.
     (define (%array-copy-impl array opts call/cc-safe?)
       (unless (array? array) (error "array-copy: not an array" array))
       (%check-boolean! (%opt opts 1 (specialized-array-default-mutable?)) "array-copy: mutable?")
@@ -367,51 +372,34 @@
              ;; checked unless provably valid (#2448)
              (getter (array-unsafe-getter array))
              (checker (%copy-value-checker array storage-class))
-             (lowers (interval-lower-bounds->list domain))
-             (uppers (interval-upper-bounds->list domain))
-             ;; The whole collection runs here, inside the binding --
-             ;; strictly before the destination below is allocated --
-             ;; calling every getter (and the value checker) into the
-             ;; scratch, so a continuation captured in a getter re-runs
-             ;; collection and materializes its own destination.
-             (scratch (and call/cc-safe?
-                           (let ((buf (make-vector (interval-volume domain))))
-                             (%domain-walk lowers uppers
-                                           (lambda (index k)
-                                             (let ((val (apply getter index)))
-                                               (when (and checker (not (checker val)))
-                                                 (error "array-copy: not all elements of the source can be stored in the destination"
-                                                        val storage-class))
-                                               (vector-set! buf k val)
-                                               (+ k 1)))
-                                           0)
-                             buf)))
-             (dest (make-specialized-array domain storage-class (storage-class-default storage-class) safe?))
-             (dest-setter (array-unsafe-setter dest)))
-        (if call/cc-safe?
-            ;; Copy-out from the scratch: the values are already
-            ;; collected, so a getter re-entry cannot change what lands
-            ;; in dest. The dest-setter is library code for the built-in
-            ;; storage classes but USER code when the destination's
-            ;; storage class came from make-storage-class -- a
-            ;; continuation captured there re-enters this copy-out with
-            ;; dest already allocated, so it does not get a fresh array
-            ;; (the same residual exposure the reference implementation's
-            ;; own accumulate-then-materialize shape has; both runs write
-            ;; identical collected values, so only the identity of the
-            ;; re-entry's result object is affected).
-            (%domain-walk lowers uppers
-                          (lambda (index k)
-                            (apply dest-setter (vector-ref scratch k) index)
-                            (+ k 1))
-                          0)
-            (interval-for-each (lambda multi-index
-                                 (let ((val (apply getter multi-index)))
-                                   (when (and checker (not (checker val)))
-                                     (error "array-copy: not all elements of the source can be stored in the destination"
-                                            val storage-class))
-                                   (apply dest-setter val multi-index)))
-                               domain))
+             (checked (lambda (val)
+                        (when (and checker (not (checker val)))
+                          (error "array-copy: not all elements of the source can be stored in the destination"
+                                 val storage-class))
+                        val))
+             (dest
+              (if (or specialized? (not call/cc-safe?))
+                  (let* ((dest (make-specialized-array domain storage-class (storage-class-default storage-class) safe?))
+                         (dest-setter (array-unsafe-setter dest)))
+                    (interval-for-each (lambda multi-index
+                                         (apply dest-setter (checked (apply getter multi-index)) multi-index))
+                                       domain)
+                    dest)
+                  ;; The whole collection runs here, inside the binding --
+                  ;; strictly before the destination below is allocated --
+                  ;; calling every getter (and the value checker) into the
+                  ;; reversed list.
+                  (let* ((reversed (%interval-fold (lambda (multi-index acc)
+                                                     (cons (checked (apply getter multi-index)) acc))
+                                                   '() domain))
+                         (dest (make-specialized-array domain storage-class (storage-class-default storage-class) safe?))
+                         (body (array-body dest))
+                         (body-set! (storage-class-setter storage-class)))
+                    (let loop ((i (- (interval-volume domain) 1)) (l reversed))
+                      (when (>= i 0)
+                        (body-set! body i (car l))
+                        (loop (- i 1) (cdr l))))
+                    dest))))
         (if mutable? dest (array-freeze! dest))))
 
     (define (array-copy array . opts) (%array-copy-impl array opts #t))

--- a/tests/scheme/srfi/fixtures/srfi231-reentry.scm
+++ b/tests/scheme/srfi/fixtures/srfi231-reentry.scm
@@ -1,0 +1,33 @@
+;; Shared driver for the SRFI 231 call/cc-safety regressions (kaappi#2539,
+;; reported by the SRFI's author). Included by the srfi231-*.scm suites;
+;; a fixture, so it opens no SRFI-64 suite of its own.
+;;
+;; (re-entry-results collect) drives `collect` -- a procedure of one
+;; argument, a getter over 0..3 that captures its continuation at x=1 and
+;; x=3 on the first run -- through a two-continuation, two-re-entry
+;; schedule and returns every result, newest first. Any collector keeping
+;; a shared mutable accumulator -- a set! cell or a scratch vector --
+;; leaks the second cont1 re-entry's 20 into both cont2 results; one
+;; re-entry alone cannot see that, which is how the scratch design passed
+;; the official suite's continuation cases. re-entry-expected is the
+;; answer for a collector that returns the four values in order.
+(define (re-entry-results collect)
+  (let* ((cont1 #f) (cont2 #f) (i 5) (first-run? #t)
+         (f (lambda (x)
+              (call-with-current-continuation
+               (lambda (c)
+                 (if first-run?
+                     (case x ((1) (set! cont1 c)) ((3) (set! cont2 c)) (else #f)))
+                 x))))
+         (results '()))
+    (let ((r (collect f)))
+      (set! first-run? #f)
+      (set! results (cons r results)))
+    (case i
+      ((5) (set! i (- i 1)) (cont1 10))
+      ((4) (set! i (- i 1)) (cont1 20))
+      ((3) (set! i (- i 1)) (cont2 10))
+      ((2) (set! i (- i 1)) (cont2 20))
+      (else #t))
+    results))
+(define re-entry-expected '((0 1 2 20) (0 1 2 10) (0 20 2 3) (0 10 2 3) (0 1 2 3)))

--- a/tests/scheme/srfi/srfi231-assembly.scm
+++ b/tests/scheme/srfi/srfi231-assembly.scm
@@ -195,6 +195,45 @@
   (test-assert "array-assign! into u1 rejects an unstorable value"
                (guard (e (#t #t)) (array-assign! dest generic) #f)))
 
+
+;;; --- call/cc safety under REPEATED re-entry (kaappi#2539, reported by
+;;; the SRFI's author) ---
+;;; Drives `collect` (a procedure of one argument: a getter over 0..3 that
+;;; captures its continuation at x=1 and x=3 on the first run) through a
+;;; two-continuation, two-re-entry schedule and returns every result,
+;;; newest first. Any collector keeping a shared mutable accumulator --
+;;; a set! cell or a scratch vector -- leaks the second cont1 re-entry's
+;;; 20 into both cont2 results; one re-entry alone cannot see that.
+(define (re-entry-results collect)
+  (let* ((cont1 #f) (cont2 #f) (i 5) (first-run? #t)
+         (f (lambda (x)
+              (call-with-current-continuation
+               (lambda (c)
+                 (if first-run?
+                     (case x ((1) (set! cont1 c)) ((3) (set! cont2 c)) (else #f)))
+                 x))))
+         (results '()))
+    (let ((r (collect f)))
+      (set! first-run? #f)
+      (set! results (cons r results)))
+    (case i
+      ((5) (set! i (- i 1)) (cont1 10))
+      ((4) (set! i (- i 1)) (cont1 20))
+      ((3) (set! i (- i 1)) (cont2 10))
+      ((2) (set! i (- i 1)) (cont2 20))
+      (else #t))
+    results))
+(define re-entry-expected '((0 1 2 20) (0 1 2 10) (0 20 2 3) (0 10 2 3) (0 1 2 3)))
+
+(define (over-f f) (make-array (make-interval '#(4)) f))
+(test-equal "array-append inherits array-copy's call/cc safety"
+            (map (lambda (r) (append r '(99))) re-entry-expected)
+            (re-entry-results
+             (lambda (f) (array->list (array-append 0 (list (over-f f) (list->array (make-interval '#(1)) '(99))))))))
+(test-equal "array-stack inherits array-copy's call/cc safety"
+            (map list re-entry-expected)
+            (re-entry-results (lambda (f) (array->list* (array-stack 0 (list (over-f f)))))))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-231-assembly")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi231-assembly.scm
+++ b/tests/scheme/srfi/srfi231-assembly.scm
@@ -196,34 +196,9 @@
                (guard (e (#t #t)) (array-assign! dest generic) #f)))
 
 
-;;; --- call/cc safety under REPEATED re-entry (kaappi#2539, reported by
-;;; the SRFI's author) ---
-;;; Drives `collect` (a procedure of one argument: a getter over 0..3 that
-;;; captures its continuation at x=1 and x=3 on the first run) through a
-;;; two-continuation, two-re-entry schedule and returns every result,
-;;; newest first. Any collector keeping a shared mutable accumulator --
-;;; a set! cell or a scratch vector -- leaks the second cont1 re-entry's
-;;; 20 into both cont2 results; one re-entry alone cannot see that.
-(define (re-entry-results collect)
-  (let* ((cont1 #f) (cont2 #f) (i 5) (first-run? #t)
-         (f (lambda (x)
-              (call-with-current-continuation
-               (lambda (c)
-                 (if first-run?
-                     (case x ((1) (set! cont1 c)) ((3) (set! cont2 c)) (else #f)))
-                 x))))
-         (results '()))
-    (let ((r (collect f)))
-      (set! first-run? #f)
-      (set! results (cons r results)))
-    (case i
-      ((5) (set! i (- i 1)) (cont1 10))
-      ((4) (set! i (- i 1)) (cont1 20))
-      ((3) (set! i (- i 1)) (cont2 10))
-      ((2) (set! i (- i 1)) (cont2 20))
-      (else #t))
-    results))
-(define re-entry-expected '((0 1 2 20) (0 1 2 10) (0 20 2 3) (0 10 2 3) (0 1 2 3)))
+;;; --- call/cc safety under REPEATED re-entry (kaappi#2539) -- the driver
+;;; and its rationale live in fixtures/srfi231-reentry.scm ---
+(include "fixtures/srfi231-reentry.scm")
 
 (define (over-f f) (make-array (make-interval '#(4)) f))
 (test-equal "array-append inherits array-copy's call/cc safety"

--- a/tests/scheme/srfi/srfi231-combinators.scm
+++ b/tests/scheme/srfi/srfi231-combinators.scm
@@ -215,34 +215,9 @@
 (test-equal '(1 0) (array->list (list->array (make-interval '#(2)) '(1 0) u1-storage-class)))
 
 
-;;; --- call/cc safety under REPEATED re-entry (kaappi#2539, reported by
-;;; the SRFI's author) ---
-;;; Drives `collect` (a procedure of one argument: a getter over 0..3 that
-;;; captures its continuation at x=1 and x=3 on the first run) through a
-;;; two-continuation, two-re-entry schedule and returns every result,
-;;; newest first. Any collector keeping a shared mutable accumulator --
-;;; a set! cell or a scratch vector -- leaks the second cont1 re-entry's
-;;; 20 into both cont2 results; one re-entry alone cannot see that.
-(define (re-entry-results collect)
-  (let* ((cont1 #f) (cont2 #f) (i 5) (first-run? #t)
-         (f (lambda (x)
-              (call-with-current-continuation
-               (lambda (c)
-                 (if first-run?
-                     (case x ((1) (set! cont1 c)) ((3) (set! cont2 c)) (else #f)))
-                 x))))
-         (results '()))
-    (let ((r (collect f)))
-      (set! first-run? #f)
-      (set! results (cons r results)))
-    (case i
-      ((5) (set! i (- i 1)) (cont1 10))
-      ((4) (set! i (- i 1)) (cont1 20))
-      ((3) (set! i (- i 1)) (cont2 10))
-      ((2) (set! i (- i 1)) (cont2 20))
-      (else #t))
-    results))
-(define re-entry-expected '((0 1 2 20) (0 1 2 10) (0 20 2 3) (0 10 2 3) (0 1 2 3)))
+;;; --- call/cc safety under REPEATED re-entry (kaappi#2539) -- the driver
+;;; and its rationale live in fixtures/srfi231-reentry.scm ---
+(include "fixtures/srfi231-reentry.scm")
 
 (define (over-f f) (make-array (make-interval '#(4)) f))
 ;; The two fold-left assertions pin the guarantee rather than reproduce a
@@ -268,6 +243,13 @@
 (test-equal "array->vector threads its accumulator functionally"
             (map list->vector re-entry-expected)
             (re-entry-results (lambda (f) (array->vector (over-f f)))))
+;; array-every returns the LAST predicate result, so only the cont2
+;; re-entries (which replace element 3) can change it; the cont1 ones
+;; replace element 1 and still end on 3. Pins the functional shape.
+(test-equal "array-every threads its accumulator functionally"
+            '((last 20) (last 10) 3 3 3)
+            (re-entry-results
+             (lambda (f) (array-every (lambda (x) (if (>= x 10) (list 'last x) x)) (over-f f)))))
 
 (let ((runner (test-runner-current)))
   (test-end "srfi-231-combinators")

--- a/tests/scheme/srfi/srfi231-combinators.scm
+++ b/tests/scheme/srfi/srfi231-combinators.scm
@@ -214,6 +214,61 @@
 (test-equal #t (guard (e (#t #t)) (vector->array (make-interval '#(2)) '#(1 0 1) u1-storage-class) #f))
 (test-equal '(1 0) (array->list (list->array (make-interval '#(2)) '(1 0) u1-storage-class)))
 
+
+;;; --- call/cc safety under REPEATED re-entry (kaappi#2539, reported by
+;;; the SRFI's author) ---
+;;; Drives `collect` (a procedure of one argument: a getter over 0..3 that
+;;; captures its continuation at x=1 and x=3 on the first run) through a
+;;; two-continuation, two-re-entry schedule and returns every result,
+;;; newest first. Any collector keeping a shared mutable accumulator --
+;;; a set! cell or a scratch vector -- leaks the second cont1 re-entry's
+;;; 20 into both cont2 results; one re-entry alone cannot see that.
+(define (re-entry-results collect)
+  (let* ((cont1 #f) (cont2 #f) (i 5) (first-run? #t)
+         (f (lambda (x)
+              (call-with-current-continuation
+               (lambda (c)
+                 (if first-run?
+                     (case x ((1) (set! cont1 c)) ((3) (set! cont2 c)) (else #f)))
+                 x))))
+         (results '()))
+    (let ((r (collect f)))
+      (set! first-run? #f)
+      (set! results (cons r results)))
+    (case i
+      ((5) (set! i (- i 1)) (cont1 10))
+      ((4) (set! i (- i 1)) (cont1 20))
+      ((3) (set! i (- i 1)) (cont2 10))
+      ((2) (set! i (- i 1)) (cont2 20))
+      (else #t))
+    results))
+(define re-entry-expected '((0 1 2 20) (0 1 2 10) (0 20 2 3) (0 10 2 3) (0 1 2 3)))
+
+(define (over-f f) (make-array (make-interval '#(4)) f))
+;; The two fold-left assertions pin the guarantee rather than reproduce a
+;; failure: the old set!-cell shape, (set! acc (operator acc (apply f ix))),
+;; read acc into a register BEFORE the getter ran, so a continuation
+;; captured in the getter carried that snapshot and the set! afterwards
+;; stored a value derived from it -- safe by Kaappi's left-to-right
+;; argument evaluation alone (under right-to-left evaluation, chibi's,
+;; the same code yields (0 1 2 3 10 2 3)). Every other shape below --
+;; and array-copy's scratch vector -- fails against the pre-#2539 code.
+(test-equal "array-fold-left threads its accumulator functionally"
+            re-entry-expected
+            (re-entry-results (lambda (f) (reverse (array-fold-left (lambda (acc x) (cons x acc)) '() (over-f f))))))
+(test-equal "array-fold-right threads its accumulator functionally"
+            re-entry-expected
+            (re-entry-results (lambda (f) (array-fold-right cons '() (over-f f)))))
+(test-equal "array-reduce threads its accumulator functionally"
+            '(23 13 25 15 6)
+            (re-entry-results (lambda (f) (array-reduce + (over-f f)))))
+(test-equal "array->list threads its accumulator functionally"
+            re-entry-expected
+            (re-entry-results (lambda (f) (array->list (over-f f)))))
+(test-equal "array->vector threads its accumulator functionally"
+            (map list->vector re-entry-expected)
+            (re-entry-results (lambda (f) (array->vector (over-f f)))))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-231-combinators")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi231-intervals.scm
+++ b/tests/scheme/srfi/srfi231-intervals.scm
@@ -193,34 +193,9 @@
 (test-equal '(2 1) (interval-upper-bounds->list (interval-scale (make-interval '#(3 1)) '#(2 3))))
 
 
-;;; --- call/cc safety under REPEATED re-entry (kaappi#2539, reported by
-;;; the SRFI's author) ---
-;;; Drives `collect` (a procedure of one argument: a getter over 0..3 that
-;;; captures its continuation at x=1 and x=3 on the first run) through a
-;;; two-continuation, two-re-entry schedule and returns every result,
-;;; newest first. Any collector keeping a shared mutable accumulator --
-;;; a set! cell or a scratch vector -- leaks the second cont1 re-entry's
-;;; 20 into both cont2 results; one re-entry alone cannot see that.
-(define (re-entry-results collect)
-  (let* ((cont1 #f) (cont2 #f) (i 5) (first-run? #t)
-         (f (lambda (x)
-              (call-with-current-continuation
-               (lambda (c)
-                 (if first-run?
-                     (case x ((1) (set! cont1 c)) ((3) (set! cont2 c)) (else #f)))
-                 x))))
-         (results '()))
-    (let ((r (collect f)))
-      (set! first-run? #f)
-      (set! results (cons r results)))
-    (case i
-      ((5) (set! i (- i 1)) (cont1 10))
-      ((4) (set! i (- i 1)) (cont1 20))
-      ((3) (set! i (- i 1)) (cont2 10))
-      ((2) (set! i (- i 1)) (cont2 20))
-      (else #t))
-    results))
-(define re-entry-expected '((0 1 2 20) (0 1 2 10) (0 20 2 3) (0 10 2 3) (0 1 2 3)))
+;;; --- call/cc safety under REPEATED re-entry (kaappi#2539) -- the driver
+;;; and its rationale live in fixtures/srfi231-reentry.scm ---
+(include "fixtures/srfi231-reentry.scm")
 
 ;; The two fold-left assertions pin the guarantee rather than reproduce a
 ;; failure: the old set!-cell shape, (set! acc (operator acc (apply f ix))),
@@ -234,6 +209,16 @@
             re-entry-expected
             (re-entry-results
              (lambda (f) (reverse (interval-fold-left f (lambda (acc x) (cons x acc)) '() (make-interval '#(4)))))))
+;; for-each is for effect: a callback returning zero or several values
+;; must not become the walk's next accumulator
+(test-equal "interval-for-each ignores a zero-values callback" 3
+            (let ((n 0))
+              (interval-for-each (lambda (i) (set! n (+ n 1)) (values)) (make-interval '#(3)))
+              n))
+(test-equal "interval-for-each ignores a two-values callback" 4
+            (let ((n 0))
+              (interval-for-each (lambda (i j) (set! n (+ n 1)) (values i j)) (make-interval '#(2 2)))
+              n))
 (test-equal "interval-fold-right threads its accumulator functionally"
             re-entry-expected
             (re-entry-results

--- a/tests/scheme/srfi/srfi231-intervals.scm
+++ b/tests/scheme/srfi/srfi231-intervals.scm
@@ -192,6 +192,53 @@
 ;; valid scaling is unchanged (ceiling semantics)
 (test-equal '(2 1) (interval-upper-bounds->list (interval-scale (make-interval '#(3 1)) '#(2 3))))
 
+
+;;; --- call/cc safety under REPEATED re-entry (kaappi#2539, reported by
+;;; the SRFI's author) ---
+;;; Drives `collect` (a procedure of one argument: a getter over 0..3 that
+;;; captures its continuation at x=1 and x=3 on the first run) through a
+;;; two-continuation, two-re-entry schedule and returns every result,
+;;; newest first. Any collector keeping a shared mutable accumulator --
+;;; a set! cell or a scratch vector -- leaks the second cont1 re-entry's
+;;; 20 into both cont2 results; one re-entry alone cannot see that.
+(define (re-entry-results collect)
+  (let* ((cont1 #f) (cont2 #f) (i 5) (first-run? #t)
+         (f (lambda (x)
+              (call-with-current-continuation
+               (lambda (c)
+                 (if first-run?
+                     (case x ((1) (set! cont1 c)) ((3) (set! cont2 c)) (else #f)))
+                 x))))
+         (results '()))
+    (let ((r (collect f)))
+      (set! first-run? #f)
+      (set! results (cons r results)))
+    (case i
+      ((5) (set! i (- i 1)) (cont1 10))
+      ((4) (set! i (- i 1)) (cont1 20))
+      ((3) (set! i (- i 1)) (cont2 10))
+      ((2) (set! i (- i 1)) (cont2 20))
+      (else #t))
+    results))
+(define re-entry-expected '((0 1 2 20) (0 1 2 10) (0 20 2 3) (0 10 2 3) (0 1 2 3)))
+
+;; The two fold-left assertions pin the guarantee rather than reproduce a
+;; failure: the old set!-cell shape, (set! acc (operator acc (apply f ix))),
+;; read acc into a register BEFORE the getter ran, so a continuation
+;; captured in the getter carried that snapshot and the set! afterwards
+;; stored a value derived from it -- safe by Kaappi's left-to-right
+;; argument evaluation alone (under right-to-left evaluation, chibi's,
+;; the same code yields (0 1 2 3 10 2 3)). Every other shape below --
+;; and array-copy's scratch vector -- fails against the pre-#2539 code.
+(test-equal "interval-fold-left threads its accumulator functionally"
+            re-entry-expected
+            (re-entry-results
+             (lambda (f) (reverse (interval-fold-left f (lambda (acc x) (cons x acc)) '() (make-interval '#(4)))))))
+(test-equal "interval-fold-right threads its accumulator functionally"
+            re-entry-expected
+            (re-entry-results
+             (lambda (f) (interval-fold-right f cons '() (make-interval '#(4))))))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-231-intervals")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))

--- a/tests/scheme/srfi/srfi231-views.scm
+++ b/tests/scheme/srfi/srfi231-views.scm
@@ -357,34 +357,9 @@
   (test-assert "array-copy into u8 rejects an unstorable value"
                (guard (e (#t #t)) (array-copy generic u8-storage-class) #f)))
 
-;;; --- call/cc safety under REPEATED re-entry (kaappi#2539, reported by
-;;; the SRFI's author) ---
-;;; Drives `collect` (a procedure of one argument: a getter over 0..3 that
-;;; captures its continuation at x=1 and x=3 on the first run) through a
-;;; two-continuation, two-re-entry schedule and returns every result,
-;;; newest first. Any collector keeping a shared mutable accumulator --
-;;; a set! cell or a scratch vector -- leaks the second cont1 re-entry's
-;;; 20 into both cont2 results; one re-entry alone cannot see that.
-(define (re-entry-results collect)
-  (let* ((cont1 #f) (cont2 #f) (i 5) (first-run? #t)
-         (f (lambda (x)
-              (call-with-current-continuation
-               (lambda (c)
-                 (if first-run?
-                     (case x ((1) (set! cont1 c)) ((3) (set! cont2 c)) (else #f)))
-                 x))))
-         (results '()))
-    (let ((r (collect f)))
-      (set! first-run? #f)
-      (set! results (cons r results)))
-    (case i
-      ((5) (set! i (- i 1)) (cont1 10))
-      ((4) (set! i (- i 1)) (cont1 20))
-      ((3) (set! i (- i 1)) (cont2 10))
-      ((2) (set! i (- i 1)) (cont2 20))
-      (else #t))
-    results))
-(define re-entry-expected '((0 1 2 20) (0 1 2 10) (0 20 2 3) (0 10 2 3) (0 1 2 3)))
+;;; --- call/cc safety under REPEATED re-entry (kaappi#2539) -- the driver
+;;; and its rationale live in fixtures/srfi231-reentry.scm ---
+(include "fixtures/srfi231-reentry.scm")
 
 (test-equal "array-copy: each re-entry materializes its own array from its own prefix"
             re-entry-expected

--- a/tests/scheme/srfi/srfi231-views.scm
+++ b/tests/scheme/srfi/srfi231-views.scm
@@ -356,6 +356,51 @@
 (let ((generic (array-copy (make-array (make-interval (vector 2 2)) (lambda (i j) 300)))))
   (test-assert "array-copy into u8 rejects an unstorable value"
                (guard (e (#t #t)) (array-copy generic u8-storage-class) #f)))
+
+;;; --- call/cc safety under REPEATED re-entry (kaappi#2539, reported by
+;;; the SRFI's author) ---
+;;; Drives `collect` (a procedure of one argument: a getter over 0..3 that
+;;; captures its continuation at x=1 and x=3 on the first run) through a
+;;; two-continuation, two-re-entry schedule and returns every result,
+;;; newest first. Any collector keeping a shared mutable accumulator --
+;;; a set! cell or a scratch vector -- leaks the second cont1 re-entry's
+;;; 20 into both cont2 results; one re-entry alone cannot see that.
+(define (re-entry-results collect)
+  (let* ((cont1 #f) (cont2 #f) (i 5) (first-run? #t)
+         (f (lambda (x)
+              (call-with-current-continuation
+               (lambda (c)
+                 (if first-run?
+                     (case x ((1) (set! cont1 c)) ((3) (set! cont2 c)) (else #f)))
+                 x))))
+         (results '()))
+    (let ((r (collect f)))
+      (set! first-run? #f)
+      (set! results (cons r results)))
+    (case i
+      ((5) (set! i (- i 1)) (cont1 10))
+      ((4) (set! i (- i 1)) (cont1 20))
+      ((3) (set! i (- i 1)) (cont2 10))
+      ((2) (set! i (- i 1)) (cont2 20))
+      (else #t))
+    results))
+(define re-entry-expected '((0 1 2 20) (0 1 2 10) (0 20 2 3) (0 10 2 3) (0 1 2 3)))
+
+(test-equal "array-copy: each re-entry materializes its own array from its own prefix"
+            re-entry-expected
+            (re-entry-results
+             (lambda (f) (array->list* (array-copy (make-array (make-interval '#(4)) f))))))
+(test-equal "array-copy into a typed storage class is call/cc safe too"
+            re-entry-expected
+            (re-entry-results
+             (lambda (f) (array->list (array-copy (make-array (make-interval '#(4)) f) u8-storage-class)))))
+;; the collected-list fill covers every volume: zero-dimensional (one
+;; element, no axes) and empty (no elements at all)
+(test-equal "array-copy of a zero-dimensional array" 42
+            (array-ref (array-copy (make-array (make-interval '#()) (lambda () 42)))))
+(test-equal "array-copy of an empty array" #t
+            (array-empty? (array-copy (make-array (make-interval '#(0 3)) (lambda (i j) (error "never called"))))))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-231-views")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Closes #2539 — Brad Lucier's r/KaappiScheme report "SRFI 231: array-copy and friends are not call/cc-safe".

## What was wrong

`array-copy` collected a non-specialized source's values into a **shared, mutable scratch vector** before allocating the destination (#2454), threading only the position functionally. One re-entry of a getter's continuation looks right that way, and that is all the official suite's continuation cases (entries 737-741) exercise. But the scratch is one object shared by every continuation captured during the collection: a second re-entry, or a second continuation captured on the first run, resumes over positions an earlier re-entry already overwrote and materializes the wrong prefix. `array-stack`/`append`/`block`/`decurry` delegate to `array-copy`, so one loop accounted for five procedures.

| | result of the reporter's case |
|---|---|
| Gambit (reference) | `((0 1 2 20) (0 1 2 10) (0 20 2 3) (0 10 2 3) (0 1 2 3))` |
| Kaappi before | `((0 20 2 20) (0 20 2 10) (0 20 2 3) (0 10 2 3) (0 1 2 3))` |
| Kaappi after | `((0 1 2 20) (0 1 2 10) (0 20 2 3) (0 10 2 3) (0 1 2 3))` |

The spec is precise about the rule: a call/cc-safe procedure is one "written in a way that does not modify the state of any data captured by a continuation", and every procedure without a trailing `!` is intended to be one. The older `set!`-cell accumulators in `interval-fold-left`/`-right`, `array-fold-left`/`-right`, `array-reduce`, `array-every` and `array->list` are the same defect. (The two fold-left variants escaped notice only because Kaappi's left-to-right argument evaluation reads the accumulator into a register before the getter runs, so the continuation happened to carry a snapshot — the same code returns garbage under chibi's right-to-left order.)

## The fix

The reference implementation's shape, validated against the spec text and `generic-arrays.scm`:

- **`%interval-fold`** (`intervals.sld`, exported for sibling files like `arrays.sld`'s `%`-helpers): one lexicographic walk that threads the accumulator through loop variables and return values, never a cell. `interval-for-each`, both interval folds, and every accumulating combinator are built on it.
- **`array-copy`** of a non-specialized source collects into a reversed list, allocates the destination only afterwards, and fills the body by linear position through the storage class's own setter (a fresh destination's body *is* the lexicographic order), which also drops the per-element multi-index regeneration the copy-out used to do. A specialized source takes the direct fill, as in the reference (`%!array-copy`), since no user code runs in its getter.
- The costs the scratch design was chosen to avoid (#2464) return for the non-specialized path only: N live pairs during the collection.

## Tests

Regression tests in the four SRFI 231 test files drive **two continuations, each invoked twice** — a single re-entry cannot distinguish a shared buffer from a functional accumulator, which is how the previous design passed its tests. The driver is one included fixture, `tests/scheme/srfi/fixtures/srfi231-reentry.scm`. Sixteen new assertions; **nine** fail against main's `lib/srfi/231/*.sld` (verified by shadowing the checkout via an isolated `KAAPPI_HOME`): both fold-rights, `array-reduce`, `array->list`/`->vector`, `array-append`, `array-stack`, and both `array-copy` re-entry cases. The rest pin behavior: the two fold-lefts (safe on main only by evaluation-order luck, explained in a comment), `array-every` (returns the last predicate result, so only the cont2 re-entries can move it), the zero-dimensional and empty `array-copy` shapes, and two `interval-for-each` multiple-values callbacks.

- the 7 `srfi231*.scm` unit files: all pass
- `srfi231-official.scm`: 10936 passed, 0 unexpected failures, 1 known divergence (unchanged)
- `docs/dev/srfi-implementation-notes.md` gains the call/cc-safety rule; markdownlint clean

## Measurements (recorded in `views.sld`)

| shape | source | time | peak RSS |
|---|---|---|---|
| #2454 scratch vector | non-specialized, 1M elements × 20 copies | 114.9s | — |
| this PR's list collector | same | 73.5s | — |
| direct fill (kept) | specialized u8, 1M × 6 copies | 33.3s | 12.5 MB |
| list collector (not used here) | same | 18.7s | 176 MB |

The list collector is *faster* than the scratch it replaces — the old copy-out's per-element indexer call cost more than the pairs it avoided, so the #2464 objection no longer holds for that shape. For specialized sources the pairs would cost 14× the peak memory, so the direct fill stays, as in the reference's `%!array-copy`; that exemption (a custom storage-class getter or a `specialized-array-share` mapping is user code inside the direct fill) is now documented as a deliberate exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
