### PR TITLE
Add differential testing of SRFI 231 against the reference implementation

### DIFF
--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -920,7 +920,10 @@ that a second re-entry of a getter's continuation resumes over an earlier
 re-entry's overwrites. A single re-entry cannot distinguish a shared buffer
 from a functional accumulator — the official suite's own continuation cases
 (entries 737-741) passed over the scratch design — so the regression tests
-drive two continuations, each invoked twice. `array-copy` of a non-specialized
+drive two continuations, each invoked twice — and `tools/srfi231_diff.py`
+(`docs/dev/testing.md`) now generates random view/reshape programs and diffs
+Kaappi against the reference under Gambit, for the properties fixed cases
+cannot see. `array-copy` of a non-specialized
 source is therefore the reference's exact shape (reversed list, then a body
 filled by linear position). A specialized source takes the direct fill, as in
 the reference's `%!array-copy` — a deliberate, documented exception: a

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -385,11 +385,14 @@ f16/f32 rounding is compared bit-exactly and Gambit's `.5` never differs
 textually from Kaappi's `0.5`; `--classes u1,f16` narrows the draw. New
 modes are one generator function each in `MODES`.
 
-Two oracle divergences are known and recorded in the tool's docstring: Gambit's
+The known oracle divergences are recorded in the tool's docstring: Gambit's
 bundled reference flips `specialized-array-default-safe?` to `#t` (the spec
-and the SRFI repository's copy say `#f`; the storage prelude pins it), and
-chibi raises on a `copy-on-failure? #t` reshape that needs the copy. The
-storage mode's first real finding is kaappi#2542.
+and the SRFI repository's copy say `#f`; the storage prelude pins it); chibi
+raises on a `copy-on-failure? #t` reshape that needs the copy, does not
+validate `make-specialized-array`'s initial value, has checker bugs on
+u16/u64/c64, and returns a list rather than a boolean from its u1 checker
+(the storage mode prints only the boolean verdict, so that one never fires).
+The storage mode's first real finding is kaappi#2542.
 
 It is not part of `run-all.sh`: it needs an oracle installed and a useful
 run takes minutes.

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -354,10 +354,8 @@ output differs. The oracle is the reference itself — this SRFI's documented
 rule is "when prose and reference code disagree, trust the code" — as
 bundled by Gambit (`brew install gambit-scheme`; `gsi` may be shadowed by a
 shell alias, the tool defaults to `/opt/homebrew/bin/gsi`), with chibi's
-independent port as a tie-breaker (`--oracle chibi`; chibi 0.12 itself
-raises on a `copy-on-failure? #t` reshape that needs the copy, where the spec,
-Gambit and Kaappi return one — confirm a chibi-only mismatch against Gambit
-before chasing it).
+independent port as a tie-breaker (`--oracle chibi`; confirm a chibi-only
+mismatch against Gambit before chasing it).
 
 ```bash
 tools/srfi231_diff.py reshape --count 500          # seeds 1..500 vs Gambit
@@ -375,8 +373,23 @@ the base to compare body sharing; every step is guarded, so *whether* a
 step errors is compared too. It is deliberately biased toward the affine
 boundary — merging axes whose strides no longer chain after a permute or
 sample — since that is where `specialized-array-reshape` reasons about index
-arithmetic rather than mirroring the reference's structure. New modes are
-one generator function each in `MODES`.
+arithmetic rather than mirroring the reference's structure. The `storage`
+mode takes one storage class per case through everything that consults its
+checker, getter and setter — the checker's verdict on boundary and
+wrong-typed values, `make-specialized-array` with an initial value,
+`array-set!` directly and through a reversed extract, `array-copy`,
+`list->array` and `vector->array` from a generic source, `array-assign!`
+into a view — with every value canonicalized before printing (finite reals
+as exact rationals, complex as pairs of those, chars as code points), so
+f16/f32 rounding is compared bit-exactly and Gambit's `.5` never differs
+textually from Kaappi's `0.5`; `--classes u1,f16` narrows the draw. New
+modes are one generator function each in `MODES`.
+
+Two oracle divergences are known and recorded in the tool's docstring: Gambit's
+bundled reference flips `specialized-array-default-safe?` to `#t` (the spec
+and the SRFI repository's copy say `#f`; the storage prelude pins it), and
+chibi raises on a `copy-on-failure? #t` reshape that needs the copy. The
+storage mode's first real finding is kaappi#2542.
 
 It is not part of `run-all.sh`: it needs an oracle installed and a useful
 run takes minutes.

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -342,6 +342,45 @@ Conventions specific to this suite:
   (`KAAPPI_SRFI231_OFFICIAL_TIMEOUT`, default 600 s) instead of the 60 s
   default.
 
+### Differential testing against the reference (`tools/srfi231_diff.py`)
+
+The official suite encodes the reference implementation's answers on the
+inputs its author wrote down; it cannot see a property its cases never
+exercise. kaappi#2539 — `array-copy` breaking the spec's own definition of
+call/cc-safe — passed all of it. `tools/srfi231_diff.py` looks for what
+fixed cases miss: it generates random SRFI 231 programs from a seed, runs
+each under Kaappi and an oracle, and reports every program whose printed
+output differs. The oracle is the reference itself — this SRFI's documented
+rule is "when prose and reference code disagree, trust the code" — as
+bundled by Gambit (`brew install gambit-scheme`; `gsi` may be shadowed by a
+shell alias, the tool defaults to `/opt/homebrew/bin/gsi`), with chibi's
+independent port as a tie-breaker (`--oracle chibi`; chibi 0.12 itself
+raises on a `copy-on-failure? #t` reshape that needs the copy, where the spec,
+Gambit and Kaappi return one — confirm a chibi-only mismatch against Gambit
+before chasing it).
+
+```bash
+tools/srfi231_diff.py reshape --count 500          # seeds 1..500 vs Gambit
+tools/srfi231_diff.py reshape --seed 7 --print     # the program for one seed
+```
+
+Each case is a pure function of (mode, seed). A mismatch is saved with both
+outputs and the run exits 1; reduce it by hand, then pin it as an ordinary
+test under `tests/scheme/srfi/` with the seed in a comment. The `reshape`
+mode chains view operations (extract, translate, permute, reverse, sample,
+curry-pick, tile-pick, copy, reshape with and without `copy-on-failure?`)
+over one specialized array, printing domain, `array-packed?`, mutability and
+contents after every step, then writes through the final view and prints
+the base to compare body sharing; every step is guarded, so *whether* a
+step errors is compared too. It is deliberately biased toward the affine
+boundary — merging axes whose strides no longer chain after a permute or
+sample — since that is where `specialized-array-reshape` reasons about index
+arithmetic rather than mirroring the reference's structure. New modes are
+one generator function each in `MODES`.
+
+It is not part of `run-all.sh`: it needs an oracle installed and a useful
+run takes minutes.
+
 ### Writing a Scheme test
 
 A Scheme test is a SRFI-64 suite that **exits nonzero when an assertion

--- a/tools/srfi231_diff.py
+++ b/tools/srfi231_diff.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Differential testing of Kaappi's SRFI 231 against the reference implementation.
+
+SRFI 231's documented rule in this codebase is "when the spec's prose and its
+reference implementation disagree, trust the code" -- which makes the reference
+an oracle in the strict sense. Gambit bundles it as `(srfi 231)`, and chibi
+ships an independent port. This tool generates random SRFI 231 programs in the
+subset of R7RS all three run, executes each under Kaappi and an oracle, and
+reports any program whose printed output differs.
+
+Why this exists: the official conformance suite (10,936 evaluations) encodes
+the reference's answers on the inputs its author wrote down. It cannot see a
+property violation its cases never exercise -- kaappi#2539 passed the whole
+suite while breaking the spec's own definition of call/cc-safe. Generated
+inputs find bugs at the rate of inputs, not ideas.
+
+It is **not** part of `run-all.sh`: it needs an oracle installed (`brew install
+gambit-scheme` or `chibi-scheme`) and a useful run takes minutes. Cases it
+finds get reduced and pinned as ordinary regression tests under
+tests/scheme/srfi/, with the seed in the comment so they replay:
+
+    tools/srfi231_diff.py reshape --count 500              # gambit oracle
+    tools/srfi231_diff.py reshape --oracle chibi --count 200
+    tools/srfi231_diff.py reshape --seed 7 --count 1        # exactly one case
+    tools/srfi231_diff.py reshape --seed 7 --print          # show its program
+
+Modes
+  reshape  A chain of view operations over one specialized array -- extract,
+           translate, permute, reverse, sample, curry-pick, tile-pick, copy,
+           and specialized-array-reshape with and without copy-on-failure? --
+           printing the domain, array-packed?, mutability and contents after
+           every step, then writing through the final view and printing the
+           base array to compare body sharing. Every step is guarded, so
+           "errors here" versus "does not" is compared too. Aimed at the
+           NumPy-derived affine-reshape detection in lib/srfi/231/views.sld
+           and at array-packed? over composed views, the two places where the
+           implementation reasons about index arithmetic rather than copying
+           the reference's structure.
+
+Known oracle divergence: chibi 0.12's port raises on a `copy-on-failure? #t`
+reshape that needs the copy, where the spec (and Gambit, and Kaappi) return a
+copy -- expect that mismatch shape with `--oracle chibi` (seeds 5227 and 5248
+of the reshape mode show it) and confirm against Gambit before chasing it.
+
+Each case is a pure function of (mode, seed); `--seed N --count K` runs seeds
+N..N+K-1. Mismatches are saved as <save-dir>/<mode>-<seed>.scm with the two
+outputs beside them, and the run exits 1.
+"""
+
+import argparse
+import os
+import random
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+
+PRELUDE = """\
+(import (scheme base) (scheme write) (srfi 231))
+(define (show . xs) (for-each (lambda (x) (write x) (display " ")) xs) (newline))
+(define (dom a)
+  (let ((d (array-domain a)))
+    (list (interval-lower-bounds->list d) (interval-upper-bounds->list d))))
+(define (describe tag a)
+  (show tag (dom a) (specialized-array? a) (mutable-array? a) (array-packed? a)
+        (array->list* a)))
+(define-syntax try
+  (syntax-rules () ((_ e) (guard (c (#t 'ERROR)) e))))
+;; write-through probe: set the r-th multi-index (lexicographic) of a to 'X
+;; and print the BASE array, so body sharing across the whole chain is
+;; compared; the index is chosen here, from a's actual domain, so it is
+;; valid whatever the chain did
+(define (probe a r)
+  (if (array-empty? a)
+      (show 'write-through 'empty)
+      (let* ((idxs (reverse (interval-fold-left list (lambda (acc x) (cons x acc)) '()
+                                               (array-domain a))))
+             (idx (list-ref idxs (modulo r (length idxs)))))
+        (show 'write-through idx
+              (try (begin (apply array-set! a 'X idx) (array->list* a0)))))))
+;; a step: bind the result if it succeeded, else keep the previous array so
+;; the chain (and the oracle comparison of every later step) continues
+(define-syntax step
+  (syntax-rules ()
+    ((_ name tag prev e)
+     (define name (let ((r (try e)))
+                    (if (eq? r 'ERROR) (begin (show tag 'ERROR) prev)
+                        (begin (describe tag r) r)))))))
+"""
+
+
+# --- interval helpers (Python side) ----------------------------------------
+
+def volume(lo, hi):
+    v = 1
+    for l, h in zip(lo, hi):
+        v *= h - l
+    return v
+
+
+def fmt_vec(xs):
+    return "'#(" + " ".join(str(x) for x in xs) + ")"
+
+
+def fmt_interval(lo, hi):
+    return f"(make-interval {fmt_vec(lo)} {fmt_vec(hi)})"
+
+
+def random_factorization(rng, v, max_axes=4):
+    """Split v >= 1 into 0..max_axes factors >= 1, width-1 axes included."""
+    if v == 1 and rng.random() < 0.2:
+        return []
+    n = rng.randint(1, max_axes)
+    dims = [1] * n
+    rest = v
+    # distribute prime factors randomly across the axes
+    p = 2
+    while rest > 1:
+        while rest % p == 0:
+            dims[rng.randrange(n)] *= p
+            rest //= p
+        p += 1
+    return dims
+
+
+def merge_or_split(rng, widths):
+    """Merge two adjacent axes into one, or split one axis into two factors.
+    Merging axes with non-chaining strides is the exact affine boundary."""
+    w = list(widths)
+    if len(w) >= 2 and (rng.random() < 0.6 or not any(x > 1 for x in w)):
+        i = rng.randrange(len(w) - 1)
+        return w[:i] + [w[i] * w[i + 1]] + w[i + 2:]
+    cands = [i for i, x in enumerate(w) if x > 1]
+    if not cands:
+        return w + [1]
+    i = rng.choice(cands)
+    divs = [f for f in range(1, w[i] + 1) if w[i] % f == 0]
+    f = rng.choice(divs)
+    return w[:i] + [f, w[i] // f] + w[i + 1:]
+
+
+def random_same_volume_domain(rng, lo, hi):
+    v = volume(lo, hi)
+    if v > 0 and rng.random() < 0.5:
+        widths = merge_or_split(rng, [h - l for l, h in zip(lo, hi)])
+        nlo = [rng.randint(-2, 2) for _ in widths]
+        return nlo, [l + w for l, w in zip(nlo, widths)]
+    if v == 0:
+        n = rng.randint(1, 4)
+        widths = [rng.randint(0, 3) for _ in range(n)]
+        widths[rng.randrange(n)] = 0
+    else:
+        widths = random_factorization(rng, v)
+    nlo = [rng.randint(-2, 2) for _ in widths]
+    return nlo, [l + w for l, w in zip(nlo, widths)]
+
+
+# --- the reshape-mode generator ---------------------------------------------
+
+class Chain:
+    """Tracks the current array's domain on the Python side so every generated
+    argument is valid by construction; the guards catch what is not."""
+
+    def __init__(self, rng):
+        self.rng = rng
+        self.lines = [PRELUDE]
+        # mostly 2-3 axes of width 2-4 -- the shapes where affine-reshape
+        # detection has real work to do -- with a tail of empty, width-1
+        # and zero-dimensional cases
+        d = rng.choice([0, 1, 2, 2, 2, 3, 3, 3, 4])
+        self.lo = [rng.randint(-2, 2) for _ in range(d)]
+        self.hi = [l + rng.choice([0, 1, 2, 2, 3, 3, 4, 4]) for l in self.lo]
+        self.n = 0
+        # elements are their own multi-index, so contents identify positions
+        # unambiguously whatever order an implementation visits them in
+        self.lines.append(
+            f"(define a0 (array-copy (make-array {fmt_interval(self.lo, self.hi)} list)))")
+        self.lines.append("(describe 'base a0)")
+
+    @property
+    def cur(self):
+        return f"a{self.n}"
+
+    @property
+    def d(self):
+        return len(self.lo)
+
+    def emit(self, tag, expr, lo, hi):
+        prev = self.cur
+        self.n += 1
+        self.lines.append(f"(step {self.cur} '{tag} {prev} {expr})")
+        # the step keeps prev on error; the Python-side domain only advances
+        # for arguments generated valid by construction, which is all of them
+        self.lo, self.hi = lo, hi
+
+    # each op returns True if it emitted a step
+    def op_extract(self):
+        lo, hi = [], []
+        for l, h in zip(self.lo, self.hi):
+            nl = self.rng.randint(l, h)
+            nh = self.rng.randint(nl, h)
+            lo.append(nl)
+            hi.append(nh)
+        self.emit("extract", f"(array-extract {self.cur} {fmt_interval(lo, hi)})", lo, hi)
+        return True
+
+    def op_translate(self):
+        t = [self.rng.randint(-3, 3) for _ in range(self.d)]
+        lo = [l + x for l, x in zip(self.lo, t)]
+        hi = [h + x for h, x in zip(self.hi, t)]
+        self.emit("translate", f"(array-translate {self.cur} {fmt_vec(t)})", lo, hi)
+        return True
+
+    def op_permute(self):
+        p = list(range(self.d))
+        self.rng.shuffle(p)
+        lo = [self.lo[i] for i in p]
+        hi = [self.hi[i] for i in p]
+        self.emit("permute", f"(array-permute {self.cur} {fmt_vec(p)})", lo, hi)
+        return True
+
+    def op_reverse(self):
+        if self.rng.random() < 0.3:
+            self.emit("reverse", f"(array-reverse {self.cur})", self.lo, self.hi)
+        else:
+            flips = ["#t" if self.rng.random() < 0.5 else "#f" for _ in range(self.d)]
+            self.emit("reverse", f"(array-reverse {self.cur} {fmt_vec(flips)})", self.lo, self.hi)
+        return True
+
+    def op_sample(self):
+        if any(l != 0 for l in self.lo):
+            # array-sample needs zero lower bounds; translate there first
+            t = [-l for l in self.lo]
+            self.emit("translate", f"(array-translate {self.cur} {fmt_vec(t)})",
+                      [0] * self.d, [h - l for l, h in zip(self.lo, self.hi)])
+        s = [self.rng.randint(1, 3) for _ in range(self.d)]
+        hi = [-(-h // k) for h, k in zip(self.hi, s)]  # ceiling
+        self.emit("sample", f"(array-sample {self.cur} {fmt_vec(s)})", self.lo, hi)
+        return True
+
+    def op_curry_pick(self):
+        if self.d == 0:
+            return False
+        k = self.rng.randint(0, self.d)
+        outer = self.d - k
+        if volume(self.lo[:outer], self.hi[:outer]) == 0:
+            return False
+        idx = [self.rng.randrange(l, h) for l, h in zip(self.lo[:outer], self.hi[:outer])]
+        expr = f"(array-ref (array-curry {self.cur} {k}) {' '.join(map(str, idx))})"
+        self.emit("curry-pick", expr, self.lo[outer:], self.hi[outer:])
+        return True
+
+    def op_tile_pick(self):
+        if self.d == 0:
+            return False
+        sides, jidx, tile_lo, tile_hi = [], [], [], []
+        for l, h in zip(self.lo, self.hi):
+            w = h - l
+            if w == 0:
+                # spec: a zero-width axis takes a nonempty vector of zeros
+                sides.append("#(0)")
+                jidx.append(0)
+                tile_lo.append(l)
+                tile_hi.append(l)
+            elif self.rng.random() < 0.5:
+                s = self.rng.randint(1, w)
+                j = self.rng.randrange(-(-w // s))
+                sides.append(str(s))
+                jidx.append(j)
+                tile_lo.append(l + j * s)
+                tile_hi.append(min(l + (j + 1) * s, h))
+            else:
+                # a cut vector of nonnegative widths summing to w
+                ncuts = self.rng.randint(1, min(w, 3))
+                cuts = [0] * ncuts
+                for _ in range(w):
+                    cuts[self.rng.randrange(ncuts)] += 1
+                j = self.rng.randrange(ncuts)
+                sides.append("#(" + " ".join(map(str, cuts)) + ")")
+                jidx.append(j)
+                tile_lo.append(l + sum(cuts[:j]))
+                tile_hi.append(l + sum(cuts[:j + 1]))
+        expr = (f"(array-ref (array-tile {self.cur} '#({' '.join(sides)})) "
+                f"{' '.join(map(str, jidx))})")
+        self.emit("tile-pick", expr, tile_lo, tile_hi)
+        return True
+
+    def op_copy(self):
+        self.emit("copy", f"(array-copy {self.cur})", self.lo, self.hi)
+        return True
+
+    def op_reshape(self):
+        lo, hi = random_same_volume_domain(self.rng, self.lo, self.hi)
+        if self.rng.random() < 0.5:
+            expr = f"(specialized-array-reshape {self.cur} {fmt_interval(lo, hi)} #t)"
+            self.emit("reshape-copy", expr, lo, hi)
+            return True
+        # Without copy-on-failure? the reshape may legitimately error, and
+        # the step then keeps the previous array while the Python-side
+        # domain would advance -- so this is always the chain's last step.
+        expr = f"(specialized-array-reshape {self.cur} {fmt_interval(lo, hi)})"
+        self.emit("reshape", expr, lo, hi)
+        self.terminal = True
+        return True
+
+    def finish(self):
+        self.lines.append(f"(probe {self.cur} {self.rng.randrange(1000)})")
+        self.lines.append("(show 'end)")
+        return "\n".join(self.lines) + "\n"
+
+
+def gen_reshape(seed):
+    rng = random.Random(seed)
+    c = Chain(rng)
+    ops = [c.op_extract, c.op_translate, c.op_permute, c.op_permute, c.op_reverse,
+           c.op_sample, c.op_sample, c.op_curry_pick, c.op_tile_pick, c.op_copy,
+           c.op_reshape, c.op_reshape]
+    nsteps = rng.randint(1, 6)
+    done = 0
+    while done < nsteps and not getattr(c, "terminal", False):
+        if rng.choice(ops)():
+            done += 1
+    return c.finish()
+
+
+MODES = {"reshape": gen_reshape}
+
+
+# --- running -----------------------------------------------------------------
+
+def run_one(cmd, path, env, timeout):
+    try:
+        p = subprocess.run(cmd + [path], capture_output=True, text=True,
+                           timeout=timeout, env=env)
+        return p.returncode, p.stdout, p.stderr
+    except subprocess.TimeoutExpired:
+        return -1, "", "TIMEOUT"
+
+
+def normalize(out):
+    return "\n".join(line.rstrip() for line in out.strip().splitlines())
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("mode", choices=sorted(MODES))
+    ap.add_argument("--seed", type=int, default=1)
+    ap.add_argument("--count", type=int, default=100)
+    ap.add_argument("--oracle", choices=["gambit", "chibi"], default="gambit")
+    ap.add_argument("--kaappi", default=os.path.join(ROOT, "zig-out", "bin", "kaappi"))
+    ap.add_argument("--gsi", default=shutil.which("gsi") or "/opt/homebrew/bin/gsi")
+    ap.add_argument("--chibi", default=shutil.which("chibi-scheme") or "chibi-scheme")
+    ap.add_argument("--save", default=None, help="directory for mismatching cases")
+    ap.add_argument("--timeout", type=float, default=60.0)
+    ap.add_argument("--print", action="store_true", help="print the first case's program and exit")
+    args = ap.parse_args()
+
+    gen = MODES[args.mode]
+    if args.print:
+        sys.stdout.write(gen(args.seed))
+        return 0
+
+    oracle_cmd = [args.gsi] if args.oracle == "gambit" else [args.chibi]
+    save = args.save or tempfile.mkdtemp(prefix="srfi231-diff-")
+    os.makedirs(save, exist_ok=True)
+    work = tempfile.mkdtemp(prefix="srfi231-diff-work-")
+    # one isolated KAAPPI_HOME for the whole run: the checkout's lib/ wins over
+    # any ~/.kaappi/lib (kaappi#2352) and the .sld cache warms once
+    env = dict(os.environ, KAAPPI_HOME=os.path.join(work, "home"))
+    os.makedirs(env["KAAPPI_HOME"])
+
+    mismatches = 0
+    for seed in range(args.seed, args.seed + args.count):
+        prog = gen(seed)
+        path = os.path.join(work, f"{args.mode}-{seed}.scm")
+        with open(path, "w") as f:
+            f.write(prog)
+        kc, ko, ke = run_one([args.kaappi], path, env, args.timeout)
+        oc, oo, oe = run_one(oracle_cmd, path, env, args.timeout)
+        same = normalize(ko) == normalize(oo) and (kc == 0) == (oc == 0)
+        if same:
+            continue
+        mismatches += 1
+        dst = os.path.join(save, f"{args.mode}-{seed}.scm")
+        shutil.copy(path, dst)
+        with open(dst + ".kaappi.txt", "w") as f:
+            f.write(f"exit {kc}\n--- stdout\n{ko}\n--- stderr\n{ke}")
+        with open(dst + f".{args.oracle}.txt", "w") as f:
+            f.write(f"exit {oc}\n--- stdout\n{oo}\n--- stderr\n{oe}")
+        print(f"MISMATCH seed {seed}: {dst}")
+        kl, ol = normalize(ko).splitlines(), normalize(oo).splitlines()
+        for i in range(max(len(kl), len(ol))):
+            a = kl[i] if i < len(kl) else "<none>"
+            b = ol[i] if i < len(ol) else "<none>"
+            if a != b:
+                print(f"  first difference at output line {i + 1}:")
+                print(f"    kaappi:  {a[:200]}")
+                print(f"    {args.oracle:7s}: {b[:200]}")
+                break
+        else:
+            print(f"  exit codes differ: kaappi {kc}, {args.oracle} {oc}; stderr: {ke.strip()[:200]} | {oe.strip()[:200]}")
+
+    print(f"{args.mode}: {args.count} cases from seed {args.seed}, oracle {args.oracle}, "
+          f"{mismatches} mismatches" + (f" saved under {save}" if mismatches else ""))
+    return 1 if mismatches else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/srfi231_diff.py
+++ b/tools/srfi231_diff.py
@@ -23,8 +23,23 @@ tests/scheme/srfi/, with the seed in the comment so they replay:
     tools/srfi231_diff.py reshape --oracle chibi --count 200
     tools/srfi231_diff.py reshape --seed 7 --count 1        # exactly one case
     tools/srfi231_diff.py reshape --seed 7 --print          # show its program
+    tools/srfi231_diff.py storage --count 400               # all 16 storage classes
+    tools/srfi231_diff.py storage --classes u1,f16 --count 200
 
 Modes
+  storage  One storage class per case, through everything that consults its
+           checker, getter and setter: the checker's verdict on boundary and
+           wrong-typed values, make-specialized-array with an initial value,
+           array-set! through the array and through a reversed extract of it,
+           array-copy and list->array from a generic source, array-assign!
+           into a view, and storage-class-length of the body. Values are
+           canonicalized before printing -- finite reals as exact rationals,
+           complex as a pair of those, chars as code points -- so f16/f32
+           rounding is compared bit-exactly and Gambit's `.5` never differs
+           from Kaappi's `0.5` textually. Aimed at the software u1 bit
+           packing and f16 half-floats, the interleaved c64/c128 bodies, and
+           the checker of every class (whether f64 rejects an exact integer,
+           whether c64 accepts a real flonum), through views with offsets.
   reshape  A chain of view operations over one specialized array -- extract,
            translate, permute, reverse, sample, curry-pick, tile-pick, copy,
            and specialized-array-reshape with and without copy-on-failure? --
@@ -37,7 +52,13 @@ Modes
            implementation reasons about index arithmetic rather than copying
            the reference's structure.
 
-Known oracle divergence: chibi 0.12's port raises on a `copy-on-failure? #t`
+Known oracle divergences. Gambit's bundled reference flips the initial
+value of `specialized-array-default-safe?` to #t (spec and the SRFI
+repository's copy: #f); the storage mode pins it to #f in its prelude.
+Kaappi's own open divergence kaappi#2542 (c64/c128 checkers accept real
+flonums, the reference rejects them) surfaces as `check` mismatches on those
+two classes; use `--classes` to exclude them until it is fixed, since a
+program's first difference hides everything after it. And chibi 0.12's port raises on a `copy-on-failure? #t`
 reshape that needs the copy, where the spec (and Gambit, and Kaappi) return a
 copy -- expect that mismatch shape with `--oracle chibi` (seeds 5227 and 5248
 of the reshape mode show it) and confirm against Gambit before chasing it.
@@ -312,7 +333,7 @@ class Chain:
         return "\n".join(self.lines) + "\n"
 
 
-def gen_reshape(seed):
+def gen_reshape(seed, classes=None):
     rng = random.Random(seed)
     c = Chain(rng)
     ops = [c.op_extract, c.op_translate, c.op_permute, c.op_permute, c.op_reverse,
@@ -326,7 +347,142 @@ def gen_reshape(seed):
     return c.finish()
 
 
-MODES = {"reshape": gen_reshape}
+# --- the storage-class-mode generator -----------------------------------------
+
+STORAGE_PRELUDE = PRELUDE.replace(
+    "(import (scheme base) (scheme write) (srfi 231))",
+    "(import (scheme base) (scheme write) (scheme inexact) (scheme complex) (srfi 231))") + """\
+;; the spec says (specialized-array-default-safe?) is initially #f, and so
+;; does the SRFI repository's reference source, but Gambit's bundled copy
+;; of that same file flips the initial value to #t -- pin it, so an omitted
+;; safe? argument means the same thing under both
+(specialized-array-default-safe? #f)
+;; implementations print flonums differently (Gambit: .5 and 1.; Kaappi:
+;; 0.5 and 1.0), so print every value in a representation both write
+;; identically: finite reals as exact rationals (bit-exact, so f16/f32
+;; rounding is compared precisely), complex as a tagged pair of those,
+;; chars as code points, nested lists recursively
+(define (canon v)
+  (cond ((and (number? v) (exact? v)) v)
+        ((real? v) (cond ((nan? v) 'nan)
+                         ((infinite? v) (if (> v 0) '+inf '-inf))
+                         (else (exact v))))
+        ((number? v) (list 'c (canon (real-part v)) (canon (imag-part v))))
+        ((char? v) (list 'ch (char->integer v)))
+        ((pair? v) (cons (canon (car v)) (canon (cdr v))))
+        ((array? v) 'array)
+        (else v)))
+"""
+
+CLASSES = ["generic", "char", "u1", "u8", "s8", "u16", "s16", "u32", "s32",
+           "u64", "s64", "f16", "f32", "f64", "c64", "c128"]
+
+# every candidate value, as source text both readers accept
+INTS = [-(2**64), -(2**63) - 1, -(2**63), -(2**32), -(2**31) - 1, -(2**31), -32769,
+        -32768, -129, -128, -2, -1, 0, 1, 2, 127, 128, 255, 256, 32767, 32768,
+        65535, 65536, 2**31 - 1, 2**31, 2**32 - 1, 2**32, 2**63 - 1, 2**63,
+        2**64 - 1, 2**64]
+FLOATS = ["0.0", "-0.0", "0.5", "-0.5", "0.1", "1.0", "-1.5", "2.5", "3.0",
+          "255.0", "65504.0", "65520.0", "1e-8", "6.1e-5", "5.96e-8", "1e-10",
+          "3.4e38", "3.5e38", "1e300", "+inf.0", "-inf.0", "+nan.0",
+          "1/2", "1/3"]  # the two rationals are exact reals, not flonums
+COMPLEX = ["1.0+2.0i", "0.5-0.25i", "-1.5+0.0i", "0.0+1.0i", "1+2i", "0+1i",
+           "1.0+1e300i", "65504.0+65520.0i"]
+CHARS = ["#\\a", "#\\x0", "#\\x3bb", "#\\space"]
+OTHERS = ["'sym", "\"s\"", "'(1 2)", "#t", "#f", "'()"]
+
+
+def int_range(name):
+    bits = int(name[1:]) if name[1:].isdigit() else None
+    if name == "u1":
+        return 0, 1
+    if name.startswith("u"):
+        return 0, 2**bits - 1
+    return -(2**(bits - 1)), 2**(bits - 1) - 1
+
+
+def likely_valid(rng, cls):
+    """A value the class's checker should (or plausibly might) accept."""
+    if cls == "generic":
+        return rng.choice([str(v) for v in INTS] + FLOATS + COMPLEX + CHARS + OTHERS)
+    if cls == "char":
+        return rng.choice(CHARS)
+    if cls[0] in "us":
+        lo, hi = int_range(cls)
+        return str(rng.choice([lo, hi, lo + 1, hi - 1, 0, 1] + [rng.randint(lo, hi) for _ in range(3)]))
+    if cls[0] == "f":
+        return rng.choice(FLOATS)
+    return rng.choice(COMPLEX + FLOATS)
+
+
+def any_value(rng):
+    return rng.choice([str(v) for v in INTS] + FLOATS + COMPLEX + CHARS + OTHERS)
+
+
+def value(rng, cls):
+    return likely_valid(rng, cls) if rng.random() < 0.7 else any_value(rng)
+
+
+def gen_storage(seed, classes=None):
+    rng = random.Random(seed)
+    cls = rng.choice(classes or CLASSES)
+    sc = f"{cls}-storage-class"
+    L = [STORAGE_PRELUDE]
+    L.append(f"(define sc {sc})")
+    L.append(f"(show 'class '{cls} (canon (storage-class-default sc)) (storage-class? sc))")
+    # no f8 probe: the spec lets an implementation with an 8-bit float type
+    # define f8-storage-class (chibi does); Gambit and Kaappi leave it #f
+    # the checker's verdict on a handful of values -- the most direct probe
+    for _ in range(8):
+        v = value(rng, cls)
+        L.append(f"(show 'check (canon {v}) ((storage-class-checker sc) {v}))")
+    # a small 1-2 axis domain; sometimes empty
+    d = rng.choice([1, 1, 2, 2, 2])
+    lo = [rng.randint(-2, 2) for _ in range(d)]
+    hi = [l + rng.choice([0, 1, 2, 3, 3, 4]) for l in lo]
+    vol = volume(lo, hi)
+    iv = fmt_interval(lo, hi)
+    L.append(f"(define iv {iv})")
+    init = value(rng, cls)
+    L.append(f"(define a0 (try (make-specialized-array iv sc {init} #t)))")
+    L.append(f"(show 'make (canon {init}) (if (eq? a0 'ERROR) 'ERROR (canon (array->list a0))))")
+    # keep going with a default-initialized array if the initial value was rejected
+    L.append("(define a (if (eq? a0 'ERROR) (make-specialized-array iv sc) a0))")
+    L.append("(show 'length ((storage-class-length sc) (array-body a)) (mutable-array? a) (array-safe? a))")
+    if vol > 0:
+        for _ in range(rng.randint(2, 5)):
+            v = value(rng, cls)
+            idx = " ".join(str(rng.randrange(l, h)) for l, h in zip(lo, hi))
+            L.append(f"(show 'set (canon {v}) (try (begin (array-set! a {v} {idx}) 'ok)))")
+        L.append("(show 'contents (canon (array->list a)))")
+        # a view with an offset into the body: extract a sub-interval, reverse it
+        slo = [rng.randint(l, h - 1) for l, h in zip(lo, hi)]
+        shi = [rng.randint(sl + 1, h) for sl, h in zip(slo, hi)]
+        flips = fmt_vec(["#t" if rng.random() < 0.6 else "#f" for _ in range(d)])
+        L.append(f"(define b (array-reverse (array-extract a {fmt_interval(slo, shi)}) {flips}))")
+        L.append("(show 'view (dom b) (array-packed? b) (canon (array->list b)))")
+        for _ in range(rng.randint(1, 3)):
+            v = value(rng, cls)
+            idx = " ".join(str(rng.randrange(l, h)) for l, h in zip(slo, shi))
+            L.append(f"(show 'view-set (canon {v}) (try (begin (array-set! b {v} {idx}) 'ok)))")
+        L.append("(show 'contents (canon (array->list a)))")
+        # array-assign! from a generic array of one (usually valid) value
+        v = value(rng, cls)
+        L.append(f"(show 'assign (canon {v}) (try (begin (array-assign! b (array-copy (make-array (array-domain b) (lambda idx {v})) generic-storage-class)) (canon (array->list a)))))")
+    # bulk constructors from generic sources, with the checker in the loop
+    vals = [value(rng, cls) for _ in range(vol)]
+    L.append(f"(define g (list->array iv (list {' '.join(vals)}) generic-storage-class))")
+    L.append("(show 'copy (try (canon (array->list (array-copy g sc)))))")
+    L.append(f"(show 'list->array (try (canon (array->list (list->array iv (list {' '.join(vals)}) sc)))))")
+    L.append(f"(show 'vector->array (try (canon (array->list (vector->array iv (vector {' '.join(vals)}) sc)))))")
+    # and a copy of the typed array back to generic and to itself
+    L.append("(show 'copy-generic (try (canon (array->list (array-copy a generic-storage-class)))))")
+    L.append("(show 'copy-same (try (canon (array->list (array-copy a)))) (try (eq? sc (array-storage-class (array-copy a)))))")
+    L.append("(show 'end)")
+    return "\n".join(L) + "\n"
+
+
+MODES = {"reshape": gen_reshape, "storage": gen_storage}
 
 
 # --- running -----------------------------------------------------------------
@@ -356,9 +512,21 @@ def main():
     ap.add_argument("--save", default=None, help="directory for mismatching cases")
     ap.add_argument("--timeout", type=float, default=60.0)
     ap.add_argument("--print", action="store_true", help="print the first case's program and exit")
+    ap.add_argument("--classes", default=None,
+                    help="storage mode: comma-separated storage classes to draw from "
+                         "(default all 16), e.g. --classes u1,f16,c64")
     args = ap.parse_args()
 
-    gen = MODES[args.mode]
+    classes = None
+    if args.classes:
+        classes = args.classes.split(",")
+        bad = [c for c in classes if c not in CLASSES]
+        if bad:
+            sys.exit(f"unknown storage class(es): {', '.join(bad)}; known: {', '.join(CLASSES)}")
+
+    def gen(seed):
+        return MODES[args.mode](seed, classes)
+
     if args.print:
         sys.stdout.write(gen(args.seed))
         return 0

--- a/tools/srfi231_diff.py
+++ b/tools/srfi231_diff.py
@@ -25,6 +25,7 @@ tests/scheme/srfi/, with the seed in the comment so they replay:
     tools/srfi231_diff.py reshape --seed 7 --print          # show its program
     tools/srfi231_diff.py storage --count 400               # all 16 storage classes
     tools/srfi231_diff.py storage --classes u1,f16 --count 200
+    tools/srfi231_diff.py storage --count 50 --keep         # keep the work dir
 
 Modes
   storage  One storage class per case, through everything that consults its
@@ -63,7 +64,10 @@ reshape that needs the copy, where the spec (and Gambit, and Kaappi) return a
 copy -- expect that mismatch shape with `--oracle chibi` (seeds 5227 and 5248
 of the reshape mode show it) and confirm against Gambit before chasing it.
 Its storage classes have checker bugs of their own (u16 accepts 65536, u64
-accepts negatives, c64 accepts a real flonum), all contradicted by Gambit.
+accepts negatives, c64 accepts a real flonum, make-specialized-array does
+not validate its initial value), all contradicted by Gambit; its u1 checker
+returns a list rather than a boolean, which the storage mode hides by
+printing only the boolean verdict.
 
 Each case is a pure function of (mode, seed); `--seed N --count K` runs seeds
 N..N+K-1. Mismatches are saved as <save-dir>/<mode>-<seed>.scm with the two
@@ -92,6 +96,11 @@ PRELUDE = """\
         (array->list* a)))
 (define-syntax try
   (syntax-rules () ((_ e) (guard (c (#t 'ERROR)) e))))
+;; specialized-array-default-safe? is deliberately left unpinned here,
+;; unlike the storage prelude: every array in this mode is generic (the
+;; checker accepts anything), every index is valid by construction, and
+;; nothing printed observes the flag -- so Gambit's flipped default cannot
+;; show. The storage mode prints array-safe?, hence pins it.
 ;; write-through probe: set the r-th multi-index (lexicographic) of a to 'X
 ;; and print the BASE array, so body sharing across the whole chain is
 ;; compared; the index is chosen here, from a's actual domain, so it is
@@ -197,6 +206,8 @@ class Chain:
         self.lo = [rng.randint(-2, 2) for _ in range(d)]
         self.hi = [l + rng.choice([0, 1, 2, 2, 3, 3, 4, 4]) for l in self.lo]
         self.n = 0
+        # set by a no-copy reshape, which is always the chain's last step
+        self.terminal = False
         # elements are their own multi-index, so contents identify positions
         # unambiguously whatever order an implementation visits them in
         self.lines.append(
@@ -343,7 +354,7 @@ def gen_reshape(seed, classes=None):
            c.op_reshape, c.op_reshape]
     nsteps = rng.randint(1, 6)
     done = 0
-    while done < nsteps and not getattr(c, "terminal", False):
+    while done < nsteps and not c.terminal:
         if rng.choice(ops)():
             done += 1
     return c.finish()
@@ -439,7 +450,9 @@ def gen_storage(seed, classes=None):
     # the checker's verdict on a handful of values -- the most direct probe
     for _ in range(8):
         v = value(rng, cls)
-        L.append(f"(show 'check (canon {v}) ((storage-class-checker sc) {v}))")
+        # `(and ... #t)`: chibi's u1 checker is memv-shaped and returns the
+        # tail, so only the boolean verdict is compared, never its spelling
+        L.append(f"(show 'check (canon {v}) (and ((storage-class-checker sc) {v}) #t))")
     # a small 1-2 axis domain; sometimes empty
     d = rng.choice([1, 1, 2, 2, 2])
     lo = [rng.randint(-2, 2) for _ in range(d)]
@@ -491,13 +504,16 @@ MODES = {"reshape": gen_reshape, "storage": gen_storage}
 
 # --- running -----------------------------------------------------------------
 
+TIMED_OUT = object()  # never compares equal to an exit status
+
+
 def run_one(cmd, path, env, timeout):
     try:
         p = subprocess.run(cmd + [path], capture_output=True, text=True,
                            timeout=timeout, env=env)
         return p.returncode, p.stdout, p.stderr
-    except subprocess.TimeoutExpired:
-        return -1, "", "TIMEOUT"
+    except subprocess.TimeoutExpired as e:
+        return TIMED_OUT, (e.stdout or b"").decode(errors="replace"), "timed out"
 
 
 def normalize(out):
@@ -513,7 +529,10 @@ def main():
     ap.add_argument("--kaappi", default=os.path.join(ROOT, "zig-out", "bin", "kaappi"))
     ap.add_argument("--gsi", default=shutil.which("gsi") or "/opt/homebrew/bin/gsi")
     ap.add_argument("--chibi", default=shutil.which("chibi-scheme") or "chibi-scheme")
-    ap.add_argument("--save", default=None, help="directory for mismatching cases")
+    ap.add_argument("--save", default=None,
+                    help="directory for mismatching cases (default: a temp dir, created on the first mismatch)")
+    ap.add_argument("--keep", action="store_true",
+                    help="do not delete the work dir (generated cases, warm KAAPPI_HOME) on exit")
     ap.add_argument("--timeout", type=float, default=60.0)
     ap.add_argument("--print", action="store_true", help="print the first case's program and exit")
     ap.add_argument("--classes", default=None,
@@ -535,14 +554,28 @@ def main():
         sys.stdout.write(gen(args.seed))
         return 0
 
-    oracle_cmd = [args.gsi] if args.oracle == "gambit" else [args.chibi]
-    save = args.save or tempfile.mkdtemp(prefix="srfi231-diff-")
-    os.makedirs(save, exist_ok=True)
+    oracle = args.gsi if args.oracle == "gambit" else args.chibi
+    for name, exe, hint in (("kaappi", args.kaappi, "run zig build, or pass --kaappi"),
+                            (args.oracle, oracle, "brew install gambit-scheme / chibi-scheme, or pass --gsi/--chibi")):
+        if not (os.access(exe, os.X_OK) or shutil.which(exe)):
+            sys.exit(f"no {name} binary at {exe} ({hint})")
+
     work = tempfile.mkdtemp(prefix="srfi231-diff-work-")
+    try:
+        return run(args, gen, [oracle], work)
+    finally:
+        if args.keep:
+            print(f"work dir kept: {work}")
+        else:
+            shutil.rmtree(work, ignore_errors=True)
+
+
+def run(args, gen, oracle_cmd, work):
     # one isolated KAAPPI_HOME for the whole run: the checkout's lib/ wins over
     # any ~/.kaappi/lib (kaappi#2352) and the .sld cache warms once
     env = dict(os.environ, KAAPPI_HOME=os.path.join(work, "home"))
     os.makedirs(env["KAAPPI_HOME"])
+    save = args.save  # created on the first mismatch, so a clean run leaves nothing behind
 
     mismatches = 0
     for seed in range(args.seed, args.seed + args.count):
@@ -552,17 +585,29 @@ def main():
             f.write(prog)
         kc, ko, ke = run_one([args.kaappi], path, env, args.timeout)
         oc, oo, oe = run_one(oracle_cmd, path, env, args.timeout)
-        same = normalize(ko) == normalize(oo) and (kc == 0) == (oc == 0)
+        # a timeout on either side is always a finding -- a hang with the
+        # same partial output as the other side's error is the case that
+        # matters most, not the one to hide
+        timed_out = kc is TIMED_OUT or oc is TIMED_OUT
+        same = (not timed_out and normalize(ko) == normalize(oo)
+                and (kc == 0) == (oc == 0))
         if same:
             continue
         mismatches += 1
+        if save is None:
+            save = tempfile.mkdtemp(prefix="srfi231-diff-")
+        os.makedirs(save, exist_ok=True)
         dst = os.path.join(save, f"{args.mode}-{seed}.scm")
         shutil.copy(path, dst)
-        with open(dst + ".kaappi.txt", "w") as f:
-            f.write(f"exit {kc}\n--- stdout\n{ko}\n--- stderr\n{ke}")
-        with open(dst + f".{args.oracle}.txt", "w") as f:
-            f.write(f"exit {oc}\n--- stdout\n{oo}\n--- stderr\n{oe}")
+        for label, code, out, err in (("kaappi", kc, ko, ke), (args.oracle, oc, oo, oe)):
+            with open(f"{dst}.{label}.txt", "w") as f:
+                status = "timed out" if code is TIMED_OUT else f"exit {code}"
+                f.write(f"{status}\n--- stdout\n{out}\n--- stderr\n{err}")
         print(f"MISMATCH seed {seed}: {dst}")
+        if timed_out:
+            who = [n for n, c in (("kaappi", kc), (args.oracle, oc)) if c is TIMED_OUT]
+            print(f"  timed out after {args.timeout}s: {', '.join(who)}")
+            continue
         kl, ol = normalize(ko).splitlines(), normalize(oo).splitlines()
         for i in range(max(len(kl), len(ol))):
             a = kl[i] if i < len(kl) else "<none>"

--- a/tools/srfi231_diff.py
+++ b/tools/srfi231_diff.py
@@ -62,6 +62,8 @@ program's first difference hides everything after it. And chibi 0.12's port rais
 reshape that needs the copy, where the spec (and Gambit, and Kaappi) return a
 copy -- expect that mismatch shape with `--oracle chibi` (seeds 5227 and 5248
 of the reshape mode show it) and confirm against Gambit before chasing it.
+Its storage classes have checker bugs of their own (u16 accepts 65536, u64
+accepts negatives, c64 accepts a real flonum), all contradicted by Gambit.
 
 Each case is a pure function of (mode, seed); `--seed N --count K` runs seeds
 N..N+K-1. Mismatches are saved as <save-dir>/<mode>-<seed>.scm with the two
@@ -361,12 +363,14 @@ STORAGE_PRELUDE = PRELUDE.replace(
 ;; 0.5 and 1.0), so print every value in a representation both write
 ;; identically: finite reals as exact rationals (bit-exact, so f16/f32
 ;; rounding is compared precisely), complex as a tagged pair of those,
-;; chars as code points, nested lists recursively
+;; chars as code points, nested lists recursively; infinities and nan as
+;; tagged lists rather than symbols, which chibi would write as |+inf|
 (define (canon v)
-  (cond ((and (number? v) (exact? v)) v)
-        ((real? v) (cond ((nan? v) 'nan)
-                         ((infinite? v) (if (> v 0) '+inf '-inf))
+  (cond ((and (real? v) (exact? v)) v)
+        ((real? v) (cond ((nan? v) '(nan))
+                         ((infinite? v) (if (> v 0) '(inf 1) '(inf -1)))
                          (else (exact v))))
+        ;; exact complex too: chibi writes 0+1i as 0+i, Kaappi as +i
         ((number? v) (list 'c (canon (real-part v)) (canon (imag-part v))))
         ((char? v) (list 'ch (char->integer v)))
         ((pair? v) (cons (canon (car v)) (canon (cdr v))))


### PR DESCRIPTION
Follow-up to #2540. The official suite passed all 10,936 evaluations while `array-copy` broke the spec's definition of call/cc-safe (#2539): fixed cases find bugs at the rate of ideas. This adds `tools/srfi231_diff.py`, which generates random SRFI 231 programs from a seed, runs each under Kaappi and an oracle, and reports every program whose printed output differs.

**Oracle.** The reference implementation itself, as bundled by Gambit (`(srfi 231)` in 4.9.8), since this SRFI's documented rule is "trust the code" where prose and code disagree. Chibi's independent port is the tie-breaker (`--oracle chibi`).

**First mode: `reshape`.** A chain of view operations (extract, translate, permute, reverse, sample, curry-pick, tile-pick, copy, `specialized-array-reshape` with and without `copy-on-failure?`) over one specialized array whose elements are their own multi-index. After every step it prints domain, `specialized-array?`, `mutable-array?`, `array-packed?` and contents; at the end it writes through the final view and prints the base, so body sharing across the chain is compared. Every step is guarded, so whether a step errors is compared too. The generator is biased toward the affine boundary (merging axes whose strides stop chaining after a permute or sample), which is where the reshape code reasons about index arithmetic rather than copying the reference's structure.

**Results so far.**

| oracle | cases | mismatches |
|---|---|---|
| Gambit 4.9.8 | 1,500 (seeds 1000..2499) | 0 |
| chibi 0.12 | 500 (seeds 5000..5499) | 4, all one chibi bug, Gambit sides with Kaappi on each |

Chibi raises on a `copy-on-failure? #t` reshape that needs the copy, where the spec, Gambit and Kaappi return one (seeds 5227, 5248, 5281, 5412; every later error in those chains is the guarded step keeping the previous array). Recorded in the tool's docstring and `docs/dev/testing.md` as a known oracle divergence.

**Second mode: `storage`.** One storage class per case through everything that consults its checker, getter and setter (checker verdicts on boundary and wrong-typed values, `make-specialized-array` with an initial value, `array-set!` directly and through a reversed extract, `array-copy`/`list->array`/`vector->array` from a generic source, `array-assign!` into a view, `storage-class-length`). Values are canonicalized before printing (finite reals as exact rationals, complex as pairs of those, chars as code points) so f16/f32 rounding is compared bit-exactly and Gambit's `.5` never differs textually from Kaappi's `0.5`. `--classes u1,f16` narrows the draw.

| oracle | cases | mismatches |
|---|---|---|
| Gambit, all 16 classes | 400 | 48, every one on c64/c128 and every one **kaappi#2542** |
| Gambit, the other 14 classes (u1, f16, u64 … included) | 120 | 0 |
| chibi, all 16 classes | 100 | 22, all chibi's own (u16 accepts 65536, u64 accepts negatives, unvalidated initial values, c64 accepts reals); Gambit contradicts each, and Gambit's only disagreements with Kaappi on those programs are #2542 |

**#2542** is the mode's first real finding: the reference's c64/c128 checker rejects a real flonum because Gambit's `imag-part` returns an exact `0`, while Kaappi's line-for-line identical checker accepts it because its `imag-part` returns `0.0` (R7RS permits either; the SRFI's "trust the code" rule makes it a Kaappi divergence).

Two more oracle divergences had to be neutralized: Gambit's bundled reference flips `specialized-array-default-safe?` to `#t` against the spec and the SRFI repository's own copy of the same file (the storage prelude pins it to `#f`), and chibi defines a real `f8-storage-class` where the spec allows it (no f8 probe).

Each case is a pure function of (mode, seed); a mismatch is saved with both outputs and the run exits 1, to be reduced and pinned as an ordinary regression test. Not part of `run-all.sh` (needs an oracle, takes minutes). New modes are one generator function each; call/cc under every callback-taking procedure and the spec's prose examples are the planned next ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


