### PR TITLE
Reject bare real flonums in the c64/c128 storage-class checkers

### DIFF
--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -923,7 +923,14 @@ from a functional accumulator — the official suite's own continuation cases
 drive two continuations, each invoked twice — and `tools/srfi231_diff.py`
 (`docs/dev/testing.md`) now generates random view/reshape programs and diffs
 Kaappi against the reference under Gambit, for the properties fixed cases
-cannot see. `array-copy` of a non-specialized
+cannot see. The tester's first find (kaappi#2542) is the imag-part
+convention leaking through the reference's own code: its c64/c128 checker
+is textually `(and (complex? obj) (inexact? (real-part obj)) (inexact?
+(imag-part obj)))`, but Gambit's exact-0 `(imag-part 1.0)` makes it reject
+a bare real flonum that Kaappi's equally R7RS-legal inexact `0.0` accepted
+— so the shipped checker carries an explicit `(not (real? x))`, encoding
+the reference's verdict under either convention (an `1.0+0.0i` with a real
+inexact-zero imaginary part is still accepted). `array-copy` of a non-specialized
 source is therefore the reference's exact shape (reversed list, then a body
 filled by linear position). A specialized source takes the direct fill, as in
 the reference's `%!array-copy` — a deliberate, documented exception: a

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -935,8 +935,8 @@ cannot reach: a mixed-exactness complex (`1+2.0i`,
 `(make-rectangular 1 2.0)`) keeps an exact real part under Gambit, so the
 reference rejects it, while Kaappi's complex representation makes
 exactness contagious — both parts are inexact before any checker runs —
-and accepts it (chibi's `real-part` stays exact like Gambit's, so Kaappi
-is the only lenient side). R7RS-legal on both; if the tester's value pool
+and accepts it (chibi accepts it as well, through a checker that is not
+the reference's). R7RS-legal on both; if the tester's value pool
 ever grows a mixed-exactness literal, the Kaappi-accepts/Gambit-rejects
 verdict it will surface is this known residual, not a new bug.
 `array-copy` of a non-specialized

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -929,8 +929,17 @@ is textually `(and (complex? obj) (inexact? (real-part obj)) (inexact?
 (imag-part obj)))`, but Gambit's exact-0 `(imag-part 1.0)` makes it reject
 a bare real flonum that Kaappi's equally R7RS-legal inexact `0.0` accepted
 — so the shipped checker carries an explicit `(not (real? x))`, encoding
-the reference's verdict under either convention (an `1.0+0.0i` with a real
-inexact-zero imaginary part is still accepted). `array-copy` of a non-specialized
+the reference's verdict under either convention (a `1.0+0.0i` with a real
+inexact-zero imaginary part is still accepted). A residual the checker
+cannot reach: a mixed-exactness complex (`1+2.0i`,
+`(make-rectangular 1 2.0)`) keeps an exact real part under Gambit, so the
+reference rejects it, while Kaappi's complex representation makes
+exactness contagious — both parts are inexact before any checker runs —
+and accepts it (chibi's `real-part` stays exact like Gambit's, so Kaappi
+is the only lenient side). R7RS-legal on both; if the tester's value pool
+ever grows a mixed-exactness literal, the Kaappi-accepts/Gambit-rejects
+verdict it will surface is this known residual, not a new bug.
+`array-copy` of a non-specialized
 source is therefore the reference's exact shape (reversed list, then a body
 filled by linear position). A specialized source takes the direct fill, as in
 the reference's `%!array-copy` — a deliberate, documented exception: a

--- a/lib/srfi/231/storage-classes.sld
+++ b/lib/srfi/231/storage-classes.sld
@@ -129,13 +129,22 @@
 
     ;; fX/cX checkers match the reference exactly: f32/f64 accept only
     ;; inexact reals (flonum?, generic-arrays.scm's f32/f64 checker) and
-    ;; c64/c128 only complexes whose real and imaginary parts are both
-    ;; inexact. Accepting exact values silently coerces them (1/3 stored
-    ;; into c64 narrows to f32 precision), diverging from the reference's
-    ;; "value cannot be stored in body" error (#2355).
+    ;; c64/c128 only proper complexes whose real and imaginary parts are
+    ;; both inexact. Accepting exact values silently coerces them (1/3
+    ;; stored into c64 narrows to f32 precision), diverging from the
+    ;; reference's "value cannot be stored in body" error (#2355). The
+    ;; reference's checker is (and (complex? obj) (inexact? (real-part
+    ;; obj)) (inexact? (imag-part obj))), but under Gambit's exact-0
+    ;; (imag-part 1.0) that rejects a bare real flonum, while Kaappi's
+    ;; inexact 0.0 (also R7RS-legal, 6.2.6 mandates only zero?, not
+    ;; exactness) accepted it -- so (not (real? x)) encodes the
+    ;; reference's verdict independently of the host's imag-part
+    ;; convention; 1.0+0.0i with an explicit inexact zero imaginary part
+    ;; is still accepted (#2542).
     (define (%flonum-checker x) (and (real? x) (inexact? x)))
     (define (%inexact-complex-checker x)
-      (and (complex? x) (inexact? (real-part x)) (inexact? (imag-part x))))
+      (and (complex? x) (not (real? x))
+           (inexact? (real-part x)) (inexact? (imag-part x))))
 
     (define f32-storage-class
       (make-storage-class f32vector-ref f32vector-set! %flonum-checker

--- a/tests/scheme/srfi/srfi231-storage-classes.scm
+++ b/tests/scheme/srfi/srfi231-storage-classes.scm
@@ -1,11 +1,12 @@
-;; SRFI 231 (Intervals and Generalized Arrays) tests -- phase 1b: storage
-;; classes. Arrays themselves are a later phase of this multi-slice SRFI,
-;; tracked under issue #1694; (srfi 231) itself is not yet an importable
-;; bare library.
+;; SRFI 231 (Intervals and Generalized Arrays) tests -- storage classes.
+;; The intervals/arrays/views imports exist only for the end-to-end
+;; array-copy checker assertions below; the storage-class surface itself
+;; needs none of them.
 ;; Run directly: zig-out/bin/kaappi tests/scheme/srfi/srfi231-storage-classes.scm
 
 (import (scheme base) (scheme inexact) (scheme process-context) (srfi 64)
         (srfi 160 u16) (srfi 160 f32) (srfi 160 f64) (srfi 160 c64)
+        (srfi 231 intervals) (srfi 231 arrays) (srfi 231 views)
         (srfi 231 storage-classes))
 
 (test-begin "srfi-231-storage-classes")
@@ -223,6 +224,17 @@
 (test-equal #f ((storage-class-checker c64-storage-class) (make-rectangular 3 4)))
 (test-equal #f ((storage-class-checker c64-storage-class) 1/3))
 (test-equal #f ((storage-class-checker c128-storage-class) (make-rectangular 1/2 2)))
+;; the user-visible symptom of #2542 was array-copy of a real-flonum
+;; array SUCCEEDING -- the generic->typed copy branch is the only copy
+;; path that consults the checker at all (same-class copies skip it,
+;; #2448), so pin it end to end
+(test-assert "array-copy of real flonums into c64 is rejected (#2542)"
+             (guard (e (#t #t))
+               (array-copy (make-array (make-interval '#(2)) (lambda (i) 1.5)) c64-storage-class)
+               #f))
+(test-assert "array-copy of 1.0+0.0i into c64 is accepted (#2542)"
+             (guard (e (#t #f))
+               (array-ref (array-copy (make-array (make-interval '#(2)) (lambda (i) 1.5+0.0i)) c64-storage-class) 0)))
 
 ;;; --- c64/c128 use the reference's interleaved-float representation
 ;;; (#2382): the body is an f32/f64vector of twice the logical length

--- a/tests/scheme/srfi/srfi231-storage-classes.scm
+++ b/tests/scheme/srfi/srfi231-storage-classes.scm
@@ -208,16 +208,18 @@
   (test-equal 2046 nan-patterns))
 
 ;;; --- fX/cX checkers match the reference exactly: inexact reals only
-;;; for f32/f64 (flonum?), inexact-real-part + inexact-imag-part for
-;;; c64/c128 -- exact values were silently coerced (1/3 into c64 lost
-;;; f32 precision) before kaappi#2355 ---
+;;; for f32/f64 (flonum?), proper complexes with inexact real and
+;;; imaginary parts for c64/c128 -- exact values were silently coerced
+;;; (1/3 into c64 lost f32 precision) before kaappi#2355 ---
 (test-equal #t ((storage-class-checker f64-storage-class) 3.5))
 (test-equal #t ((storage-class-checker f64-storage-class) -0.0))
 (test-equal #f ((storage-class-checker f64-storage-class) 3))
 (test-equal #f ((storage-class-checker f64-storage-class) 1/3))
 (test-equal #f ((storage-class-checker f32-storage-class) 42))
 (test-equal #t ((storage-class-checker c64-storage-class) (make-rectangular 3.5 -1.0)))
-(test-equal #t ((storage-class-checker c64-storage-class) 3.5))     ; inexact real: imag-part is 0.0
+(test-equal #t ((storage-class-checker c64-storage-class) 1.0+0.0i)) ; explicit inexact zero imag
+(test-equal #f ((storage-class-checker c64-storage-class) 3.5))     ; bare real: reference rejects (#2542)
+(test-equal #f ((storage-class-checker c128-storage-class) 1.0))    ; same, under the other convention too
 (test-equal #f ((storage-class-checker c64-storage-class) (make-rectangular 3 4)))
 (test-equal #f ((storage-class-checker c64-storage-class) 1/3))
 (test-equal #f ((storage-class-checker c128-storage-class) (make-rectangular 1/2 2)))

--- a/tools/srfi231_diff.py
+++ b/tools/srfi231_diff.py
@@ -58,10 +58,11 @@ value of `specialized-array-default-safe?` to #t (spec and the SRFI
 repository's copy: #f); the storage mode pins it to #f in its prelude.
 kaappi#2542 (the c64/c128 checkers accepted real flonums, which the
 reference rejects) used to surface as `check` mismatches on those two
-classes -- before kaappi#2543 fixed it, the workaround was excluding
-them with `--classes`, and both are back in the default draw. Since a
+classes; before kaappi#2543 fixed it, the workaround was excluding them
+with `--classes`, and both are back in the default draw. Since a
 program's first difference hides everything after it, `--classes` is
-still the way to focus a run on the classes you care about. And chibi 0.12's port raises on a `copy-on-failure? #t`
+still the way to focus a run on the classes you care about.
+And chibi 0.12's port raises on a `copy-on-failure? #t`
 reshape that needs the copy, where the spec (and Gambit, and Kaappi) return a
 copy -- expect that mismatch shape with `--oracle chibi` (seeds 5227 and 5248
 of the reshape mode show it) and confirm against Gambit before chasing it.

--- a/tools/srfi231_diff.py
+++ b/tools/srfi231_diff.py
@@ -56,10 +56,12 @@ Modes
 Known oracle divergences. Gambit's bundled reference flips the initial
 value of `specialized-array-default-safe?` to #t (spec and the SRFI
 repository's copy: #f); the storage mode pins it to #f in its prelude.
-Kaappi's own open divergence kaappi#2542 (c64/c128 checkers accept real
-flonums, the reference rejects them) surfaces as `check` mismatches on those
-two classes; use `--classes` to exclude them until it is fixed, since a
-program's first difference hides everything after it. And chibi 0.12's port raises on a `copy-on-failure? #t`
+kaappi#2542 (the c64/c128 checkers accepted real flonums, which the
+reference rejects) used to surface as `check` mismatches on those two
+classes -- before kaappi#2543 fixed it, the workaround was excluding
+them with `--classes`, and both are back in the default draw. Since a
+program's first difference hides everything after it, `--classes` is
+still the way to focus a run on the classes you care about. And chibi 0.12's port raises on a `copy-on-failure? #t`
 reshape that needs the copy, where the spec (and Gambit, and Kaappi) return a
 copy -- expect that mismatch shape with `--oracle chibi` (seeds 5227 and 5248
 of the reshape mode show it) and confirm against Gambit before chasing it.


### PR DESCRIPTION
Closes #2542

## What

`%inexact-complex-checker` in `lib/srfi/231/storage-classes.sld` gains an
explicit `(not (real? x))`:

```scheme
(define (%inexact-complex-checker x)
  (and (complex? x) (not (real? x))
       (inexact? (real-part x)) (inexact? (imag-part x))))
```

so `((storage-class-checker c64-storage-class) 1.0)` is now `#f`, matching
the reference implementation, while `1.0+0.0i` (explicit inexact zero
imaginary part) is still `#t`.

## Why

The reference's checker is textually `(and (complex? obj) (inexact?
(real-part obj)) (inexact? (imag-part obj)))`, and Kaappi's was that line
verbatim — yet the verdicts differed on every real flonum: Gambit's
`(imag-part 1.0)` is an exact `0`, so the reference rejects `1.0`, while
Kaappi's `imag-part` returns `0.0` (also R7RS-legal; 6.2.6 requires only
`zero?`, not exactness) and the same line accepted it. A program copying
real flonum data into a `c64`/`c128` array succeeded on Kaappi and errored
on the reference. The official suite never caught this because its
c64/c128 fixtures are all proper complex values.

## Verification

- The issue's reproduction script now matches the reference's column on
  every line (bare real rejected, exact complex rejected, `1.0+0.0i` and
  `1.0+2.0i` accepted, `array-copy` of real flonums errors).
- `tools/srfi231_diff.py storage --seed 1 --count 50` against Gambit
  4.9.8: 6 mismatches (seeds 9, 11, 12, 27, 40, 50, all this divergence)
  with the pre-fix binary → **0 mismatches** with this branch. The tool
  previously reported seeds 3/12/27/40 on a slightly earlier generator;
  same mechanism.
- `tests/scheme/srfi/srfi231-*.scm`: all 7 files pass (747 assertions),
  including the updated checker block — the bare-real case now asserts
  rejection, plus new `c128` bare-real and `1.0+0.0i` acceptance cases.
- Official suite `srfi231-official.scm`: 10,936 passed, 0 unexpected
  failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)