### PR TITLE
Add the call/cc mode to the SRFI 231 differential tester

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -391,7 +391,7 @@ under a copy, and stack/append/block/decurry) is driven by the kaappi#2539
 schedule generalized — two continuations captured on the first run at random
 positions, re-invoked with random values in a random order, the whole result
 history printed — with the capture placed either in the source's getter or
-in the callback itself, plus an escape-out variant. Against the pre-#2539
+in the callback itself, plus an escape-out variant. Against the pre-#2540
 library it mismatches on the accumulating families; against main it is
 clean. New modes are one generator function each in `MODES`.
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -382,8 +382,18 @@ wrong-typed values, `make-specialized-array` with an initial value,
 into a view — with every value canonicalized before printing (finite reals
 as exact rationals, complex as pairs of those, chars as code points), so
 f16/f32 rounding is compared bit-exactly and Gambit's `.5` never differs
-textually from Kaappi's `0.5`; `--classes u1,f16` narrows the draw. New
-modes are one generator function each in `MODES`.
+textually from Kaappi's `0.5`; `--classes u1,f16` narrows the draw. The
+`callcc` mode checks the spec's promise that every procedure without a
+trailing `!` is call/cc safe: one accumulating or callback-taking procedure
+per case (`array-copy`, the list/vector conversions, the array and interval
+folds, `array-reduce`, `array-every`/`-any`, `array-for-each`, `array-map`
+under a copy, and stack/append/block/decurry) is driven by the kaappi#2539
+schedule generalized — two continuations captured on the first run at random
+positions, re-invoked with random values in a random order, the whole result
+history printed — with the capture placed either in the source's getter or
+in the callback itself, plus an escape-out variant. Against the pre-#2539
+library it mismatches on the accumulating families; against main it is
+clean. New modes are one generator function each in `MODES`.
 
 The known oracle divergences are recorded in the tool's docstring: Gambit's
 bundled reference flips `specialized-array-default-safe?` to `#t` (the spec

--- a/tools/srfi231_diff.py
+++ b/tools/srfi231_diff.py
@@ -554,12 +554,19 @@ CALLCC_PRELUDE = """\
     (let ((r (collect hook)))
       (set! first-run? #f)
       (set! results (cons r results)))
-    (if (< i (length schedule))
-        (let ((step (list-ref schedule i)))
-          (set! i (+ i 1))
-          (if (= (car step) 1)
-              (if cont1 (cont1 (cdr step)) 'never-captured)
-              (if cont2 (cont2 (cdr step)) 'never-captured))))
+    ;; a step whose continuation was never captured (the walk stopped
+    ;; before its position: array-any past its short-circuit, a reduce
+    ;; seeded from element 0) is skipped, never allowed to end the
+    ;; schedule and starve the steps after it
+    (let loop ()
+      (if (< i (length schedule))
+          (let ((step (list-ref schedule i)))
+            (set! i (+ i 1))
+            (let ((k (if (= (car step) 1) cont1 cont2)))
+              (if k (k (cdr step)) (loop))))))
+    ;; which positions were reached is itself a differential signal: a
+    ;; differing short-circuit point or fold seeding shows up here
+    (show 'captured (and cont1 #t) (and cont2 #t))
     (reverse results)))
 ;; escape variant: the hook throws to a continuation OUTSIDE the
 ;; procedure under test at position p1, then the same procedure is run
@@ -577,7 +584,7 @@ CALLCC_PRELUDE = """\
 # puts the capture in the callback, one that only uses {A} relies on the
 # getter capture. {IV} is the domain, {L} a lambda mapping a multi-index
 # to its linear position (so a capture position means the same thing in
-# every dimension), {N} the volume.
+# every dimension).
 CALLCC_FAMILIES = [
     # capture in the source array's getter
     ("copy", "(array->list* (array-copy {A}))"),
@@ -598,6 +605,11 @@ CALLCC_FAMILIES = [
     # so the hook's value is always bound first
     ("for-each", "(let ((acc '())) (array-for-each (lambda (x) (set! acc (cons x acc))) {A}) (reverse acc))"),
     ("map-copy", "(array->list* (array-copy (array-map (lambda (x) (* 2 x)) {A})))"),
+    # the same source twice: the hook fires twice per position and the later
+    # capture at p1 overwrites the earlier, which is benign only because both
+    # calls carry the same position and + commutes. An implementation that
+    # read a duplicated source once per position would show a re-entry as
+    # (+ v v) rather than (+ v p1) -- that is what a mismatch here means.
     ("map2-copy", "(array->list* (array-copy (array-map + {A} {A})))"),
     ("stack", "(array->list* (array-stack 0 (list {A} (make-array {IV} (lambda idx 99)))))"),
     ("append", "(array->list* (array-append 0 (list {A} (make-array {IV} (lambda idx 99)))))"),
@@ -640,7 +652,7 @@ def gen_callcc(seed, classes=None):
     # the plain source for callback-capturing families
     P = f"(make-array {iv} (lambda idx ({lin} idx)))"
     outer = f"(make-interval {fmt_vec([2] + [1] * (len(shape) - 1))})"
-    body = tmpl.format(A=A, P=P, H="h", IV=iv, L=lin, N=n, OUTER=outer)
+    body = tmpl.format(A=A, P=P, H="h", IV=iv, L=lin, OUTER=outer)
     L = [CALLCC_PRELUDE, f"(define collect (lambda (h) {body}))"]
     L.append(f"(show 'family '{name} 'shape '({' '.join(map(str, shape))}) 'p1 {p1} 'p2 {p2})")
     if rng.random() < 0.2:

--- a/tools/srfi231_diff.py
+++ b/tools/srfi231_diff.py
@@ -91,7 +91,10 @@ printing only the boolean verdict. In the callcc mode chibi's array-copy --
 into a typed storage class, or of an array-map result -- keeps a value
 written by an earlier re-entry across a second continuation: the
 kaappi#2539 shape, a shared scratch behind a call/cc-safe procedure, which
-Gambit and Kaappi (since #2540) rebuild from the captured prefix instead.
+Gambit and Kaappi (since #2540) rebuild from the captured prefix instead;
+its array-fold-right and interval-fold-right accumulate through a set! cell,
+so a re-entry conses onto the whole first run's list. Gambit sides with
+Kaappi on every one of these.
 
 Each case is a pure function of (mode, seed); `--seed N --count K` runs seeds
 N..N+K-1. Mismatches are saved as <save-dir>/<mode>-<seed>.scm with the two

--- a/tools/srfi231_diff.py
+++ b/tools/srfi231_diff.py
@@ -26,8 +26,25 @@ tests/scheme/srfi/, with the seed in the comment so they replay:
     tools/srfi231_diff.py storage --count 400               # all 16 storage classes
     tools/srfi231_diff.py storage --classes u1,f16 --count 200
     tools/srfi231_diff.py storage --count 50 --keep         # keep the work dir
+    tools/srfi231_diff.py callcc --count 300                # continuation re-entry
 
 Modes
+  callcc   Call/cc safety of every accumulating or callback-taking non-!
+           procedure -- the spec's promise that such procedures "do not
+           modify the state of any data captured by a continuation". One
+           procedure per case (array-copy, array->list/vector and their *
+           forms, the array and interval folds, array-reduce, array-every,
+           array-any, array-for-each, array-map under array-copy, and
+           array-stack/append/block/decurry) is driven by the kaappi#2539
+           schedule generalized: two continuations captured on the first
+           run at random positions, then re-invoked with random values in
+           a random order, the whole result history printed at the end.
+           The capture sits either in the source array's getter or in the
+           callback itself (fold kernel, predicate, operator), and an
+           escape-out variant invokes an outer continuation from inside
+           the walk and then runs the procedure again. One re-entry cannot
+           tell a shared accumulator from a functional one; the second
+           can, which is how #2539 passed the official suite's own cases.
   storage  One storage class per case, through everything that consults its
            checker, getter and setter: the checker's verdict on boundary and
            wrong-typed values, make-specialized-array with an initial value,
@@ -502,7 +519,128 @@ def gen_storage(seed, classes=None):
     return "\n".join(L) + "\n"
 
 
-MODES = {"reshape": gen_reshape, "storage": gen_storage}
+# --- the call/cc-mode generator ----------------------------------------------
+
+CALLCC_PRELUDE = """\
+(import (scheme base) (scheme write) (srfi 231))
+(define (show . xs) (for-each (lambda (x) (write x) (display " ")) xs) (newline))
+;; The kaappi#2539 driver, generalized. `collect` is a procedure of one
+;; argument: a hook (lambda (x) ...) that returns x, which the case
+;; threads into the source array's getter or into the callback under
+;; test. On the FIRST run the hook captures its continuation at two
+;; positions; afterwards the schedule re-invokes those continuations with
+;; fresh values in the generated order, and every result the procedure
+;; returned -- first run and each re-entry -- is recorded. All of it is
+;; one procedure body, so a re-entered continuation resumes inside this
+;; frame and never re-executes a top-level form. The schedule index and
+;; the result list are shared mutable state on purpose: that is the
+;; caller's own state, which each re-entry is meant to see.
+(define (drive collect p1 p2 schedule)
+  (let* ((cont1 #f) (cont2 #f) (first-run? #t) (i 0) (results '())
+         (hook (lambda (x)
+                 (call-with-current-continuation
+                  (lambda (c)
+                    (if first-run?
+                        (cond ((= x p1) (set! cont1 c))
+                              ((= x p2) (set! cont2 c))))
+                    x)))))
+    (let ((r (collect hook)))
+      (set! first-run? #f)
+      (set! results (cons r results)))
+    (if (< i (length schedule))
+        (let ((step (list-ref schedule i)))
+          (set! i (+ i 1))
+          (if (= (car step) 1)
+              (if cont1 (cont1 (cdr step)) 'never-captured)
+              (if cont2 (cont2 (cdr step)) 'never-captured))))
+    (reverse results)))
+;; escape variant: the hook throws to a continuation OUTSIDE the
+;; procedure under test at position p1, then the same procedure is run
+;; again with an identity hook -- the escape must not have left it or
+;; its inputs in a state the second run can observe
+(define (escape collect p1)
+  (list (call-with-current-continuation
+         (lambda (k)
+           (collect (lambda (x) (if (= x p1) (k (list 'escaped x)) x)))))
+        (collect (lambda (x) x))))
+"""
+
+# Each family is (name, template). In the template, {A} is the source
+# array expression and {H} the hook; a template that uses {H} directly
+# puts the capture in the callback, one that only uses {A} relies on the
+# getter capture. {IV} is the domain, {L} a lambda mapping a multi-index
+# to its linear position (so a capture position means the same thing in
+# every dimension), {N} the volume.
+CALLCC_FAMILIES = [
+    # capture in the source array's getter
+    ("copy", "(array->list* (array-copy {A}))"),
+    ("copy-typed", "(array->list* (array-copy {A} s32-storage-class))"),
+    ("->list", "(array->list {A})"),
+    ("->vector", "(array->vector {A})"),
+    ("->list*", "(array->list* {A})"),
+    ("->vector*", "(array->vector* {A})"),
+    ("fold-left", "(reverse (array-fold-left (lambda (acc x) (cons x acc)) '() {A}))"),
+    ("fold-right", "(array-fold-right cons '() {A})"),
+    ("reduce", "(array-reduce + {A})"),
+    ("every", "(array-every list {A})"),
+    ("any", "(array-any (lambda (x) (and (>= x 2) (list x))) {A})"),
+    ("for-each", "(let ((acc '())) (array-for-each (lambda (x) (set! acc (cons x acc))) {A}) (reverse acc))"),
+    ("map-copy", "(array->list* (array-copy (array-map (lambda (x) (* 2 x)) {A})))"),
+    ("map2-copy", "(array->list* (array-copy (array-map + {A} {A})))"),
+    ("stack", "(array->list* (array-stack 0 (list {A} (make-array {IV} (lambda idx 99)))))"),
+    ("append", "(array->list* (array-append 0 (list {A} (make-array {IV} (lambda idx 99)))))"),
+    ("block", "(array->list* (array-block (list->array (make-interval '#(2)) (list (array-copy {A}) (array-copy {A})))))"),
+    ("decurry", "(array->list* (array-decurry (list->array (make-interval '#(2)) (list {A} (make-array {IV} (lambda idx 99))))))"),
+    ("interval-fold-left", "(reverse (interval-fold-left (lambda idx ({H} ({L} idx))) (lambda (acc x) (cons x acc)) '() {IV}))"),
+    ("interval-fold-right", "(interval-fold-right (lambda idx ({H} ({L} idx))) cons '() {IV})"),
+    ("interval-for-each", "(let ((acc '())) (interval-for-each (lambda idx (set! acc (cons ({H} ({L} idx)) acc))) {IV}) (reverse acc))"),
+    # capture in the callback, over a plain (non-capturing) array
+    ("kernel-fold-left", "(reverse (array-fold-left (lambda (acc x) (cons ({H} x) acc)) '() {P}))"),
+    ("kernel-fold-right", "(array-fold-right (lambda (x acc) (cons ({H} x) acc)) '() {P})"),
+    ("kernel-reduce", "(array-reduce (lambda (a b) (+ a ({H} b))) {P})"),
+    ("kernel-every", "(array-every (lambda (x) (list ({H} x))) {P})"),
+    ("kernel-any", "(array-any (lambda (x) (let ((y ({H} x))) (and (>= y 2) (list y)))) {P})"),
+    ("kernel-for-each", "(let ((acc '())) (array-for-each (lambda (x) (set! acc (cons ({H} x) acc))) {P}) (reverse acc))"),
+    ("kernel-map-copy", "(array->list* (array-copy (array-map (lambda (x) ({H} x)) {P})))"),
+    ("kernel-interval-fold-left", "(reverse (interval-fold-left (lambda idx ({L} idx)) (lambda (acc x) (cons ({H} x) acc)) '() {IV}))"),
+]
+
+
+def gen_callcc(seed, classes=None):
+    rng = random.Random(seed)
+    # a small domain: 1-D of 4..6, or 2-D 2x2 / 2x3 / 3x2, lower bounds 0
+    shape = rng.choice([[4], [5], [6], [2, 2], [2, 3], [3, 2]])
+    n = 1
+    for w in shape:
+        n *= w
+    iv = f"(make-interval {fmt_vec(shape)})"
+    if len(shape) == 1:
+        lin = "(lambda (idx) (car idx))"
+    else:
+        lin = f"(lambda (idx) (+ (* (car idx) {shape[1]}) (cadr idx)))"
+    p1 = rng.randrange(0, n - 1)
+    p2 = rng.randrange(p1 + 1, n)
+    name, tmpl = rng.choice(CALLCC_FAMILIES)
+    # the getter-capturing source: element = linear position through the hook
+    A = f"(make-array {iv} (lambda idx (h ({lin} idx))))"
+    # the plain source for callback-capturing families
+    P = f"(make-array {iv} (lambda idx ({lin} idx)))"
+    body = tmpl.format(A=A, P=P, H="h", IV=iv, L=lin, N=n)
+    L = [CALLCC_PRELUDE, f"(define collect (lambda (h) {body}))"]
+    L.append(f"(show 'family '{name} 'shape '({' '.join(map(str, shape))}) 'p1 {p1} 'p2 {p2})")
+    if rng.random() < 0.2:
+        L.append(f"(show 'escape (escape collect {p1}))")
+    else:
+        # 3-5 re-invocations, each of a random continuation with a fresh value
+        steps = [(rng.choice([1, 2]), rng.randint(10, 40)) for _ in range(rng.randint(3, 5))]
+        sched = " ".join(f"(cons {c} {v})" for c, v in steps)
+        L.append(f"(show 'schedule '({' '.join(f'({c} {v})' for c, v in steps)}))")
+        L.append(f"(show 'results (drive collect {p1} {p2} (list {sched})))")
+    L.append("(show 'end)")
+    return "\n".join(L) + "\n"
+
+
+MODES = {"reshape": gen_reshape, "storage": gen_storage, "callcc": gen_callcc}
 
 
 # --- running -----------------------------------------------------------------

--- a/tools/srfi231_diff.py
+++ b/tools/srfi231_diff.py
@@ -87,7 +87,11 @@ Its storage classes have checker bugs of their own (u16 accepts 65536, u64
 accepts negatives, c64 accepts a real flonum, make-specialized-array does
 not validate its initial value), all contradicted by Gambit; its u1 checker
 returns a list rather than a boolean, which the storage mode hides by
-printing only the boolean verdict.
+printing only the boolean verdict. In the callcc mode chibi's array-copy --
+into a typed storage class, or of an array-map result -- keeps a value
+written by an earlier re-entry across a second continuation: the
+kaappi#2539 shape, a shared scratch behind a call/cc-safe procedure, which
+Gambit and Kaappi (since #2540) rebuild from the captured prefix instead.
 
 Each case is a pure function of (mode, seed); `--seed N --count K` runs seeds
 N..N+K-1. Mismatches are saved as <save-dir>/<mode>-<seed>.scm with the two
@@ -584,23 +588,30 @@ CALLCC_FAMILIES = [
     ("reduce", "(array-reduce + {A})"),
     ("every", "(array-every list {A})"),
     ("any", "(array-any (lambda (x) (and (>= x 2) (list x))) {A})"),
+    # the for-each families accumulate through a set! cell on the CALLER's
+    # side, which is legitimate -- but (set! acc (cons (h x) acc)) would read
+    # acc before or after the capture depending on the implementation's
+    # argument evaluation order (unspecified by R7RS; chibi is right-to-left),
+    # so the hook's value is always bound first
     ("for-each", "(let ((acc '())) (array-for-each (lambda (x) (set! acc (cons x acc))) {A}) (reverse acc))"),
     ("map-copy", "(array->list* (array-copy (array-map (lambda (x) (* 2 x)) {A})))"),
     ("map2-copy", "(array->list* (array-copy (array-map + {A} {A})))"),
     ("stack", "(array->list* (array-stack 0 (list {A} (make-array {IV} (lambda idx 99)))))"),
     ("append", "(array->list* (array-append 0 (list {A} (make-array {IV} (lambda idx 99)))))"),
-    ("block", "(array->list* (array-block (list->array (make-interval '#(2)) (list (array-copy {A}) (array-copy {A})))))"),
+    # the outer array of blocks must have the pieces' rank: two blocks
+    # stacked along axis 0, so its domain is 2 x 1 x ... x 1
+    ("block", "(array->list* (array-block (list->array {OUTER} (list (array-copy {A}) (array-copy {A})))))"),
     ("decurry", "(array->list* (array-decurry (list->array (make-interval '#(2)) (list {A} (make-array {IV} (lambda idx 99))))))"),
     ("interval-fold-left", "(reverse (interval-fold-left (lambda idx ({H} ({L} idx))) (lambda (acc x) (cons x acc)) '() {IV}))"),
     ("interval-fold-right", "(interval-fold-right (lambda idx ({H} ({L} idx))) cons '() {IV})"),
-    ("interval-for-each", "(let ((acc '())) (interval-for-each (lambda idx (set! acc (cons ({H} ({L} idx)) acc))) {IV}) (reverse acc))"),
+    ("interval-for-each", "(let ((acc '())) (interval-for-each (lambda idx (let ((y ({H} ({L} idx)))) (set! acc (cons y acc)))) {IV}) (reverse acc))"),
     # capture in the callback, over a plain (non-capturing) array
     ("kernel-fold-left", "(reverse (array-fold-left (lambda (acc x) (cons ({H} x) acc)) '() {P}))"),
     ("kernel-fold-right", "(array-fold-right (lambda (x acc) (cons ({H} x) acc)) '() {P})"),
     ("kernel-reduce", "(array-reduce (lambda (a b) (+ a ({H} b))) {P})"),
     ("kernel-every", "(array-every (lambda (x) (list ({H} x))) {P})"),
     ("kernel-any", "(array-any (lambda (x) (let ((y ({H} x))) (and (>= y 2) (list y)))) {P})"),
-    ("kernel-for-each", "(let ((acc '())) (array-for-each (lambda (x) (set! acc (cons ({H} x) acc))) {P}) (reverse acc))"),
+    ("kernel-for-each", "(let ((acc '())) (array-for-each (lambda (x) (let ((y ({H} x))) (set! acc (cons y acc)))) {P}) (reverse acc))"),
     ("kernel-map-copy", "(array->list* (array-copy (array-map (lambda (x) ({H} x)) {P})))"),
     ("kernel-interval-fold-left", "(reverse (interval-fold-left (lambda idx ({L} idx)) (lambda (acc x) (cons ({H} x) acc)) '() {IV}))"),
 ]
@@ -625,7 +636,8 @@ def gen_callcc(seed, classes=None):
     A = f"(make-array {iv} (lambda idx (h ({lin} idx))))"
     # the plain source for callback-capturing families
     P = f"(make-array {iv} (lambda idx ({lin} idx)))"
-    body = tmpl.format(A=A, P=P, H="h", IV=iv, L=lin, N=n)
+    outer = f"(make-interval {fmt_vec([2] + [1] * (len(shape) - 1))})"
+    body = tmpl.format(A=A, P=P, H="h", IV=iv, L=lin, N=n, OUTER=outer)
     L = [CALLCC_PRELUDE, f"(define collect (lambda (h) {body}))"]
     L.append(f"(show 'family '{name} 'shape '({' '.join(map(str, shape))}) 'p1 {p1} 'p2 {p2})")
     if rng.random() < 0.2:


### PR DESCRIPTION
Third mode for `tools/srfi231_diff.py` (#2541, #2543): the spec's promise that every procedure without a trailing `!` is call/cc safe, "does not modify the state of any data captured by a continuation". #2539 showed why a single re-entry cannot check that promise — the official suite's own continuation cases passed over a shared scratch vector — so this mode generalizes the #2539 driver.

**What a case does.** One accumulating or callback-taking procedure per case: `array-copy` (generic and into a typed class), `array->list`/`->vector` and their `*` forms, `array-fold-left`/`-right`, `array-reduce`, `array-every`, `array-any`, `array-for-each`, `array-map` under a copy (one and two sources), `array-stack`/`append`/`block`/`decurry`, and the interval folds and for-each. Two continuations are captured on the first run at random positions of a random 1-D or 2-D domain, then re-invoked 3–5 times with random values in a random order, and the whole result history is compared. The capture sits either in the source array's getter or in the callback itself (fold kernel, predicate, operator), and one case in five is the escape variant: the hook throws to a continuation outside the procedure mid-walk, then the procedure runs again. The driver is one procedure body, so a re-entered continuation resumes inside that frame and never re-executes a top-level form.

**Negative control.** Against the library as it was before #2540 (scratch-vector `array-copy`, `set!`-cell folds) the mode mismatches on 25 of 60 cases, across exactly the families that fix changed: copy, the conversions, both folds, reduce, map under copy, and all four assembly procedures that delegate to `array-copy`.

| oracle | cases | mismatches |
|---|---|---|
| Gambit 4.9.8 (reference) | 400 (seeds 5000..5399) | 0 |
| chibi 0.12 | 100 (seeds 3000..3099) | 21, all chibi's own; Gambit sides with Kaappi on every one of the 21 programs |

**Two generator bugs found by the oracles and fixed in the second commit**, both worth knowing for future modes: `array-block` needs an outer array of the pieces' rank (both implementations rejected my 1-D outer for 2-D pieces; the only "difference" was Gambit printing the error on stdout), and an accumulator written as `(set! acc (cons (h x) acc))` reads `acc` before or after the capture depending on the implementation's argument evaluation order, which R7RS leaves unspecified — chibi's is right-to-left — so the hook's value is now bound first.

**A chibi finding.** Its `array-copy` (into a typed storage class, of an `array-map` result, and under stack/append/block) keeps a value written by an earlier re-entry across a second continuation: the #2539 shape, a shared scratch behind a call/cc-safe procedure. Its `array-fold-right` and `interval-fold-right` accumulate through a `set!` cell, so a re-entry conses onto the whole first run's list — e.g. `(0 1 2 30 1 2 3 4 5)` where Gambit and Kaappi give `(0 1 2 30 4 5)`. Both are the shapes #2540 removed from Kaappi. Recorded in the docstring's divergence list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
