### PR TITLE
Update CodeRabbit's tests/** harness description to SRFI 64

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -106,8 +106,16 @@ reviews:
 
     - path: "tests/**"
       instructions: |
-        Test files. Every bug fix must include a regression test. Scheme tests
-        use either (chibi test) or simple display+newline assertions.
+        Test files. Every bug fix must include a regression test. The
+        standard Scheme harness is (srfi 64) with a name on every
+        test-assert/test-equal — an unnamed failure prints a bare #f — and
+        an (exit 1) epilogue when the runner's fail count is nonzero; that
+        is what tests/scheme/srfi/ uses almost uniformly and what new
+        tests everywhere under tests/scheme/ should use (see
+        tests/scheme/CLAUDE.md). Do not ask a test to drop SRFI 64.
+        Older smoke/ and compliance/ files that predate it may still use
+        display+newline or hand-rolled counters, and tests/scheme/r7rs/
+        uses (chibi test); both are acceptable as-is.
         Check that tests actually exercise the behavior being tested and
         would fail without the corresponding fix.
 


### PR DESCRIPTION
## Why

The `tests/**` path instruction in `.coderabbit.yaml` said Scheme tests use "(chibi test) or simple display+newline assertions". That was stale: 200 of 239 files under `tests/scheme/srfi/` import `(srfi 64)`, `tests/scheme/CLAUDE.md` prescribes it for every new test, and `(chibi test)` is used only by the R7RS suite.

On #2546 CodeRabbit cited the stale text to demand that the new `srfi277.scm` drop SRFI 64 — a false finding produced entirely by the config.

## What

The instruction now names SRFI 64 with a name on every assertion (an unnamed failure prints a bare `#f`, per `docs/dev/testing.md`) plus the `(exit 1)` epilogue as the standard harness, points reviewers at `tests/scheme/CLAUDE.md`, and says outright not to ask a test to drop SRFI 64. Older `smoke/` and `compliance/` files that predate it may still use display+newline or hand-rolled counters, and `tests/scheme/r7rs/` keeps `(chibi test)`; both stay acceptable as-is.

The regression-test-per-bug-fix and must-fail-without-the-fix sentences are unchanged. No edits to `tests/scheme/CLAUDE.md` were needed — it already matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
