### PR TITLE
Report whether a failed REPL pty scenario's output arrives late

### DIFF
--- a/tests/scheme/smoke/repl-mouse-click-2264.sh
+++ b/tests/scheme/smoke/repl-mouse-click-2264.sh
@@ -195,6 +195,34 @@ def send(data):
     os.write(fd, data)
     time.sleep(0.05)
 
+# Issue #2550: when a scenario fails, a 20 s wait that a loaded, Debug-speed
+# runner outran and bytes that were lost look identical in the captured
+# output. Before reporting, keep the pty open and keep pumping for this many
+# more seconds (answering anchor queries as they come, stopping early once
+# everything missing has shown up). The failure line then says which it was:
+# a marker that arrived during the drain is a slow-output flake; one that
+# never arrived is candidate reader byte loss — that report is the issue's
+# escalation criterion, so do not remove it.
+DRAIN_S = 30
+
+def record(failed, expect, mark, needles):
+    produced = seen(mark)
+    missing = [n for n in needles if n not in produced]
+    late, never = [], []
+    if missing:
+        end = time.time() + DRAIN_S
+        while time.time() < end:
+            if all(n in seen(mark) for n in missing):
+                break
+            answer_dsr()
+            if eof:
+                break
+            pump(0.5)
+        final = seen(mark)
+        late = [n for n in missing if n in final]
+        never = [n for n in missing if n not in final]
+    failures.append((failed, expect, produced, late, never))
+
 if not wait_for(b'kaappi> ', 0, 25):
     # Two very different things look alike here, and conflating them is how a
     # test goes quietly green: a REPL that wrote *nothing at all* did not run,
@@ -225,7 +253,7 @@ if scenario == 'ahead':
     ok2 = wait_for(b'\n(9 8)\n', mark, 20)
     idle()
     if not (ok1 and ok2):
-        failures.append((b'ahead', b'3 then (9 8)', seen(mark)))
+        record(b'ahead', b'3 then (9 8)', mark, [b'\n3\n', b'\n(9 8)\n'])
 elif scenario == 'garble':
     # Hostile terminal report (maintainer review, memory safety): a CSI with
     # 40 digits/semicolons not terminated by R, arriving while the DSR
@@ -244,7 +272,7 @@ elif scenario == 'garble':
     ok2 = wait_for(b'\n42\n', mark, 20)
     idle()
     if not (ok1 and ok2):
-        failures.append((b'garble', b'3 then 42 (no crash)', seen(mark)))
+        record(b'garble', b'3 then 42 (no crash)', mark, [b'\n3\n', b'\n42\n'])
 else:
     for send_bytes, echo, clk, editkey, expect, reject in cases:
         mark = len(buf)
@@ -253,7 +281,7 @@ else:
         # and typing on while the REPL is still evaluating puts the bytes in the
         # tty's canonical buffer, where the click then arrives as a literal ESC.
         if not wait_for(echo, mark, 20):
-            failures.append((send_bytes, expect, seen(mark)))
+            record(send_bytes, expect, mark, [echo])
             idle()
             continue
         idle(0.3)
@@ -272,7 +300,7 @@ else:
         # substring check.
         produced = seen(mark)
         if not ok or (reject is not None and (b'\n' + reject + b'\n') in produced):
-            failures.append((send_bytes, expect, produced))
+            record(send_bytes, expect, mark, [b'\n' + expect + b'\n'])
 
 send(b',quit\r')
 while pump(1.0):
@@ -283,8 +311,18 @@ try:
 except OSError:
     pass
 
-for failed, expect, produced in failures:
+for failed, expect, produced, late, never in failures:
     sys.stdout.write('FAIL %r: expected %r in\n%r\n\n' % (failed, expect, produced))
+    if late:
+        sys.stdout.write(
+            'TAIL-CHECK: %r arrived during the %ds drain after the failure'
+            ' — late output on a loaded runner, not lost bytes\n\n'
+            % (late, DRAIN_S))
+    if never:
+        sys.stdout.write(
+            'TAIL-CHECK: %r never arrived, even after %ds more pumping'
+            ' — candidate byte loss in the reader; this is the escalation'
+            ' criterion in issue #2550\n\n' % (never, DRAIN_S))
 sys.exit(1 if failures else 0)
 PY
 

--- a/tests/scheme/smoke/repl-mouse-click-2264.sh
+++ b/tests/scheme/smoke/repl-mouse-click-2264.sh
@@ -241,14 +241,16 @@ def record(failed, expect, mark, needles):
                          ' drain -- late output on a loaded runner, not lost'
                          ' bytes' % (late,))
         if never and eof:
-            # The child is gone: the garble scenario's expected failure mode
-            # is exactly this, so name it instead of claiming a 30 s silence
-            # that never happened. eof, not a flag set inside the loop: the
-            # final pump(0.5) can be the one that observes the exit, after
-            # which the deadline check ends the loop without ever looking.
-            lines.append('TAIL-CHECK: %r never arrived and the REPL exited'
-                         ' during the drain -- not a 30 s silence, see the'
-                         ' buffer above' % (never,))
+            # The child is gone -- during the drain, or already when the
+            # failure was detected (a failed send sets eof too): the garble
+            # scenario's expected failure mode is exactly this, so name it
+            # instead of claiming a 30 s silence that never happened. eof,
+            # not a flag set inside the loop: the final pump(0.5) can be
+            # the one that observes the exit, after which the deadline
+            # check ends the loop without ever looking.
+            lines.append('TAIL-CHECK: %r never arrived; the REPL had exited'
+                         ' by the end of the drain -- not a 30 s silence,'
+                         ' see the buffer above' % (never,))
         if never and not eof:
             # Still missing and the child is alive. Passive pumping cannot
             # separate bytes the reader dropped from a reader wedged shut,
@@ -264,7 +266,12 @@ def record(failed, expect, mark, needles):
             idle(0.3)
             send(b'(+ 40 2)\r')
             pend = time.monotonic() + 5
-            while time.monotonic() < pend:
+            while time.monotonic() < pend and not eof:
+                # not eof, matching the drain loop: a dead master's select
+                # reports readable at once and read raises, so pump returns
+                # immediately -- without the check this loop would spin at
+                # full speed for the remaining seconds and then misreport
+                # an exited REPL as a wedged reader.
                 if b'\n42\n' in seen(p0):
                     break
                 pump(0.5)
@@ -276,6 +283,9 @@ def record(failed, expect, mark, needles):
                 lines.append('PROBE: ctrl-C then (+ 40 2) printed 42 -- the'
                              ' reader is alive; the missing bytes were'
                              ' dropped')
+            elif eof:
+                lines.append('PROBE: the REPL exited during the probe --'
+                             ' see the buffer above')
             else:
                 lines.append('PROBE: no answer to ctrl-C then (+ 40 2)'
                              ' within 5 s -- the reader is wedged, not'

--- a/tests/scheme/smoke/repl-mouse-click-2264.sh
+++ b/tests/scheme/smoke/repl-mouse-click-2264.sh
@@ -151,13 +151,17 @@ def pump(timeout):
 def answer_dsr():
     """Answer every ESC[6n anchor query the child sent, the way a terminal
     emulator would. The child blocks ~400ms waiting, so we answer on sight."""
-    global answered_dsr
+    global answered_dsr, eof
     while True:
         idx = buf.find(b'\x1b[6n', answered_dsr)
         if idx < 0:
             return
         answered_dsr = idx + 4
-        os.write(fd, DSR)
+        try:
+            os.write(fd, DSR)
+        except OSError:
+            eof = True        # the child is gone; same handling as a dead read
+            return
 
 def seen(mark=0):
     """Everything the child has written since *raw* byte `mark`, escapes
@@ -192,7 +196,16 @@ def idle(quiet=0.5, limit=5.0):
             return
 
 def send(data):
-    os.write(fd, data)
+    global eof
+    try:
+        os.write(fd, data)
+    except OSError:
+        # A child that died mid-scenario (the garble case's expected failure
+        # mode) leaves the master unwritable: writing raises EIO. Mark eof,
+        # exactly like a dead read, and let the caller's wait end in the
+        # eof checks — no call site needs a guard of its own.
+        eof = True
+        return
     time.sleep(0.05)
 
 # Issue #2550: when a scenario fails, a 20 s wait that a loaded, Debug-speed
@@ -212,34 +225,31 @@ def record(failed, expect, mark, needles):
     lines = []
     if missing:
         n0 = len(buf)
-        died = False
         end = time.monotonic() + DRAIN_S
         while time.monotonic() < end:
             if all(n in seen(mark) for n in missing):
                 break
             answer_dsr()
             if eof:
-                died = True
                 break
             pump(0.5)
         final = seen(mark)
         late = [n for n in missing if n in final]
         never = [n for n in missing if n not in final]
-        tail = ansi.sub(b'', buf[n0:])
-        if tail:
-            lines.append('DRAIN-TAIL: %r' % (tail,))
         if late:
             lines.append('TAIL-CHECK: %r arrived during the post-failure'
                          ' drain -- late output on a loaded runner, not lost'
                          ' bytes' % (late,))
-        if never and died:
+        if never and eof:
             # The child is gone: the garble scenario's expected failure mode
             # is exactly this, so name it instead of claiming a 30 s silence
-            # that never happened.
+            # that never happened. eof, not a flag set inside the loop: the
+            # final pump(0.5) can be the one that observes the exit, after
+            # which the deadline check ends the loop without ever looking.
             lines.append('TAIL-CHECK: %r never arrived and the REPL exited'
                          ' during the drain -- not a 30 s silence, see the'
                          ' buffer above' % (never,))
-        if never and not died:
+        if never and not eof:
             # Still missing and the child is alive. Passive pumping cannot
             # separate bytes the reader dropped from a reader wedged shut,
             # so probe it: ctrl-C clears whatever open form the editor
@@ -270,6 +280,14 @@ def record(failed, expect, mark, needles):
                 lines.append('PROBE: no answer to ctrl-C then (+ 40 2)'
                              ' within 5 s -- the reader is wedged, not'
                              ' merely lossy')
+        # Everything that arrived after the failure was detected: the drain
+        # and, when the probe ran, its exchange. That output is the evidence
+        # for the verdicts above -- a ctrl-C redraw showing what the buffer
+        # still held, the missing result turning up, or silence -- so print
+        # it rather than discard it.
+        tail = ansi.sub(b'', buf[n0:])
+        if tail:
+            lines.append('DRAIN-TAIL: %r' % (tail,))
     failures.append((failed, expect, produced, lines))
 
 if not wait_for(b'kaappi> ', 0, 25):
@@ -356,17 +374,14 @@ else:
             # #2550 drain would only misreport it as byte loss -- and this
             # is exactly the failure shape a click-mapping or repl.mouse
             # regression produces, the thing this script exists to catch.
-            failures.append((send_bytes, expect, produced, []))
+            failures.append((send_bytes, expect, produced, [
+                'VERDICT: the no-click result %r printed -- the form arrived'
+                ' and was evaluated, the click did not reposition (not a'
+                ' #2550 timing question)' % (reject,)]))
         elif not ok:
             record(send_bytes, expect, mark, [b'\n' + expect + b'\n'])
 
-try:
-    send(b',quit\r')
-except OSError:
-    # A child that died mid-scenario (the garble case's expected failure
-    # mode) leaves the master unwritable: writing raises EIO. The failure
-    # report below is the whole point, so absorb this and carry on.
-    pass
+send(b',quit\r')
 while pump(1.0):
     pass
 try:

--- a/tests/scheme/smoke/repl-mouse-click-2264.sh
+++ b/tests/scheme/smoke/repl-mouse-click-2264.sh
@@ -199,29 +199,78 @@ def send(data):
 # runner outran and bytes that were lost look identical in the captured
 # output. Before reporting, keep the pty open and keep pumping for this many
 # more seconds (answering anchor queries as they come, stopping early once
-# everything missing has shown up). The failure line then says which it was:
+# everything missing has shown up). The verdict lines then say which it was:
 # a marker that arrived during the drain is a slow-output flake; one that
-# never arrived is candidate reader byte loss — that report is the issue's
-# escalation criterion, so do not remove it.
+# never arrived is candidate reader byte loss -- the issue's escalation
+# criterion, so do not remove it. monotonic, not time.time: a wall-clock
+# step must not cut the drain short or stretch it.
 DRAIN_S = 30
 
 def record(failed, expect, mark, needles):
     produced = seen(mark)
     missing = [n for n in needles if n not in produced]
-    late, never = [], []
+    lines = []
     if missing:
-        end = time.time() + DRAIN_S
-        while time.time() < end:
+        n0 = len(buf)
+        died = False
+        end = time.monotonic() + DRAIN_S
+        while time.monotonic() < end:
             if all(n in seen(mark) for n in missing):
                 break
             answer_dsr()
             if eof:
+                died = True
                 break
             pump(0.5)
         final = seen(mark)
         late = [n for n in missing if n in final]
         never = [n for n in missing if n not in final]
-    failures.append((failed, expect, produced, late, never))
+        tail = ansi.sub(b'', buf[n0:])
+        if tail:
+            lines.append('DRAIN-TAIL: %r' % (tail,))
+        if late:
+            lines.append('TAIL-CHECK: %r arrived during the post-failure'
+                         ' drain -- late output on a loaded runner, not lost'
+                         ' bytes' % (late,))
+        if never and died:
+            # The child is gone: the garble scenario's expected failure mode
+            # is exactly this, so name it instead of claiming a 30 s silence
+            # that never happened.
+            lines.append('TAIL-CHECK: %r never arrived and the REPL exited'
+                         ' during the drain -- not a 30 s silence, see the'
+                         ' buffer above' % (never,))
+        if never and not died:
+            # Still missing and the child is alive. Passive pumping cannot
+            # separate bytes the reader dropped from a reader wedged shut,
+            # so probe it: ctrl-C clears whatever open form the editor
+            # holds (the garble scenario's recovery), then a form with an
+            # unambiguous result decides it -- a 42 means the reader works
+            # and the missing bytes were dropped in flight (the issue's
+            # high-priority case); silence means wedged. The probe's output
+            # lands in buf before the next scenario takes its mark, so it
+            # cannot pollute later assertions.
+            p0 = len(buf)
+            send(b'\x03')
+            idle(0.3)
+            send(b'(+ 40 2)\r')
+            pend = time.monotonic() + 5
+            while time.monotonic() < pend:
+                if b'\n42\n' in seen(p0):
+                    break
+                pump(0.5)
+            lines.append('TAIL-CHECK: %r never arrived, even after %ds more'
+                         ' pumping -- candidate byte loss in the reader; this'
+                         ' is the escalation criterion in issue #2550'
+                         % (never, DRAIN_S))
+            if b'\n42\n' in seen(p0):
+                lines.append('PROBE: ctrl-C then (+ 40 2) printed 42 -- the'
+                             ' reader is alive; the missing bytes were'
+                             ' dropped')
+            else:
+                lines.append('PROBE: no answer to ctrl-C then (+ 40 2)'
+                             ' within 5 s -- the reader is wedged, not'
+                             ' merely lossy')
+    failures.append((failed, expect, produced, lines))
 
 if not wait_for(b'kaappi> ', 0, 25):
     # Two very different things look alike here, and conflating them is how a
@@ -299,10 +348,25 @@ else:
         # typed echo of `abc` contains `ab`, which would false-positive a plain
         # substring check.
         produced = seen(mark)
-        if not ok or (reject is not None and (b'\n' + reject + b'\n') in produced):
+        rejected = reject is not None and (b'\n' + reject + b'\n') in produced
+        if rejected:
+            # The REPL evaluated the form and printed the no-click result:
+            # the bytes all arrived and were evaluated, the click just did
+            # not reposition. Nothing can be late or lost here, so the
+            # #2550 drain would only misreport it as byte loss -- and this
+            # is exactly the failure shape a click-mapping or repl.mouse
+            # regression produces, the thing this script exists to catch.
+            failures.append((send_bytes, expect, produced, []))
+        elif not ok:
             record(send_bytes, expect, mark, [b'\n' + expect + b'\n'])
 
-send(b',quit\r')
+try:
+    send(b',quit\r')
+except OSError:
+    # A child that died mid-scenario (the garble case's expected failure
+    # mode) leaves the master unwritable: writing raises EIO. The failure
+    # report below is the whole point, so absorb this and carry on.
+    pass
 while pump(1.0):
     pass
 try:
@@ -311,18 +375,10 @@ try:
 except OSError:
     pass
 
-for failed, expect, produced, late, never in failures:
+for failed, expect, produced, lines in failures:
     sys.stdout.write('FAIL %r: expected %r in\n%r\n\n' % (failed, expect, produced))
-    if late:
-        sys.stdout.write(
-            'TAIL-CHECK: %r arrived during the %ds drain after the failure'
-            ' — late output on a loaded runner, not lost bytes\n\n'
-            % (late, DRAIN_S))
-    if never:
-        sys.stdout.write(
-            'TAIL-CHECK: %r never arrived, even after %ds more pumping'
-            ' — candidate byte loss in the reader; this is the escalation'
-            ' criterion in issue #2550\n\n' % (never, DRAIN_S))
+    for line in lines:
+        sys.stdout.write('%s\n\n' % line)
 sys.exit(1 if failures else 0)
 PY
 


### PR DESCRIPTION
## Summary

Closes #2550.

The `ahead` scenario of `tests/scheme/smoke/repl-mouse-click-2264.sh` failed once on the ubuntu Debug CI job (PR #2549) with the echo of the second form stalled after `(list` — and nothing more in 20 s of continuous pumping plus the idle drain. The issue identifies two candidate causes that the captured failure buffer cannot distinguish:

1. a **timing flake** — a loaded runner plus the ~500x-slower Debug build pushed the echo past the 20 s waits;
2. **genuine loss/stall of type-ahead bytes** in the isocline pushback path (kaappi#2264 patch 5) — which would be `priority: high` as user-reachable input loss.

This PR implements the discriminating observation the issue asks for: when any scenario fails, the driver now keeps the pty open and keeps pumping for **30 more seconds** (still answering `ESC[6n` anchor queries, stopping early once every missing marker has shown up) before reporting. The failure output then gains a one-line `TAIL-CHECK` verdict:

- `arrived during the 30s drain after the failure — late output on a loaded runner, not lost bytes` → it was a slow-output flake;
- `never arrived, even after 30s more pumping — candidate byte loss in the reader; this is the escalation criterion in issue #2550` → raise to `high` and treat as a reader bug.

All failure paths (click cases, off-mode, wrapped-row, `ahead`, `garble`) record through the same check, so the verdict covers every scenario, not only the one that flaked.

## Verification

- All 5 scenarios pass on a ReleaseSafe build and on a Debug build (the CI configuration that flaked).
- Both verdict branches exercised by running extracted driver copies with an unreachable needle (→ `never arrived`) and with a zero-timeout wait on a still-evaluating form (→ `arrived during the drain`).
- `zig build test` passes.

## Checklist

- [x] `zig build test` passes
- [x] `zig fmt --check src/` passes (no Zig changes)
- [x] Scheme test suites pass (`bash tests/scheme/run-all.sh` not needed — driver-only change; the affected script itself passes in full on both build modes)
- [ ] New tests added for new behavior (this *is* test-driver diagnostics; both branches verified manually as above)
- [ ] Documentation updated (if applicable — none needed)
- [x] Commit body explains *why* — release notes are written from it at release time; do not edit `CHANGELOG.md`