### PR TITLE
Implement SRFI 4's homogeneous-vector literal syntax (#2548)

### DIFF
--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -629,8 +629,11 @@ touch points. c64/c128 (complex) elements are stored as two consecutive f32s
 or f64s (real, imag) packed contiguously in the raw byte buffer, decoded into
 a real Kaappi `Complex` only at the `%numeric-vector-ref`/`-set!` boundary;
 multi-byte elements use host-native byte order (`builtin.cpu.arch.endian()`),
-since there is no reader syntax to round-trip and no cross-process
-persistence. Six generic `%`-prefixed primitives in `primitives_srfi160.zig`
+matching the `#TAG(` literal reader (kaappi#2548: SRFI 4's external
+representation, which `read`/`write` must support, plus SRFI 160's optional
+c64/c128 extension) and the `.sbc` constant codec (`TAG_NUMERICVECTOR`) —
+all three halves live in the same binary on the same host. Six generic
+`%`-prefixed primitives in `primitives_srfi160.zig`
 (registered under `.srfi_160_primitives`, the same
 registry-shadows-a-same-named-.sld precedent as `.srfi_237_primitives`) —
 create/predicate/kind/length/ref/set! — are the *entire* native surface; every

--- a/src/bytecode_file.zig
+++ b/src/bytecode_file.zig
@@ -60,7 +60,10 @@ pub const MAGIC = [4]u8{ 'K', 'P', 'B', 'C' };
 /// else stops the reader from parsing an older tail under the new layout. A
 /// bump that only appends header fields may leave `MIN_READ_VERSION` alone,
 /// provided the readers gate the new fields on `ver >=` a named threshold
-/// like `TARGET_FIELDS_SINCE`.
+/// like `TARGET_FIELDS_SINCE`. v14 also gained `TAG_NUMERICVECTOR`
+/// (kaappi#2548) without a bump: additive, and an older same-version reader
+/// that meets tag 19 returns CorruptedFile, which the cache treats as a
+/// plain miss — it misses rather than misreads.
 pub const VERSION: u16 = 14;
 /// Oldest header version this binary reads. v13 files lack the target and
 /// version strings but share v14's tail layout (entry kind, slots, sections),
@@ -146,16 +149,23 @@ pub const TAG_RATIONAL: u8 = 13;
 pub const TAG_COMPLEX: u8 = 14;
 pub const TAG_EOF: u8 = 15;
 pub const TAG_UNDEFINED: u8 = 16;
-/// Back-reference to an already-decoded pair/string/vector/bytevector, by
-/// pre-order first-encounter index (kaappi#2111). This is what lets datum-label
-/// sharing (`'(#1=(1 2) #1#)`) and cyclic literals round-trip as the *same*
-/// object instead of a copy per reference.
+/// Back-reference to an already-decoded pair/string/vector/bytevector/
+/// numeric-vector, by pre-order first-encounter index (kaappi#2111). This is
+/// what lets datum-label sharing (`'(#1=(1 2) #1#)`) and cyclic literals
+/// round-trip as the *same* object instead of a copy per reference.
 pub const TAG_BACKREF: u8 = 17;
 /// A closure (kaappi#1888): a nested function-table reference plus its captured
 /// upvalues. Reached from serialized procedural (`er-macro-transformer`)
 /// transformer `proc`s; an ordinary compiled body never needs it, because a HIT
 /// re-runs the body and recreates its closures against the live environment.
 pub const TAG_CLOSURE: u8 = 18;
+/// SRFI 4/160 homogeneous-vector literal (#s16( ... / #f64( ... / #c128( ...):
+/// an immutability byte, a kind byte (a NumericElementKind discriminant),
+/// a u32 byte length, then the raw element bytes in host-native order — the
+/// same element encoding the heap type and the #TAG( reader already share.
+/// Byte order is host-local by construction: a cache entry or bundle is
+/// consumed by a binary of the same architecture that wrote it.
+pub const TAG_NUMERICVECTOR: u8 = 19;
 
 pub const BytecodeError = error{
     InvalidMagic,

--- a/src/bytecode_file_read.zig
+++ b/src/bytecode_file_read.zig
@@ -108,15 +108,15 @@ fn freePreambleEntries(allocator: std.mem.Allocator, entries: [][]const u8, coun
 // ---------------------------------------------------------------------------
 
 /// Decoded-object table for `TAG_BACKREF` (kaappi#2111): every
-/// pair/string/vector/bytevector is appended at the same pre-order position
-/// the writer assigned its id, so `shared.items[n]` is the object
-/// `TAG_BACKREF n` names. Entries need no rooting of their own: an object is
-/// registered only after being linked into (or while rooted as part of) the
-/// constant under construction, whose spine is rooted, and completed
-/// constants hang off functions rooted in `gc.extra_roots`.
+/// pair/string/vector/bytevector/numeric-vector is appended at the same
+/// pre-order position the writer assigned its id, so `shared.items[n]` is
+/// the object `TAG_BACKREF n` names. Entries need no rooting of their own: an
+/// object is registered only after being linked into (or while rooted as
+/// part of) the constant under construction, whose spine is rooted, and
+/// completed constants hang off functions rooted in `gc.extra_roots`.
 const SharedTable = std.ArrayList(Value);
 
-/// The `1`/`0` immutability byte v11 adds after the tag of the four mutable
+/// The `1`/`0` immutability byte v11 adds after the tag of the mutable
 /// literal types (kaappi#2110). The reader restores `Object.flags.immutable`
 /// so a `set-car!` on a literal raises KP3002 warm exactly as it does cold.
 fn readImmutableByte(r: *Reader) !bool {
@@ -259,10 +259,26 @@ fn readConstantTagged(r: *Reader, gc: *GC, all_funcs: []*Function, shared: *Shar
         },
         bf.TAG_BYTEVECTOR => {
             const immutable = try readImmutableByte(r);
-            const len = try r.readU32();
-            if (len > bf.MAX_BYTEVECTOR_LEN) return BytecodeError.CorruptedFile;
-            const data = try r.readBytes(len);
+            const data_len = try r.readU32();
+            if (data_len > bf.MAX_BYTEVECTOR_LEN) return BytecodeError.CorruptedFile;
+            const data = try r.readBytes(data_len);
             const v = gc.allocBytevector(data) catch return BytecodeError.OutOfMemory;
+            markImmutable(v, immutable);
+            shared.append(gc.allocator, v) catch return BytecodeError.OutOfMemory;
+            return v;
+        },
+        bf.TAG_NUMERICVECTOR => {
+            const immutable = try readImmutableByte(r);
+            const kind_byte = try r.readU8();
+            if (kind_byte >= @typeInfo(types.NumericElementKind).@"enum".fields.len) return BytecodeError.CorruptedFile;
+            const kind: types.NumericElementKind = @enumFromInt(kind_byte);
+            const data_len = try r.readU32();
+            if (data_len > bf.MAX_BYTEVECTOR_LEN) return BytecodeError.CorruptedFile;
+            // A kind's element width must divide the byte count exactly: the
+            // writer only ever emits whole elements.
+            if (data_len % kind.elementWidth() != 0) return BytecodeError.CorruptedFile;
+            const data = try r.readBytes(data_len);
+            const v = gc.allocNumericVector(kind, data) catch return BytecodeError.OutOfMemory;
             markImmutable(v, immutable);
             shared.append(gc.allocator, v) catch return BytecodeError.OutOfMemory;
             return v;

--- a/src/bytecode_file_write.zig
+++ b/src/bytecode_file_write.zig
@@ -220,7 +220,7 @@ fn writeConstant(w: *Writer, allocator: std.mem.Allocator, val: Value, all_funcs
         // (kaappi#2111), so shared structure and cycles read back as the same
         // object, not a fresh copy per reference.
         switch (obj.tag) {
-            .pair, .string, .vector, .bytevector => {
+            .pair, .string, .vector, .bytevector, .numeric_vector => {
                 if (seen.get(@intFromPtr(obj))) |id| {
                     try w.writeU8(allocator, bf.TAG_BACKREF);
                     try w.writeU32(allocator, id);
@@ -310,6 +310,16 @@ fn writeConstant(w: *Writer, allocator: std.mem.Allocator, val: Value, all_funcs
                 try w.writeU8(allocator, immutableByte(obj));
                 try w.writeU32(allocator, @intCast(bv.data.len));
                 try w.writeBytes(allocator, bv.data);
+            },
+            .numeric_vector => {
+                const nv = obj.as(types.NumericVector);
+                if (nv.data.len > bf.MAX_BYTEVECTOR_LEN) return BytecodeError.LimitExceeded;
+                try noteShared(seen, obj);
+                try w.writeU8(allocator, bf.TAG_NUMERICVECTOR);
+                try w.writeU8(allocator, immutableByte(obj));
+                try w.writeU8(allocator, @intFromEnum(nv.kind));
+                try w.writeU32(allocator, @intCast(nv.data.len));
+                try w.writeBytes(allocator, nv.data);
             },
             .bignum => {
                 const bn = obj.as(types.Bignum);

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -823,7 +823,13 @@ pub const Compiler = struct {
             return;
         }
 
-        if (types.isBytevector(expr)) {
+        if (types.isBytevector(expr) or types.isNumericVector(expr)) {
+            // SRFI 4/160 literals reach here as macro EXPANSIONS (the
+            // syntax-rules template's constant output, compiler_macro.zig)
+            // and passthrough IR — code that went through lowerWithMacros
+            // already saw them via ir.zig's own self-evaluating arm, so this
+            // sibling must accept them too or `(lit)` expanding to #s16(1 2)
+            // dies with KP2001 (#2548 review).
             const idx = try self.addConstant(expr);
             try self.emitOp(.load_const);
             try self.emitU16(dst);

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -98,7 +98,8 @@ pub const Node = struct {
     /// separated them. Drives trailing-vs-leading comment placement and
     /// blank-line grouping; ordinary code layout is otherwise reflowed.
     newlines_before: u32 = 0,
-    /// A `#(` / `#u8(` literal, whose first element is data, never an operator.
+    /// A `#(` / `#u8(` / `#s16(`-style homogeneous-vector literal, whose
+    /// first element is data, never an operator.
     is_data: bool = false,
     /// Memoised inline width (see `fmt_print`), so fit checks stay linear.
     inline_width: ?usize = null,
@@ -123,7 +124,7 @@ const max_nesting: u32 = 1024;
 const TokKind = enum {
     lparen,
     rparen,
-    list_open, // "#(" or "#u8("
+    list_open, // "#(" or "#u8("/"#s16("-style vector opens
     atom,
     prefix, // ' ` , ,@ #N=
     datum_comment, // #;
@@ -235,9 +236,22 @@ const Lexer = struct {
             self.pos += 2;
             return .list_open;
         }
-        if (rest.len >= 4 and std.mem.eql(u8, rest[0..4], "#u8(")) {
-            self.pos += 4;
-            return .list_open;
+        // SRFI 4/160 homogeneous-vector opens -- #u8( plus the eleven
+        // NumericElementKind prefixes (#s16(, #f64(, #c128(, ...). The tag
+        // and its '(' are ONE lexeme, a list_open, exactly like #(: the '('
+        // belongs to the literal, so splitting "#s16" off as an atom and
+        // "(1 2)" off as a following list would reflow the program into
+        // something the reader rejects (or reads differently), which the
+        // round-trip check would then refuse.
+        if (rest.len >= 2) {
+            var i: usize = 1;
+            while (i < rest.len and std.ascii.isAlphanumeric(rest[i])) i += 1;
+            if (i >= 2 and i < rest.len and rest[i] == '(' and
+                types.isHomogeneousVectorTag(rest[1..i]))
+            {
+                self.pos += i + 1;
+                return .list_open;
+            }
         }
         // SRFI 207 string-notated bytevector #u8"...": one verbatim lexeme,
         // like the ordinary string it contains-ish -- checked before the

--- a/src/ir.zig
+++ b/src/ir.zig
@@ -621,7 +621,8 @@ pub fn isSpecialForm(name: []const u8) bool {
 pub fn lowerWithMacros(ir: *IR, expr: Value, macros: ?*std.StringHashMap(Value)) CompileError!*Node {
     if (types.isFixnum(expr) or types.isFlonum(expr) or types.isBignum(expr) or
         types.isComplex(expr) or types.isRationalObj(expr) or types.isString(expr) or
-        types.isChar(expr) or types.isVector(expr) or types.isBytevector(expr))
+        types.isChar(expr) or types.isVector(expr) or types.isBytevector(expr) or
+        types.isNumericVector(expr))
     {
         return ir.makeConst(expr);
     }

--- a/src/primitives_srfi160.zig
+++ b/src/primitives_srfi160.zig
@@ -27,8 +27,9 @@
 //! default for both).
 //!
 //! Multi-byte elements are stored in host-native byte order (matching
-//! printer.zig's own numeric-vector display arm) -- there is no reader
-//! syntax to round-trip and no cross-process persistence, so native order
+//! printer.zig's own numeric-vector display arm) -- the #TAG( literal syntax
+//! and the .sbc constant codec both carry kind-tagged raw bytes, and both
+//! halves live in the same binary reading its own output, so native order
 //! avoids needless byte-swaps on big-endian hosts (s390x, ppc64le).
 
 const std = @import("std");
@@ -102,67 +103,6 @@ fn magnitudeAndSign(val: Value) ExactMag {
     return .not_exact;
 }
 
-fn expectSignedInRange(proc: []const u8, val: Value, comptime bits: u7) PrimitiveError!i64 {
-    const ms = switch (magnitudeAndSign(val)) {
-        .fits => |m| m,
-        .too_wide => return argError(proc, "integer does not fit a signed {d}-bit element", .{bits}),
-        .not_exact => return typeError(proc, "exact integer", val),
-    };
-    const shift: u6 = bits - 1;
-    const max_mag_pos: u64 = (@as(u64, 1) << shift) - 1;
-    const max_mag_neg: u64 = @as(u64, 1) << shift;
-    if (ms.positive) {
-        if (ms.mag > max_mag_pos) return argError(proc, "integer does not fit a signed {d}-bit element", .{bits});
-        return @intCast(ms.mag);
-    }
-    if (ms.mag > max_mag_neg) return argError(proc, "integer does not fit a signed {d}-bit element", .{bits});
-    if (ms.mag == max_mag_neg) {
-        // Only reachable when bits == 64 and mag == 2^63 (i64::MIN) -- for
-        // bits < 64, max_mag_neg fits comfortably in a positive i64 already,
-        // so the general path below would work too; this keeps it exact.
-        if (bits == 64) return std.math.minInt(i64);
-        return -@as(i64, @intCast(ms.mag));
-    }
-    return -@as(i64, @intCast(ms.mag));
-}
-
-fn expectUnsignedInRange(proc: []const u8, val: Value, comptime bits: u7) PrimitiveError!u64 {
-    const ms = switch (magnitudeAndSign(val)) {
-        .fits => |m| m,
-        // A negative one is rejected for being negative, not for being wide --
-        // the same reason, and the same message, a negative fixnum gets below.
-        .too_wide => |w| return if (w.positive)
-            argError(proc, "integer does not fit an unsigned {d}-bit element", .{bits})
-        else
-            argError(proc, "negative integer for an unsigned {d}-bit element", .{bits}),
-        .not_exact => return typeError(proc, "exact integer", val),
-    };
-    if (!ms.positive and ms.mag != 0) return argError(proc, "negative integer for an unsigned {d}-bit element", .{bits});
-    const max_mag: u64 = if (bits == 64) std.math.maxInt(u64) else blk: {
-        const shift: u6 = bits;
-        break :blk (@as(u64, 1) << shift) - 1;
-    };
-    if (ms.mag > max_mag) return argError(proc, "integer does not fit an unsigned {d}-bit element", .{bits});
-    return ms.mag;
-}
-
-fn expectReal(proc: []const u8, val: Value) PrimitiveError!f64 {
-    if (types.isFixnum(val) or types.isFlonum(val) or types.isBignum(val) or types.isRationalObj(val)) {
-        return types.toF64(val);
-    }
-    return typeError(proc, "real number", val);
-}
-
-const ComplexParts = struct { re: f64, im: f64 };
-
-fn expectComplexParts(proc: []const u8, val: Value) PrimitiveError!ComplexParts {
-    if (types.isComplex(val)) {
-        const c = types.toComplex(val);
-        return .{ .re = try expectReal(proc, c.real), .im = try expectReal(proc, c.imag) };
-    }
-    return .{ .re = try expectReal(proc, val), .im = 0.0 };
-}
-
 fn makeExactFromI64(gc: *memory.GC, n: i64) PrimitiveError!Value {
     const fixnum_min: i64 = -(@as(i64, 1) << 47);
     const fixnum_max: i64 = (@as(i64, 1) << 47) - 1;
@@ -182,34 +122,151 @@ fn makeExactFromU64(gc: *memory.GC, n: u64) PrimitiveError!Value {
 // Encode (Value -> element bytes) / decode (element bytes -> Value)
 // ---------------------------------------------------------------------------
 
-fn encodeElement(proc: []const u8, kind: NumericElementKind, val: Value, out: []u8) PrimitiveError!void {
+/// The typed failure reasons of element coercion. The pure core
+/// (`encodeElementRaw`) answers only with these -- the reader's #TAG(
+/// literal syntax shares it and must not touch the VM error-detail channel
+/// a primitive failure would write (a stale detail set during reading
+/// would otherwise leak into an unrelated runtime error's report). The
+/// primitive-shaped wrapper (`encodeElement`) maps the same reasons onto
+/// typeError/argError. ONE range/exactness table serves both callers, so a
+/// literal and a constructor can never disagree about what an element is.
+pub const ElementCoerceError = error{
+    not_a_number,
+    not_exact_integer,
+    not_real,
+    out_of_range,
+    negative_unsigned,
+};
+
+fn signedElement(val: Value, comptime bits: u7) ElementCoerceError!i64 {
+    const ms = switch (magnitudeAndSign(val)) {
+        .fits => |m| m,
+        .too_wide => return error.out_of_range,
+        .not_exact => return error.not_exact_integer,
+    };
+    const shift: u6 = bits - 1;
+    const max_mag_pos: u64 = (@as(u64, 1) << shift) - 1;
+    const max_mag_neg: u64 = @as(u64, 1) << shift;
+    if (ms.positive) {
+        if (ms.mag > max_mag_pos) return error.out_of_range;
+        return @intCast(ms.mag);
+    }
+    if (ms.mag > max_mag_neg) return error.out_of_range;
+    if (ms.mag == max_mag_neg) {
+        // Only reachable when bits == 64 and mag == 2^63 (i64::MIN) -- for
+        // bits < 64, max_mag_neg fits comfortably in a positive i64 already,
+        // so the general path below would work too; this keeps it exact.
+        if (bits == 64) return std.math.minInt(i64);
+        return -@as(i64, @intCast(ms.mag));
+    }
+    return -@as(i64, @intCast(ms.mag));
+}
+
+fn unsignedElement(val: Value, comptime bits: u7) ElementCoerceError!u64 {
+    const ms = switch (magnitudeAndSign(val)) {
+        .fits => |m| m,
+        // A negative multi-limb bignum is rejected for being negative, not
+        // for being wide -- the same reason, and the same mapped failure, a
+        // negative fixnum gets below.
+        .too_wide => |w| return if (w.positive) error.out_of_range else error.negative_unsigned,
+        .not_exact => return error.not_exact_integer,
+    };
+    if (!ms.positive and ms.mag != 0) return error.negative_unsigned;
+    const max_mag: u64 = if (bits == 64) std.math.maxInt(u64) else blk: {
+        const shift: u6 = bits;
+        break :blk (@as(u64, 1) << shift) - 1;
+    };
+    if (ms.mag > max_mag) return error.out_of_range;
+    return ms.mag;
+}
+
+fn realElement(val: Value) ElementCoerceError!f64 {
+    if (types.isComplex(val)) return error.not_real;
+    if (types.isFixnum(val) or types.isFlonum(val) or types.isBignum(val) or types.isRationalObj(val)) {
+        return types.toF64(val);
+    }
+    return error.not_a_number;
+}
+
+const ComplexParts = struct { re: f64, im: f64 };
+
+fn complexElementParts(val: Value) ElementCoerceError!ComplexParts {
+    if (types.isComplex(val)) {
+        const c = types.toComplex(val);
+        return .{ .re = try realElement(c.real), .im = try realElement(c.imag) };
+    }
+    return .{ .re = try realElement(val), .im = 0.0 };
+}
+
+/// Pure Value -> element bytes: no VM state, no error details. Shared by
+/// `%numeric-vector-set!` (through `encodeElement`) and the reader's #TAG(
+/// literal syntax (reader_datum.zig's readNumericVector), so a literal and a
+/// constructor call can never disagree about what an element may be.
+pub fn encodeElementRaw(kind: NumericElementKind, val: Value, out: []u8) ElementCoerceError!void {
     switch (kind) {
-        .s8 => out[0] = @bitCast(@as(i8, @intCast(try expectSignedInRange(proc, val, 8)))),
-        .u16 => std.mem.writeInt(u16, out[0..2], @intCast(try expectUnsignedInRange(proc, val, 16)), native_endian),
-        .s16 => std.mem.writeInt(i16, out[0..2], @intCast(try expectSignedInRange(proc, val, 16)), native_endian),
-        .u32 => std.mem.writeInt(u32, out[0..4], @intCast(try expectUnsignedInRange(proc, val, 32)), native_endian),
-        .s32 => std.mem.writeInt(i32, out[0..4], @intCast(try expectSignedInRange(proc, val, 32)), native_endian),
-        .u64 => std.mem.writeInt(u64, out[0..8], try expectUnsignedInRange(proc, val, 64), native_endian),
-        .s64 => std.mem.writeInt(i64, out[0..8], try expectSignedInRange(proc, val, 64), native_endian),
+        .s8 => out[0] = @bitCast(@as(i8, @intCast(try signedElement(val, 8)))),
+        .u16 => std.mem.writeInt(u16, out[0..2], @intCast(try unsignedElement(val, 16)), native_endian),
+        .s16 => std.mem.writeInt(i16, out[0..2], @intCast(try signedElement(val, 16)), native_endian),
+        .u32 => std.mem.writeInt(u32, out[0..4], @intCast(try unsignedElement(val, 32)), native_endian),
+        .s32 => std.mem.writeInt(i32, out[0..4], @intCast(try signedElement(val, 32)), native_endian),
+        .u64 => std.mem.writeInt(u64, out[0..8], try unsignedElement(val, 64), native_endian),
+        .s64 => std.mem.writeInt(i64, out[0..8], try signedElement(val, 64), native_endian),
         .f32 => {
-            const f = try expectReal(proc, val);
+            const f = try realElement(val);
             std.mem.writeInt(u32, out[0..4], @bitCast(@as(f32, @floatCast(f))), native_endian);
         },
         .f64 => {
-            const f = try expectReal(proc, val);
+            const f = try realElement(val);
             std.mem.writeInt(u64, out[0..8], @bitCast(f), native_endian);
         },
         .c64 => {
-            const parts = try expectComplexParts(proc, val);
+            const parts = try complexElementParts(val);
             std.mem.writeInt(u32, out[0..4], @bitCast(@as(f32, @floatCast(parts.re))), native_endian);
             std.mem.writeInt(u32, out[4..8], @bitCast(@as(f32, @floatCast(parts.im))), native_endian);
         },
         .c128 => {
-            const parts = try expectComplexParts(proc, val);
+            const parts = try complexElementParts(val);
             std.mem.writeInt(u64, out[0..8], @bitCast(parts.re), native_endian);
             std.mem.writeInt(u64, out[8..16], @bitCast(parts.im), native_endian);
         },
     }
+}
+
+fn kindIsUnsigned(kind: NumericElementKind) bool {
+    return switch (kind) {
+        .u16, .u32, .u64 => true,
+        else => false,
+    };
+}
+
+fn kindIntegerBits(kind: NumericElementKind) u7 {
+    return switch (kind) {
+        .s8 => 8,
+        .u16, .s16 => 16,
+        .u32, .s32, .f32, .c64 => 32,
+        .u64, .s64, .f64, .c128 => 64,
+    };
+}
+
+/// The primitive-shaped wrapper: same coercion as `encodeElementRaw`, with
+/// the typed failure reasons mapped onto the typeError/argError reports a
+/// `%`-primitive caller expects. The messages match the pre-refactor ones
+/// exactly, including kaappi#1916's too-wide-vs-not-exact distinction.
+pub fn encodeElement(proc: []const u8, kind: NumericElementKind, val: Value, out: []u8) PrimitiveError!void {
+    encodeElementRaw(kind, val, out) catch |err| switch (err) {
+        error.not_a_number, error.not_exact_integer => switch (kind) {
+            .f32, .f64, .c64, .c128 => return typeError(proc, "real number", val),
+            else => return typeError(proc, "exact integer", val),
+        },
+        error.not_real => return typeError(proc, "real number", val),
+        error.negative_unsigned => return argError(proc, "negative integer for an unsigned {d}-bit element", .{kindIntegerBits(kind)}),
+        error.out_of_range => {
+            if (kindIsUnsigned(kind)) {
+                return argError(proc, "integer does not fit an unsigned {d}-bit element", .{kindIntegerBits(kind)});
+            }
+            return argError(proc, "integer does not fit a signed {d}-bit element", .{kindIntegerBits(kind)});
+        },
+    };
 }
 
 fn decodeElement(gc: *memory.GC, kind: NumericElementKind, bytes: []const u8) PrimitiveError!Value {
@@ -304,6 +361,12 @@ fn numericVectorRefFn(args: []const Value) PrimitiveError!Value {
 fn numericVectorSetFn(args: []const Value) PrimitiveError!Value {
     if (!types.isNumericVector(args[0])) return typeError("%numeric-vector-set!", "numeric-vector", args[0]);
     const nv = asNumericVector(args[0]);
+    // A #TAG( literal reads back immutable, exactly like #u8( and #(...)
+    // literals — set-car!/bytevector-u8-set! on a literal raise, so
+    // TAGvector-set! must too. The message names the kind ("immutable
+    // s16vector") so the user knows which literal they hit.
+    if (types.toObject(args[0]).flags.immutable)
+        return argError("%numeric-vector-set!", "cannot mutate an immutable {s}vector", .{@tagName(nv.kind)});
     if (!types.isFixnum(args[1])) return typeError("%numeric-vector-set!", "exact integer", args[1]);
     const raw_idx = types.toFixnum(args[1]);
     const width = nv.kind.elementWidth();

--- a/src/printer.zig
+++ b/src/printer.zig
@@ -5,10 +5,11 @@ const reader_mod = @import("reader.zig");
 const Value = types.Value;
 
 /// Numeric vectors store multi-byte elements in host-native byte order --
-/// there's no reader syntax to round-trip and no cross-process persistence
-/// (bytecode serialization is out of scope, see docs/dev/srfi-exclusions
-/// equivalent notes), so native order avoids needless byte-swaps on
-/// big-endian hosts (s390x, ppc64le) for zero portability cost.
+/// the #TAG( literal reader (reader_datum.zig) and the .sbc constant codec
+/// go through the same encoder the (srfi 160 <tag>) constructors use, and
+/// all three live in the same binary on the same host, so native order
+/// avoids needless byte-swaps on big-endian hosts (s390x, ppc64le) for zero
+/// portability cost.
 const native_endian = builtin.cpu.arch.endian();
 
 pub const PrintMode = enum {
@@ -633,12 +634,19 @@ fn printValueOnce(
             },
             .numeric_vector => {
                 const nv = obj.as(types.NumericVector);
-                try writer.print("#<{s}vector", .{@tagName(nv.kind)});
+                // SRFI 4's external representation, which both read and write
+                // must support: #s16(1 2 3), #f64(-1.5), and SRFI 160's
+                // #c64(1.5+0.0i) extension. Elements print exactly as the
+                // decoder would return them, so write's output is the
+                // read-identical literal — which the native tier's
+                // constant embedding (print + re-read at runtime) also
+                // relies on.
+                try writer.print("#{s}(", .{@tagName(nv.kind)});
                 const width = nv.kind.elementWidth();
                 var buf: [64]u8 = undefined;
                 var i: usize = 0;
                 while (i < nv.data.len) : (i += width) {
-                    try writer.writeByte(' ');
+                    if (i > 0) try writer.writeByte(' ');
                     switch (nv.kind) {
                         .s8 => try writer.print("{d}", .{@as(i8, @bitCast(nv.data[i]))}),
                         .u16 => try writer.print("{d}", .{std.mem.readInt(u16, nv.data[i..][0..2], native_endian)}),
@@ -671,7 +679,7 @@ fn printValueOnce(
                         },
                     }
                 }
-                try writer.writeByte('>');
+                try writer.writeByte(')');
             },
             .promise => {
                 try writer.writeAll("#<promise>");
@@ -984,7 +992,13 @@ fn isInfComponent(v: Value) bool {
     return types.isFlonum(v) and std.math.isInf(types.toFlonum(v));
 }
 
-pub fn formatFlonum(buf: []u8, f: f64) []const u8 {
+/// Format an inexact element the way `read` accepts it. Generic over f32/f64
+/// deliberately: a numeric-vector f32 element formats at F32 precision (the
+/// shortest decimal that round-trips the stored bits), not the f64 promotion
+/// of it — `#f32(0.1)`, not `#f32(0.10000000149011612)`. Both round-trip
+/// bit-exactly through the reader's f64-parse-then-narrow, but the f32 form
+/// is what every other Scheme writes.
+pub fn formatFlonum(buf: []u8, f: anytype) []const u8 {
     if (std.math.isNan(f)) return "+nan.0";
     if (std.math.isInf(f)) return if (f > 0) "+inf.0" else "-inf.0";
 
@@ -1061,7 +1075,7 @@ pub fn formatFlonum(buf: []u8, f: f64) []const u8 {
 /// NaN/Inf/signbit handling below -- unlike a standalone `Complex` Value,
 /// a numeric-vector element is always inexact, so this always calls
 /// `formatFlonum` directly rather than `formatComplexPart`.
-fn writeImaginaryPart(writer: anytype, buf: []u8, im: f64) !void {
+fn writeImaginaryPart(writer: anytype, buf: []u8, im: anytype) !void {
     if (std.math.isNan(im)) {
         try writer.writeAll("+nan.0i");
     } else if (std.math.isInf(im)) {

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -47,7 +47,7 @@ pub fn resetReadErrorDetail() void {
 /// writer directly and read back exactly how much it actually wrote -- same
 /// pattern as `compiler.formatSyntaxError`. The result is a cleanly truncated
 /// prefix of the intended message, never a partially-overwritten buffer.
-fn setReadErrorDetail(comptime fmt: []const u8, args: anytype) void {
+pub fn setReadErrorDetail(comptime fmt: []const u8, args: anytype) void {
     var w: std.Io.Writer = .fixed(&read_error_detail);
     w.print(fmt, args) catch {};
     read_error_detail_len = w.buffered().len;
@@ -63,6 +63,10 @@ pub const Token = union(enum) {
     comma_at,
     hash_lparen,
     hash_u8_lparen,
+    /// SRFI 4/160 homogeneous-vector literal, #TAG(: the datum constructor
+    /// reads elements through the same encodeElement the (srfi 160 <tag>)
+    /// constructors use, so a literal and a constructor can never disagree.
+    hash_numvec_lparen: types.NumericElementKind,
     boolean: bool,
     fixnum: i64,
     flonum: f64,

--- a/src/reader_datum.zig
+++ b/src/reader_datum.zig
@@ -114,6 +114,7 @@ fn tokenToValue(self: *Reader, tok: Token) ReadError!Value {
         .comma_at => return readAbbreviation(self, "unquote-splicing"),
         .hash_lparen => return readVector(self),
         .hash_u8_lparen => return readBytevector(self),
+        .hash_numvec_lparen => |kind| return readNumericVector(self, kind),
         .datum_label_def => |n| {
             if (n >= self.labels.len) return ReadError.InvalidNumber;
             // Pre-allocate a placeholder pair for circular references.
@@ -344,6 +345,31 @@ fn patchPlaceholder(gc: *memory.GC, datum: Value, placeholder: Value) error{OutO
     }
 }
 
+/// One element of a `#u8(` / `#TAG(` homogeneous-vector literal: the next
+/// token, converted by the same datum constructor readDatum uses, but
+/// WITHOUT the per-datum depth increment — a literal's elements are lexical
+/// parts of the enclosing datum, not nested datums, so a #u8( leaf under
+/// 1023 plain parens reads and one under 1024 is NestingTooDeep, exactly as
+/// for a plain atom (the "nested homogeneous-vector literals pay the depth
+/// gate" test in tests_reader_incremental.zig pins the boundary). The one
+/// exception is a
+/// compound element — a nested `#u8(`/#TAG( literal — which recurses into
+/// another literal loop, so it pays the depth gate exactly once; without
+/// it, `#s8(` nested 2000 deep would recurse unboundedly on the native
+/// stack instead of reporting NestingTooDeep.
+fn readElementValue(self: *Reader) ReadError!Value {
+    const tok = try self.nextToken();
+    switch (tok) {
+        .hash_u8_lparen, .hash_numvec_lparen => {
+            if (self.depth >= Reader.MAX_NESTING_DEPTH) return ReadError.NestingTooDeep;
+            self.depth += 1;
+            defer self.depth -= 1;
+            return tokenToValue(self, tok);
+        },
+        else => return tokenToValue(self, tok),
+    }
+}
+
 fn readBytevector(self: *Reader) ReadError!Value {
     var bytes: std.ArrayList(u8) = .empty;
     defer bytes.deinit(self.gc.allocator);
@@ -355,17 +381,82 @@ fn readBytevector(self: *Reader) ReadError!Value {
             self.pos += 1;
             break;
         }
-        const tok = try self.nextToken();
-        switch (tok) {
-            .fixnum => |n| {
-                if (n < 0 or n > 255) return ReadError.InvalidNumber;
-                bytes.append(self.gc.allocator, @intCast(@as(u64, @bitCast(n)))) catch return ReadError.OutOfMemory;
-            },
-            else => return ReadError.UnexpectedChar,
+        // SRFI 4 (kaappi#2548): the u8vector is one of its ten kinds, and the
+        // spec's own example -- #u8(0 #e1e2 #xff) -- writes elements in full
+        // integer syntax, so accept any exact integer 0..255. Elements are
+        // read token-level (nextToken + tokenToValue, no datum nesting), so
+        // they do not count toward the reader's depth limit -- a #u8( leaf
+        // under 1023 plain parens reads and one under 1024 is
+        // NestingTooDeep, pinned by the depth-gate test in
+        // tests_reader_incremental.zig. Anything not in 0..255 is a read
+        // error, as the R7RS bytevector grammar demands.
+        const elem = try readElementValue(self);
+        // No root needed: nothing between here and the rejection/accept
+        // decision allocates (toFixnum and two compares), and the buffer
+        // growth below happens only after elem is dead.
+        const is_byte = types.isFixnum(elem) and
+            types.toFixnum(elem) >= 0 and types.toFixnum(elem) <= 255;
+        const n: i64 = if (is_byte) types.toFixnum(elem) else 0;
+        if (!is_byte) {
+            reader_mod.setReadErrorDetail("bad element for #u8(...): expected an exact integer in 0..255", .{});
+            return ReadError.InvalidNumber;
         }
+        bytes.append(self.gc.allocator, @intCast(n)) catch return ReadError.OutOfMemory;
     }
 
     const bv = self.gc.allocBytevector(bytes.items) catch return ReadError.OutOfMemory;
     if (self.mark_immutable) types.toObject(bv).flags.immutable = true;
     return bv;
+}
+
+/// SRFI 4/160 homogeneous-vector literal: #s8( ... #u16( ... #f64( ... and
+/// SRFI 160's #c64(/#c128(. Elements use full number syntax — the spec's own
+/// example is #u8(0 #e1e2 #xff) — and are read token-level (no datum
+/// nesting), like the bytevector literal's elements, then validated/coerced
+/// by the very encodeElementRaw the (srfi 160 <tag>) constructors use, making
+/// a literal and a constructor call inseparable in what they accept. A
+/// literal is immutable like #u8( and #(... literals.
+fn readNumericVector(self: *Reader, kind: types.NumericElementKind) ReadError!Value {
+    const srfi160 = @import("primitives_srfi160.zig");
+    const tag_name = @tagName(kind);
+    var data: std.ArrayList(u8) = .empty;
+    defer data.deinit(self.gc.allocator);
+    const width = kind.elementWidth();
+
+    while (true) {
+        try self.skipWhitespaceAndCommentsChecked();
+        if (self.pos >= self.source.len) return ReadError.UnexpectedEof;
+        if (self.source[self.pos] == ')') {
+            self.pos += 1;
+            break;
+        }
+        const elem = try readElementValue(self);
+        // Cheap insurance around the coercion: nothing in this window
+        // collects today (ArrayList.resize on the GC allocator bypasses
+        // maybeCollect, and encodeElementRaw never allocates), but the
+        // push/pop costs nothing and roots elem if that ever changes.
+        var elem_root = elem;
+        self.gc.pushRoot(&elem_root);
+        const old_len = data.items.len;
+        data.resize(self.gc.allocator, old_len + width) catch {
+            self.gc.popRoot();
+            return ReadError.OutOfMemory;
+        };
+        const encoded = srfi160.encodeElementRaw(kind, elem, data.items[old_len..]);
+        self.gc.popRoot();
+        encoded catch |err| switch (err) {
+            error.not_a_number => {
+                reader_mod.setReadErrorDetail("not a number in #{s}(...) literal", .{tag_name});
+                return ReadError.UnexpectedChar;
+            },
+            else => {
+                reader_mod.setReadErrorDetail("bad element for #{s}(...): the value cannot be stored in a {s}vector", .{ tag_name, tag_name });
+                return ReadError.InvalidNumber;
+            },
+        };
+    }
+
+    const nv = self.gc.allocNumericVector(kind, data.items) catch return ReadError.OutOfMemory;
+    if (self.mark_immutable) types.toObject(nv).flags.immutable = true;
+    return nv;
 }

--- a/src/reader_tokens.zig
+++ b/src/reader_tokens.zig
@@ -796,6 +796,28 @@ fn readNumberPrefixed(self: *Reader, radix0: u8, exact0: ?bool) ReadError!Token 
     }
 }
 
+/// What the token after `#` may name as a homogeneous-vector literal.
+/// `bytevector` is `u8` — the R7RS bytevector form, reading to a plain
+/// Bytevector; every other prefix reads to a NumericVector of that element
+/// kind (SRFI 4's ten kinds plus SRFI 160's optional c64/c128 extension).
+const HomogeneousVectorPrefix = union(enum) {
+    bytevector,
+    numeric_vector: types.NumericElementKind,
+};
+
+/// The fixed prefix table of the `#TAG(` homogeneous-vector literals. All
+/// eleven non-u8 kinds route through NumericElementKind, so the literal and
+/// the `(srfi 160 <tag>)` constructors can never disagree about an element;
+/// the name set is types.isHomogeneousVectorTag, shared with the fmt/REPL
+/// lexeme layers.
+fn homogeneousVectorPrefix(word: []const u8) ?HomogeneousVectorPrefix {
+    if (std.mem.eql(u8, word, "u8")) return .bytevector;
+    if (types.isHomogeneousVectorTag(word)) {
+        return .{ .numeric_vector = std.meta.stringToEnum(types.NumericElementKind, word).? };
+    }
+    return null;
+}
+
 pub fn readHash(self: *Reader) ReadError!Token {
     self.pos += 1; // skip #
     if (self.pos >= self.source.len) return ReadError.UnexpectedEof;
@@ -820,48 +842,53 @@ pub fn readHash(self: *Reader) ReadError!Token {
                 return ReadError.UnexpectedChar;
             return .{ .boolean = true };
         },
-        'f' => {
-            self.pos += 1;
-            if (self.pos < self.source.len and std.ascii.isAlphabetic(self.source[self.pos])) {
-                const start = self.pos - 1;
-                while (self.pos < self.source.len and std.ascii.isAlphabetic(self.source[self.pos])) {
-                    self.pos += 1;
-                }
-                if (self.truncatedHere()) return ReadError.UnexpectedEof;
-                const word = self.source[start..self.pos];
-                if (!std.mem.eql(u8, word, "false")) return ReadError.UnexpectedChar;
-            }
-            if (self.truncatedHere()) return ReadError.UnexpectedEof;
-            if (self.pos < self.source.len and !Reader.isDelimiter(self.source[self.pos]))
-                return ReadError.UnexpectedChar;
-            return .{ .boolean = false };
-        },
         '\\' => return readCharacter(self),
         '"' => return readRawString(self), // SRFI 267 raw string: #"X"..."X"
         '(' => {
             self.pos += 1;
             return .hash_lparen;
         },
-        'u' => {
-            // #u8( bytevector literal, or SRFI 207's #u8"..." string-
-            // notated form.
-            if (self.pos + 2 < self.source.len and self.source[self.pos + 1] == '8') {
-                if (self.source[self.pos + 2] == '(') {
-                    self.pos += 3;
-                    return .hash_u8_lparen;
-                }
-                if (self.source[self.pos + 2] == '"') {
-                    self.pos += 2;
-                    return readByteStringLiteral(self);
-                }
+        'u', 's', 'f', 'c' => {
+            // SRFI 4's homogeneous-vector literals (#u8(, #s16(, #f64(, ...)
+            // and SRFI 160's extension of the same shape to #c64(/#c128(:
+            // a fixed lowercase alphanumeric prefix directly followed by '('.
+            // 'u8' stays the R7RS bytevector form (hash_u8_lparen) and
+            // #u8"..." is SRFI 207's string-notated bytevector; the same arm
+            // also serves the boolean #f/#false, which the prefix match must
+            // not swallow.
+            const word_start = self.pos;
+            while (self.pos < self.source.len and std.ascii.isAlphanumeric(self.source[self.pos])) {
+                self.pos += 1;
             }
-            // "#u" or "#u8" cut at end-of-slice may still become #u8( or
-            // #u8" once the next chunk arrives (#1940). "#u<other>" is a
-            // real error regardless of what follows.
-            if (self.incomplete_input and
-                (self.pos + 1 >= self.source.len or
-                    (self.source[self.pos + 1] == '8' and self.pos + 2 >= self.source.len)))
-                return ReadError.UnexpectedEof;
+            const word = self.source[word_start..self.pos];
+            if (std.mem.eql(u8, word, "f") or std.mem.eql(u8, word, "false")) {
+                if (self.pos >= self.source.len) {
+                    // A cut "#f"/"#false" may still gain its delimiter (and
+                    // "#f" grow into "#false" or "#f32(") in the next chunk
+                    // (#1940); a true end-of-input is a complete boolean.
+                    if (self.truncatedHere()) return ReadError.UnexpectedEof;
+                    return .{ .boolean = false };
+                }
+                if (!Reader.isDelimiter(self.source[self.pos])) return ReadError.UnexpectedChar;
+                return .{ .boolean = false };
+            }
+            // Any other cut run may still complete into a prefix (#1940).
+            if (self.truncatedHere()) return ReadError.UnexpectedEof;
+            if (self.pos >= self.source.len) return ReadError.UnexpectedChar;
+            const next = self.source[self.pos];
+            if (next == '(') {
+                if (homogeneousVectorPrefix(word)) |prefix| {
+                    self.pos += 1;
+                    return switch (prefix) {
+                        .bytevector => .hash_u8_lparen,
+                        .numeric_vector => |kind| .{ .hash_numvec_lparen = kind },
+                    };
+                }
+                return ReadError.UnexpectedChar;
+            }
+            if (std.mem.eql(u8, word, "u8") and next == '"') {
+                return readByteStringLiteral(self);
+            }
             return ReadError.UnexpectedChar;
         },
         'b', 'B' => {

--- a/src/repl_highlight.zig
+++ b/src/repl_highlight.zig
@@ -18,6 +18,7 @@ const std = @import("std");
 const is_wasm = @import("builtin").os.tag == .wasi;
 const reader = @import("reader.zig");
 const config_mod = @import("config.zig");
+const types = @import("types.zig");
 
 const use_isocline = !is_wasm;
 const ic = if (use_isocline) @import("isocline.zig") else struct {};
@@ -157,11 +158,16 @@ fn scanHighlight(input: []const u8, ctx: anytype) void {
             continue;
         }
 
-        // #u8( bytevector literal
-        if (ch == '#' and i + 3 < input.len and input[i + 1] == 'u' and input[i + 2] == '8' and input[i + 3] == '(') {
-            i += 4;
-            ctx.emit(start, i, style_paren);
-            continue;
+        // #u8( / #s16( / ... SRFI 4/160 homogeneous-vector literal opens
+        // (tag table mirrors reader_tokens.homogeneousVectorPrefix)
+        if (ch == '#' and i + 2 < input.len and std.ascii.isAlphanumeric(input[i + 1])) {
+            var j = i + 1;
+            while (j < input.len and std.ascii.isAlphanumeric(input[j])) j += 1;
+            if (j < input.len and input[j] == '(' and types.isHomogeneousVectorTag(input[i + 1 .. j])) {
+                i = j + 1;
+                ctx.emit(start, i, style_paren);
+                continue;
+            }
         }
 
         // #( vector literal
@@ -434,6 +440,9 @@ test "scanHighlight — #trueish is not boolean" {
 test "scanHighlight — vector and bytevector open" {
     try expectSpan("#(1 2)", 0, 2, style_paren);
     try expectSpan("#u8(1 2)", 0, 4, style_paren);
+    // SRFI 4 homogeneous-vector opens (#2548)
+    try expectSpan("#s16(1 2)", 0, 5, style_paren);
+    try expectSpan("#c128(1.5-2.5i)", 0, 6, style_paren);
 }
 
 test "scanHighlight — radix prefixes are numbers" {

--- a/src/repl_sexp.zig
+++ b/src/repl_sexp.zig
@@ -29,6 +29,7 @@
 //! (returns null) rather than guessing.
 
 const std = @import("std");
+const types = @import("types.zig");
 const Reader = @import("reader.zig").Reader;
 
 /// A half-open byte range `[start, end)` of the buffer.
@@ -116,16 +117,23 @@ fn skipTrivia(src: []const u8, from: usize, depth: u32) usize {
     }
 }
 
-/// How many bytes open a list at `i`, or null if nothing does. `#(` and `#u8(`
-/// are list openers as much as `(` is: their contents are datums that barf and
-/// slurp move across.
+/// How many bytes open a list at `i`, or null if nothing does. `#(` and the
+/// `#u8(`-style SRFI 4/160 homogeneous-vector opens are list openers as much
+/// as `(` is: their contents are datums that barf and slurp move across.
 fn listOpenLen(src: []const u8, i: usize) ?usize {
     if (i >= src.len) return null;
     if (src[i] == '(') return 1;
     if (src[i] != '#') return null;
     if (i + 1 < src.len and src[i + 1] == '(') return 2;
-    if (i + 3 < src.len and (src[i + 1] == 'u' or src[i + 1] == 'U') and
-        src[i + 2] == '8' and src[i + 3] == '(') return 4;
+    // #T( where T is one of the SRFI 4/160 tags (u8, s16, f64, c128, ...).
+    // Tag table mirrors reader_tokens.homogeneousVectorPrefix.
+    if (i + 2 < src.len and std.ascii.isAlphanumeric(src[i + 1])) {
+        var j = i + 1;
+        while (j < src.len and std.ascii.isAlphanumeric(src[j])) j += 1;
+        if (j < src.len and src[j] == '(' and j > i + 1 and types.isHomogeneousVectorTag(src[i + 1 .. j])) {
+            return j + 1 - i;
+        }
+    }
     return null;
 }
 
@@ -430,8 +438,13 @@ fn rotate(allocator: std.mem.Allocator, src: []const u8, form: Form, pos: usize)
     var kids: std.ArrayList(Span) = .empty;
     defer kids.deinit(allocator);
     try collectChildren(allocator, src, form, &kids);
-    if (kids.items.len < 3) return null;
-    const args = kids.items[1..];
+    // A `#(`/`#TAG(` literal has no call head -- every child is data and all
+    // of them rotate. A plain list keeps kids[0] as the head and cycles only
+    // its arguments.
+    const is_data = src[form.open] == '#';
+    const min_kids: usize = if (is_data) 2 else 3;
+    if (kids.items.len < min_kids) return null;
+    const args = if (is_data) kids.items else kids.items[1..];
 
     var slots: std.ArrayList(usize) = .empty;
     defer slots.deinit(allocator);
@@ -648,6 +661,14 @@ test "vector and bytevector literals are forms too" {
     try expectEdit(.barf, "#(1 2| 3)", "#(1 2|) 3");
     try expectEdit(.slurp, "#u8(1 2|) 3", "#u8(1 2 3|)");
     try expectEdit(.rotate, "#(a| b c)", "#(b c a|)");
+    // SRFI 4 homogeneous-vector opens (#2548): the whole #TAG( is the form.
+    try expectEdit(.barf, "#s16(1 2| 3)", "#s16(1 2|) 3");
+    try expectEdit(.slurp, "#f32(1.5 2.5|) 3", "#f32(1.5 2.5 3|)");
+    // A cursor on a MIDDLE child is what separates "every child rotates"
+    // from "kids[0] is a head": the child under the cursor moves to the
+    // front slot and the cursor rides with it (#2548 review).
+    try expectEdit(.rotate, "#(a b| c)", "#(b| c a)");
+    try expectEdit(.rotate, "#s16(1 2| 3)", "#s16(2| 3 1)");
 }
 
 test "a quoted form is still a form (its prefix is not a datum boundary)" {

--- a/src/tests_bytecode_cache.zig
+++ b/src/tests_bytecode_cache.zig
@@ -207,6 +207,17 @@ test "sbc equiv: list operations" {
     try expectSbcEquivalence("(car (cons 42 '()))");
 }
 
+test "sbc equiv: SRFI 4 homogeneous-vector literals" {
+    if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
+    // A literal reaches the codec as a TAG_NUMERICVECTOR constant — bare,
+    // and nested inside a vector constant (the SRFI 231 spec-example shape,
+    // kaappi#2548). `equal?` against a reconstructed literal checks the
+    // kind, length and element bytes across the round trip.
+    try expectSbcEquivalence("(equal? #s16(1 -2 #xff) #s16(1 -2 255))");
+    try expectSbcEquivalence("(equal? (list 16 #u16(3895)) '(16 #u16(3895)))");
+    try expectSbcEquivalence("(equal? #c64(1.5+0.5i) #c64(1.5+0.5i))");
+}
+
 test "sbc equiv: tail-recursive loop" {
     if (comptime platform.is_wasm) return error.SkipZigTest; // bytecode-file writes are gated off on wasm (bytecode_file_write.zig)
     try expectSbcEquivalence(

--- a/src/tests_fmt.zig
+++ b/src/tests_fmt.zig
@@ -71,6 +71,17 @@ test "vector literals keep their prefix" {
     try expectFormat("#u8( 0 255 )", "#u8(0 255)\n");
 }
 
+test "SRFI 4 homogeneous-vector literals keep their prefix (#2548)" {
+    // The tag and its '(' are one lexeme for every prefix: splitting "#s16"
+    // off as an atom used to leave "(1 2)" a separate form, which changed
+    // the program and made fmt refuse the file.
+    try expectFormat("#s16( 1 -2 )", "#s16(1 -2)\n");
+    try expectFormat("#f64( 1.5 )", "#f64(1.5)\n");
+    try expectFormat("#c128( 1.5-2.5i )", "#c128(1.5-2.5i)\n");
+    try expectRoundTrips("(display (list 16 #u16(3895)))\n(write #s16(1\n 2))\n");
+    try expectIdempotent("(define v #s32(1 2 3))\n");
+}
+
 // ── Special-form indentation ──────────────────────────────────────────────────
 
 test "define body breaks to two-space indent" {

--- a/src/tests_reader_incremental.zig
+++ b/src/tests_reader_incremental.zig
@@ -106,6 +106,14 @@ test "incomplete mode: every proper prefix of every token class is UnexpectedEof
         "...",
         ".5",
         "#u8(1 2)",
+        // SRFI 4 homogeneous-vector literals (#2548): the same closed
+        // self-delimiting class as #u8(, and the prefix cut points the
+        // 'u'/'s'/'f'/'c' dispatch must refill on, not finalize ("#s1" is
+        // not a #s1 datum — it is the beginning of #s16( ... )).
+        "#s16(1 -2)",
+        "#f32(1.5)",
+        "#u64(1 2)",
+        "#c64(1.5+0.5i)",
         // multi-byte UTF-8 codepoints (#1945): 2-, 3-, 4-byte, bare and
         // inside a container
         "λλ",
@@ -148,7 +156,7 @@ test "incomplete mode: bare tokens at end-of-slice do not finalize" {
 test "incomplete mode: self-delimiting closers finalize at end-of-slice" {
     var gc = memory.GC.init(testing.allocator);
     defer gc.deinit();
-    const closed = [_][]const u8{ "(a b)", "\"zz\"", "#u8(1)", "#(x)", "|qq|", "(a . b)", "#\"D\"r\"D\"", "#u8\"a\"" };
+    const closed = [_][]const u8{ "(a b)", "\"zz\"", "#u8(1)", "#(x)", "|qq|", "(a . b)", "#\"D\"r\"D\"", "#u8\"a\"", "#s16(1)", "#f32(1.5)" };
     for (closed) |src| {
         const parsed = try parseOne(&gc, src, true);
         try testing.expect(parsed != null);
@@ -181,6 +189,105 @@ test "whole-input mode keeps the precise final verdicts" {
     const sym_str = try printer.valueToString(testing.allocator, sym, .write);
     defer testing.allocator.free(sym_str);
     try testing.expectEqualStrings("zzz", sym_str);
+}
+
+test "homogeneous-vector prefixes: cut runs refill, complete verdicts (#2548)" {
+    var gc = memory.GC.init(testing.allocator);
+    defer gc.deinit();
+    // A run cut at end-of-slice may still complete into a #TAG( prefix once
+    // the next chunk arrives — "#s1" is the beginning of #s16( ... ), never
+    // a finished "#s1" datum.
+    const cut_prefixes = [_][]const u8{ "#s", "#s1", "#s16", "#s8", "#u", "#u1", "#u16", "#f3", "#f32", "#c", "#c6", "#c128" };
+    for (cut_prefixes) |src| {
+        try testing.expectError(ReadError.UnexpectedEof, parseOne(&gc, src, true));
+        try testing.expectError(ReadError.UnexpectedChar, parseOne(&gc, src, false));
+    }
+    // "#f"/"#false" keep the boolean verdicts: cut runs refill (#1940), a
+    // true end-of-input is the boolean.
+    for ([_][]const u8{ "#f", "#false" }) |src| {
+        try testing.expectError(ReadError.UnexpectedEof, parseOne(&gc, src, true));
+        try testing.expect((try parseOne(&gc, src, false)) != null);
+    }
+    // A complete prefix before '(' is a closed literal even in incomplete
+    // mode; a mismatched prefix ('u9') is a final error in both modes.
+    try testing.expect((try parseOne(&gc, "#s16(1)", true)) != null);
+    try testing.expectError(ReadError.UnexpectedChar, parseOne(&gc, "#u9(1)", true));
+    try testing.expectError(ReadError.UnexpectedChar, parseOne(&gc, "#u9(1)", false));
+    // "#u8\"...\"" (SRF 207) is untouched, and its cut before the quote
+    // still refills.
+    try testing.expect((try parseOne(&gc, "#u8\"ab\"", true)) != null);
+}
+
+test "SRFI 4 homogeneous-vector literals: kinds, immutability, round-trip (#2548)" {
+    var gc = memory.GC.init(testing.allocator);
+    defer gc.deinit();
+
+    // Reads to a NumericVector of the right kind, elements stored exactly,
+    // including full integer syntax in an element (#xff).
+    const v = (try parseOne(&gc, "#s16(1 -2 #xff)", false)) orelse return error.TestUnexpectedResult;
+    try testing.expect(types.isNumericVector(v));
+    const nv = types.toObject(v).as(types.NumericVector);
+    try testing.expectEqual(types.NumericElementKind.s16, nv.kind);
+    try testing.expectEqual(@as(usize, 6), nv.data.len);
+    var expect: [6]u8 = undefined;
+    const native_endian = @import("builtin").cpu.arch.endian();
+    std.mem.writeInt(i16, expect[0..2], 1, native_endian);
+    std.mem.writeInt(i16, expect[2..4], -2, native_endian);
+    std.mem.writeInt(i16, expect[4..6], 255, native_endian);
+    try testing.expectEqualSlices(u8, &expect, nv.data);
+
+    // A literal is immutable, like #u8( and #(... literals.
+    try testing.expect(types.toObject(v).flags.immutable);
+
+    // Range and type failures are read errors with kinds. An integer-vector
+    // element that is not an exact integer (a symbol, or 1.5) is InvalidNumber;
+    // a float/complex-vector element that is not a number at all is the
+    // tokenizer-level UnexpectedChar.
+    try testing.expectError(ReadError.InvalidNumber, parseOne(&gc, "#u16(70000)", false));
+    try testing.expectError(ReadError.InvalidNumber, parseOne(&gc, "#u8(300)", false));
+    try testing.expectError(ReadError.InvalidNumber, parseOne(&gc, "#s16(sym)", false));
+    try testing.expectError(ReadError.UnexpectedChar, parseOne(&gc, "#f32(sym)", false));
+
+    // write produces the read-identical literal (SRFI 4's external
+    // representation) — the native tier's constant embedding relies on it.
+    const s = try printer.valueToString(testing.allocator, v, .write);
+    defer testing.allocator.free(s);
+    try testing.expectEqualStrings("#s16(1 -2 255)", s);
+    const back = (try parseOne(&gc, s, false)) orelse return error.TestUnexpectedResult;
+    try testing.expect(types.isNumericVector(back));
+    try testing.expectEqualSlices(u8, nv.data, types.toObject(back).as(types.NumericVector).data);
+}
+
+test "nested homogeneous-vector literals pay the depth gate (#2548 review)" {
+    var gc = memory.GC.init(testing.allocator);
+    defer gc.deinit();
+
+    // Scalar elements are depth-neutral, so a literal under the LAST plain
+    // nesting that still reads (1023 parens, the same boundary the plain-atom
+    // controls in tests/scheme/compliance/printer-gaps.scm sit at) reads
+    // fine — a real seam guard, since it fails if elements ever start paying
+    // the per-datum depth increment.
+    var leaf: std.ArrayList(u8) = .empty;
+    defer leaf.deinit(testing.allocator);
+    const plain = Reader.MAX_NESTING_DEPTH - 1; // 1023: the last depth that reads
+    for (0..plain) |_| leaf.append(testing.allocator, '(') catch return error.OutOfMemory;
+    leaf.appendSlice(testing.allocator, "#s16(1 2)") catch return error.OutOfMemory;
+    for (0..plain) |_| leaf.append(testing.allocator, ')') catch return error.OutOfMemory;
+    try testing.expect((try parseOne(&gc, leaf.items, false)) != null);
+    // One more paren on each side crosses the seam: the literal token now
+    // sits at MAX_NESTING_DEPTH and pays the gate, so the same shape reads
+    // as NestingTooDeep.
+    leaf.insert(testing.allocator, 0, '(') catch return error.OutOfMemory;
+    leaf.append(testing.allocator, ')') catch return error.OutOfMemory;
+    try testing.expectError(ReadError.NestingTooDeep, parseOne(&gc, leaf.items, false));
+
+    var nested: std.ArrayList(u8) = .empty;
+    defer nested.deinit(testing.allocator);
+    const depth = Reader.MAX_NESTING_DEPTH + 50;
+    for (0..depth) |_| nested.appendSlice(testing.allocator, "#s8(") catch return error.OutOfMemory;
+    nested.append(testing.allocator, '1') catch return error.OutOfMemory;
+    for (0..depth) |_| nested.append(testing.allocator, ')') catch return error.OutOfMemory;
+    try testing.expectError(ReadError.NestingTooDeep, parseOne(&gc, nested.items, false));
 }
 
 test "readDatumOrEof: trailing trivia is clean EOF, not a read error" {

--- a/src/types.zig
+++ b/src/types.zig
@@ -516,6 +516,7 @@ pub const Bytevector = struct {
 const types_numeric = @import("types_numeric.zig");
 pub const NumericElementKind = types_numeric.NumericElementKind;
 pub const NumericVector = types_numeric.NumericVector;
+pub const isHomogeneousVectorTag = types_numeric.isHomogeneousVectorTag;
 
 pub const Promise = struct {
     header: Object,

--- a/src/types_numeric.zig
+++ b/src/types_numeric.zig
@@ -1,6 +1,18 @@
+const std = @import("std");
 const types = @import("types.zig");
 const Value = types.Value;
 const Object = types.Object;
+
+/// Is `name` one of the `#TAG(` homogeneous-vector literal tags — every
+/// `NumericElementKind` name, plus the `u8` special case (the R7RS
+/// bytevector form, which is not an enum member)? This is the ONE table
+/// behind the reader's prefix match and the fmt/REPL lexeme layers
+/// (kaappi#2548); deriving it from the enum means a new element kind cannot
+/// drift out of the literal syntax.
+pub fn isHomogeneousVectorTag(name: []const u8) bool {
+    if (std.mem.eql(u8, name, "u8")) return true;
+    return std.meta.stringToEnum(NumericElementKind, name) != null;
+}
 
 /// SRFI 160's homogeneous numeric vector element types, minus `u8` (which
 /// stays a plain R7RS bytevector -- SRFI 160 explicitly recommends

--- a/tests/scheme/audit/endianness-audit.scm
+++ b/tests/scheme/audit/endianness-audit.scm
@@ -301,28 +301,28 @@
 
 (test-equal "u16vector: ref agrees with the encoder" 258 (u16vector-ref (u16vector 258) 0))
 (test-equal "u16vector: printer agrees with the encoder"
-            "#<u16vector 258>" (write-to-string (u16vector 258)))
+            "#u16(258)" (write-to-string (u16vector 258)))
 (test-equal "s16vector: ref agrees with the encoder on a negative"
             -2 (s16vector-ref (s16vector -2) 0))
 (test-equal "s16vector: printer agrees with the encoder on a negative"
-            "#<s16vector -2>" (write-to-string (s16vector -2)))
+            "#s16(-2)" (write-to-string (s16vector -2)))
 (test-equal "u32vector: ref agrees with the encoder"
             16909060 (u32vector-ref (u32vector 16909060) 0))
 (test-equal "u32vector: printer agrees with the encoder"
-            "#<u32vector 16909060>" (write-to-string (u32vector 16909060)))
+            "#u32(16909060)" (write-to-string (u32vector 16909060)))
 (test-equal "s32vector: ref agrees with the encoder on a negative"
             -2 (s32vector-ref (s32vector -2) 0))
 (test-equal "u64vector: ref agrees with the encoder"
             72623859790382856 (u64vector-ref (u64vector 72623859790382856) 0))
 (test-equal "u64vector: printer agrees with the encoder"
-            "#<u64vector 72623859790382856>"
+            "#u64(72623859790382856)"
             (write-to-string (u64vector 72623859790382856)))
 (test-equal "s64vector: ref agrees with the encoder on a negative"
             -2 (s64vector-ref (s64vector -2) 0))
 (test-equal "f32vector: ref agrees with the encoder" 1.5 (f32vector-ref (f32vector 1.5) 0))
 (test-equal "f64vector: ref agrees with the encoder" 1.5 (f64vector-ref (f64vector 1.5) 0))
 (test-equal "f64vector: printer agrees with the encoder"
-            "#<f64vector 1.5>" (write-to-string (f64vector 1.5)))
+            "#f64(1.5)" (write-to-string (f64vector 1.5)))
 (test-equal "f64vector: an asymmetric double survives encode/decode"
             1.0000000000000002 (f64vector-ref (f64vector 1.0000000000000002) 0))
 
@@ -336,7 +336,7 @@
             (make-rectangular 1.5 -2.5)
             (c128vector-ref (c128vector (make-rectangular 1.5 -2.5)) 0))
 (test-equal "c64vector: printer agrees with the encoder"
-            "#<c64vector 1.5-2.5i>"
+            "#c64(1.5-2.5i)"
             (write-to-string (c64vector (make-rectangular 1.5 -2.5))))
 
 ;; Adjacent elements must not bleed into one another -- the failure mode a

--- a/tests/scheme/audit/primitives_srfi160-audit.scm
+++ b/tests/scheme/audit/primitives_srfi160-audit.scm
@@ -258,8 +258,8 @@
                (eq? (real? e)
                     (real? (read (open-input-string (write-to-string e)))))))
 ;; Control 3: the vector printer is honest about the zero imaginary part.
-(test-equal "#<c128vector 1.5+0.0i>" (write-to-string (c128vector 1.5)))
-(test-equal "#<c64vector 1.5+0.0i>" (write-to-string (c64vector 1.5)))
+(test-equal "c128vector writes the zero imaginary part" "#c128(1.5+0.0i)" (write-to-string (c128vector 1.5)))
+(test-equal "c64vector writes the zero imaginary part" "#c64(1.5+0.0i)" (write-to-string (c64vector 1.5)))
 
 ;;; #1951/#2269 (a zero-imaginary c64/c128 element writes as a real): a
 ;;; +0.0 imaginary part now decodes to the complex 1.5+0.0i and `write`
@@ -536,12 +536,12 @@
 ;;; ------------------------------------------------------------------
 
 (define endian-probe
-  (list (list 'u16  (u16vector 258)                "#<u16vector 258>")
-        (list 's16  (s16vector 258)                "#<s16vector 258>")
-        (list 'u32  (u32vector 16909060)           "#<u32vector 16909060>")
-        (list 's32  (s32vector 16909060)           "#<s32vector 16909060>")
-        (list 'u64  (u64vector 72623859790382856)  "#<u64vector 72623859790382856>")
-        (list 's64  (s64vector 72623859790382856)  "#<s64vector 72623859790382856>")))
+  (list (list 'u16  (u16vector 258)                "#u16(258)")
+        (list 's16  (s16vector 258)                "#s16(258)")
+        (list 'u32  (u32vector 16909060)           "#u32(16909060)")
+        (list 's32  (s32vector 16909060)           "#s32(16909060)")
+        (list 'u64  (u64vector 72623859790382856)  "#u64(72623859790382856)")
+        (list 's64  (s64vector 72623859790382856)  "#s64(72623859790382856)")))
 
 (for-each
  (lambda (p)
@@ -555,8 +555,9 @@
 (test-equal 16909060 (u32vector-ref (u32vector 16909060) 0))
 (test-equal 72623859790382856 (u64vector-ref (u64vector 72623859790382856) 0))
 (test-equal 1.5 (f64vector-ref (f64vector 1.5) 0))
-(test-equal "#<f64vector 1.5>" (write-to-string (f64vector 1.5)))
-(test-equal "#<c64vector 1.5-2.5i>"
+(test-equal "f64vector writes the readable literal" "#f64(1.5)" (write-to-string (f64vector 1.5)))
+(test-equal "c64vector writes the readable literal"
+            "#c64(1.5-2.5i)"
             (write-to-string (c64vector (make-rectangular 1.5 -2.5))))
 
 ;; Multi-element buffers: element N must not bleed into element N+1.
@@ -814,21 +815,23 @@
 ;;; ------------------------------------------------------------------
 ;;; 12. write-@vector and the external representation
 ;;;
-;;; SRFI 160's lexical-syntax section is titled "Optional lexical syntax",
-;;; so omitting the `#s8(...)` read syntax is permitted. What is pinned
-;;; here is the resulting INCONSISTENCY: u8 writes the spec's readable
-;;; `#u8(...)` because it is a bytevector, while the other 11 kinds write
-;;; an unreadable `#<...>` form. If the read syntax is ever added, these
-;;; are the assertions to revisit.
+;;; SRFI 4's external representation (#TAG( ... ) for the flat kinds,
+;;; SRFI 160's optional extension for c64/c128) is what `write` produces
+;;; and what `read` accepts for every kind, kaappi#2548: the written form
+;;; round-trips through read bit-exactly, which the native tier's
+;;; print-and-re-read constant embedding relies on.
 ;;; ------------------------------------------------------------------
 
-(test-equal "#u8(1 2 3)" (write-to-string (u8vector 1 2 3)))
-(test-equal "#<s8vector 1 2 3>" (write-to-string (s8vector 1 2 3)))
-(test-equal "#<f32vector 1.5>" (write-to-string (f32vector 1.5)))
+(test-equal "write-to-string writes a u8vector literal"
+            "#u8(1 2 3)" (write-to-string (u8vector 1 2 3)))
+(test-equal "write-to-string writes an s8vector literal"
+            "#s8(1 2 3)" (write-to-string (s8vector 1 2 3)))
+(test-equal "write-to-string writes an f32vector literal"
+            "#f32(1.5)" (write-to-string (f32vector 1.5)))
 (test-assert "write-s8vector writes what write writes"
              (let ((p (open-output-string)))
                (write-s8vector (s8vector 1 2) p)
-               (string=? "#<s8vector 1 2>" (get-output-string p))))
+               (string=? "#s8(1 2)" (get-output-string p))))
 (test-assert "write-u8vector writes the spec's readable syntax"
              (let ((p (open-output-string)))
                (write-u8vector (u8vector 1 2) p)

--- a/tests/scheme/compile/srfi4-literal-roundtrip-2548.sh
+++ b/tests/scheme/compile/srfi4-literal-roundtrip-2548.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Regression test for #2548 (LLVM native backend): SRFI 4's homogeneous-vector
+# literal syntax must survive native compilation.
+#
+# `#s16(1 -2)` and friends are read to NumericVector constants, and the
+# native tier embeds every heap-value constant by PRINTING it and re-reading
+# the `(quote ...)` source at run time (LLVMEmitter.emitQuotedEvalExpr).
+# That makes the two reader/printer halves of this feature one dependency
+# chain: before the fix the reader rejected the literal outright ("read
+# error[KP1002]"), and a printer that wrote an unreadable `#<...>` form
+# would have produced a native binary that died at run time on its own
+# constant. The interpreted run is the oracle, per tests/scheme/CLAUDE.md.
+#
+# Hermetic: KAAPPI_HOME points at a throwaway dir; the probe file lives in a
+# temp dir. The program imports only (scheme base)/(scheme write) — the
+# literals are reader syntax, so no SRFI library is needed, which also keeps
+# the native gate from refusing disk-resolved .sld imports.
+#
+# Usage: bash tests/scheme/compile/srfi4-literal-roundtrip-2548.sh [path-to-kaappi]
+
+set -euo pipefail
+
+. "$(dirname "$0")/../shell-common.sh"
+skip_on_windows "compile suite needs a native Zig toolchain on this machine (kaappi#1613)"
+
+KAAPPI="${1:-zig-out/bin/kaappi}"
+KAAPPI_ABS="$(cd "$(dirname "$KAAPPI")" && pwd)/$(basename "$KAAPPI")" || exit 1
+REPO_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+ensure_runtime_lib "$REPO_DIR"
+
+DIR="$(mktemp -d)" || exit 1
+KAAPPI_HOME="$(mktemp -d)" || { rm -rf "$DIR"; exit 1; }
+export KAAPPI_HOME
+cleanup() { rm -rf "$DIR" "$KAAPPI_HOME"; }
+trap cleanup EXIT
+
+cat > "$DIR/probe.scm" <<'SCM'
+(import (scheme base) (scheme write) (scheme read))
+;; The SRFI 231 spec-example shape that found the bug: a u16vector literal
+;; in code position, nested inside a vector/list constant.
+(write (list 16 #u16(3895))) (newline)
+;; Every SRFI 4 element kind, plus SRFI 160's complex extension.
+(write #s8(-128 127)) (newline)
+(write #u16(1 2 3)) (newline)
+(write #s16(1 -2 #xff)) (newline)
+(write #u32(4294967295)) (newline)
+(write #s32(-2147483648)) (newline)
+(write #u64(18446744073709551615)) (newline)
+(write #s64(-9223372036854775808)) (newline)
+(write #f32(1.5)) (newline)
+(write #f64(-1.5)) (newline)
+(write #c64(1.5+0.5i)) (newline)
+(write #c128(1.5-2.5i)) (newline)
+;; Quoted literal; structural equality across two separately read literals;
+;; and a native constant equal to a literal read at run time (the print +
+;; re-read constant embedding must hold the same element bytes).
+(write (bytevector-u8-ref '#u8(5 6) 1)) (newline)
+(write (equal? #s16(1 -2) #s16(1 -2))) (newline)
+(write (equal? (list 16 #u16(3895)) '(16 #u16(3895)))) (newline)
+(write (equal? '#s16(1 -2) (read (open-input-string "#s16(1 -2)")))) (newline)
+;; A literal that IS a macro's expansion goes through Compiler.compileExpr,
+;; not lowerWithMacros -- the one code position with its own self-evaluating
+;; arm.
+(define-syntax %lit (syntax-rules () ((_) #s16(1 2))))
+(write (%lit)) (newline)
+(write (let-syntax ((m (syntax-rules () ((_) #u16(7))))) (m))) (newline)
+SCM
+
+n=0
+fail=0
+
+ok() {
+    echo "PASS: $1"
+}
+
+GOLDEN="$(cat <<'GOLD'
+(16 #u16(3895))
+#s8(-128 127)
+#u16(1 2 3)
+#s16(1 -2 255)
+#u32(4294967295)
+#s32(-2147483648)
+#u64(18446744073709551615)
+#s64(-9223372036854775808)
+#f32(1.5)
+#f64(-1.5)
+#c64(1.5+0.5i)
+#c128(1.5-2.5i)
+6
+#t
+#t
+#t
+#s16(1 2)
+#u16(7)
+GOLD
+)"
+
+n=$((n + 1))
+interp_status=0
+interp_out="$(interp_stdout "$KAAPPI_ABS" "$DIR" "$DIR/probe.scm" "$DIR/probe.interp.err")" || interp_status=$?
+if [ "$interp_status" -ne 0 ]; then
+    echo "FAIL: interpreter oracle exited $interp_status" >&2
+    show_interp_stderr "$DIR/probe.interp.err"
+    exit 1
+fi
+# Fixed expected output first: both tiers agreeing on WRONG output must fail.
+if [ "$interp_out" == "$GOLDEN" ]; then
+    ok "interpreted run matches the golden output"
+else
+    echo "FAIL: interpreter output differs from the golden output" >&2
+    diff <(printf '%s\n' "$GOLDEN") <(printf '%s\n' "$interp_out") >&2 || true
+    show_interp_stderr "$DIR/probe.interp.err"
+    exit 1
+fi
+
+n=$((n + 1))
+bin="$DIR/probe.bin"
+if ! (cd "$REPO_DIR" && "$KAAPPI_ABS" compile "$DIR/probe.scm" -o "$bin" > /dev/null 2>&1); then
+    echo "FAIL: native compile of the literal program failed" >&2
+    exit 1
+fi
+ok "native compile accepted the literal program"
+
+n=$((n + 1))
+native_status=0
+native_out="$("$bin" 2> /dev/null)" || native_status=$?
+if assert_tiers_agree "native binary vs interpreter" \
+    "$interp_out" "$interp_status" "$native_out" "$native_status"; then
+    ok "the native binary agrees with the interpreter on stdout and exit status"
+else
+    fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "Interpreter output was:" >&2
+    printf '%s\n' "$interp_out" >&2
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+    echo "Passed: $n"
+else
+    echo "FAILED: $fail of $n"
+    exit 1
+fi

--- a/tests/scheme/srfi/srfi4.scm
+++ b/tests/scheme/srfi/srfi4.scm
@@ -134,6 +134,74 @@
   (s32vector-set! v 0 -1000000)
   (test-equal -1000000 (s32vector-ref v 0)))
 
+;;; --- the external representation: #TAG( ... ) literals (kaappi#2548) ---
+;;; SRFI 4's read/write syntax for every one of its ten kinds. Before the
+;;; fix the reader accepted only #u8( and rejected the rest at read time,
+;;; so a conforming program failed before it ran.
+(test-equal "u16vector literal reads" 3 (u16vector-length #u16(1 2 3)))
+(test-equal "u8vector literal reads" 3 (u8vector-length #u8(1 2 3)))
+(test-equal "s16vector literal reads, full integer syntax in elements" '(1 -2 255) (s16vector->list #s16(1 -2 #xff)))
+(test-equal "s8vector literal reads" '(-128 127) (s8vector->list #s8(-128 127)))
+(test-equal "u16vector literal bounds" '(0 65535) (u16vector->list #u16(0 65535)))
+(test-equal "s16vector literal bounds" '(-32768 32767) (s16vector->list #s16(-32768 32767)))
+(test-equal "u32vector literal bounds" '(0 4294967295) (u32vector->list #u32(0 4294967295)))
+(test-equal "s32vector literal bounds" '(-2147483648 2147483647) (s32vector->list #s32(-2147483648 2147483647)))
+(test-equal "u64vector literal bounds" '(0 18446744073709551615) (u64vector->list #u64(0 18446744073709551615)))
+(test-equal "s64vector literal bounds" '(-9223372036854775808 1) (s64vector->list #s64(-9223372036854775808 1)))
+(test-equal "f32vector literal reads" 1.5 (f32vector-ref #f32(1.5) 0))
+(test-equal "f64vector literal reads" -1.5 (f64vector-ref #f64(-1.5) 0))
+;;; The spec's own example: full integer syntax inside the literal.
+(test-equal "the spec's #u8(0 #e1e2 #xff) example" '(0 100 255) (u8vector->list #u8(0 #e1e2 #xff)))
+;;; An empty literal.
+(test-equal "empty literal reads" 0 (u16vector-length #u16()))
+;;; Literals are self-evaluating in code position, including nested inside
+;;; other literals (the shape of SRFI 231's u1-body spec example).
+(test-equal "literal self-evaluates in a list" 3895 (u16vector-ref (list-ref (list 16 #u16(3895)) 1) 0))
+(test-equal "literal self-evaluates in a vector" 3895 (u16vector-ref (vector-ref (vector #u16(3895)) 0) 0))
+(test-equal "nested literal equal? against quoted form" #t (equal? '(16 #u16(3895)) '(16 #u16(3895))))
+;;; Quoted literals read to the same objects.
+(test-equal "quoted literal keeps its elements" 6 (u16vector-ref '#u16(5 6) 1))
+;;; A literal that IS a macro's expansion goes through Compiler.compileExpr,
+;;; not lowerWithMacros — the one code position that needed its own
+;;; self-evaluating arm (kaappi#2548 review).
+(define-syntax %lit (syntax-rules () ((_) #s16(1 2))))
+(test-equal "macro expanding to a bare literal" '(1 2) (s16vector->list (%lit)))
+(test-equal "let-syntax expanding to a bare literal" 7 (u16vector-ref (let-syntax ((m (syntax-rules () ((_) #u16(7))))) (m)) 0))
+
+;;; write produces the readable form, and read accepts it back.
+(let* ((w (open-output-string)))
+  (write #s16(1 -2) w)
+  (test-equal "write emits the readable form" "#s16(1 -2)" (get-output-string w)))
+(test-equal "written s16vector reads back equal" #t
+            (let* ((w (open-output-string))
+                   (v (s16vector 1 -2 255)))
+              (write v w)
+              (equal? v (read (open-input-string (get-output-string w))))))
+(test-equal "written f64vector reads back equal" #t
+            (let* ((w (open-output-string))
+                   (v (f64vector -1.5 2.5)))
+              (write v w)
+              (equal? v (read (open-input-string (get-output-string w))))))
+(test-equal "written f32vector reads back bit-exact" #t
+            (let* ((w (open-output-string))
+                   (v (f32vector 0.1)))
+              (write v w)
+              ;; f32 elements write at f32 precision and round-trip the
+              ;; stored bits exactly.
+              (equal? v (read (open-input-string (get-output-string w))))))
+(test-equal "write-u16vector output is the literal" "#u16(3895)" (let ((w (open-output-string))) (write (u16vector 3895) w) (get-output-string w)))
+
+;;; Literals are immutable, like #u8( and #(... literals.
+(test-equal "immutable s16vector literal refuses set!" 'caught (guard (e (#t 'caught)) (s16vector-set! #s16(1) 0 9)))
+(test-equal "immutable u16vector literal refuses set!" 'caught (guard (e (#t 'caught)) (u16vector-set! #u16(1) 0 9)))
+(test-equal "immutable f64vector literal refuses set!" 'caught (guard (e (#t 'caught)) (f64vector-set! #f64(1.0) 0 2.0)))
+
+;;; Out-of-range / non-number elements are read errors.
+(test-equal "out-of-range literal element is a read error" 'caught (guard (e (#t 'caught)) (read (open-input-string "#u16(70000)"))))
+(test-equal "out-of-range s8 element is a read error" 'caught (guard (e (#t 'caught)) (read (open-input-string "#s8(200)"))))
+(test-equal "non-number literal element is a read error" 'caught (guard (e (#t 'caught)) (read (open-input-string "#s16(foo)"))))
+(test-equal "out-of-range u8 element is a read error" 'caught (guard (e (#t 'caught)) (read (open-input-string "#u8(300)"))))
+
 (let ((runner (test-runner-current)))
   (test-end "srfi-4")
   (when (> (test-runner-fail-count runner) 0) (exit 1)))


### PR DESCRIPTION
Closes #2548.

## What

The reader now accepts SRFI 4's external representation for all ten homogeneous-vector kinds — `#s8(...)`, `#u8(...)`, `#s16(...)`, `#u16(...)`, `#s32(...)`, `#u32(...)`, `#s64(...)`, `#u64(...)`, `#f32(...)`, `#f64(...)` — plus SRFI 160's optional extension of the same shape to `#c64(...)`/`#c128(...)`. `write` produces the same readable form, so a written homogeneous vector round-trips through `read` bit-exactly, as the SRFI requires. Previously the reader accepted only `#u8(` (the R7RS bytevector form) and rejected every other prefix at read time, so a conforming program — the SRFI 231 spec corpus writes `#(16 #u16(3895))` in code position — failed before it ran.

```scheme
$ kaappi repro.scm   # (import (srfi 4)) (write (u16vector-length #u16(1 2 3))) ...
3                    # was: read error[KP1002]: unexpected character
(write #s16(1 -2 #xff))  ⇒ #s16(1 -2 255)
```

## How

- **Reader** (`reader_tokens.zig`, `reader_datum.zig`): the `#`-dispatch arm for `u`/`s`/`f`/`c` matches the fixed prefix table (a new token carries the `NumericElementKind`; `u8` keeps the bytevector form and `#u8"..."` SRFI 207's notation, and `#f`/`#false` share the arm). Elements take full number syntax — the spec's own example is `#u8(0 #e1e2 #xff)`, so the bytevector path accepts it too — and are read token-level, so a literal is ONE datum to the reader's depth limit (the printer-gaps depth-1023 controls pin that). Literals are immutable like `#u8(`/`#(...` literals, and `%numeric-vector-set!` now refuses immutable vectors to match `set-car!`/`bytevector-u8-set!`. A prefix cut at end-of-slice refills under incremental reads (#1940 semantics preserved and extended).
- **Element coercion** (`primitives_srfi160.zig`): split into a pure core (`encodeElementRaw`) the literal reader shares, with the primitive-shaped `encodeElement` wrapping it for `set!` — ONE range/exactness table, so a literal and a constructor can never disagree, and a read failure can never write the VM error-detail channel (that detail would otherwise leak into an unrelated runtime error's report — caught in testing).
- **Printer** (`printer.zig`): `write` emits `#s16(1 -2 255)` / `#c64(1.5+0.0i)` for every kind; f32/c64 elements format at f32 precision, so `#f32(0.1)`, not `#f32(0.10000000149011612)` — both round-trip bit-exactly, the f32-shortest form is what other Schemes write. This readable form is also what makes the **native tier** work: `emitQuotedEvalExpr` embeds heap constants by printing them and re-reading at run time.
- **Compiler** (`ir.zig`): a NumericVector literal in code position is a self-evaluating constant (was KP2001 invalid syntax).
- **`.sbc` codec** (`bytecode_file*.zig`): `TAG_NUMERICVECTOR` (immutability byte, kind byte, raw element bytes, backref-eligible) — a program with literals now caches and bundles instead of taking a permanent cache miss.
- **`kaappi fmt`** (its lexer's round-trip guard refused a file containing a new literal), the **REPL structural editor** (slurp/barf/rotate) and the **REPL highlighter** learned the `#TAG(` opens.
- Stale "no reader syntax to round-trip" notes updated in `printer.zig`, `primitives_srfi160.zig` and `docs/dev/srfi-implementation-notes.md`; the audit assertions that pinned the old opaque `#<u16vector ...>` print now pin the readable form.

## Tests

- Reader unit tests: kinds/bytes, cut-prefix refills, immutability, error kinds, write→read round-trip (`tests_reader_incremental.zig`).
- `.sbc` equivalence through the new tag, bare and nested (`tests_bytecode_cache.zig`); fmt round-trip and idempotence (`tests_fmt.zig`); slurp/barf and highlight spans (`repl_sexp.zig`, `repl_highlight.zig`).
- `tests/scheme/srfi/srfi4.scm`: +30 literal assertions (all ten kinds, the spec's `#e`/`#x` example, self-evaluation incl. the SRFI 231 spec-example shape, write/read round-trips, immutability, error cases).
- New `tests/scheme/compile/srfi4-literal-roundtrip-2548.sh`: the whole literal surface through `kaappi compile` (LLVM native) against the interpreter oracle.
- `tools/srfi231_diff.py prose` (the tool that found this): 172 examples, 0 mismatches.

`zig build test` 1959 pass / 0 fail; `tests/scheme/run-all.sh` 2154 pass / 0 fail (incl. R7RS 1395); targeted `-Dgc-stress=true` runs on the touched reader/cache filters green.