### PR TITLE
Add a per-script timeout for shell test scripts (#2555)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,16 +334,19 @@ jobs:
           # the same "catch hangs, don't race the slowest legitimate build"
           # budget the per-file timeout above gives the .scm suites.
           #
-          # bundle-cpu-baseline-2515 outgrew even the 600: on top of the
-          # fixture it builds TWO full -Doptimize=ReleaseSafe bundle variants
-          # (default vs baseline CPU -- deliberately separate cache keys,
-          # comparing them is the test's point), so its all-cold total sits at
-          # ~600s on the Debug leg and runner-load variance alone decides it:
-          # killed at 600s twice on PR #2538 (2026-09-06) where the identical
-          # script had passed inside the same budget on the PR's first commit
-          # the day's run before. Debug gets 900 -- a hang still dies three
-          # times over inside the 40m job cap -- and ReleaseSafe legs stay at
-          # 600, where this has not flaked.
+          # bundle-cpu-baseline-2515 outgrew any leg-wide budget: its premise
+          # is full -Doptimize=ReleaseSafe builds, all cold when the Zig cache
+          # is -- the Debug leg always (the Build step warms only its own
+          # optimize mode), and any leg the moment GH Actions discards the
+          # cache mid-run for size. The flat 600s cap killed it twice on PR
+          # #2538 (2026-09-06) and again on the v0.27.0 tag push (ReleaseFast;
+          # kaappi#2555), the last one cancelling the release ci-gate over a
+          # commit whose only code change was a version string. Since that
+          # issue the script carries its own budget in run-all.sh's
+          # PER_SCRIPT_TIMEOUTS (1200s; KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT to
+          # tune), which supersedes this variable for that one script. The
+          # 900/600 split below remains as generic Debug headroom for every
+          # other script.
           KAAPPI_SHELL_TEST_TIMEOUT: ${{ matrix.optimize == 'Debug' && '900' || '600' }}
 
       - name: Sandbox escape tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,9 +336,10 @@ jobs:
           #
           # bundle-cpu-baseline-2515 outgrew any leg-wide budget: its premise
           # is full -Doptimize=ReleaseSafe builds, all cold when the Zig cache
-          # is -- the Debug leg always (the Build step warms only its own
-          # optimize mode), and any leg the moment GH Actions discards the
-          # cache mid-run for size. The flat 600s cap killed it twice on PR
+          # has been cleared or never warmed -- the Debug leg always (the
+          # Build step warms only its own optimize mode), and any leg the
+          # moment GH Actions discards the cache mid-run for size. The flat
+          # 600s cap killed it twice on PR
           # #2538 (2026-09-06) and again on the v0.27.0 tag push (ReleaseFast;
           # kaappi#2555), the last one cancelling the release ci-gate over a
           # commit whose only code change was a version string. Since that

--- a/docs/dev/test-runner.md
+++ b/docs/dev/test-runner.md
@@ -328,7 +328,7 @@ Three things make that safe and worthwhile (kaappi#1926):
   `shell-common.sh` serialise anything that installs into `zig-out/`, using a
   `mkdir` lock (atomic on POSIX and Git Bash alike; `flock` is Linux-only and
   macOS has none). A lock whose holder died — `run-all.sh` kills a script that
-  overruns `SHELL_TIMEOUT` — is stolen by the next waiter via the recorded pid.
+  overruns its timeout — is stolen by the next waiter via the recorded pid.
 - **One interpreter rebuild, not two.** `zig build -Dbundle=…` recompiles the
   whole interpreter, because the embedded bytecode is part of the compiled
   module graph; at ~180s on a 4-core runner, the two scripts that needed one
@@ -363,6 +363,22 @@ Three things make that safe and worthwhile (kaappi#1926):
   builds at the time — sat close enough to the 600s `KAAPPI_SHELL_TEST_TIMEOUT`
   that ordinary runner variance decided it, failing a *required* check about
   one run in fourteen. Keep the count of full builds per script at one.
+
+  When a script's cold-cache cost cannot come down, its budget goes up
+  instead — per script, not per leg: `run_shell_worker` consults
+  `PER_SCRIPT_TIMEOUTS` (the shell twin of the `.scm` runner's
+  `PER_FILE_TIMEOUTS`) before every launch, and the TIMEOUT report names the
+  budget that actually applied. `bundle-cpu-baseline-2515.sh` is the one
+  entry: three full ReleaseSafe builds when the Zig cache is cold (fixture
+  interpreter, default bundle, `-Dcpu=native` twin), ~600s of builds alone on
+  an idle 4-core runner. The flat 600s cap killed it on PR #2538 and again on
+  the v0.27.0 tag push — that time because Actions discarded the cache
+  mid-run for size, cancelling the release ci-gate over a version-string
+  commit (kaappi#2555). Its 1200s default (`KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT`
+  to tune) buys the measured all-cold total twice over; a genuine hang still
+  dies at 20 minutes, inside every job cap that runs this suite.
+  `tests/scheme/test-runner/shell-timeout-override.sh` pins the routing,
+  the bounding, and the reporting.
 
   The same one-key discipline applies to the CPU: since kaappi#2515 every
   `-Dbundle=` build resolves the portable **baseline** CPU model by default

--- a/docs/dev/test-runner.md
+++ b/docs/dev/test-runner.md
@@ -376,7 +376,9 @@ Three things make that safe and worthwhile (kaappi#1926):
   mid-run for size, cancelling the release ci-gate over a version-string
   commit (kaappi#2555). Its 1200s default (`KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT`
   to tune) buys the measured all-cold total twice over; a genuine hang still
-  dies at 20 minutes, inside every job cap that runs this suite.
+  dies at that tick budget — `wait_with_timeout` counts `sleep 0.05` ticks,
+  not wall clock, so ~20 min on Linux, somewhat more where sleep spawns cost
+  more — inside every job cap that runs this suite.
   `tests/scheme/test-runner/shell-timeout-override.sh` pins the routing,
   the bounding, and the reporting.
 

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -92,6 +92,33 @@ timeout_for() {
     echo "$TIMEOUT"
 }
 
+# The shell-suite twin of the list above, for scripts that legitimately outlive
+# SHELL_TIMEOUT. bundle-cpu-baseline-2515.sh is the one entry so far: warm it
+# is ~116s of cache hits, but its premise is three full -Doptimize=ReleaseSafe
+# builds (fixture interpreter, default bundle, -Dcpu=native twin), and when the
+# Zig cache is cold — the Debug leg always, and any leg the moment GH Actions
+# discards the cache mid-run for size — that is ~600s of builds alone on an
+# idle 4-core runner, leaving nothing for load. The flat 600s cap killed it on
+# PR #2538 and again on the v0.27.0 tag push, the second time cancelling the
+# release ci-gate over a commit whose only code change was a version string
+# (kaappi#2555). A leg-wide bump is the wrong tool — every other script fits
+# the shared budget — so this one script gets its own, at twice the measured
+# all-cold total. A genuine hang still dies at 20 minutes, inside every job
+# cap that runs this suite.
+PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:${KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT:-1200}"
+
+shell_timeout_for() {
+    local base entry
+    base=$(basename "$1")
+    for entry in $PER_SCRIPT_TIMEOUTS; do
+        if [[ "$base" == "${entry%%:*}" ]]; then
+            echo "${entry##*:}"
+            return
+        fi
+    done
+    echo "$SHELL_TIMEOUT"
+}
+
 # How many .scm files to run at once. Each file is a fresh interpreter with no
 # shared state (see tests/scheme/CLAUDE.md), so they parallelise cleanly — the
 # suite's own audit found no cross-file collisions on fixed paths or ports.
@@ -334,7 +361,9 @@ run_suite() {
 # Same shape as run_file_worker: record the verdict, never touch the counters.
 run_shell_worker() {
     local script="$1" slot="$2"
-    local pid status
+    local pid status tmo
+    # The budget is per script (PER_SCRIPT_TIMEOUTS), not the flat SHELL_TIMEOUT.
+    tmo=$(shell_timeout_for "$script")
     # Launch under `set -m` so the script leads its own process group (pgid ==
     # pid): a shell script can fork a whole `zig build`, and on timeout we must
     # signal that build too. Killing the script pid alone leaves the build
@@ -349,7 +378,7 @@ run_shell_worker() {
     KAAPPI="$KAAPPI" bash "$script" "$KAAPPI" > "$slot.out" 2>&1 &
     pid=$!
     set +m
-    if wait_with_timeout "$pid" "$SHELL_TIMEOUT"; then
+    if wait_with_timeout "$pid" "$tmo"; then
         status=0
         wait "$pid" || status=$?
     else
@@ -358,7 +387,7 @@ run_shell_worker() {
         # with the script rather than racing the next writer's install.
         kill -- "-$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
         wait "$pid" 2>/dev/null || true
-        echo "TIMEOUT" > "$slot.rec"
+        echo "TIMEOUT ${tmo}s" > "$slot.rec"
         return 0
     fi
     case $status in
@@ -384,8 +413,10 @@ report_shell_result() {
             echo "  SKIP  $script"
             SKIPPED=$((SKIPPED + 1))
             ;;
-        TIMEOUT)
-            echo "  TIMEOUT  $script  (killed after ${SHELL_TIMEOUT}s)"
+        TIMEOUT*)
+            # ${kind#TIMEOUT } is the "<n>s" the worker recorded, which for a
+            # PER_SCRIPT_TIMEOUTS entry is not SHELL_TIMEOUT.
+            echo "  TIMEOUT  $script  (killed after ${kind#TIMEOUT })"
             [[ -f "$slot.out" ]] && cat "$slot.out"
             TIMEDOUT=$((TIMEDOUT + 1))
             ;;

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -103,8 +103,10 @@ timeout_for() {
 # release ci-gate over a commit whose only code change was a version string
 # (kaappi#2555). A leg-wide bump is the wrong tool — every other script fits
 # the shared budget — so this one script gets its own, at twice the measured
-# all-cold total. A genuine hang still dies at 20 minutes, inside every job
-# cap that runs this suite.
+# all-cold total. A genuine hang still dies at the 1200s tick budget —
+# wait_with_timeout counts sleep 0.05 ticks, not wall clock, so that is
+# ~20 min of wall clock on Linux and stretches further where sleep spawns
+# cost more — inside every job cap that runs this suite.
 PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:${KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT:-1200}"
 
 shell_timeout_for() {

--- a/tests/scheme/test-runner/shell-timeout-override.sh
+++ b/tests/scheme/test-runner/shell-timeout-override.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# The shell suites' per-script timeout override (kaappi#2555).
+#
+# bundle-cpu-baseline-2515.sh does three full -Doptimize=ReleaseSafe builds
+# when the Zig cache is cold, and the flat KAAPPI_SHELL_TEST_TIMEOUT cap
+# (600s on the Release legs) killed it on the v0.27.0 tag push — a commit
+# whose only code change was a version string — cancelling the release
+# ci-gate. The fix was not a smaller test but a per-script budget: the shell
+# workers consult PER_SCRIPT_TIMEOUTS exactly the way the .scm workers
+# consult PER_FILE_TIMEOUTS.
+#
+# This pins the mechanism by driving run-all.sh's own dispatch functions
+# against fixture scripts that only sleep, with both budgets dialed down to
+# seconds. The functions are extracted from run-all.sh with sed rather than
+# copied here, so the shipping code is what runs — the same technique
+# runner-agreement.sh uses to keep its verdict regex honest.
+#
+# No kaappi binary and no zig are needed, so this runs on every leg that can
+# run bash, including the ones with no toolchain.
+
+set -euo pipefail
+
+RUN_ALL="$(cd "$(dirname "$0")/.." && pwd)/run-all.sh"
+if [[ ! -f "$RUN_ALL" ]]; then
+    echo "FAIL: cannot find run-all.sh next to this suite" >&2
+    exit 1
+fi
+
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+
+# The table entry itself is part of the fix. Without this check the behaviour
+# assertions below could pass against a PER_SCRIPT_TIMEOUTS the test set
+# itself, and the override for the script that motivated it could be dropped
+# silently.
+if ! grep -q '^PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:' "$RUN_ALL"; then
+    echo "FAIL: run-all.sh has no PER_SCRIPT_TIMEOUTS entry for bundle-cpu-baseline-2515.sh" >&2
+    exit 1
+fi
+
+# Extract the dispatch path's functions. Ranges are anchored on each
+# definition and its column-0 closing brace, the shape every function in
+# run-all.sh already has.
+sed -n -e '/^wait_with_timeout() {/,/^}/p' \
+       -e '/^shell_timeout_for() {/,/^}/p' \
+       -e '/^run_shell_worker() {/,/^}/p' \
+       -e '/^report_shell_result() {/,/^}/p' \
+       "$RUN_ALL" > "$DIR/functions.sh"
+
+# Guard the guard: an extraction that silently missed a function would make
+# everything after it fail for the wrong reason.
+for fn in wait_with_timeout shell_timeout_for run_shell_worker report_shell_result; do
+    if ! grep -q "^$fn() {" "$DIR/functions.sh"; then
+        echo "FAIL: could not extract '$fn' from run-all.sh" >&2
+        exit 1
+    fi
+done
+
+. "$DIR/functions.sh"
+
+# The globals the extracted functions read. run-all.sh sets these at top
+# level, outside any function, so the sed ranges above do not carry them;
+# here they are the second-scale stand-ins: the budget every other script
+# gets, and the override the listed script gets instead.
+SHELL_TIMEOUT=2
+PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:6"
+TICKS_PER_SEC=20
+sleep 0.05 2>/dev/null || TICKS_PER_SEC=1
+export KAAPPI=/bin/true
+
+# --- the lookup --------------------------------------------------------------
+# Basename-matched, so the dispatch that passes full paths still finds the
+# entry; an unlisted script (and a near-miss name) falls back to the global.
+if [[ "$(shell_timeout_for "$DIR/bundle-cpu-baseline-2515.sh")" != "6" ]]; then
+    echo "FAIL: listed script did not get its PER_SCRIPT_TIMEOUTS budget" >&2
+    exit 1
+fi
+if [[ "$(shell_timeout_for "$DIR/unlisted-script.sh")" != "2" ]]; then
+    echo "FAIL: unlisted script did not fall back to SHELL_TIMEOUT" >&2
+    exit 1
+fi
+if [[ "$(shell_timeout_for "$DIR/bundle-cpu-baseline-2515.sh2")" != "2" ]]; then
+    echo "FAIL: near-miss basename was matched instead of falling back" >&2
+    exit 1
+fi
+
+# --- the worker, end to end --------------------------------------------------
+# Fixtures only sleep, so the verdicts below are decided purely by the
+# budgets. run_shell_worker is backgrounded exactly as run_shell_suite
+# backgrounds it (it relies on its own `set -m` window).
+mk_fixture() { # <path-under-$DIR> <seconds-to-sleep>
+    printf '#!/bin/bash\nsleep %s\n' "$2" > "$DIR/$1.sh"
+    chmod +x "$DIR/$1.sh"
+}
+
+run_fixture() { # <slot-label> <script-path> — prints the recorded verdict
+    local slot="$DIR/slot-$1"
+    rm -f "$slot.rec" "$slot.out"
+    run_shell_worker "$2" "$slot" &
+    local pid=$!
+    wait "$pid"
+    cat "$slot.rec"
+}
+
+# The regression this file exists for, in miniature: a script that outlives
+# the global budget but fits its own override must PASS. Under the old flat
+# timeout this is killed at 2s and reported TIMEOUT — the v0.27.0 ci-gate
+# cancellation, at 1/300th scale.
+mk_fixture bundle-cpu-baseline-2515 3
+if [[ "$(run_fixture listed "$DIR/bundle-cpu-baseline-2515.sh")" != "PASS" ]]; then
+    echo "FAIL: script killed inside its per-script budget (was the worker wired to shell_timeout_for?)" >&2
+    exit 1
+fi
+
+# The override is a budget, not a waiver: past it, the listed script dies too.
+# A second copy under slow/ so both basename matches can exist at once.
+mkdir -p "$DIR/slow"
+mk_fixture slow/bundle-cpu-baseline-2515 8
+if [[ "$(run_fixture listed-slow "$DIR/slow/bundle-cpu-baseline-2515.sh")" != "TIMEOUT 6s" ]]; then
+    echo "FAIL: listed script was not killed (and recorded) at its own budget" >&2
+    exit 1
+fi
+
+# Every other script still lives under the global budget...
+mk_fixture unlisted-slow 4
+if [[ "$(run_fixture unlisted-slow "$DIR/unlisted-slow.sh")" != "TIMEOUT 2s" ]]; then
+    echo "FAIL: unlisted script was not killed at SHELL_TIMEOUT" >&2
+    exit 1
+fi
+# ...and is not broken by it.
+mk_fixture unlisted-fast 1
+if [[ "$(run_fixture unlisted-fast "$DIR/unlisted-fast.sh")" != "PASS" ]]; then
+    echo "FAIL: unlisted fast script did not pass under SHELL_TIMEOUT" >&2
+    exit 1
+fi
+
+# --- the report --------------------------------------------------------------
+# The printed kill time must be the budget that actually applied — it used to
+# hardcode SHELL_TIMEOUT, which would misreport an overridden script.
+PASS=0 FAIL=0 TIMEDOUT=0 SKIPPED=0
+report_shell_result "$DIR/slow/bundle-cpu-baseline-2515.sh" "$DIR/slot-listed-slow" > "$DIR/report.txt" 2>&1
+if ! grep -q 'TIMEOUT  .*(killed after 6s)' "$DIR/report.txt"; then
+    echo "FAIL: TIMEOUT report did not name the per-script budget: $(cat "$DIR/report.txt")" >&2
+    exit 1
+fi
+report_shell_result "$DIR/unlisted-slow.sh" "$DIR/slot-unlisted-slow" > "$DIR/report2.txt" 2>&1
+if ! grep -q 'TIMEOUT  .*(killed after 2s)' "$DIR/report2.txt"; then
+    echo "FAIL: TIMEOUT report did not name the global budget: $(cat "$DIR/report2.txt")" >&2
+    exit 1
+fi
+
+echo "PASS: shell-suite per-script timeout override routes, bounds, and reports correctly"

--- a/tests/scheme/test-runner/shell-timeout-override.sh
+++ b/tests/scheme/test-runner/shell-timeout-override.sh
@@ -11,9 +11,10 @@
 #
 # This pins the mechanism by driving run-all.sh's own dispatch functions
 # against fixture scripts that only sleep, with both budgets dialed down to
-# seconds. The functions are extracted from run-all.sh with sed rather than
-# copied here, so the shipping code is what runs — the same technique
-# runner-agreement.sh uses to keep its verdict regex honest.
+# seconds. The functions are extracted from run-all.sh with sed and executed
+# directly — one step further than runner-agreement.sh, which keeps a copy
+# of its net regex and only greps that the copy still appears verbatim in
+# run-all.sh; here the shipping code itself is what runs.
 #
 # No kaappi binary and no zig are needed, so this runs on every leg that can
 # run bash, including the ones with no toolchain.
@@ -32,9 +33,11 @@ trap 'rm -rf "$DIR"' EXIT
 # The table entry itself is part of the fix. Without this check the behaviour
 # assertions below could pass against a PER_SCRIPT_TIMEOUTS the test set
 # itself, and the override for the script that motivated it could be dropped
-# silently.
-if ! grep -q '^PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:' "$RUN_ALL"; then
-    echo "FAIL: run-all.sh has no PER_SCRIPT_TIMEOUTS entry for bundle-cpu-baseline-2515.sh" >&2
+# silently. -F -x: the whole line as a fixed string, so a malformed key or a
+# retuned default cannot slip through a looser match.
+if ! grep -Fxq 'PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:${KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT:-1200}"' "$RUN_ALL"; then
+    echo "FAIL: run-all.sh's PER_SCRIPT_TIMEOUTS entry is not exactly:" >&2
+    echo '       PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:${KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT:-1200}"' >&2
     exit 1
 fi
 
@@ -61,12 +64,16 @@ done
 # The globals the extracted functions read. run-all.sh sets these at top
 # level, outside any function, so the sed ranges above do not carry them;
 # here they are the second-scale stand-ins: the budget every other script
-# gets, and the override the listed script gets instead.
+# gets, and the override the listed script gets instead. KAAPPI is the
+# runner-provided binary argument ($1) where one was passed — the fixtures
+# ignore it, but taking it keeps this script's invocation contract the same
+# as every other script the runners launch.
 SHELL_TIMEOUT=2
 PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:6"
 TICKS_PER_SEC=20
 sleep 0.05 2>/dev/null || TICKS_PER_SEC=1
-export KAAPPI=/bin/true
+KAAPPI="${1:-/bin/true}"
+export KAAPPI
 
 # --- the lookup --------------------------------------------------------------
 # Basename-matched, so the dispatch that passes full paths still finds the
@@ -114,15 +121,26 @@ fi
 
 # The override is a budget, not a waiver: past it, the listed script dies too.
 # A second copy under slow/ so both basename matches can exist at once.
+#
+# The over-budget fixtures sleep 60, far past the budgets that kill them
+# (6s and 2s), on purpose: wait_with_timeout counts `sleep 0.05` ticks, not
+# wall clock, so a nominal budget stretches by the per-spawn cost of sleep —
+# a few percent on Linux, ~36% on macOS (120 ticks = 8.2s), worse under
+# MSYS/Git Bash — and a fixture that only slightly outlives the budget can
+# complete inside the stretched window and record PASS (the macOS and both
+# Windows legs of this PR's first CI run, exactly). A fixture past the
+# budget by 10x is killed at the budget whatever the drift; the kill is
+# the assertion.
 mkdir -p "$DIR/slow"
-mk_fixture slow/bundle-cpu-baseline-2515 8
+mk_fixture slow/bundle-cpu-baseline-2515 60
 if [[ "$(run_fixture listed-slow "$DIR/slow/bundle-cpu-baseline-2515.sh")" != "TIMEOUT 6s" ]]; then
     echo "FAIL: listed script was not killed (and recorded) at its own budget" >&2
     exit 1
 fi
 
-# Every other script still lives under the global budget...
-mk_fixture unlisted-slow 4
+# Every other script still lives under the global budget... (same drift
+# argument for the 60)
+mk_fixture unlisted-slow 60
 if [[ "$(run_fixture unlisted-slow "$DIR/unlisted-slow.sh")" != "TIMEOUT 2s" ]]; then
     echo "FAIL: unlisted script was not killed at SHELL_TIMEOUT" >&2
     exit 1


### PR DESCRIPTION
Closes #2555.

## Summary

`bundle-cpu-baseline-2515.sh` was killed at the flat 600s `KAAPPI_SHELL_TEST_TIMEOUT` on the v0.27.0 tag push (ubuntu-latest / ReleaseFast), cancelling the release `ci-gate` — GH Actions had discarded the Zig cache mid-run for size, so the script's three full ReleaseSafe builds (fixture interpreter, default bundle, `-Dcpu=native` twin) all ran cold. The test's behaviour and its assertions are correct and load-bearing for #2515; only its budget was wrong. This implements the issue's option 1: a per-script timeout override, the shell-suite twin of the `.scm` runner's `PER_FILE_TIMEOUTS`.

- `tests/scheme/run-all.sh`: new `PER_SCRIPT_TIMEOUTS` table + `shell_timeout_for()`, consulted by `run_shell_worker` before every launch. The one entry gives `bundle-cpu-baseline-2515.sh` **1200s** — twice its measured all-cold total (~600s of builds on an idle 4-core runner), so a genuine hang still dies at 20 minutes, inside every job cap that runs this suite. Tunable via `KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT`. A killed script's report now prints the budget that actually applied instead of hardcoding `SHELL_TIMEOUT`.
- `tests/scheme/test-runner/shell-timeout-override.sh`: regression test. It drives run-all.sh's **own** dispatch functions (sed-extracted, the technique `runner-agreement.sh` uses for its verdict regex) against sleeping fixtures with second-scale budgets, and pins three things, each of which fails without the fix: the routing (a script that outlives the global but fits its override must PASS — the v0.27.0 incident at 1/300th scale), the bounding (past its own budget the listed script still dies, and every other script still lives under the global), and the reporting (the kill time names the budget that applied). Needs no kaappi binary and no Zig, so it runs on every bash-capable leg.
- `.github/workflows/ci.yml`: the Debug-900 comment block was falsified by this very flake ("ReleaseSafe legs stay at 600, where this has not flaked") — rewritten to record the v0.27.0 incident and point at `PER_SCRIPT_TIMEOUTS`. The env values themselves are unchanged: the 900/600 split stays as generic Debug headroom for every other script, and the per-script entry supersedes it for this one.
- `docs/dev/test-runner.md`: documents the table, the sizing, and the env knob.

Options 2 (drop a build) and 3 (shrink the bundled program) were rejected per the issue: both assertions the script makes are load-bearing for #2515, and the interpreter compile — not the bundled source — dominates each build.

## Checklist

- [ ] `zig build test` passes — not run: no `.zig` file changed (runner/docs/CI only)
- [x] `zig fmt --check src/` passes — no `src/` change to format
- [x] Scheme test suites pass — full `run-all.sh` not run; the changed dispatch is exercised by the whole `tests/scheme/test-runner/` suite (9/9 green through the same worker code) plus the new test, under both bash 5 and macOS bash 3.2
- [x] New tests added for new behavior — and verified to fail without the fix (stash → guard fires; flat-timeout rewiring → behavioural assertion fires)
- [x] Documentation updated (test-runner.md, ci.yml comment)
- [x] Commit body explains *why* — no `CHANGELOG.md` edit
