### PR TITLE
Call SRFI 231's bundled implementation what the SRFI calls it

### DIFF
--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -873,7 +873,7 @@ textual relationship, per its own spec) shipped across 6 phases (issues
 tracked under #1694;
 `lib/srfi/231/{misc,intervals,storage-classes,arrays,views,combinators,assembly}.sld`,
 merged into a public `lib/srfi/231.sld` re-export hub — 118 bindings total, an
-exact bijection confirmed against the reference implementation's own export
+exact bijection confirmed against the sample implementation's own export
 clause) — the largest single SRFI in this codebase by an order of magnitude.
 An `<interval>` is two parallel exact-integer vectors (lower/upper bounds,
 arbitrary — including negative — per axis), not 25/164's shape-of-pairs nor
@@ -886,54 +886,55 @@ conventions on two independent axes: `array?` is disjoint from vector/string
 (matching 25/164, not 63), while `array-set!`'s new-value argument is
 *second*, right after the array (matching 63, not 25/164's value-last). A
 storage class (17 singletons, 16 real, plus `make-storage-class` for custom
-ones; only `f8` is deferred to `#f` — even the reference leaves it `#f`,
-since no standard 8-bit float type exists. `u1` and `f16` are ports of the
-reference's own bit-packing and software half-floats over `u16vector`) is a
-9-field record
+ones; only `f8` is deferred to `#f` — even the sample implementation leaves it
+`#f`, since no standard 8-bit float type exists. `u1` and `f16` are ports of
+the sample implementation's own bit-packing and software half-floats over
+`u16vector`) is a 9-field record
 (getter/setter/checker/maker/copier/length/default/data?/data->body) that a
 specialized array's `body`/`indexer` pair delegates to for the actual
-backing-store representation. c64/c128 bodies follow the reference's
-interleaved-float representation — an f32/f64vector of twice the logical
-length holding re/im pairs — rather than native `c64vector`/`c128vector`
-(whose byte layout is identical: 2 consecutive f32s/f64s per element): the
-spec's `data?` contract ("`#t` iff `data->body` returns a body sharing the
-data, without copying") makes accepting the reference's even-length float
-vectors possible only by actually using them as the body, and that shape is
-what reference-coupled code and the official suite's fixtures feed to
-`make-specialized-array-from-data` (#2382). The single most-reused implementation pattern
-across the views/combinators/assembly phases: build a lazy virtual array via
-`make-array` with a computed getter over the target domain, then delegate to
-`array-copy` (which already owns all storage-class/mutable?/safe? option
-parsing and the materializing fill loop) rather than hand-rolling a fill
-mechanism per procedure — used for `array-stack`, `array-decurry`,
-`array-append`, `array-block`, and more. Their `!` twins are confirmed-safe
-pure aliases (verified by reading the reference implementation: both entry
-points wrap one shared helper differing only in whether inputs are eagerly
-pre-materialized before the fill, a distinction observable only under
-multi-shot-continuation re-entry, which the spec itself declares undefined).
-Every *accumulating* non-`!` procedure — `interval-fold-left`/`-right`,
-`array-fold-left`/`-right`, `array-reduce`, `array-every`, `array->list`, and
-the collection half of `array-copy` — threads its accumulator functionally
-through one shared walk (`%interval-fold` in `intervals.sld`), never a `set!`
-cell or a pre-sized scratch vector. The spec defines *call/cc safe* as written
-"in a way that does not modify the state of any data captured by a
-continuation" and intends every procedure without a trailing `!` to be that;
-both mutable shapes shipped here until the SRFI's author showed (kaappi#2539)
-that a second re-entry of a getter's continuation resumes over an earlier
-re-entry's overwrites. A single re-entry cannot distinguish a shared buffer
-from a functional accumulator — the official suite's own continuation cases
-(entries 737-741) passed over the scratch design — so the regression tests
-drive two continuations, each invoked twice — and `tools/srfi231_diff.py`
-(`docs/dev/testing.md`) now generates random view/reshape programs and diffs
-Kaappi against the reference under Gambit, for the properties fixed cases
-cannot see. The tester's first find (kaappi#2542) is the imag-part
-convention leaking through the reference's own code: its c64/c128 checker
-is textually `(and (complex? obj) (inexact? (real-part obj)) (inexact?
-(imag-part obj)))`, but Gambit's exact-0 `(imag-part 1.0)` makes it reject
-a bare real flonum that Kaappi's equally R7RS-legal inexact `0.0` accepted
-— so the shipped checker carries an explicit `(not (real? x))`, encoding
-the sample implementation's verdict under either convention (a `1.0+0.0i`
-with a real inexact-zero imaginary part is still accepted).
+backing-store representation. c64/c128 bodies follow the sample
+implementation's interleaved-float representation — an f32/f64vector of twice
+the logical length holding re/im pairs — rather than native
+`c64vector`/`c128vector` (whose byte layout is identical: 2 consecutive
+f32s/f64s per element): the spec's `data?` contract ("`#t` iff `data->body`
+returns a body sharing the data, without copying") makes accepting the sample
+implementation's even-length float vectors possible only by actually using them
+as the body, and that shape is what sample-implementation-coupled code and the
+official suite's fixtures feed to `make-specialized-array-from-data` (#2382).
+The single most-reused implementation pattern across the
+views/combinators/assembly phases: build a lazy virtual array via `make-array`
+with a computed getter over the target domain, then delegate to `array-copy`
+(which already owns all storage-class/mutable?/safe? option parsing and the
+materializing fill loop) rather than hand-rolling a fill mechanism per
+procedure — used for `array-stack`, `array-decurry`, `array-append`,
+`array-block`, and more. Their `!` twins are confirmed-safe pure aliases
+(verified by reading the sample implementation: both entry points wrap one
+shared helper differing only in whether inputs are eagerly pre-materialized
+before the fill, a distinction observable only under multi-shot-continuation
+re-entry, which the spec itself declares undefined). Every *accumulating*
+non-`!` procedure — `interval-fold-left`/`-right`, `array-fold-left`/`-right`,
+`array-reduce`, `array-every`, `array->list`, and the collection half of
+`array-copy` — threads its accumulator functionally through one shared walk
+(`%interval-fold` in `intervals.sld`), never a `set!` cell or a pre-sized
+scratch vector. The spec defines *call/cc safe* as written "in a way that does
+not modify the state of any data captured by a continuation" and intends every
+procedure without a trailing `!` to be that; both mutable shapes shipped here
+until the SRFI's author showed (kaappi#2539) that a second re-entry of a
+getter's continuation resumes over an earlier re-entry's overwrites. A single
+re-entry cannot distinguish a shared buffer from a functional accumulator — the
+official suite's own continuation cases (entries 737-741) passed over the
+scratch design — so the regression tests drive two continuations, each invoked
+twice — and `tools/srfi231_diff.py` (`docs/dev/testing.md`) now generates
+random view/reshape programs and diffs Kaappi against the sample implementation
+under Gambit, for the properties fixed cases cannot see. The tester's first
+find (kaappi#2542) is the imag-part convention leaking through the sample
+implementation's own code: its c64/c128 checker is textually `(and (complex?
+obj) (inexact? (real-part obj)) (inexact? (imag-part obj)))`, but Gambit's
+exact-0 `(imag-part 1.0)` makes it reject a bare real flonum that Kaappi's
+equally R7RS-legal inexact `0.0` accepted — so the shipped checker carries an
+explicit `(not (real? x))`, encoding the sample implementation's verdict under
+either convention (a `1.0+0.0i` with a real inexact-zero imaginary part is
+still accepted).
 
 **That clause is under review (see the terminology note below), because the
 document does not require it.** The normative prose says `cX-storage-class`
@@ -949,36 +950,36 @@ not conformance. Raised with the SRFI's author; revisit when he answers.
 
 A residual the checker cannot reach: a mixed-exactness complex (`1+2.0i`,
 `(make-rectangular 1 2.0)`) keeps an exact real part under Gambit, so the
-reference rejects it, while Kaappi's complex representation makes
-exactness contagious — both parts are inexact before any checker runs —
-and accepts it (chibi accepts it as well, through a checker that is not
-the reference's). R7RS-legal on both; if the tester's value pool
-ever grows a mixed-exactness literal, the Kaappi-accepts/Gambit-rejects
-verdict it will surface is this known residual, not a new bug.
-`array-copy` of a non-specialized
-source is therefore the reference's exact shape (reversed list, then a body
-filled by linear position). A specialized source takes the direct fill, as in
-the reference's `%!array-copy` — a deliberate, documented exception: a
-`make-storage-class` getter or a `specialized-array-share` mapping is user code
-that runs inside that fill and could capture a continuation, and neither the
-reference nor Kaappi defends it (the list path would cost 14× the peak memory
-on the common typed-array copy; the measurements are in `views.sld`).
+sample implementation rejects it, while Kaappi's complex representation makes
+exactness contagious — both parts are inexact before any checker runs — and
+accepts it (chibi accepts it as well, through a checker that is not the sample
+implementation's). R7RS-legal on both; if the tester's value pool ever grows a
+mixed-exactness literal, the Kaappi-accepts/Gambit-rejects verdict it will
+surface is this known residual, not a new bug. `array-copy` of a
+non-specialized source is therefore the sample implementation's exact shape
+(reversed list, then a body filled by linear position). A specialized source
+takes the direct fill, as in the sample implementation's `%!array-copy` — a
+deliberate, documented exception: a `make-storage-class` getter or a
+`specialized-array-share` mapping is user code that runs inside that fill and
+could capture a continuation, and neither the sample implementation nor Kaappi
+defends it (the list path would cost 14× the peak memory on the common
+typed-array copy; the measurements are in `views.sld`).
 `specialized-array-reshape` uses a deliberate packed-check-based
-affine-detection simplification instead of the reference's full multi-group
-algorithm, verified identical on the spec's own worked examples. (`array-packed?`
-itself means consecutive-increasing from any body base — not a zero base —
-per #2314; an `array-extract` view with a non-zero offset is packed and
-reshapes in place through this same fast path, like the reference.) `array-block`
-needed a genuinely two-phase algorithm unlike everything else in the SRFI:
-full per-axis width-consistency validation (reusing
-`array-curry`+`array-permute`+`index-first`) followed by cheap
+affine-detection simplification instead of the sample implementation's full
+multi-group algorithm, verified identical on the spec's own worked examples.
+(`array-packed?` itself means consecutive-increasing from any body base — not a
+zero base — per #2314; an `array-extract` view with a non-zero offset is packed
+and reshapes in place through this same fast path, like the sample
+implementation.) `array-block` needed a genuinely two-phase algorithm unlike
+everything else in the SRFI: full per-axis width-consistency validation
+(reusing `array-curry`+`array-permute`+`index-first`) followed by cheap
 single-pencil-probing for offsets (reusing
-`array-curry`+`array-permute`+`index-last`), both confirmed against the
-sample implementation. The SRFI's own prose pseudocode disagreed with its
-sample implementation at least twice (`check-nested-list`'s dimension-0
-case returns `'()`, not the prose's nonsensical `#t`; `array-inner-product`'s
-prose omits a required `array-curry` argument the sample code supplies), so
-where the two diverge we read the code to work out what was meant.
+`array-curry`+`array-permute`+`index-last`), both confirmed against the sample
+implementation. The SRFI's own prose pseudocode disagreed with its sample
+implementation at least twice (`check-nested-list`'s dimension-0 case returns
+`'()`, not the prose's nonsensical `#t`; `array-inner-product`'s prose omits a
+required `array-curry` argument the sample code supplies), so where the two
+diverge we read the code to work out what was meant.
 
 **That is a working heuristic, not a rule the SRFI states.** An earlier
 version of this note called it "this SRFI's documented rule"; the document

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -932,9 +932,22 @@ is textually `(and (complex? obj) (inexact? (real-part obj)) (inexact?
 (imag-part obj)))`, but Gambit's exact-0 `(imag-part 1.0)` makes it reject
 a bare real flonum that Kaappi's equally R7RS-legal inexact `0.0` accepted
 — so the shipped checker carries an explicit `(not (real? x))`, encoding
-the reference's verdict under either convention (a `1.0+0.0i` with a real
-inexact-zero imaginary part is still accepted). A residual the checker
-cannot reach: a mixed-exactness complex (`1+2.0i`,
+the sample implementation's verdict under either convention (a `1.0+0.0i`
+with a real inexact-zero imaginary part is still accepted).
+
+**That clause is under review (see the terminology note below), because the
+document does not require it.** The normative prose says `cX-storage-class`
+procedures "manipulate complex numbers with, respectively, 32- and 64-bit
+floating-point numbers as real and imaginary parts" — and under Kaappi's
+representation `1.0` is one: `(complex? 1.0)` is `#t` with `real-part` `1.0`
+and `imag-part` `0.0`, both inexact. The one normative constraint on a
+checker is that `(checker (getter v i))` be `#t`, which holds either way
+(the getter returns `1.0+0.0i`). So rejecting a bare real matches Gambit's
+verdict rather than the document's requirement, and it is a portability
+choice — code written against Kaappi will not silently break on Gambit —
+not conformance. Raised with the SRFI's author; revisit when he answers.
+
+A residual the checker cannot reach: a mixed-exactness complex (`1+2.0i`,
 `(make-rectangular 1 2.0)`) keeps an exact real part under Gambit, so the
 reference rejects it, while Kaappi's complex representation makes
 exactness contagious — both parts are inexact before any checker runs —
@@ -961,12 +974,22 @@ full per-axis width-consistency validation (reusing
 `array-curry`+`array-permute`+`index-first`) followed by cheap
 single-pencil-probing for offsets (reusing
 `array-curry`+`array-permute`+`index-last`), both confirmed against the
-reference implementation. The SRFI's own prose pseudocode disagreed with its
-reference implementation at least twice (`check-nested-list`'s dimension-0
+sample implementation. The SRFI's own prose pseudocode disagreed with its
+sample implementation at least twice (`check-nested-list`'s dimension-0
 case returns `'()`, not the prose's nonsensical `#t`; `array-inner-product`'s
-prose omits a required `array-curry` argument the reference code supplies) —
-confirming "when this SRFI's prose and its reference implementation disagree,
-trust the code" as a load-bearing rule for this SRFI specifically.
+prose omits a required `array-curry` argument the sample code supplies), so
+where the two diverge we read the code to work out what was meant.
+
+**That is a working heuristic, not a rule the SRFI states.** An earlier
+version of this note called it "this SRFI's documented rule"; the document
+says no such thing, and Brad Lucier (the SRFI's author) corrected us on it:
+the implementation Gambit bundles is a *sample* implementation, not a
+reference one, and "generally speaking the document is the specification."
+The document uses "sample implementation" throughout and "reference
+implementation" nowhere. Where prose and sample code disagree, the prose
+governs unless there is positive reason to think it is an error — and a
+divergence that turns on the *host's* representation choices (see the
+c64/c128 checker note above) is not evidence of a prose error at all.
 `array-extract`-derived views preserve **absolute** source coordinates, never
 resetting to 0-based, per the spec's own worked example. SRFI 231 supersedes
 SRFI 179 (its own abstract: "a revised and improved version of SRFI 179") with

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -376,7 +376,7 @@ the base to compare body sharing; every step is guarded, so *whether* a
 step errors is compared too. It is deliberately biased toward the affine
 boundary — merging axes whose strides no longer chain after a permute or
 sample — since that is where `specialized-array-reshape` reasons about index
-arithmetic rather than mirroring the reference's structure. The `storage`
+arithmetic rather than mirroring the sample implementation's structure. The `storage`
 mode takes one storage class per case through everything that consults its
 checker, getter and setter — the checker's verdict on boundary and
 wrong-typed values, `make-specialized-array` with an initial value,

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -342,18 +342,21 @@ Conventions specific to this suite:
   (`KAAPPI_SRFI231_OFFICIAL_TIMEOUT`, default 600 s) instead of the 60 s
   default.
 
-### Differential testing against the reference (`tools/srfi231_diff.py`)
+### Differential testing against the sample implementation (`tools/srfi231_diff.py`)
 
-The official suite encodes the reference implementation's answers on the
+The official suite encodes the sample implementation's answers on the
 inputs its author wrote down; it cannot see a property its cases never
 exercise. kaappi#2539 — `array-copy` breaking the spec's own definition of
 call/cc-safe — passed all of it. `tools/srfi231_diff.py` looks for what
 fixed cases miss: it generates random SRFI 231 programs from a seed, runs
 each under Kaappi and an oracle, and reports every program whose printed
-output differs. The oracle is the reference itself — this SRFI's documented
-rule is "when prose and reference code disagree, trust the code" — as
-bundled by Gambit (`brew install gambit-scheme`; `gsi` may be shadowed by a
-shell alias, the tool defaults to `/opt/homebrew/bin/gsi`), with chibi's
+output differs. The oracle is the SRFI's own *sample* implementation — the
+document's term; it says "reference implementation" nowhere, and its author
+notes that "generally speaking the document is the specification", so a
+Kaappi/oracle divergence is a lead to investigate against the prose, not a
+verdict on its own — as bundled by Gambit (`brew install gambit-scheme`;
+`gsi` may be shadowed by a shell alias, the tool defaults to
+`/opt/homebrew/bin/gsi`), with chibi's
 independent port as a tie-breaker (`--oracle chibi`; confirm a chibi-only
 mismatch against Gambit before chasing it).
 

--- a/lib/srfi/231/arrays.sld
+++ b/lib/srfi/231/arrays.sld
@@ -7,7 +7,7 @@
 ;;;
 ;;; An array is a domain (an interval) plus a getter (a procedure called
 ;;; with SEPARATE positional index arguments, confirmed throughout the
-;;; primary spec text and its reference implementation -- never a packed
+;;; primary spec text and its sample implementation -- never a packed
 ;;; vector/list). A setter, if present, makes it mutable; array-set!'s
 ;;; value argument is SECOND (right after the array), matching SRFI 63's
 ;;; convention, not SRFI 25/164's value-last -- confirmed directly from
@@ -111,14 +111,12 @@
     ;; because the caller asked for an unsafe array (#2448).
     ;;
     ;; Returns the checker to apply per element, or #f when the check is
-    ;; provably vacuous:
-    ;;   - a generic destination manipulates every value; or
-    ;;   - source and destination share a storage class, so every value
-    ;;     read out of the source body already satisfies the destination's
-    ;;     checker by construction.
-    ;; (The reference goes further with a widening table -- u8 into u32 and
-    ;; friends. Not needed for the paths here; the two cases above already
-    ;; cover same-class copies and generic destinations.)
+    ;; provably vacuous: - a generic destination manipulates every value; or -
+    ;; source and destination share a storage class, so every value read out of
+    ;; the source body already satisfies the destination's checker by
+    ;; construction. (The sample implementation goes further with a widening
+    ;; table -- u8 into u32 and friends. Not needed for the paths here; the two
+    ;; cases above already cover same-class copies and generic destinations.)
     (define (%copy-value-checker source dest-storage-class)
       (if (or (eq? dest-storage-class generic-storage-class)
               (and (specialized-array? source)
@@ -148,19 +146,20 @@
       (let ((setter (if (null? maybe-setter) #f (car maybe-setter))))
         (unless (or (not setter) (procedure? setter))
           (error "make-array: setter must be a procedure or #f" setter))
-        ;; The reference wraps EVERY generalized array's getter/setter in
-        ;; index checks (%%make-safer-array, generic-arrays.scm): out-of-
-        ;; domain, wrong-arity, and empty-domain calls all error there, and
-        ;; the official suite tests it -- plain arrays are not exempt
-        ;; (#2362). Valid accesses are unaffected. Plain arrays have no
-        ;; storage-class checker, so the setter's value check is vacuous.
+        ;; The sample implementation wraps EVERY generalized array's
+        ;; getter/setter in index checks (%%make-safer-array,
+        ;; generic-arrays.scm): out-of- domain, wrong-arity, and empty-domain
+        ;; calls all error there, and the official suite tests it -- plain
+        ;; arrays are not exempt (#2362). Valid accesses are unaffected. Plain
+        ;; arrays have no storage-class checker, so the setter's value check is
+        ;; vacuous.
         (%make-array interval (%safe-getter interval getter)
                      (and setter (%safe-setter interval (lambda (v) #t) setter))
                      #f #f #f #f)))
 
     ;; safe?/mutable? are booleans everywhere they appear (the two default
     ;; parameters and both specialized constructors' options) -- the
-    ;; reference implementation rejects non-booleans at each site rather
+    ;; sample implementation rejects non-booleans at each site rather
     ;; than letting a truthy wrong-typed value silently flip a mode.
     (define (%check-boolean! x who)
       (unless (boolean? x) (error (string-append who ": argument must be a boolean") x)))
@@ -180,7 +179,7 @@
     ;; widths -- a direct generalization of SRFI 63's %row-major-offset to
     ;; arbitrary (not just zero-based) lower bounds. The walk consumes
     ;; exactly d arguments; anything left over is a too-long multi-index,
-    ;; which must error even on the unsafe path -- the reference's
+    ;; which must error even on the unsafe path -- the sample implementation's
     ;; fixed-arity getters reject wrong arity regardless of safe? (#2358).
     (define (%make-lex-indexer interval)
       (let ((lo (interval-lower-bounds->vector interval))
@@ -218,11 +217,11 @@
       (let* ((storage-class (%opt opts 0 generic-storage-class))
              (initial-value (%opt opts 1 (storage-class-default storage-class)))
              (safe? (%opt opts 2 (specialized-array-default-safe?))))
-        ;; Upfront validation matching the reference (:2587-:2601): a
-        ;; non-storage-class second argument and an initial value the
-        ;; class cannot manipulate both error at construction, named by
-        ;; this procedure, instead of surfacing from the maker later (or,
-        ;; for float classes, silently coercing) (#2359).
+        ;; Upfront validation matching the sample implementation (:2587-:2601):
+        ;; a non-storage-class second argument and an initial value the class
+        ;; cannot manipulate both error at construction, named by this
+        ;; procedure, instead of surfacing from the maker later (or, for float
+        ;; classes, silently coercing) (#2359).
         (unless (storage-class? storage-class)
           (error "make-specialized-array: not a storage class" storage-class))
         (unless ((storage-class-checker storage-class) initial-value)
@@ -275,7 +274,7 @@
     ;; lexicographical order, are stored in (array-body array) with
     ;; increasing and consecutive indices". The first visited position may
     ;; be ANY base (a non-zero offset view such as array-extract's is still
-    ;; packed), matching the reference implementation, which checks only
+    ;; packed), matching the sample implementation, which checks only
     ;; stride-1 differences between lexicographic neighbors and treats a
     ;; length-1 axis as trivially packed. Always true immediately after
     ;; make-specialized-array/make-specialized-array-from-data; becomes

--- a/lib/srfi/231/arrays.sld
+++ b/lib/srfi/231/arrays.sld
@@ -111,12 +111,14 @@
     ;; because the caller asked for an unsafe array (#2448).
     ;;
     ;; Returns the checker to apply per element, or #f when the check is
-    ;; provably vacuous: - a generic destination manipulates every value; or -
-    ;; source and destination share a storage class, so every value read out of
-    ;; the source body already satisfies the destination's checker by
-    ;; construction. (The sample implementation goes further with a widening
-    ;; table -- u8 into u32 and friends. Not needed for the paths here; the two
-    ;; cases above already cover same-class copies and generic destinations.)
+    ;; provably vacuous:
+    ;;   - a generic destination manipulates every value; or
+    ;;   - source and destination share a storage class, so every value read
+    ;;     out of the source body already satisfies the destination's checker
+    ;;     by construction.
+    ;; (The sample implementation goes further with a widening table -- u8
+    ;; into u32 and friends. Not needed for the paths here; the two cases
+    ;; above already cover same-class copies and generic destinations.)
     (define (%copy-value-checker source dest-storage-class)
       (if (or (eq? dest-storage-class generic-storage-class)
               (and (specialized-array? source)
@@ -148,11 +150,11 @@
           (error "make-array: setter must be a procedure or #f" setter))
         ;; The sample implementation wraps EVERY generalized array's
         ;; getter/setter in index checks (%%make-safer-array,
-        ;; generic-arrays.scm): out-of- domain, wrong-arity, and empty-domain
+        ;; generic-arrays.scm): out-of-domain, wrong-arity, and empty-domain
         ;; calls all error there, and the official suite tests it -- plain
-        ;; arrays are not exempt (#2362). Valid accesses are unaffected. Plain
-        ;; arrays have no storage-class checker, so the setter's value check is
-        ;; vacuous.
+        ;; arrays are not exempt (#2362). Valid accesses are unaffected.
+        ;; Plain arrays have no storage-class checker, so the setter's value
+        ;; check is vacuous.
         (%make-array interval (%safe-getter interval getter)
                      (and setter (%safe-setter interval (lambda (v) #t) setter))
                      #f #f #f #f)))

--- a/lib/srfi/231/assembly.sld
+++ b/lib/srfi/231/assembly.sld
@@ -9,7 +9,7 @@
 ;;; stack/decurry/append/block, it has no bang-less/bang-ful pair (just
 ;;; itself) and is intrinsically NOT call/cc safe (it explicitly mutates
 ;;; destination in place, interleaved get-then-set per index in
-;;; lexicographic order -- confirmed via the reference implementation,
+;;; lexicographic order -- confirmed via the sample implementation,
 ;;; since the spec's own prose is ambiguous between "read all, then
 ;;; write all" and "interleaved"; the spec's own aliasing warning --
 ;;; "if assigning any element of destination affects the value of any
@@ -18,7 +18,7 @@
 ;;; Requires EXACT domain equality (interval=, confirmed via the spec's
 ;;; own regression test showing same-volume-but-different-domain is
 ;;; explicitly rejected, not merely discouraged) and returns an
-;;; unspecified value (confirmed via the reference implementation
+;;; unspecified value (confirmed via the sample implementation
 ;;; returning (void), not destination).
 ;;;
 ;;; array-stack/array-decurry/array-append/array-block all follow the
@@ -29,7 +29,7 @@
 ;;; safe? option parsing and the materializing fill loop) rather than
 ;;; hand-rolling a separate fill mechanism per procedure. Their `!`
 ;;; twins are implemented as pure aliases of the non-! version --
-;;; confirmed by reading the reference implementation directly: every
+;;; confirmed by reading the sample implementation directly: every
 ;;; one of these four's `!` and non-`!` entry points are two one-line
 ;;; wrappers around one shared internal helper differing only in
 ;;; whether input arrays are eagerly materialized before the fill runs.
@@ -74,11 +74,11 @@
       ;; interval-for-each over them, so the index check is redundant on
       ;; both sides -- but the VALUE check is not (#2448).
       (let ((dest-setter (array-unsafe-setter destination)) (src-getter (array-unsafe-getter source)))
-        ;; The reference validates every element against the destination's
-        ;; checker even when the destination is an UNSAFE specialized array
-        ;; ("should check anyway", test-arrays.scm:4361); the unsafe setter
-        ;; skips checking, which for e.g. u1 silently corrupts bits
-        ;; instead of erroring (#2359).
+        ;; The sample implementation validates every element against the
+        ;; destination's checker even when the destination is an UNSAFE
+        ;; specialized array ("should check anyway", test-arrays.scm:4361); the
+        ;; unsafe setter skips checking, which for e.g. u1 silently corrupts
+        ;; bits instead of erroring (#2359).
         (let ((checker (and (specialized-array? destination)
                             (%copy-value-checker source (array-storage-class destination)))))
           (interval-for-each (lambda multi-index
@@ -117,21 +117,21 @@
 
     (define (array-stack! k arrays . opts) (apply array-stack k arrays opts))
 
-    ;; Takes a "curried" array of arrays (all inner arrays sharing one
-    ;; common domain -- actively validated here, matching the reference
-    ;; implementation's stricter-than-the-bare-spec behavior) and returns
-    ;; a single specialized array with domain (interval-cartesian-product
-    ;; outer-domain inner-domain) -- outer axes first, inner axes second.
-    ;; An inverse to array-curry; a multi-dimensional version of
-    ;; array-stack.
+    ;; Takes a "curried" array of arrays (all inner arrays sharing one common
+    ;; domain -- actively validated here, matching the sample implementation
+    ;; implementation's stricter-than-the-bare-spec behavior) and returns a
+    ;; single specialized array with domain (interval-cartesian-product
+    ;; outer-domain inner-domain) -- outer axes first, inner axes second. An
+    ;; inverse to array-curry; a multi-dimensional version of array-stack.
     (define (array-decurry AofA . opts)
       (unless (array? AofA) (error "array-decurry: not an array" AofA))
       (when (array-empty? AofA) (error "array-decurry: outer array must be nonempty" AofA))
-      ;; Copy AofA before any validation or consumption, as the reference
-      ;; does ((array-copy A-arg) up front): the user-visible outer getter
-      ;; then fires exactly once per element -- during this copy -- per
-      ;; the spec's access-count guarantee, instead of once per validation
-      ;; probe plus once per result element via the virtual getter (#2356).
+      ;; Copy AofA before any validation or consumption, as the sample
+      ;; implementation does ((array-copy A-arg) up front): the user-visible
+      ;; outer getter then fires exactly once per element -- during this copy
+      ;; -- per the spec's access-count guarantee, instead of once per
+      ;; validation probe plus once per result element via the virtual getter
+      ;; (#2356).
       (let* ((Acopy (array-copy AofA))
              (outer-domain (array-domain Acopy))
              (outer-d (array-dimension Acopy))
@@ -248,17 +248,17 @@
     ;; array-append. AofA's own domain is normalized to zero lower bounds
     ;; first so every "corner"/pencil-start probe used by validation and
     ;; offset computation is always literally an all-zeros multi-index,
-    ;; matching the reference implementation's own approach and avoiding
+    ;; matching the sample implementation's own approach and avoiding
     ;; having to track bounds by hand through the axis permutations both
     ;; helpers perform internally.
     (define (array-block AofA . opts)
       (unless (array? AofA) (error "array-block: not an array" AofA))
       (when (array-empty? AofA) (error "array-block: outer array must be nonempty" AofA))
-      ;; Copy AofA before validating, as the reference does -- the outer
-      ;; getter fires once per element (during this copy) instead of once
+      ;; Copy AofA before validating, as the sample implementation does -- the
+      ;; outer getter fires once per element (during this copy) instead of once
       ;; for validation and once for the fill (#2356). The copy is also
-      ;; normalized to zero lower bounds so every "corner"/pencil-start
-      ;; probe below is always literally an all-zeros multi-index.
+      ;; normalized to zero lower bounds so every "corner"/pencil-start probe
+      ;; below is always literally an all-zeros multi-index.
       (let* ((d (array-dimension AofA))
              (orig-lowers (interval-lower-bounds->vector (array-domain AofA)))
              (A (array-translate (array-copy AofA) (vector-map - orig-lowers)))

--- a/lib/srfi/231/assembly.sld
+++ b/lib/srfi/231/assembly.sld
@@ -118,7 +118,7 @@
     (define (array-stack! k arrays . opts) (apply array-stack k arrays opts))
 
     ;; Takes a "curried" array of arrays (all inner arrays sharing one common
-    ;; domain -- actively validated here, matching the sample implementation
+    ;; domain -- actively validated here, matching the sample
     ;; implementation's stricter-than-the-bare-spec behavior) and returns a
     ;; single specialized array with domain (interval-cartesian-product
     ;; outer-domain inner-domain) -- outer axes first, inner axes second. An

--- a/lib/srfi/231/combinators.sld
+++ b/lib/srfi/231/combinators.sld
@@ -9,14 +9,14 @@
 ;;; arrays, ALL of which must have the exact SAME domain -- interval
 ;;; equality, not just matching shape). array-reduce is the one
 ;;; exception: fixed 2-arg, single array only, hard-errors on an empty
-;;; array (confirmed unconditional in the reference implementation --
+;;; array (confirmed unconditional in the sample implementation --
 ;;; there is no seed/identity to fall back on, unlike fold-left/right).
 ;;; array-map returns a lazy (recomputed on every access), immutable,
 ;;; non-specialized array -- never eagerly evaluated.
 ;;;
 ;;; array-fold-left calls operator as (operator acc e0 e1 ...); array-
 ;;; fold-right calls it as (operator e0 e1 ... acc) -- accumulator LAST,
-;;; not first -- confirmed via the spec's own formal reference
+;;; not first -- confirmed via the spec's own formal
 ;;; definition, which passes elements as SEPARATE positional arguments
 ;;; via apply, never as one packed list argument. Confirmed via the
 ;;; spec's own example that this distinction is observable, not just
@@ -28,10 +28,10 @@
 ;;; copy + outer-product + map + reduce) needed care in two places the
 ;;; spec's own prose pseudocode gets subtly wrong: it omits the required
 ;;; second argument to array-curry on its second call (both calls need
-;;; it -- confirmed against the reference implementation, not just the
+;;; it -- confirmed against the sample implementation, not just the
 ;;; inconsistent prose), and its "Assumes" paragraph doesn't mention
 ;;; that the shared axis's width must be nonzero (also confirmed only
-;;; via the reference implementation -- needed because the inner
+;;; via the sample implementation -- needed because the inner
 ;;; reduction would otherwise call array-reduce on an empty array).
 ;;;
 ;;; list*->array/array->list*/vector*->array/array->vector* infer or
@@ -64,7 +64,7 @@
 
     (define (%opt lst i default) (if (> (length lst) i) (list-ref lst i) default))
 
-    ;; The reference implementation validates the function argument of
+    ;; The sample implementation validates the function argument of
     ;; every combinator at call time -- without this, the lazy ones
     ;; (array-map, array-outer-product) would defer the failure to the
     ;; first element access (possibly never), and the eager ones would
@@ -74,11 +74,11 @@
       (unless (procedure? x) (error (string-append who ": the function argument must be a procedure") x)))
 
     (define (%check-same-domain! all who)
-      ;; Every element must be an array before array-domain can be called
-      ;; on it -- otherwise a non-array argument surfaces as an internal
-      ;; %record-ref type error instead of a message naming the procedure
-      ;; (the reference checks "Not all arguments after the first are
-      ;; arrays" up front) (#2359).
+      ;; Every element must be an array before array-domain can be called on it
+      ;; -- otherwise a non-array argument surfaces as an internal %record-ref
+      ;; type error instead of a message naming the procedure (the sample
+      ;; implementation checks "Not all arguments after the first are arrays"
+      ;; up front) (#2359).
       (for-each (lambda (a)
                   (unless (array? a)
                     (error (string-append who ": all arguments after the first must be arrays") all)))
@@ -92,7 +92,7 @@
     ;; --- mapping / folding / iteration ---
 
     ;; Lazy: the result's getter recomputes f on every access, never
-    ;; eagerly evaluated -- confirmed by the spec's own reference
+    ;; eagerly evaluated -- confirmed by the spec's own
     ;; definition, which builds an ordinary (immutable, non-specialized)
     ;; make-array rather than a specialized/precomputed one.
     (define (array-map f array . arrays)
@@ -141,7 +141,7 @@
 
     ;; No identity/seed -- a private sentinel distinguishes "no elements
     ;; combined yet" from a legitimate accumulated value, matching the
-    ;; reference implementation's own technique (needed because there is
+    ;; sample implementation's own technique (needed because there is
     ;; no safe placeholder value that couldn't collide with a real
     ;; element). Hard error on an empty array -- confirmed unconditional,
     ;; not gated by any safety flag.
@@ -247,11 +247,10 @@
       (let* ((storage-class (%opt opts 0 generic-storage-class))
              (mutable? (%opt opts 1 (specialized-array-default-mutable?)))
              (safe? (%opt opts 2 (specialized-array-default-safe?)))
-             ;; The reference validates every element against the checker
-             ;; up front ("Not all elements of the source can be
-             ;; manipulated by the storage class"); the raw fill below
-             ;; skips checking, which for e.g. u1 silently corrupts bits
-             ;; (#2359).
+             ;; The sample implementation validates every element against the
+             ;; checker up front ("Not all elements of the source can be
+             ;; manipulated by the storage class"); the raw fill below skips
+             ;; checking, which for e.g. u1 silently corrupts bits (#2359).
              (checker (storage-class-checker storage-class)))
         (for-each (lambda (x)
                     (unless (checker x)
@@ -281,7 +280,8 @@
       (let* ((storage-class (%opt opts 0 generic-storage-class))
              (mutable? (%opt opts 1 (specialized-array-default-mutable?)))
              (safe? (%opt opts 2 (specialized-array-default-safe?)))
-             ;; see list->array: upfront element validation per the reference
+             ;; see list->array: upfront element validation per the sample
+             ;; implementation
              (checker (storage-class-checker storage-class)))
         (let loop ((i 0))
           (when (< i (vector-length vect))
@@ -317,7 +317,7 @@
       (nested-list->nested-vector (array-dimension array) (array->list* array)))
 
     ;; dimension=0 short-circuits to '() unconditionally (per the
-    ;; reference implementation -- the spec's own prose pseudocode has a
+    ;; sample implementation -- the spec's own prose pseudocode has a
     ;; documentation bug here, returning #t via `or`, which cannot
     ;; possibly be right since the caller immediately does
     ;; (list->vector (check-nested-list ...))). A length-0 list at ANY
@@ -346,10 +346,10 @@
         (else (apply append (map (lambda (l) (%flatten-nested-list (- dimension 1) l)) nested-list)))))
 
     (define (list*->array dimension nested-list . opts)
-      ;; The reference validates the dimension argument up front ("The
-      ;; first argument is not a nonnegative fixnum"); without this a
-      ;; negative or non-integer dimension fails inside make-list or the
-      ;; shape walk with an internal error instead (#2359).
+      ;; The sample implementation validates the dimension argument up front
+      ;; ("The first argument is not a nonnegative fixnum"); without this a
+      ;; negative or non-integer dimension fails inside make-list or the shape
+      ;; walk with an internal error instead (#2359).
       (unless (and (exact-integer? dimension) (>= dimension 0))
         (error "list*->array: dimension must be a nonnegative exact integer" dimension))
       (let ((shape (%check-nested-list dimension nested-list)))

--- a/lib/srfi/231/intervals.sld
+++ b/lib/srfi/231/intervals.sld
@@ -20,7 +20,7 @@
 ;;;
 ;;; Every procedure's calling convention and error behavior below was
 ;;; confirmed against the primary spec text (srfi.schemers.org/srfi-231)
-;;; and its official reference implementation before being written --
+;;; and its official sample implementation before being written --
 ;;; including two procedures (translation?, permutation?) whose exact
 ;;; validation rule the spec states only in prose, not executable
 ;;; pseudocode, and interval-fold-right's "all f evaluations before any
@@ -262,9 +262,9 @@
 
     (define (interval-scale interval scales)
       (%check-dimension-match! scales interval "interval-scale")
-      ;; The spec requires "a length-d vector of positive exact integers";
-      ;; the reference rejects bad scales up front. Without this check a
-      ;; negative scale on a zero-width axis or a rational scale silently
+      ;; The spec requires "a length-d vector of positive exact integers"; the
+      ;; sample implementation rejects bad scales up front. Without this check
+      ;; a negative scale on a zero-width axis or a rational scale silently
       ;; produces a plausible-looking interval instead of an error (#2357).
       (let ((d (vector-length scales)))
         (let loop ((i 0))

--- a/lib/srfi/231/storage-classes.sld
+++ b/lib/srfi/231/storage-classes.sld
@@ -3,7 +3,7 @@
 ;;; A storage-class is a 9-field record of procedures/values managing a
 ;;; specialized array's backing store (getter, setter, checker, maker,
 ;;; copier, length, default, data?, data->body) -- confirmed via primary
-;;; source + the official reference implementation before writing any code.
+;;; source + the official sample implementation before writing any code.
 ;;; This mirrors, and can directly extend, the (kind maker ref setter!
 ;;; length default) table already built for SRFI 63's array kinds
 ;;; (lib/srfi/63.sld's %kind-table), just with two more fields (checker,
@@ -12,22 +12,21 @@
 ;;; phase) and itself a first-class Scheme object rather than a bare list.
 ;;;
 ;;; 17 storage-class global variables must all be BOUND, but per spec --
-;;; "Implementations with an appropriate homogeneous vector type should
-;;; define the associated global variable using make-storage-class.
-;;; Otherwise, they shall define the associated global variable to #f" --
-;;; an implementation lacking the underlying element type may bind one to
-;;; #f. 12 of the 17 map cleanly onto this codebase's already-shipped
-;;; (srfi 160 <tag>) NumericVector substrate; 2 more (generic, char) need
-;;; no numeric substrate at all -- Kaappi's native vector/string already
-;;; satisfy the "linearly indexed, 0-based, vector-like" contract, and the
-;;; spec gives their exact reference definitions verbatim, reused here
-;;; unchanged. u1 is a direct port of the reference's own bit-packing over
-;;; u16vector (the representation the spec itself documents for bit
-;;; arrays), and f16 a faithful port of its software half-floats over
-;;; u16vector (#2379) -- the spec's #f escape clause is for implementations
-;;; lacking the substrate, which neither port is. f8 alone is left #f,
-;;; even in the SRFI's OWN reference implementation (no standard 8-bit
-;;; float Scheme type exists anywhere).
+;;; "Implementations with an appropriate homogeneous vector type should define
+;;; the associated global variable using make-storage-class. Otherwise, they
+;;; shall define the associated global variable to #f" -- an implementation
+;;; lacking the underlying element type may bind one to #f. 12 of the 17 map
+;;; cleanly onto this codebase's already-shipped (srfi 160 <tag>) NumericVector
+;;; substrate; 2 more (generic, char) need no numeric substrate at all --
+;;; Kaappi's native vector/string already satisfy the "linearly indexed,
+;;; 0-based, vector-like" contract, and the spec gives their exact definitions
+;;; verbatim, reused here unchanged. u1 is a direct port of the sample
+;;; implementation's own bit-packing over u16vector (the representation the
+;;; spec itself documents for bit arrays), and f16 a faithful port of its
+;;; software half-floats over u16vector (#2379) -- the spec's #f escape clause
+;;; is for implementations lacking the substrate, which neither port is. f8
+;;; alone is left #f, even in the SRFI's OWN sample implementation (no standard
+;;; 8-bit float Scheme type exists anywhere).
 (define-library (srfi 231 storage-classes)
   (import (scheme base)
           (srfi 160 s8) (srfi 160 s16) (srfi 160 s32) (srfi 160 s64)
@@ -65,7 +64,7 @@
     ;; data->body: the body IS the data for every built-in class (no
     ;; offset/scale to install), but the contract still requires rejecting
     ;; wrong-typed data instead of handing it back as a would-be body
-    ;; (reference implementation: "converts data to a body, raising an
+    ;; (sample implementation: "converts data to a body, raising an
     ;; exception if needed").
     (define (%checked-data->body pred class-name type-name)
       (lambda (data)
@@ -86,9 +85,10 @@
                            make-vector vector-copy! vector-length
                            #f vector? (%checked-data->body vector? "generic-storage-class" "vector")))
 
-    ;; Reference default is #\null (NUL, U+0000) -- generic-arrays.scm's
-    ;; defaults list and the official test suite both assert it; the spec
-    ;; prose's #\0 (digit zero) is stale relative to its own reference.
+    ;; The sample implementation's default is #\null (NUL, U+0000) --
+    ;; generic-arrays.scm's defaults list and the official test suite both
+    ;; assert it; the spec prose's #\0 (digit zero) is stale relative to its
+    ;; own sample implementation.
     (define char-storage-class
       (make-storage-class string-ref string-set! char?
                            make-string string-copy! string-length
@@ -127,20 +127,19 @@
       (make-storage-class u64vector-ref u64vector-set! (%exact-int-range-checker 0 18446744073709551615)
                            make-u64vector u64vector-copy! u64vector-length 0 u64vector? (%checked-data->body u64vector? "u64-storage-class" "u64vector")))
 
-    ;; fX/cX checkers match the reference exactly: f32/f64 accept only
-    ;; inexact reals (flonum?, generic-arrays.scm's f32/f64 checker) and
-    ;; c64/c128 only proper complexes whose real and imaginary parts are
-    ;; both inexact. Accepting exact values silently coerces them (1/3
-    ;; stored into c64 narrows to f32 precision), diverging from the
-    ;; reference's "value cannot be stored in body" error (#2355). The
-    ;; reference's checker is (and (complex? obj) (inexact? (real-part
-    ;; obj)) (inexact? (imag-part obj))), but under Gambit's exact-0
-    ;; (imag-part 1.0) that rejects a bare real flonum, while Kaappi's
-    ;; inexact 0.0 (also R7RS-legal, 6.2.6 mandates only zero?, not
-    ;; exactness) accepted it -- so (not (real? x)) encodes the
-    ;; reference's verdict independently of the host's imag-part
-    ;; convention; 1.0+0.0i with an explicit inexact zero imaginary part
-    ;; is still accepted (#2542).
+    ;; fX/cX checkers match the sample implementation exactly: f32/f64 accept
+    ;; only inexact reals (flonum?, generic-arrays.scm's f32/f64 checker) and
+    ;; c64/c128 only proper complexes whose real and imaginary parts are both
+    ;; inexact. Accepting exact values silently coerces them (1/3 stored into
+    ;; c64 narrows to f32 precision), diverging from the sample
+    ;; implementation's "value cannot be stored in body" error (#2355). The
+    ;; sample implementation's checker is (and (complex? obj) (inexact?
+    ;; (real-part obj)) (inexact? (imag-part obj))), but under Gambit's exact-0
+    ;; (imag-part 1.0) that rejects a bare real flonum, while Kaappi's inexact
+    ;; 0.0 (also R7RS-legal, 6.2.6 mandates only zero?, not exactness) accepted
+    ;; it -- so (not (real? x)) encodes the sample implementation's verdict
+    ;; independently of the host's imag-part convention; 1.0+0.0i with an
+    ;; explicit inexact zero imaginary part is still accepted (#2542).
     (define (%flonum-checker x) (and (real? x) (inexact? x)))
     (define (%inexact-complex-checker x)
       (and (complex? x) (not (real? x))
@@ -153,28 +152,27 @@
       (make-storage-class f64vector-ref f64vector-set! %flonum-checker
                            make-f64vector f64vector-copy! f64vector-length 0.0 f64vector? (%checked-data->body f64vector? "f64-storage-class" "f64vector")))
 
-    ;; c64/c128 -- a faithful port of the reference's representation
-    ;; (generic-arrays.scm's make-complex-storage-classes): the body is a
-    ;; homogeneous FLOAT vector (f32vector for c64, f64vector for c128) of
-    ;; twice the logical length, real and imaginary parts interleaved.
-    ;; data? accepts exactly the even-length float vectors that can serve
-    ;; as the body zero-copy -- the spec's data? contract ("returns #t if
-    ;; and only if data->body returns a body sharing data with data,
-    ;; without copying") permits accepting the reference's data shape only
-    ;; by actually using it as the body, so reference-coupled portable code
+    ;; c64/c128 -- a faithful port of the sample implementation's
+    ;; representation (generic-arrays.scm's make-complex-storage-classes): the
+    ;; body is a homogeneous FLOAT vector (f32vector for c64, f64vector for
+    ;; c128) of twice the logical length, real and imaginary parts interleaved.
+    ;; data? accepts exactly the even-length float vectors that can serve as
+    ;; the body zero-copy -- the spec's data? contract ("returns #t if and only
+    ;; if data->body returns a body sharing data with data, without copying")
+    ;; permits accepting the sample implementation's data shape only by
+    ;; actually using it as the body, so portable code coupled to that shape
     ;; and the official suite's fixtures flow into
-    ;; make-specialized-array-from-data unchanged (#2382; the class
-    ;; previously rejected them -- kaappi's bodies were native
-    ;; c64vector/c128vector). Kaappi's SRFI 160 c64vector/c128vector use
-    ;; the identical byte layout -- 2 consecutive f32s/f64s per element,
-    ;; never boxed -- so this is a change of type tag, not of memory
-    ;; shape; the spec explicitly allows either representation ("another
-    ;; implementation ... might make another choice"), and reference
-    ;; fidelity is what interoperates. Consequence:
-    ;; c64vector/c128vector data is no longer accepted -- convert with
-    ;; make-specialized-array's maker or a copy loop if needed. Like the
-    ;; reference's own c64vector-copy!/c128vector-copy! wrappers, the
-    ;; copier takes LOGICAL complex-element offsets and scales by 2
+    ;; make-specialized-array-from-data unchanged (#2382; the class previously
+    ;; rejected them -- kaappi's bodies were native c64vector/c128vector).
+    ;; Kaappi's SRFI 160 c64vector/c128vector use the identical byte layout --
+    ;; 2 consecutive f32s/f64s per element, never boxed -- so this is a change
+    ;; of type tag, not of memory shape; the spec explicitly allows either
+    ;; representation ("another implementation ... might make another choice"),
+    ;; and matching the sample implementation is what interoperates.
+    ;; Consequence: c64vector/c128vector data is no longer accepted -- convert
+    ;; with make-specialized-array's maker or a copy loop if needed. Like the
+    ;; sample implementation's own c64vector-copy!/c128vector-copy! wrappers,
+    ;; the copier takes LOGICAL complex-element offsets and scales by 2
     ;; internally -- the same units as every other storage-class field.
     (define (%complex-storage-class float-ref float-set! make-float-vector
                                     float-copy! float-length vec?
@@ -209,8 +207,8 @@
                        ((= i l) result)
                      (float-set! result i re)
                      (float-set! result (+ i 1) im))))))
-         ;; copier -- the reference's c64vector-copy! wrapper: logical
-         ;; element offsets, scaled by 2 onto the float block copy
+         ;; copier -- the sample implementation's c64vector-copy! wrapper:
+         ;; logical element offsets, scaled by 2 onto the float block copy
          (lambda (to at from start end)
            (float-copy! to (* 2 at) from (* 2 start) (* 2 end)))
          ;; length -- half the physical float count
@@ -233,16 +231,16 @@
                               f64vector-copy! f64vector-length f64vector?
                               "c128-storage-class" "f64vector"))
 
-    ;; u1 -- bit arrays, ported from the reference implementation's own
+    ;; u1 -- bit arrays, ported from the sample implementation's own
     ;; bit-packing (generic-arrays.scm's u1-storage-class): the body is a
-    ;; (vector n u16vector) pair where n is the number of VALID bits and
-    ;; the u16vector holds the bit string little-endian within each u16
-    ;; (bit i lives at u16[i div 16], bit position i mod 16). The spec
-    ;; mandates uX for X=1 and documents exactly this representation, and
-    ;; (srfi 160 u16) supplies the substrate, so #f was not the spec's
-    ;; sanctioned fallback here (#2353). The reference passes #f for the
-    ;; copier ("no copier (for now") and so do we; nothing in this
-    ;; package ever calls storage-class-copier.
+    ;; (vector n u16vector) pair where n is the number of VALID bits and the
+    ;; u16vector holds the bit string little-endian within each u16 (bit i
+    ;; lives at u16[i div 16], bit position i mod 16). The spec mandates uX for
+    ;; X=1 and documents exactly this representation, and (srfi 160 u16)
+    ;; supplies the substrate, so #f was not the spec's sanctioned fallback
+    ;; here (#2353). The sample implementation passes #f for the copier ("no
+    ;; copier (for now") and so do we; nothing in this package ever calls
+    ;; storage-class-copier.
     (define u1-storage-class
       (make-storage-class
        ;; getter
@@ -268,7 +266,7 @@
        (lambda (size initializer)
          (let ((u16-size (quotient (+ size 15) 16)))
            (vector size (make-u16vector u16-size (if (= 0 initializer) 0 65535)))))
-       ;; no copier, as in the reference
+       ;; no copier, as in the sample implementation
        #f
        ;; length -- the valid-bit count, not 16 * u16 length
        (lambda (v) (vector-ref v 0))
@@ -282,12 +280,12 @@
              (error "Expecting a u16vector passed to (storage-class-data->body u1-storage-class): " data)
              (vector (* 16 (u16vector-length data)) data)))))
 
-    ;; f8 -- #f even in the SRFI's OWN reference implementation: no
+    ;; f8 -- #f even in the SRFI's OWN sample implementation: no
     ;; standard 8-bit float format exists to conform to.
     (define f8-storage-class #f)
 
     ;; f16 -- software half-floats over a u16vector: a faithful
-    ;; transliteration of the reference implementation's own codec
+    ;; transliteration of the sample implementation's own codec
     ;; (generic-arrays.scm's f16->double / double->f16), hand-expanded
     ;; from its defining macro for the single instantiation (mantissa-width
     ;; 10, exponent-width 5, bias 15) the class needs (#2379). The codec
@@ -304,7 +302,7 @@
     ;;     (comparisons don't distinguish -0.0; eqv? does, per R7RS)
     ;;   flfinite?/flnan? -> finite?/nan? from (scheme inexact)
     ;; The two structural properties that make this codec correct, both
-    ;; from the reference and both preserved:
+    ;; from the sample implementation and both preserved:
     ;;   - the subnormal branch scales by 2^24 directly: ONE rounding at
     ;;     the subnormal ulp (a normalize-then-shift formula would round
     ;;     twice, at the wrong ulp);
@@ -335,13 +333,13 @@
                (let ((n (if (= s 0) m (- m))))
                  (* n (expt 2.0 -24)))))))
 
-    ;; floor(log2|x|), clamped to [-15, 16], for a finite, nonzero real
-    ;; x -- the reference's flilogb, written fresh as a halving/doubling
-    ;; loop (exact at every step: multiplying by 2.0 or 0.5 never
-    ;; rounds). The clamp loses nothing: %f16-encode only ever consumes
-    ;; the classification ("<= -15", "in [-14,15]", ">= 16") plus the
-    ;; exact exponent inside the normal range, and it bounds the loop to
-    ;; ~31 iterations even for astronomically large or tiny doubles.
+    ;; floor(log2|x|), clamped to [-15, 16], for a finite, nonzero real x --
+    ;; the sample implementation's flilogb, written fresh as a halving/doubling
+    ;; loop (exact at every step: multiplying by 2.0 or 0.5 never rounds). The
+    ;; clamp loses nothing: %f16-encode only ever consumes the classification
+    ;; ("<= -15", "in [-14,15]", ">= 16") plus the exact exponent inside the
+    ;; normal range, and it bounds the loop to ~31 iterations even for
+    ;; astronomically large or tiny doubles.
     (define (%ilogb x)
       (let ((ax (abs x)))
         (if (>= ax 1.0)
@@ -403,8 +401,8 @@
                               ;; overflow to smallest normal
                               (%construct sign-bit 1 0))))))))))
 
-    ;; Class wiring mirrors the reference's f16 entry exactly: the same
-    ;; checker acceptance as f32/f64 (flonum? -- the setter ROUNDS, never
+    ;; Class wiring mirrors the sample implementation's f16 entry exactly: the
+    ;; same checker acceptance as f32/f64 (flonum? -- the setter ROUNDS, never
     ;; rejects), the fill encoded once by the maker, and the identity
     ;; data->body contract of every u16vector-backed class.
     (define f16-storage-class

--- a/lib/srfi/231/views.sld
+++ b/lib/srfi/231/views.sld
@@ -29,7 +29,7 @@
 ;;; specialized-array-reshape's affine-detectability test is, in the
 ;;; spec's own words, "modeled on the corresponding code in the Python
 ;;; library NumPy" and not specified in prose beyond that. This port
-;;; follows the reference implementation's actual algorithm, derived from
+;;; follows the sample implementation's actual algorithm, derived from
 ;;; NumPy's _attempt_nocopy_reshape: empirically probe the source array's
 ;;; own (affine) indexer to recover its base and per-axis strides, drop
 ;;; the size-1 axes, then greedily match minimal adjacent-axis volume
@@ -46,7 +46,7 @@
 ;;;
 ;;; The reshape matching loops (loop-1..loop-4 in %specialized-array-reshape)
 ;;; are a line-by-line translation of NumPy's _attempt_nocopy_reshape
-;;; (numpy/core/src/multiarray/shape.c), by way of the SRFI 231 reference
+;;; (numpy/core/src/multiarray/shape.c), by way of the SRFI 231 sample
 ;;; implementation, which carries the same derivation note. NumPy is
 ;;; distributed under the BSD 3-Clause License, Copyright (c) 2005-2024,
 ;;; NumPy Developers.
@@ -255,7 +255,7 @@
        ((and (integer? Sk) (exact? Sk) (positive? Sk))
         ;; A scalar slice-width is legal only on a positive-width axis; a
         ;; zero-width axis must use the explicit-vector form (e.g. #(0)),
-        ;; whose entries sum to the width -- the reference implementation's
+        ;; whose entries sum to the width -- the sample implementation's
         ;; own rule.
         (if (eqv? width 0)
             (error "array-tile: a scalar slice-width is allowed only on an axis of positive width" k Sk width)
@@ -310,62 +310,58 @@
     ;; generic-storage-class/specialized-array-default-mutable?/-safe? --
     ;; confirmed via an explicit spec quote naming this exact asymmetry.
     ;;
-    ;; array-copy must be call/cc safe -- the spec's term for "does not
-    ;; modify the state of any data captured by a continuation", the
-    ;; whole documented difference from array-copy!, whose getter
-    ;; continuations it is an error to invoke more than once. A getter
-    ;; that captures a continuation and re-invokes it after the copy
-    ;; returned must get a FRESH array, computed from the values ITS run
-    ;; had collected at the capture point, and the array the first call
-    ;; already returned must never mutate under its holder. Two shapes
-    ;; fail that, and both have shipped here:
-    ;;   * a direct fill into a pre-allocated destination (pre-#2454):
-    ;;     the resumed fill overwrites the already-returned array;
-    ;;   * collecting into a shared scratch vector before the destination
-    ;;     exists, with only the position threaded functionally
-    ;;     (#2454..#2539): one re-entry looks right, but the scratch is
-    ;;     one object shared by every continuation captured during the
-    ;;     collection, so a second re-entry -- or a second continuation
-    ;;     captured on the first run -- resumes over positions an earlier
-    ;;     re-entry has already overwritten and materializes ITS prefix.
-    ;;     The official suite's single-re-entry cases (737-741) cannot
-    ;;     see this; the SRFI's author's two-continuation, two-re-entry
-    ;;     case (kaappi#2539) can.
-    ;; Any partially filled structure that a *-set! procedure modifies
-    ;; is state a continuation captured mid-collection shares with every
-    ;; other invocation of it. So this is the reference implementation's
-    ;; shape exactly (%%generalized-array->specialized-array): collect
-    ;; the values into a reversed LIST through %interval-fold's
-    ;; functionally threaded accumulator, allocate the destination only
-    ;; afterwards, and fill its body from the list. The list's prefix is
-    ;; immutable, so a re-entry re-runs the collection over precisely
-    ;; the cells its own frames hold and allocates its own destination.
-    ;; The costs the scratch design was chosen to avoid (kaappi#2464) come
-    ;; back for this path -- N live pairs during the collection, one
-    ;; cons per element -- but the copy-out no longer regenerates a
-    ;; multi-index per element: a fresh destination's body IS the
+    ;; array-copy must be call/cc safe -- the spec's term for "does not modify
+    ;; the state of any data captured by a continuation", the whole documented
+    ;; difference from array-copy!, whose getter continuations it is an error
+    ;; to invoke more than once. A getter that captures a continuation and
+    ;; re-invokes it after the copy returned must get a FRESH array, computed
+    ;; from the values ITS run had collected at the capture point, and the
+    ;; array the first call already returned must never mutate under its
+    ;; holder. Two shapes fail that, and both have shipped here: * a direct
+    ;; fill into a pre-allocated destination (pre-#2454): the resumed fill
+    ;; overwrites the already-returned array; * collecting into a shared
+    ;; scratch vector before the destination exists, with only the position
+    ;; threaded functionally (#2454..#2539): one re-entry looks right, but the
+    ;; scratch is one object shared by every continuation captured during the
+    ;; collection, so a second re-entry -- or a second continuation captured on
+    ;; the first run -- resumes over positions an earlier re-entry has already
+    ;; overwritten and materializes ITS prefix. The official suite's
+    ;; single-re-entry cases (737-741) cannot see this; the SRFI's author's
+    ;; two-continuation, two-re-entry case (kaappi#2539) can. Any partially
+    ;; filled structure that a *-set! procedure modifies is state a
+    ;; continuation captured mid-collection shares with every other invocation
+    ;; of it. So this is the sample implementation's shape exactly
+    ;; (%%generalized-array->specialized-array): collect the values into a
+    ;; reversed LIST through %interval-fold's functionally threaded
+    ;; accumulator, allocate the destination only afterwards, and fill its body
+    ;; from the list. The list's prefix is immutable, so a re-entry re-runs the
+    ;; collection over precisely the cells its own frames hold and allocates
+    ;; its own destination. The costs the scratch design was chosen to avoid
+    ;; (kaappi#2464) come back for this path -- N live pairs during the
+    ;; collection, one cons per element -- but the copy-out no longer
+    ;; regenerates a multi-index per element: a fresh destination's body IS the
     ;; lexicographic order (%make-lex-indexer), so it is filled by linear
-    ;; position through the storage class's own setter, the shape the
-    ;; reference uses too. Measured, that trade is a net win in time: 20
-    ;; copies of a 1M-element non-specialized array took 73.5s here
-    ;; against 114.9s over the scratch design (PR #2540 review) -- the
-    ;; per-element indexer call the copy-out used to make cost more than
-    ;; the pairs it avoided. What the pairs DO cost is peak memory: a 1M
-    ;; u8 specialized source copied 6 times peaks at 176 MB RSS through
-    ;; the list against 12.5 MB through the direct fill (18.7s vs 33.3s),
-    ;; which is why the direct fill below stays for specialized sources
-    ;; rather than being retired for speed.
+    ;; position through the storage class's own setter, the shape the sample
+    ;; implementation uses too. Measured, that trade is a net win in time: 20
+    ;; copies of a 1M-element non-specialized array took 73.5s here against
+    ;; 114.9s over the scratch design (PR #2540 review) -- the per-element
+    ;; indexer call the copy-out used to make cost more than the pairs it
+    ;; avoided. What the pairs DO cost is peak memory: a 1M u8 specialized
+    ;; source copied 6 times peaks at 176 MB RSS through the list against 12.5
+    ;; MB through the direct fill (18.7s vs 33.3s), which is why the direct
+    ;; fill below stays for specialized sources rather than being retired for
+    ;; speed.
     ;;
-    ;; A specialized SOURCE takes the direct fill, as in the reference
-    ;; (%!array-copy): its getter is the storage class's, so no user
-    ;; code runs during the copy and nothing can capture a continuation
-    ;; in it. (A make-storage-class getter, or a specialized-array-share
-    ;; mapping, is user code that could -- the reference does not defend
-    ;; that either, and neither does this.) The storage-class setter on
-    ;; the copy-out is likewise user code for a custom storage class; a
+    ;; A specialized SOURCE takes the direct fill, as in the sample
+    ;; implementation (%!array-copy): its getter is the storage class's, so no
+    ;; user code runs during the copy and nothing can capture a continuation in
+    ;; it. (A make-storage-class getter, or a specialized-array-share mapping,
+    ;; is user code that could -- the sample implementation does not defend
+    ;; that either, and neither does this.) The storage-class setter on the
+    ;; copy-out is likewise user code for a custom storage class; a
     ;; continuation captured THERE re-enters with the destination already
     ;; allocated and rewrites the same collected values into it, the same
-    ;; residual exposure the reference's shape has.
+    ;; residual exposure the sample implementation's shape has.
     (define (%array-copy-impl array opts call/cc-safe?)
       (unless (array? array) (error "array-copy: not an array" array))
       (%check-boolean! (%opt opts 1 (specialized-array-default-mutable?)) "array-copy: mutable?")
@@ -416,11 +412,11 @@
     ;; --- specialized-array-reshape: see the file header for the
     ;; algorithm description. ---
 
-    ;; Returns all-lowers first, then one multi-index per axis with that
-    ;; single axis incremented by 1 (staying in-domain if the axis width
-    ;; permits, else left at its lower bound). Probing the array's affine
-    ;; indexer at the base and at each of these recovers base + per-axis
-    ;; strides. Mirrors the reference impl's %%compute-multi-index-increments.
+    ;; Returns all-lowers first, then one multi-index per axis with that single
+    ;; axis incremented by 1 (staying in-domain if the axis width permits, else
+    ;; left at its lower bound). Probing the array's affine indexer at the base
+    ;; and at each of these recovers base + per-axis strides. Mirrors the
+    ;; sample implementation impl's %%compute-multi-index-increments.
     (define (%reshape-index-increments lowers uppers)
       (if (null? lowers)
           (list lowers)
@@ -487,11 +483,11 @@
                  (newdims (interval-widths new-domain))
                  (newnd (vector-length newdims))
                  (oldnd (vector-length olddims))
-                 ;; Any new axis not assigned a stride by the matching below
-                 ;; is a width-1 axis, whose (index - lower) term is always 0,
-                 ;; so its stride value is never observed -- leaving it 0 is
-                 ;; safe (the reference notes NumPy instead sets these to a
-                 ;; value; "we leave it zero").
+                 ;; Any new axis not assigned a stride by the matching below is
+                 ;; a width-1 axis, whose (index - lower) term is always 0, so
+                 ;; its stride value is never observed -- leaving it 0 is safe
+                 ;; (the sample implementation notes NumPy instead sets these
+                 ;; to a value; "we leave it zero").
                  (newstrides (make-vector newnd 0))
                  (fail (lambda ()
                          (if copy-on-failure?

--- a/lib/srfi/231/views.sld
+++ b/lib/srfi/231/views.sld
@@ -317,20 +317,21 @@
     ;; re-invokes it after the copy returned must get a FRESH array, computed
     ;; from the values ITS run had collected at the capture point, and the
     ;; array the first call already returned must never mutate under its
-    ;; holder. Two shapes fail that, and both have shipped here: * a direct
-    ;; fill into a pre-allocated destination (pre-#2454): the resumed fill
-    ;; overwrites the already-returned array; * collecting into a shared
-    ;; scratch vector before the destination exists, with only the position
-    ;; threaded functionally (#2454..#2539): one re-entry looks right, but the
-    ;; scratch is one object shared by every continuation captured during the
-    ;; collection, so a second re-entry -- or a second continuation captured on
-    ;; the first run -- resumes over positions an earlier re-entry has already
-    ;; overwritten and materializes ITS prefix. The official suite's
-    ;; single-re-entry cases (737-741) cannot see this; the SRFI's author's
-    ;; two-continuation, two-re-entry case (kaappi#2539) can. Any partially
-    ;; filled structure that a *-set! procedure modifies is state a
-    ;; continuation captured mid-collection shares with every other invocation
-    ;; of it. So this is the sample implementation's shape exactly
+    ;; holder. Two shapes fail that, and both have shipped here:
+    ;;   * a direct fill into a pre-allocated destination (pre-#2454): the
+    ;;     resumed fill overwrites the already-returned array;
+    ;;   * collecting into a shared scratch vector before the destination
+    ;;     exists, with only the position threaded functionally
+    ;;     (#2454..#2539): one re-entry looks right, but the scratch is one
+    ;;     object shared by every continuation captured during the
+    ;;     collection, so a second re-entry -- or a second continuation
+    ;;     captured on the first run -- resumes over positions an earlier
+    ;;     re-entry has already overwritten and materializes ITS prefix.
+    ;; The official suite's single-re-entry cases (737-741) cannot see this;
+    ;; the SRFI's author's two-continuation, two-re-entry case (kaappi#2539)
+    ;; can. Any partially filled structure that a *-set! procedure modifies is
+    ;; state a continuation captured mid-collection shares with every other
+    ;; invocation of it. So this is the sample implementation's shape exactly
     ;; (%%generalized-array->specialized-array): collect the values into a
     ;; reversed LIST through %interval-fold's functionally threaded
     ;; accumulator, allocate the destination only afterwards, and fill its body

--- a/tools/srfi231_diff.py
+++ b/tools/srfi231_diff.py
@@ -2,7 +2,7 @@
 """Differential testing of Kaappi's SRFI 231 against the sample implementation.
 
 "Sample implementation" is the SRFI's own term -- the document uses it
-throughout and never says "sample implementation" -- and its author has
+throughout and never says "reference implementation" -- and its author has
 noted that "generally speaking the document is the specification". So this
 tool's oracle is a very good second opinion, not an authority: a divergence
 is a lead to check against the prose, and where the two genuinely disagree
@@ -13,9 +13,10 @@ subset of R7RS all three run, executes each under Kaappi and an oracle, and
 reports any program whose printed output differs.
 
 Why this exists: the official conformance suite (10,936 evaluations) encodes
-the sample implementation's answers on the inputs its author wrote down. It cannot see a
-property violation its cases never exercise -- kaappi#2539 passed the whole
-suite while breaking the spec's own definition of call/cc-safe. Generated
+the sample implementation's answers on the inputs its author wrote down. It
+cannot see a property violation its cases never exercise -- kaappi#2539
+passed the whole suite while breaking the spec's own definition of
+call/cc-safe. Generated
 inputs find bugs at the rate of inputs, not ideas.
 
 It is **not** part of `run-all.sh`: it needs an oracle installed (`brew install
@@ -90,11 +91,13 @@ Modes
            implementation reasons about index arithmetic rather than copying
            the sample implementation's structure.
 
-Known oracle divergences. Gambit's bundled sample implementation flips the initial
+Known oracle divergences. Gambit's bundled sample implementation flips the
+initial
 value of `specialized-array-default-safe?` to #t (spec and the SRFI
 repository's copy: #f); the storage mode pins it to #f in its prelude.
 kaappi#2542 (the c64/c128 checkers accepted real flonums, which the
-sample implementation rejects) used to surface as `check` mismatches on those two
+sample implementation rejects) used to surface as `check` mismatches on those
+two
 classes; before kaappi#2543 fixed it, the workaround was excluding them
 with `--classes`, and both are back in the default draw. Since a
 program's first difference hides everything after it, `--classes` is
@@ -416,7 +419,8 @@ STORAGE_PRELUDE = PRELUDE.replace(
     "(import (scheme base) (scheme write) (srfi 231))",
     "(import (scheme base) (scheme write) (scheme inexact) (scheme complex) (srfi 231))") + """\
 ;; the spec says (specialized-array-default-safe?) is initially #f, and so
-;; does the SRFI repository's sample-implementation source, but Gambit's bundled copy
+;; does the SRFI repository's sample-implementation source, but Gambit's
+;; bundled copy
 ;; of that same file flips the initial value to #t -- pin it, so an omitted
 ;; safe? argument means the same thing under both
 (specialized-array-default-safe? #f)
@@ -729,7 +733,8 @@ PROSE_PRELUDE = """\
         ;; (c64vector? v) arm here would raise unbound-variable for EVERY
         ;; value that reaches it, which try turns into ERROR: the mode would
         ;; silently degrade to ERROR==ERROR agreement. Their bodies are
-        ;; f32/f64vectors in the sample implementation and here, so they render through
+        ;; f32/f64vectors in the sample implementation and here, so they
+        ;; render through
         ;; the arms below; an arm for a native type would need a guard.
         ((u8vector? v) (list 'u8 (u8vector->list v)))
         ((s8vector? v) (list 's8 (s8vector->list v)))

--- a/tools/srfi231_diff.py
+++ b/tools/srfi231_diff.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
-"""Differential testing of Kaappi's SRFI 231 against the reference implementation.
+"""Differential testing of Kaappi's SRFI 231 against the sample implementation.
 
-SRFI 231's documented rule in this codebase is "when the spec's prose and its
-reference implementation disagree, trust the code" -- which makes the reference
-an oracle in the strict sense. Gambit bundles it as `(srfi 231)`, and chibi
-ships an independent port. This tool generates random SRFI 231 programs in the
+"Sample implementation" is the SRFI's own term -- the document uses it
+throughout and never says "sample implementation" -- and its author has
+noted that "generally speaking the document is the specification". So this
+tool's oracle is a very good second opinion, not an authority: a divergence
+is a lead to check against the prose, and where the two genuinely disagree
+the prose governs unless there is positive reason to think it is an error.
+Gambit bundles the sample implementation as `(srfi 231)`, and chibi ships an
+independent port. This tool generates random SRFI 231 programs in the
 subset of R7RS all three run, executes each under Kaappi and an oracle, and
 reports any program whose printed output differs.
 
 Why this exists: the official conformance suite (10,936 evaluations) encodes
-the reference's answers on the inputs its author wrote down. It cannot see a
+the sample implementation's answers on the inputs its author wrote down. It cannot see a
 property violation its cases never exercise -- kaappi#2539 passed the whole
 suite while breaking the spec's own definition of call/cc-safe. Generated
 inputs find bugs at the rate of inputs, not ideas.
@@ -84,13 +88,13 @@ Modes
            NumPy-derived affine-reshape detection in lib/srfi/231/views.sld
            and at array-packed? over composed views, the two places where the
            implementation reasons about index arithmetic rather than copying
-           the reference's structure.
+           the sample implementation's structure.
 
-Known oracle divergences. Gambit's bundled reference flips the initial
+Known oracle divergences. Gambit's bundled sample implementation flips the initial
 value of `specialized-array-default-safe?` to #t (spec and the SRFI
 repository's copy: #f); the storage mode pins it to #f in its prelude.
 kaappi#2542 (the c64/c128 checkers accepted real flonums, which the
-reference rejects) used to surface as `check` mismatches on those two
+sample implementation rejects) used to surface as `check` mismatches on those two
 classes; before kaappi#2543 fixed it, the workaround was excluding them
 with `--classes`, and both are back in the default draw. Since a
 program's first difference hides everything after it, `--classes` is
@@ -412,7 +416,7 @@ STORAGE_PRELUDE = PRELUDE.replace(
     "(import (scheme base) (scheme write) (srfi 231))",
     "(import (scheme base) (scheme write) (scheme inexact) (scheme complex) (srfi 231))") + """\
 ;; the spec says (specialized-array-default-safe?) is initially #f, and so
-;; does the SRFI repository's reference source, but Gambit's bundled copy
+;; does the SRFI repository's sample-implementation source, but Gambit's bundled copy
 ;; of that same file flips the initial value to #t -- pin it, so an omitted
 ;; safe? argument means the same thing under both
 (specialized-array-default-safe? #f)
@@ -725,7 +729,7 @@ PROSE_PRELUDE = """\
         ;; (c64vector? v) arm here would raise unbound-variable for EVERY
         ;; value that reaches it, which try turns into ERROR: the mode would
         ;; silently degrade to ERROR==ERROR agreement. Their bodies are
-        ;; f32/f64vectors in the reference and here, so they render through
+        ;; f32/f64vectors in the sample implementation and here, so they render through
         ;; the arms below; an arm for a native type would need a guard.
         ((u8vector? v) (list 'u8 (u8vector->list v)))
         ((s8vector? v) (list 's8 (s8vector->list v)))
@@ -777,7 +781,7 @@ PROSE_SKIP_MARKERS = ["read-char", "read-line", "open-input", "open-output",
                       # signature lines with optional arguments are prose
                       "[",
                       # a lazy array of 10^9 elements summed in blocks: the
-                      # reference needs minutes for it
+                      # the sample implementation needs minutes for it
                       "'#(1000000001)"]
 
 


### PR DESCRIPTION
We described the implementation Gambit bundles as SRFI 231's **"reference implementation"**, and wrote up *"when prose and reference code disagree, trust the code"* as **this SRFI's documented rule** — in `docs/dev/srfi-implementation-notes.md`, `docs/dev/testing.md`, and `tools/srfi231_diff.py`'s docstring.

Neither is right, and I checked the document rather than taking it on faith:

| | |
|---|---|
| `"sample implementation"` in srfi-231.html | **15** |
| `"reference implementation"` | **0** |
| a "trust the code" rule | **not present** |

The heuristic was ours. Calling it *documented* asserted something about the spec that isn't in it. Brad Lucier (the SRFI's author) [corrected us on r/KaappiScheme](https://github.com/kaappi/kaappi/pull/2541): the bundled code is a *sample* implementation, and "generally speaking the document is the specification."

## What changed

- **The rule paragraph says what it actually is** — a working heuristic adopted after two real prose/code divergences (`check-nested-list`'s dimension-0 case; `array-inner-product`'s missing `array-curry` argument) — and records that the prose governs unless there's positive reason to think it's in error.
- **The differential tester's oracle is demoted to match.** A Kaappi/oracle divergence is a lead to check against the prose, not a verdict on its own. Its CLI is unchanged.
- **Terminology follows** across `lib/srfi/231/*.sld`, `docs/dev/testing.md` and the tool.

Most of the diff is reflow: "sample implementation" is 12 characters longer than "reference", which pushed 30 comment lines past these files' 79-column wrap. **No code changed** — `git diff` on the `.sld` files touches only `;;` lines.

## This puts #2543 in question, and the note now says so

That PR added `(not (real? x))` to the c64/c128 checkers so a bare real flonum is rejected — purely to reproduce the sample implementation's verdict under Gambit, where `(imag-part 1.0)` is an exact `0`. It was justified by the rule this PR retracts.

The normative prose says `cX-storage-class` procedures "manipulate complex numbers with, respectively, 32- and 64-bit floating-point numbers as real and imaginary parts". Under Kaappi's representation `1.0` **is** one — verified: `(complex? 1.0)` → `#t`, `(real-part 1.0)` → `1.0`, `(imag-part 1.0)` → `0.0`, both inexact. And the one normative constraint on a checker, that `(checker (getter v i))` be `#t`, holds either way, since the getter returns `1.0+0.0i`.

So rejecting a bare real is a **portability choice** — code written against Kaappi won't silently break on Gambit — not conformance. **Left in place and asked upstream**; this PR makes no behavior change. The note records the reasoning so the answer can be applied without re-deriving it.

## Verification

- All eight SRFI 231 suites pass; the official suite reports **10936 passed, 0 unexpected failures**
- `tools/srfi231_diff.py` parses and its `--help` is unchanged
- `markdownlint-cli2`: 0 issues

## Not in scope

Other SRFIs' notes also say "reference implementation". Many SRFIs do use that term for their own bundled code, so this is scoped to 231 — where the author told us the term is wrong — rather than blanket-renamed. The released v0.27.0 changelog entry and its GitHub release body carry the phrase too; leaving those, since editing a published release body is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)