### PR TITLE
Accept bare real flonums in the c64/c128 checkers again

### DIFF
--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -931,10 +931,10 @@ find (kaappi#2542) is the imag-part convention leaking through the sample
 implementation's own code: its c64/c128 checker is textually `(and (complex?
 obj) (inexact? (real-part obj)) (inexact? (imag-part obj)))`, but Gambit's
 exact-0 `(imag-part 1.0)` makes it reject a bare real flonum that Kaappi's
-equally R7RS-legal inexact `0.0` accepted — so the shipped checker carries an
-explicit `(not (real? x))`, encoding the sample implementation's verdict under
-either convention (a `1.0+0.0i` with a real inexact-zero imaginary part is
-still accepted).
+equally R7RS-legal inexact `0.0` accepted — so #2543 shipped the checker with
+an explicit `(not (real? x))` clause, encoding the sample implementation's
+verdict under either convention (a `1.0+0.0i` with a real inexact-zero
+imaginary part was still accepted).
 
 **That clause was reverted in #2559.** The two checkers are the sample
 implementation's line verbatim; the verdicts differ because Gambit's

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -941,7 +941,19 @@ implementation's line verbatim; the verdicts differ because Gambit's
 `(imag-part 1.0)` is an exact `0` and Kaappi's is `0.0`. Brad Lucier confirmed
 that exact-0 is **R6RS**'s rule — adopted there on his own suggestion — and
 "that's not what R7RS small does", adding that implementers can argue either
-way. Kaappi is R7RS-small, which leaves the exactness open, and the normative
+way. Verified against `docs/errata-corrected-r7rs.pdf` §6.2.6 rather than
+taken on report: the section's sole exactness permission is that `real-part`
+and `imag-part` "may return exact real numbers when applied to an inexact
+complex number **if** the corresponding argument passed to `make-rectangular`
+was exact", which a bare `1.0` never went through; what governs it instead is
+"`(real? z)` is true if and only if `(zero? (imag-part z))` is true", and
+`(zero? 0.0)` is `#t`, so an inexact `0.0` satisfies that rule exactly as an
+exact `0` would. Nothing in the document requires one over the other. (That
+iff rule does *not* survive contact with the inexact-zero-imaginary case —
+§6.2.6 also prints `(real? -2.5+0.0i) ⇒ #f`, which the rule would make `#t`;
+the rule and the example contradict each other and every implementation,
+Kaappi and Gambit included, follows the example.) Kaappi is R7RS-small, and
+the normative
 prose asks only for "complex numbers with, respectively, 32- and 64-bit
 floating-point numbers as real and imaginary parts", which `1.0` is under our
 tower: `(complex? 1.0)` is `#t` with `real-part` `1.0` and `imag-part` `0.0`,

--- a/docs/dev/srfi-implementation-notes.md
+++ b/docs/dev/srfi-implementation-notes.md
@@ -936,17 +936,20 @@ explicit `(not (real? x))`, encoding the sample implementation's verdict under
 either convention (a `1.0+0.0i` with a real inexact-zero imaginary part is
 still accepted).
 
-**That clause is under review (see the terminology note below), because the
-document does not require it.** The normative prose says `cX-storage-class`
-procedures "manipulate complex numbers with, respectively, 32- and 64-bit
-floating-point numbers as real and imaginary parts" — and under Kaappi's
-representation `1.0` is one: `(complex? 1.0)` is `#t` with `real-part` `1.0`
-and `imag-part` `0.0`, both inexact. The one normative constraint on a
-checker is that `(checker (getter v i))` be `#t`, which holds either way
-(the getter returns `1.0+0.0i`). So rejecting a bare real matches Gambit's
-verdict rather than the document's requirement, and it is a portability
-choice — code written against Kaappi will not silently break on Gambit —
-not conformance. Raised with the SRFI's author; revisit when he answers.
+**That clause was reverted in #2559.** The two checkers are the sample
+implementation's line verbatim; the verdicts differ because Gambit's
+`(imag-part 1.0)` is an exact `0` and Kaappi's is `0.0`. Brad Lucier confirmed
+that exact-0 is **R6RS**'s rule — adopted there on his own suggestion — and
+"that's not what R7RS small does", adding that implementers can argue either
+way. Kaappi is R7RS-small, which leaves the exactness open, and the normative
+prose asks only for "complex numbers with, respectively, 32- and 64-bit
+floating-point numbers as real and imaginary parts", which `1.0` is under our
+tower: `(complex? 1.0)` is `#t` with `real-part` `1.0` and `imag-part` `0.0`,
+both inexact. The one normative constraint on a checker, that
+`(checker (getter v i))` be `#t`, holds either way. So a bare real flonum is
+accepted again, and the differential tester's c64/c128 disagreement with
+Gambit is a permanent known divergence rather than a finding — recorded in the
+tool so it is not re-filed as #2542 was.
 
 A residual the checker cannot reach: a mixed-exactness complex (`1+2.0i`,
 `(make-rectangular 1 2.0)`) keeps an exact real part under Gambit, so the
@@ -976,10 +979,14 @@ everything else in the SRFI: full per-axis width-consistency validation
 single-pencil-probing for offsets (reusing
 `array-curry`+`array-permute`+`index-last`), both confirmed against the sample
 implementation. The SRFI's own prose pseudocode disagreed with its sample
-implementation at least twice (`check-nested-list`'s dimension-0 case returns
-`'()`, not the prose's nonsensical `#t`; `array-inner-product`'s prose omits a
-required `array-curry` argument the sample code supplies), so where the two
-diverge we read the code to work out what was meant.
+implementation at least twice, so where the two diverge we read the code to
+work out what was meant. Both were put to the author, and neither turned out
+to support that heuristic as stated. `array-inner-product`'s prose does omit a
+required `array-curry` argument the sample code supplies — he confirmed that
+is a document error and will fix it, so the document gets corrected rather
+than overridden. And `check-nested-list`'s dimension-0 case (`'()` in the
+code, `#t` in the prose) is moot: the library does not export it, so what it
+returns is nobody's business.
 
 **That is a working heuristic, not a rule the SRFI states.** An earlier
 version of this note called it "this SRFI's documented rule"; the document

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -414,7 +414,16 @@ raises on a `copy-on-failure? #t` reshape that needs the copy, does not
 validate `make-specialized-array`'s initial value, has checker bugs on
 u16/u64/c64, and returns a list rather than a boolean from its u1 checker
 (the storage mode prints only the boolean verdict, so that one never fires).
-The storage mode's first real finding is kaappi#2542.
+
+One divergence there is permanent and expected rather than a bug in either
+side: Kaappi's c64/c128 checkers accept a bare real flonum and Gambit's
+reject it, because Gambit's `(imag-part 1.0)` is an exact `0` and Kaappi's is
+`0.0` — R6RS mandates the former, R7RS small leaves it open. Filed once as
+kaappi#2542 and "fixed" in kaappi#2543 by forcing Gambit's verdict;
+kaappi#2559 reverted that. It cascades — once the checker accepts, the setter
+runs and the contents diverge too — so the storage mode draws c64/c128 only
+when `--classes` names them, keeping a default run a usable signal. A run that
+names them compares everything.
 
 It is not part of `run-all.sh`: it needs an oracle installed and a useful
 run takes minutes.

--- a/lib/srfi/231/storage-classes.sld
+++ b/lib/srfi/231/storage-classes.sld
@@ -127,22 +127,28 @@
       (make-storage-class u64vector-ref u64vector-set! (%exact-int-range-checker 0 18446744073709551615)
                            make-u64vector u64vector-copy! u64vector-length 0 u64vector? (%checked-data->body u64vector? "u64-storage-class" "u64vector")))
 
-    ;; fX/cX checkers match the sample implementation exactly: f32/f64 accept
-    ;; only inexact reals (flonum?, generic-arrays.scm's f32/f64 checker) and
-    ;; c64/c128 only proper complexes whose real and imaginary parts are both
-    ;; inexact. Accepting exact values silently coerces them (1/3 stored into
-    ;; c64 narrows to f32 precision), diverging from the sample
-    ;; implementation's "value cannot be stored in body" error (#2355). The
-    ;; sample implementation's checker is (and (complex? obj) (inexact?
-    ;; (real-part obj)) (inexact? (imag-part obj))), but under Gambit's exact-0
-    ;; (imag-part 1.0) that rejects a bare real flonum, while Kaappi's inexact
-    ;; 0.0 (also R7RS-legal, 6.2.6 mandates only zero?, not exactness) accepted
-    ;; it -- so (not (real? x)) encodes the sample implementation's verdict
-    ;; independently of the host's imag-part convention; 1.0+0.0i with an
-    ;; explicit inexact zero imaginary part is still accepted (#2542).
+    ;; fX/cX checkers are the sample implementation's, run under our own
+    ;; numeric tower: f32/f64 accept only inexact reals (flonum?,
+    ;; generic-arrays.scm's f32/f64 checker) and c64/c128 only complexes whose
+    ;; real and imaginary parts are both inexact. Accepting exact values
+    ;; silently coerces them (1/3 stored into c64 narrows to f32 precision),
+    ;; diverging from the sample implementation's "value cannot be stored in
+    ;; body" error (#2355).
+    ;;
+    ;; A bare real flonum is ACCEPTED here and rejected under Gambit, and that
+    ;; is a numeric-tower difference, not a checker difference: the line below
+    ;; is the sample implementation's verbatim, but Gambit's (imag-part 1.0) is
+    ;; an exact 0 where ours is 0.0. #2543 added a (not (real? x)) clause to
+    ;; force Gambit's verdict; #2559 reverted it. Exact-0 imag-part is R6RS
+    ;; (which adopted it on the SRFI author's own suggestion) -- R7RS small
+    ;; leaves the exactness open, Kaappi is R7RS-small, and the SRFI's prose
+    ;; asks only for "complex numbers with ... floating-point numbers as real
+    ;; and imaginary parts", which 1.0 is under our tower. The author confirmed
+    ;; implementations may differ here. So the differential tester's c64/c128
+    ;; disagreement with Gambit is a known oracle divergence, not a bug.
     (define (%flonum-checker x) (and (real? x) (inexact? x)))
     (define (%inexact-complex-checker x)
-      (and (complex? x) (not (real? x))
+      (and (complex? x)
            (inexact? (real-part x)) (inexact? (imag-part x))))
 
     (define f32-storage-class

--- a/lib/srfi/231/storage-classes.sld
+++ b/lib/srfi/231/storage-classes.sld
@@ -139,13 +139,30 @@
     ;; is a numeric-tower difference, not a checker difference: the line below
     ;; is the sample implementation's verbatim, but Gambit's (imag-part 1.0) is
     ;; an exact 0 where ours is 0.0. #2543 added a (not (real? x)) clause to
-    ;; force Gambit's verdict; #2559 reverted it. Exact-0 imag-part is R6RS
-    ;; (which adopted it on the SRFI author's own suggestion) -- R7RS small
-    ;; leaves the exactness open, Kaappi is R7RS-small, and the SRFI's prose
-    ;; asks only for "complex numbers with ... floating-point numbers as real
-    ;; and imaginary parts", which 1.0 is under our tower. The author confirmed
-    ;; implementations may differ here. So the differential tester's c64/c128
-    ;; disagreement with Gambit is a known oracle divergence, not a bug.
+    ;; force Gambit's verdict; #2559 reverted it.
+    ;;
+    ;; Exact-0 imag-part is R6RS's rule, adopted there on the SRFI author's own
+    ;; suggestion. R7RS small does not mandate it, and Kaappi is R7RS-small.
+    ;; Checked against docs/errata-corrected-r7rs.pdf, 6.2.6: the sole
+    ;; exactness permission there is that "the real-part and imag-part
+    ;; procedures may return exact real numbers when applied to an inexact
+    ;; complex number IF the corresponding argument passed to make-rectangular
+    ;; was exact" -- which a bare 1.0 never went through, so it does not reach
+    ;; this case. What does govern it is "(real? z) is true if and only if
+    ;; (zero? (imag-part z)) is true": (zero? 0.0) is #t, so an inexact 0.0
+    ;; satisfies that rule exactly as an exact 0 would. Nothing in the document
+    ;; requires one over the other.
+    ;;
+    ;; (Do not lean on that iff rule for the INEXACT-zero-imaginary case: 6.2.6
+    ;; also prints (real? -2.5+0.0i) => #f, which the rule would make #t, since
+    ;; imag-part has no non-zero? value to return there. The rule and the
+    ;; example contradict each other; we follow the example, as Gambit does.)
+    ;;
+    ;; The SRFI's own prose asks only for "complex numbers with ...
+    ;; floating-point numbers as real and imaginary parts", which 1.0 is under
+    ;; our tower, and the author confirmed implementations may differ here. So
+    ;; the differential tester's c64/c128 disagreement with Gambit is a known
+    ;; oracle divergence, not a bug.
     (define (%flonum-checker x) (and (real? x) (inexact? x)))
     (define (%inexact-complex-checker x)
       (and (complex? x)

--- a/tests/scheme/srfi/srfi231-storage-classes.scm
+++ b/tests/scheme/srfi/srfi231-storage-classes.scm
@@ -208,10 +208,12 @@
   (test-equal #t ok)
   (test-equal 2046 nan-patterns))
 
-;;; --- fX/cX checkers match the reference exactly: inexact reals only
-;;; for f32/f64 (flonum?), proper complexes with inexact real and
-;;; imaginary parts for c64/c128 -- exact values were silently coerced
-;;; (1/3 into c64 lost f32 precision) before kaappi#2355 ---
+;;; --- fX/cX checkers are the sample implementation's line exactly:
+;;; inexact reals only for f32/f64 (flonum?), and for c64/c128 any complex
+;;; whose real and imaginary parts are both inexact -- which includes a bare
+;;; real flonum under our tower, since our (imag-part 1.0) is 0.0 (#2559).
+;;; Exact values were silently coerced (1/3 into c64 lost f32 precision)
+;;; before kaappi#2355 ---
 (test-equal #t ((storage-class-checker f64-storage-class) 3.5))
 (test-equal #t ((storage-class-checker f64-storage-class) -0.0))
 (test-equal #f ((storage-class-checker f64-storage-class) 3))
@@ -225,8 +227,10 @@
 ;; R6RS's rule, not R7RS small's. Do not "fix" these to #f to match Gambit --
 ;; that is a numeric-tower difference, and the SRFI's author confirmed
 ;; implementations may differ.
-(test-equal #t ((storage-class-checker c64-storage-class) 3.5))
-(test-equal #t ((storage-class-checker c128-storage-class) 1.0))
+(test-equal "c64 checker accepts a bare real flonum (#2559)"
+            #t ((storage-class-checker c64-storage-class) 3.5))
+(test-equal "c128 checker accepts a bare real flonum (#2559)"
+            #t ((storage-class-checker c128-storage-class) 1.0))
 (test-equal #f ((storage-class-checker c64-storage-class) (make-rectangular 3 4)))
 (test-equal #f ((storage-class-checker c64-storage-class) 1/3))
 (test-equal #f ((storage-class-checker c128-storage-class) (make-rectangular 1/2 2)))
@@ -234,10 +238,19 @@
 ;; that consults the checker at all (same-class copies skip it, #2448).
 ;; Copying real flonums into a c64 array succeeds and round-trips, the
 ;; behavior #2543 removed and #2559 restored.
-(test-equal "array-copy of real flonums into c64 succeeds (#2559)"
-            1.5+0.0i
-            (array-ref (array-copy (make-array (make-interval '#(2)) (lambda (i) 1.5))
+;; 0.1 rather than an f32-exact value like 1.5: the result proves the element
+;; really went through the interleaved f32 body, so this one assertion pins
+;; acceptance, the complex result type, AND the narrowing. The c128 case is
+;; the control -- same input, f64 body, no narrowing.
+(test-equal "array-copy of real flonums into c64 succeeds and narrows (#2559)"
+            0.10000000149011612+0.0i
+            (array-ref (array-copy (make-array (make-interval '#(2)) (lambda (i) 0.1))
                                    c64-storage-class)
+                       0))
+(test-equal "array-copy of real flonums into c128 succeeds without narrowing (#2559)"
+            0.1+0.0i
+            (array-ref (array-copy (make-array (make-interval '#(2)) (lambda (i) 0.1))
+                                   c128-storage-class)
                        0))
 (test-assert "array-copy of 1.0+0.0i into c64 is accepted (#2542)"
              (guard (e (#t #f))

--- a/tests/scheme/srfi/srfi231-storage-classes.scm
+++ b/tests/scheme/srfi/srfi231-storage-classes.scm
@@ -219,19 +219,26 @@
 (test-equal #f ((storage-class-checker f32-storage-class) 42))
 (test-equal #t ((storage-class-checker c64-storage-class) (make-rectangular 3.5 -1.0)))
 (test-equal #t ((storage-class-checker c64-storage-class) 1.0+0.0i)) ; explicit inexact zero imag
-(test-equal #f ((storage-class-checker c64-storage-class) 3.5))     ; bare real: reference rejects (#2542)
-(test-equal #f ((storage-class-checker c128-storage-class) 1.0))    ; same, under the other convention too
+;; A bare real flonum is ACCEPTED (#2559, reverting #2543). Our (imag-part
+;; 1.0) is 0.0, so the sample implementation's own checker line admits it;
+;; Gambit rejects it only because its (imag-part 1.0) is an exact 0, which is
+;; R6RS's rule, not R7RS small's. Do not "fix" these to #f to match Gambit --
+;; that is a numeric-tower difference, and the SRFI's author confirmed
+;; implementations may differ.
+(test-equal #t ((storage-class-checker c64-storage-class) 3.5))
+(test-equal #t ((storage-class-checker c128-storage-class) 1.0))
 (test-equal #f ((storage-class-checker c64-storage-class) (make-rectangular 3 4)))
 (test-equal #f ((storage-class-checker c64-storage-class) 1/3))
 (test-equal #f ((storage-class-checker c128-storage-class) (make-rectangular 1/2 2)))
-;; the user-visible symptom of #2542 was array-copy of a real-flonum
-;; array SUCCEEDING -- the generic->typed copy branch is the only copy
-;; path that consults the checker at all (same-class copies skip it,
-;; #2448), so pin it end to end
-(test-assert "array-copy of real flonums into c64 is rejected (#2542)"
-             (guard (e (#t #t))
-               (array-copy (make-array (make-interval '#(2)) (lambda (i) 1.5)) c64-storage-class)
-               #f))
+;; End-to-end through the generic->typed copy branch, the only copy path
+;; that consults the checker at all (same-class copies skip it, #2448).
+;; Copying real flonums into a c64 array succeeds and round-trips, the
+;; behavior #2543 removed and #2559 restored.
+(test-equal "array-copy of real flonums into c64 succeeds (#2559)"
+            1.5+0.0i
+            (array-ref (array-copy (make-array (make-interval '#(2)) (lambda (i) 1.5))
+                                   c64-storage-class)
+                       0))
 (test-assert "array-copy of 1.0+0.0i into c64 is accepted (#2542)"
              (guard (e (#t #f))
                (array-ref (array-copy (make-array (make-interval '#(2)) (lambda (i) 1.5+0.0i)) c64-storage-class) 0)))

--- a/tools/srfi231_diff.py
+++ b/tools/srfi231_diff.py
@@ -95,13 +95,17 @@ Known oracle divergences. Gambit's bundled sample implementation flips the
 initial
 value of `specialized-array-default-safe?` to #t (spec and the SRFI
 repository's copy: #f); the storage mode pins it to #f in its prelude.
-kaappi#2542 (the c64/c128 checkers accepted real flonums, which the
-sample implementation rejects) used to surface as `check` mismatches on those
-two
-classes; before kaappi#2543 fixed it, the workaround was excluding them
-with `--classes`, and both are back in the default draw. Since a
-program's first difference hides everything after it, `--classes` is
-still the way to focus a run on the classes you care about.
+The c64/c128 checkers disagree with Gambit on a bare real flonum -- Kaappi
+accepts `1.0`, Gambit rejects it -- and that is PERMANENT and expected, not a
+bug to re-file. Both run the sample implementation's checker line verbatim;
+they differ because Gambit's `(imag-part 1.0)` is an exact 0 and Kaappi's is
+`0.0`. Exact-0 is R6RS's rule, adopted there on the SRFI author's own
+suggestion; R7RS small leaves the exactness open and Kaappi is R7RS-small.
+The author confirmed implementations may differ. This was filed once as
+kaappi#2542 and "fixed" in kaappi#2543 by forcing Gambit's verdict; kaappi#2559
+reverted that. Expect `check` mismatches on c64/c128, and use `--classes` to
+exclude them when they would mask something else -- a program's first
+difference hides everything after it.
 And chibi 0.12's port raises on a `copy-on-failure? #t`
 reshape that needs the copy, where the spec (and Gambit, and Kaappi) return a
 copy -- expect that mismatch shape with `--oracle chibi` (seeds 5227 and 5248

--- a/tools/srfi231_diff.py
+++ b/tools/srfi231_diff.py
@@ -103,16 +103,21 @@ they differ because Gambit's `(imag-part 1.0)` is an exact 0 and Kaappi's is
 suggestion; R7RS small leaves the exactness open and Kaappi is R7RS-small.
 The author confirmed implementations may differ. This was filed once as
 kaappi#2542 and "fixed" in kaappi#2543 by forcing Gambit's verdict; kaappi#2559
-reverted that. Expect `check` mismatches on c64/c128, and use `--classes` to
-exclude them when they would mask something else -- a program's first
-difference hides everything after it.
+reverted that. Because it cascades -- once the checker accepts, the setter
+runs and the array contents diverge too -- essentially every c64/c128 case
+mismatches, so those two are drawn only when `--classes` names them. A run
+that does name them compares everything, noise included.
 And chibi 0.12's port raises on a `copy-on-failure? #t`
 reshape that needs the copy, where the spec (and Gambit, and Kaappi) return a
 copy -- expect that mismatch shape with `--oracle chibi` (seeds 5227 and 5248
 of the reshape mode show it) and confirm against Gambit before chasing it.
 Its storage classes have checker bugs of their own (u16 accepts 65536, u64
-accepts negatives, c64 accepts a real flonum, make-specialized-array does
-not validate its initial value), all contradicted by Gambit; its u1 checker
+accepts negatives, make-specialized-array does not validate its initial
+value), all contradicted by Gambit. Its c64 accepts a real flonum too, but
+that is NOT Kaappi's sanctioned divergence wearing a different hat: chibi's
+(imag-part 1.0) is an exact 0, Gambit's convention, so the sample
+implementation's checker text would REJECT the value there -- chibi diverges
+from that text, where Kaappi runs the same text under a different tower; its u1 checker
 returns a list rather than a boolean, which the storage mode hides by
 printing only the boolean verdict. In the callcc mode chibi's array-copy --
 into a typed storage class, or of an array-map result -- keeps a value
@@ -450,6 +455,16 @@ STORAGE_PRELUDE = PRELUDE.replace(
 CLASSES = ["generic", "char", "u1", "u8", "s8", "u16", "s16", "u32", "s32",
            "u64", "s64", "f16", "f32", "f64", "c64", "c128"]
 
+# c64/c128 are drawn only when asked for by name. Kaappi accepts a bare real
+# flonum there and Gambit rejects it -- a permanent numeric-tower difference
+# (kaappi#2559), not a bug on either side -- and it CASCADES: once the checker
+# accepts, the setter runs and the array contents diverge too. So essentially
+# every c64/c128 case mismatches, which would make a default run red forever
+# and bury findings in the other fourteen classes. They are not filtered out
+# of a run that names them: `--classes c64` still compares everything, noise
+# included, which is what you want when you are actually investigating c64.
+DEFAULT_CLASSES = [c for c in CLASSES if c not in ("c64", "c128")]
+
 # every candidate value, as source text both readers accept
 INTS = [-(2**64), -(2**63) - 1, -(2**63), -(2**32), -(2**31) - 1, -(2**31), -32769,
         -32768, -129, -128, -2, -1, 0, 1, 2, 127, 128, 255, 256, 32767, 32768,
@@ -498,7 +513,7 @@ def value(rng, cls):
 
 def gen_storage(seed, classes=None, spec=None):
     rng = random.Random(seed)
-    cls = rng.choice(classes or CLASSES)
+    cls = rng.choice(classes or DEFAULT_CLASSES)
     sc = f"{cls}-storage-class"
     L = [STORAGE_PRELUDE]
     L.append(f"(define sc {sc})")
@@ -1145,7 +1160,8 @@ def main():
     ap.add_argument("--print", action="store_true", help="print the first case's program and exit")
     ap.add_argument("--classes", default=None,
                     help="storage mode: comma-separated storage classes to draw from "
-                         "(default all 16), e.g. --classes u1,f16,c64")
+                         "(default: the 14 excluding c64/c128, see the module docstring), "
+                         "e.g. --classes u1,f16,c64")
     ap.add_argument("--spec", default=SPEC_URL,
                     help="prose mode: the srfi-231.html to take examples from (path or URL)")
     args = ap.parse_args()


### PR DESCRIPTION
Reverts the `(not (real? x))` clause [#2543](https://github.com/kaappi/kaappi/pull/2543) added, restoring the sample implementation's checker line verbatim.

## Why

#2543 rejected a bare real flonum so Kaappi's verdict would match Gambit's. Both run the same checker text; they disagreed only because Gambit's `(imag-part 1.0)` is an exact `0` and ours is `0.0`.

Asked about it, Brad Lucier — who suggested the exact-0 rule in the first place — confirmed **R6RS adopted it and "that's not what R7RS small does"**, adding that implementers can argue either way.

Kaappi is R7RS-small, which leaves that exactness open. So under our numeric tower `1.0` is exactly what the normative prose asks a `cX-storage-class` to manipulate — "complex numbers with, respectively, 32- and 64-bit floating-point numbers as real and imaginary parts":

```scheme
(complex? 1.0)    ⇒ #t
(real-part 1.0)   ⇒ 1.0   ; inexact
(imag-part 1.0)   ⇒ 0.0   ; inexact
```

The one normative constraint on a checker — that `(checker (getter v i))` be `#t` — holds either way, since the getter returns `1.0+0.0i`. So the restriction was never conformance, only agreement with one other implementation's tower, and it cost a legal program the ability to copy real data into a complex array.

The justification #2543 rested on was *"when prose and reference code disagree, trust the code"* — the invented rule [#2558](https://github.com/kaappi/kaappi/pull/2558) just retracted.

## Guarding against re-derivation

Gambit will now disagree with us on c64/c128 in the differential tester **permanently**. Two places say so, because both are where the next person would otherwise re-derive #2542 and re-apply #2543:

- `tools/srfi231_diff.py`'s known-divergence block, upgraded from "was a bug, now fixed" to "expected and permanent, do not re-file"
- an in-line note in the test file telling a reader not to "fix" these assertions back to `#f` to match Gambit

## Also

The two prose/code divergences #2558 cited are corrected. Brad confirmed `array-inner-product`'s missing `array-curry` argument **is** a document error and will fix it — so the document gets corrected rather than overridden — and `check-nested-list` is not exported by the library, so what it returns is nobody's business. Neither supports the heuristic as it was stated.

## Behavior change

`(array-copy <real-flonum-array> c64-storage-class)` succeeds again, as it did before v0.27.0. v0.27.0 is the only release that rejected it; the [release announcement](https://github.com/orgs/kaappi/discussions/2556) already flagged the restriction as under review.

## Tests

Checker and end-to-end `array-copy` assertions flip to the accepting behavior, with the round-trip value pinned (`1.5` → `1.5+0.0i`). Eight SRFI 231 suites pass, storage-classes at 253 expected passes, official suite **10936 passed / 0 unexpected failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)