### PR TITLE
Localise riscv64 unit-chunk wedges with a script-side watchdog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -579,23 +579,53 @@ jobs:
     # That step printed nothing until it finished, so the log said nothing
     # about which test. The unit suite therefore runs as chunks
     # (tools/run-unit-test-chunk.sh), each its own step with its own
-    # `timeout-minutes`, so the next hang names its chunk. The first
-    # three-way split measured 35m healthy and localised the first
-    # recurrence to its `rest` chunk (1646 tests); the eight-way split below
-    # cuts that remainder along its QEMU-sensitive seams at the price of
-    # five more test-binary compiles (~1.5m each).
+    # `timeout-minutes`, so the next hang names its chunk. The eight-way
+    # split cuts the suite along its QEMU-sensitive seams at the price of
+    # seven extra test-binary compiles (~1.5m each).
     #
-    # The chunk script also passes `zig build test --test-timeout` (8m by
-    # default; see its header). That is what localises to a TEST: the build
-    # runner otherwise waits forever for a test's result, and with the bound
-    # it kills the overrunning test, prints its name, and carries on with
-    # the rest of the chunk, so the log ends with a named failure and a full
-    # verdict for every other test instead of a cancel. For that to happen
-    # the step must outlive the per-test bound, so every step cap below is
-    # its healthy time plus the 8m bound plus margin -- the cap is now the
-    # backstop, not the localiser. The job cap backstops the same way: setup
-    # + build + every chunk healthy (30m) + one hung test (8m) stays inside.
-    timeout-minutes: 55
+    # kaappi#2560 then measured the `rest` chunk bimodal under its cap --
+    # 9m46s-11m32s healthy vs >24m killed, nothing in between -- and found
+    # why the kills stayed silent even with #2491's `--test-timeout` in
+    # place: `zig build` buffers ALL of its output (summaries AND the
+    # per-test timeout names) until the process exits, so a step killed at
+    # its cap takes the buffer -- names included -- with it. A test name
+    # survives only when zig exits by itself. The localisation therefore
+    # now lives in the chunk script, whose own `echo` lines are unbuffered
+    # and survive any kill:
+    #
+    #   * KAAPPI_CHUNK_BUDGET (set per step below) bounds the whole chunk
+    #     run, sized to outlive ONE per-test bound (healthy + 8m + ~2m), so
+    #     a single hung test is still named by zig at its own exit; only a
+    #     second hang, or a wedge the runner cannot see, falls through.
+    #   * When the budget fires, the script kills the zig tree and
+    #     bisects the chunk's filter list (halves re-run under a 90s
+    #     per-test bound), streaming one line per level naming the subset
+    #     in flight, all inside the KAAPPI_BISECT_BUDGET pot below. The
+    #     last line before any kill names the filter or the narrowed
+    #     subset -- the reopen criterion of #2488 -- and the step exits
+    #     124 so the run is loud, not just annotated.
+    #
+    # Cap arithmetic per chunk step: wall budget + 18m bisection pot + 2m
+    # slop. Wall budgets are each chunk's slowest observed healthy time
+    # plus the 8m per-test bound plus ~2m margin (rest from the spread in
+    # #2560; the others from the slowest run of the two-run measurement on
+    # the eight-way split). The step cap is the backstop; the script's
+    # budget is the localiser. The job cap backstops the sum: setup+build
+    # (~8m) + every chunk healthy (~38m) leaves the LAST chunk's full cap
+    # (32m) inside 80m, so a wedge anywhere localises fully; healthy runs
+    # are unchanged (~50m) and stop at the first failed chunk anyway.
+    #
+    # `rest` runs FIRST although it is the biggest chunk: it is the one
+    # that has wedged (both #2488 recurrences localised there, and both
+    # #2560 cap kills), so a wedge fails fast instead of burning ~36m of
+    # healthy chunks first, and its bisection is the least likely to be
+    # clipped by the job cap.
+    timeout-minutes: 80
+    env:
+      # Total bisection pot per chunk step, seconds (18m); see the comment
+      # above. The per-test bound used during bisection levels (90s) and
+      # the rest of the knobs are the chunk script's own defaults.
+      KAAPPI_BISECT_BUDGET: "1080"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -631,38 +661,68 @@ jobs:
       # QEMU, two runs (33684320694 and PR #2491's), slowest of each:
       # process 1.8m, concurrency 7.0m (3.3m on the other run -- the
       # timing-sensitive chunk varies most with runner load), io 2.1m,
-      # fuzz 6.0m, gc 6.1m (2.9m), native 1.7m, tooling 2.1m, rest 6.9m.
+      # fuzz 6.0m, gc 6.1m (2.9m), native 1.7m, tooling 2.1m; and rest
+      # 9m46s-11m32s across the three runs tabulated in #2560.
+      #
+      # Each step sets KAAPPI_CHUNK_BUDGET (the script's wall budget) to
+      # its chunk's slowest healthy time + the 8m per-test bound + ~2m
+      # margin, and its `timeout-minutes` to that budget + the 18m
+      # bisection pot + 2m slop, per the job comment's arithmetic.
+      - name: Unit tests, rest chunk (riscv64 via QEMU)
+        timeout-minutes: 42
+        env:
+          # 22m = 11m32s slowest healthy + 8m per-test bound + ~2m margin.
+          KAAPPI_CHUNK_BUDGET: "1320"
+        run: bash tools/run-unit-test-chunk.sh rest -Dtarget=riscv64-linux
+
       - name: Unit tests, process chunk (riscv64 via QEMU)
-        timeout-minutes: 14
+        timeout-minutes: 32
+        env:
+          # 12m = 1.8m slowest healthy + 8m + ~2m.
+          KAAPPI_CHUNK_BUDGET: "720"
         run: bash tools/run-unit-test-chunk.sh process -Dtarget=riscv64-linux
 
       - name: Unit tests, concurrency chunk (riscv64 via QEMU)
-        timeout-minutes: 20
+        timeout-minutes: 37
+        env:
+          # 17m = 7m slowest healthy + 8m + ~2m.
+          KAAPPI_CHUNK_BUDGET: "1020"
         run: bash tools/run-unit-test-chunk.sh concurrency -Dtarget=riscv64-linux
 
       - name: Unit tests, io chunk (riscv64 via QEMU)
-        timeout-minutes: 14
+        timeout-minutes: 32
+        env:
+          # 12m = 2.1m slowest healthy + 8m + ~2m.
+          KAAPPI_CHUNK_BUDGET: "720"
         run: bash tools/run-unit-test-chunk.sh io -Dtarget=riscv64-linux
 
       - name: Unit tests, fuzz chunk (riscv64 via QEMU)
-        timeout-minutes: 20
+        timeout-minutes: 36
+        env:
+          # 16m = 6m slowest healthy + 8m + ~2m.
+          KAAPPI_CHUNK_BUDGET: "960"
         run: bash tools/run-unit-test-chunk.sh fuzz -Dtarget=riscv64-linux
 
       - name: Unit tests, gc chunk (riscv64 via QEMU)
-        timeout-minutes: 18
+        timeout-minutes: 36
+        env:
+          # 16m = 6.1m slowest healthy + 8m + ~2m.
+          KAAPPI_CHUNK_BUDGET: "960"
         run: bash tools/run-unit-test-chunk.sh gc -Dtarget=riscv64-linux
 
       - name: Unit tests, native chunk (riscv64 via QEMU)
-        timeout-minutes: 12
+        timeout-minutes: 32
+        env:
+          # 12m = 1.7m slowest healthy + 8m + ~2m.
+          KAAPPI_CHUNK_BUDGET: "720"
         run: bash tools/run-unit-test-chunk.sh native -Dtarget=riscv64-linux
 
       - name: Unit tests, tooling chunk (riscv64 via QEMU)
-        timeout-minutes: 14
+        timeout-minutes: 32
+        env:
+          # 12m = 2.1m slowest healthy + 8m + ~2m.
+          KAAPPI_CHUNK_BUDGET: "720"
         run: bash tools/run-unit-test-chunk.sh tooling -Dtarget=riscv64-linux
-
-      - name: Unit tests, rest chunk (riscv64 via QEMU)
-        timeout-minutes: 24
-        run: bash tools/run-unit-test-chunk.sh rest -Dtarget=riscv64-linux
 
       - name: R7RS test suite (riscv64 via QEMU)
         run: bash tools/run-r7rs-suite.sh zig-out/bin/kaappi

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -779,7 +779,7 @@ matrix covers:
 | `test` | Ubuntu (x86, ARM), macOS | Unit tests, `run-all.sh`, robustness, sandbox, thottam integration, SRFI final-status guard |
 | `gc-stress` | Ubuntu | Unit suite under `-Dgc-stress=true` |
 | `gc-stress-scheme` | Ubuntu | Scheme suites under `-Dgc-stress=true` |
-| `riscv64-test` | Ubuntu (QEMU) | Cross-compiled unit tests + R7RS suite. The unit suite runs as eight chunks (`tools/run-unit-test-chunk.sh`: process, concurrency, io, fuzz, gc, native, tooling, and a derived rest), each its own step with its own cap, and the script passes `zig build test --test-timeout 8m`, so a hang under emulation is killed and named per test while the rest of the chunk still reports (kaappi#2488) |
+| `riscv64-test` | Ubuntu (QEMU) | Cross-compiled unit tests + R7RS suite. The unit suite runs as eight chunks (`tools/run-unit-test-chunk.sh`: rest first, then process, concurrency, io, fuzz, gc, native, tooling), each its own step with its own cap. `zig build` buffers all of its output until it exits, so a step killed at its cap loses even the per-test names `--test-timeout 8m` recorded (kaappi#2560); the script therefore enforces its own `KAAPPI_CHUNK_BUDGET` wall budget per chunk, and on expiry kills the zig tree, bisects the filter list with streamed per-level lines, and exits 124 -- the last line before any kill names the filter or narrowed subset, the reopen criterion of kaappi#2488 |
 | `s390x-test` | Ubuntu (QEMU) | Big-endian leg — the byte-order canary (kaappi#1654); same `--test-timeout 8m` |
 | `ppc64le-test` | Ubuntu (QEMU) | Cross-compiled unit tests + R7RS suite; same `--test-timeout 8m` |
 | `freebsd-test`, `openbsd-test`, `netbsd-test` | Ubuntu (VM action) | Per-BSD build + tests; see the matching `docs/dev/<os>.md` |

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -107,8 +107,7 @@ timeout_for() {
 # wait_with_timeout counts sleep 0.05 ticks, not wall clock, so that is
 # ~20 min of wall clock on Linux and stretches further where sleep spawns
 # cost more — inside every job cap that runs this suite.
-PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:${KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT:-1200}
-                     unit-chunk-watchdog-2560.sh:${KAAPPI_UNIT_CHUNK_WATCHDOG_TIMEOUT:-480}"
+PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:${KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT:-1200} unit-chunk-watchdog-2560.sh:${KAAPPI_UNIT_CHUNK_WATCHDOG_TIMEOUT:-480}"
 
 shell_timeout_for() {
     local base entry

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -107,7 +107,8 @@ timeout_for() {
 # wait_with_timeout counts sleep 0.05 ticks, not wall clock, so that is
 # ~20 min of wall clock on Linux and stretches further where sleep spawns
 # cost more — inside every job cap that runs this suite.
-PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:${KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT:-1200}"
+PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:${KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT:-1200}
+                     unit-chunk-watchdog-2560.sh:${KAAPPI_UNIT_CHUNK_WATCHDOG_TIMEOUT:-480}"
 
 shell_timeout_for() {
     local base entry
@@ -445,7 +446,7 @@ report_shell_result() {
 is_slow_shell_test() {
     # `^[^#]*`: skip comment lines, several of which mention the build they
     # deliberately do not run.
-    grep -Eq '^[^#]*(zig build -D|bundle_fixture_binary|fixture_interpreter)' "$1" 2>/dev/null
+    grep -Eq '^[^#]*(zig build -D|bundle_fixture_binary|fixture_interpreter|run-unit-test-chunk\.sh)' "$1" 2>/dev/null
 }
 
 run_shell_suite() {

--- a/tests/scheme/run-all.sh
+++ b/tests/scheme/run-all.sh
@@ -706,6 +706,9 @@ run_shell_suite "Timings" tests/scheme/timings
 run_shell_suite "Shell completions" tests/scheme/completions
 run_shell_suite "Language server" tests/scheme/lsp
 run_shell_suite "Package manager" tests/scheme/thottam
+# Tests for the repo's own tooling shell scripts (the unit-suite chunker's
+# watchdog/bisection machinery is the first tenant, kaappi#2560).
+run_shell_suite "Repo tools" tests/scheme/tools
 # Execution-tier differential: every corpus file must give the same answer with
 # the IR optimiser off and from a warm bytecode cache as it does from a cold
 # one. Defaults to the smoke+compliance+audit corpus plus its own probes

--- a/tests/scheme/test-runner/shell-timeout-override.sh
+++ b/tests/scheme/test-runner/shell-timeout-override.sh
@@ -30,14 +30,17 @@ fi
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT
 
-# The table entry itself is part of the fix. Without this check the behaviour
+# The table itself is part of the fix. Without this check the behaviour
 # assertions below could pass against a PER_SCRIPT_TIMEOUTS the test set
-# itself, and the override for the script that motivated it could be dropped
-# silently. -F -x: the whole line as a fixed string, so a malformed key or a
-# retuned default cannot slip through a looser match.
-if ! grep -Fxq 'PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:${KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT:-1200}"' "$RUN_ALL"; then
+# itself, and the override for a script that motivated the mechanism could
+# be dropped silently. -F -x: the whole line as a fixed string, so a
+# malformed key or a retuned default cannot slip through a looser match.
+# unit-chunk-watchdog-2560.sh joined the table in kaappi#2561: its shim
+# cases carry wedged-level allowances that must not be squeezed by a leg's
+# flat KAAPPI_SHELL_TEST_TIMEOUT under load.
+if ! grep -Fxq 'PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:${KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT:-1200} unit-chunk-watchdog-2560.sh:${KAAPPI_UNIT_CHUNK_WATCHDOG_TIMEOUT:-480}"' "$RUN_ALL"; then
     echo "FAIL: run-all.sh's PER_SCRIPT_TIMEOUTS entry is not exactly:" >&2
-    echo '       PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:${KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT:-1200}"' >&2
+    echo '       PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:${KAAPPI_BUNDLE_CPU_BASELINE_TIMEOUT:-1200} unit-chunk-watchdog-2560.sh:${KAAPPI_UNIT_CHUNK_WATCHDOG_TIMEOUT:-480}"' >&2
     exit 1
 fi
 
@@ -69,7 +72,7 @@ done
 # ignore it, but taking it keeps this script's invocation contract the same
 # as every other script the runners launch.
 SHELL_TIMEOUT=2
-PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:6"
+PER_SCRIPT_TIMEOUTS="bundle-cpu-baseline-2515.sh:6 unit-chunk-watchdog-2560.sh:5"
 TICKS_PER_SEC=20
 sleep 0.05 2>/dev/null || TICKS_PER_SEC=1
 KAAPPI="${1:-/bin/true}"
@@ -80,6 +83,10 @@ export KAAPPI
 # entry; an unlisted script (and a near-miss name) falls back to the global.
 if [[ "$(shell_timeout_for "$DIR/bundle-cpu-baseline-2515.sh")" != "6" ]]; then
     echo "FAIL: listed script did not get its PER_SCRIPT_TIMEOUTS budget" >&2
+    exit 1
+fi
+if [[ "$(shell_timeout_for "$DIR/unit-chunk-watchdog-2560.sh")" != "5" ]]; then
+    echo "FAIL: second table entry did not route its own budget" >&2
     exit 1
 fi
 if [[ "$(shell_timeout_for "$DIR/unlisted-script.sh")" != "2" ]]; then

--- a/tests/scheme/tools/unit-chunk-watchdog-2560.sh
+++ b/tests/scheme/tools/unit-chunk-watchdog-2560.sh
@@ -215,9 +215,12 @@ grep -q "WALL BUDGET EXCEEDED after .*s (compiling)" "$out" ||
 # and depth-2 lines must carry estimates computed from each subset's own
 # declared-test count (the test derives them independently, from the same
 # grep of the same files), so a regression back to a flat or per-filter
-# estimate changes the printed numbers and fails here. Depth 1 completing
-# (the wedge-once stamp was consumed in phase 1) puts depth 2 at filters
-# 24-34, the two windows differing in density.
+# estimate changes the printed numbers and fails here. The two probe
+# windows are derived from --list with the same mid arithmetic the script
+# uses, so a new test file landing in the derived rest chunk moves them
+# with it instead of failing the case: depth 1 is the first half, and
+# depth 1 completing (the wedge-once stamp was consumed in phase 1) puts
+# depth 2 just past it.
 est_of() { # est_of <start-1-based> <count>: 2s base + 1 tenth x the slice's tests
     local start="$1" n="$2" total=0 f c
     for f in $(bash tools/run-unit-test-chunk.sh --list rest \
@@ -228,8 +231,13 @@ est_of() { # est_of <start-1-based> <count>: 2s base + 1 tenth x the slice's tes
     done
     echo $(( 2 + total / 10 ))
 }
-e1=$(est_of 1 23)
-e2=$(est_of 24 11)
+total=$(bash tools/run-unit-test-chunk.sh --list rest | wc -l | tr -d ' ')
+mid1=$((total / 2))             # depth 1: filters 1..mid1
+mid2=$(((mid1 + total) / 2))    # depth 2 after depth 1 completes: mid1+1..mid2
+n1=$mid1
+n2=$((mid2 - mid1))
+e1=$(est_of 1 "$n1")
+e2=$(est_of $((mid1 + 1)) "$n2")
 [ "$e1" -ne "$e2" ] || fail "case 7 setup: the two probe windows estimate equal; pick denser windows"
 rc=0
 # shellcheck disable=SC2086  # base_env is a deliberate VAR=val word list for env
@@ -238,9 +246,9 @@ env $base_env KAAPPI_CHUNK_BUDGET=3 KAAPPI_BISECT_BUDGET=45 \
     SHIM_WEDGE_ONCE="$work/once7" \
     bash tools/run-unit-test-chunk.sh rest > "$out" 2>&1 || rc=$?
 [ "$rc" -eq 124 ] || fail "case 7 (per-test funding): wall-budget overrun must exit 124 (got $rc)"
-grep -q "bisect depth 1: 23 filter(s) .* budget .*s of a ${e1}s estimate" "$out" ||
+grep -q "bisect depth 1: ${n1} filter(s) .* budget .*s of a ${e1}s estimate" "$out" ||
     fail "case 7: depth 1's estimate is not ${e1}s from its subset's test count"
-grep -q "bisect depth 2: 11 filter(s) .* budget .*s of a ${e2}s estimate" "$out" ||
+grep -q "bisect depth 2: ${n2} filter(s) .* budget .*s of a ${e2}s estimate" "$out" ||
     fail "case 7: depth 2's estimate is not ${e2}s from its subset's test count"
 
 echo "PASS: watchdog, heartbeat, decisive descent, per-test NOTEs, the"

--- a/tests/scheme/tools/unit-chunk-watchdog-2560.sh
+++ b/tests/scheme/tools/unit-chunk-watchdog-2560.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# The chunk script's wall-budget watchdog and streamed bisection (kaappi#2560).
+#
+# `zig build` buffers all of its console output until the process exits
+# (verified on Zig 0.16.0: through a pipe, a file, or a pty; SIGTERM does
+# not flush it either), so a CI step killed at its `timeout-minutes` cap
+# loses even the per-test timeout names that #2491's `--test-timeout` had
+# already recorded. Every capped riscv64 `rest` run therefore died
+# silent -- the cap localised nothing, which is what #2560 filed.
+#
+# tools/run-unit-test-chunk.sh now localises with its OWN unbuffered echo
+# lines, which survive any kill: a heartbeat while the chunk runs, a
+# "WALL BUDGET EXCEEDED" line when the script's wall budget fires, and one
+# line per bisection level naming the filter subset in flight, exiting 124
+# (the timeout(1) convention) so the run fails loudly instead of just
+# quietly bleeding out at a CI cap.
+#
+# Both cases below drive that machinery with budgets small enough that the
+# initial test-binary compile itself "wedges": no real test hangs, and each
+# case is bounded by its budgets (~40s and ~75s). Which side of a bisection
+# level's own budget the machine lands on (cold compile vs warm objects)
+# varies by host, so every assertion accepts exactly the two outcomes the
+# script is allowed to print for it.
+
+. "$(dirname "$0")/../shell-common.sh"
+
+skip_on_windows "the watchdog kills the zig process tree via pgrep, which MSYS lacks"
+skip_without_zig "the chunk script runs zig build"
+
+cd "$(dirname "$0")/../../.." || exit 1
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+# Structure: --list still derives the rest chunk's filters from the tree,
+# and an unknown chunk name is a usage error, not a silent success.
+n=$(bash tools/run-unit-test-chunk.sh --list rest | wc -l | tr -d ' ')
+[ "$n" -ge 20 ] || fail "--list rest produced only $n filters (expected the derived remainder, dozens)"
+if bash tools/run-unit-test-chunk.sh --list bogus-chunk > /dev/null 2>&1; then
+    fail "an unknown chunk name must exit 2"
+fi
+
+# Case 1: the wall budget fires and the bisection pot is too dry for even
+# one level. The kill must still be loud, streamed, and exit 124.
+out=$(mktemp)
+trap 'rm -f "$out" "$out2"' EXIT
+KAAPPI_CHUNK_BUDGET=12 KAAPPI_BISECT_BUDGET=20 KAAPPI_HEARTBEAT_SECS=3 \
+    bash tools/run-unit-test-chunk.sh rest > "$out" 2>&1
+status=$?
+
+[ "$status" -eq 124 ] || fail "case 1: wall-budget overrun must exit 124 (timeout(1) convention), got $status"
+grep -q "WALL BUDGET EXCEEDED" "$out" || fail "case 1: no streamed budget-exceeded line"
+grep -q "still running at" "$out" || fail "case 1: no heartbeat line survived the kill"
+grep -q "too shallow for depth 1" "$out" || fail "case 1: the dry pot was not reported as too shallow"
+grep -q "RESULT:" "$out" || fail "case 1: no summary verdict line"
+
+# Case 2: enough pot for one bisection level (a level gets 3/5 of the pot
+# and needs >= 90s, so 180s is the smallest pot that starts one). A cold
+# cache cannot compile the subset in ~108s (level watchdog fires, descent
+# enters that half); a warm one runs the subset's tests (level finishes,
+# half is discarded). Both are correct; both must name the subset BEFORE
+# running it, and the level's outcome must be reported as a decision.
+out2=$(mktemp)
+KAAPPI_CHUNK_BUDGET=12 KAAPPI_BISECT_BUDGET=180 KAAPPI_HEARTBEAT_SECS=3 \
+    bash tools/run-unit-test-chunk.sh rest > "$out2" 2>&1
+status=$?
+
+[ "$status" -eq 124 ] || fail "case 2: wall-budget overrun must exit 124, got $status"
+grep -Eq "bisect depth 1: [0-9]+ filter\\(s\\) [a-z_0-9.]+\.\.[a-z_0-9.]+, budget [0-9]+s" "$out2" ||
+    fail "case 2: no bisect level line naming its filter subset and its budget"
+grep -Eq "(did NOT finish in [0-9]+s -- the wedge reproduces inside this half|finished in [0-9]+s \\(zig exit [0-9]+\\) -- no process wedge here)" "$out2" ||
+    fail "case 2: the level's outcome was not reported as a bisection decision"
+grep -Eq "(bisect incomplete|RESULT:)" "$out2" ||
+    fail "case 2: neither an incomplete-descent suspects list nor a verdict line was printed"
+
+echo "PASS: watchdog fired loudly, bisection streamed its subsets, exit 124"

--- a/tests/scheme/tools/unit-chunk-watchdog-2560.sh
+++ b/tests/scheme/tools/unit-chunk-watchdog-2560.sh
@@ -170,8 +170,14 @@ grep -q "NOTE: 'tests_fake.test.slow one' exceeded the tight 90s bound" "$out" |
 # the descent.
 echo 2 > "$work/count"
 rc=0
+# The pot must clear the level floor (BASE/3 = 10s here) by more than a
+# second: pot_start and depth 1's now-stamp straddle a clock-tick boundary
+# whenever a second flips between them, and a pot equal to the floor then
+# reads as one second short and the level is refused as "too shallow"
+# instead of run clipped -- a low-single-digit-percent flake per run.
+# 12 leaves that tick of slack while still clipping 12 < 30.
 # shellcheck disable=SC2086  # base_env is a deliberate VAR=val word list for env
-env $base_env KAAPPI_CHUNK_BUDGET=3 KAAPPI_BISECT_BUDGET=10 \
+env $base_env KAAPPI_CHUNK_BUDGET=3 KAAPPI_BISECT_BUDGET=12 \
     KAAPPI_BISECT_LEVEL_BASE_SECS=30 \
     SHIM_HANG_FIRST="$work/count" \
     bash tools/run-unit-test-chunk.sh rest > "$out" 2>&1 || rc=$?
@@ -205,5 +211,38 @@ env $base_env KAAPPI_CHUNK_BUDGET=3 KAAPPI_BISECT_BUDGET=0 \
 grep -q "WALL BUDGET EXCEEDED after .*s (compiling)" "$out" ||
     fail "case 6: a zig-named grandchild must be reported as compiling"
 
+# Case 7: the per-TEST funding term, with the term nonzero. The depth-1
+# and depth-2 lines must carry estimates computed from each subset's own
+# declared-test count (the test derives them independently, from the same
+# grep of the same files), so a regression back to a flat or per-filter
+# estimate changes the printed numbers and fails here. Depth 1 completing
+# (the wedge-once stamp was consumed in phase 1) puts depth 2 at filters
+# 24-34, the two windows differing in density.
+est_of() { # est_of <start-1-based> <count>: 2s base + 1 tenth x the slice's tests
+    local start="$1" n="$2" total=0 f c
+    for f in $(bash tools/run-unit-test-chunk.sh --list rest \
+               | sed -n "${start},$((start + n - 1))p" \
+               | sed 's/^-Dtest-filter=//; s/\.test\.$//'); do
+        c=$(grep -c '^test "' "src/$f.zig" | tr -d ' ')
+        total=$((total + c))
+    done
+    echo $(( 2 + total / 10 ))
+}
+e1=$(est_of 1 23)
+e2=$(est_of 24 11)
+[ "$e1" -ne "$e2" ] || fail "case 7 setup: the two probe windows estimate equal; pick denser windows"
+rc=0
+# shellcheck disable=SC2086  # base_env is a deliberate VAR=val word list for env
+env $base_env KAAPPI_CHUNK_BUDGET=3 KAAPPI_BISECT_BUDGET=45 \
+    KAAPPI_BISECT_LEVEL_PER_TEST_TENTHS=1 \
+    SHIM_WEDGE_ONCE="$work/once7" \
+    bash tools/run-unit-test-chunk.sh rest > "$out" 2>&1 || rc=$?
+[ "$rc" -eq 124 ] || fail "case 7 (per-test funding): wall-budget overrun must exit 124 (got $rc)"
+grep -q "bisect depth 1: 23 filter(s) .* budget .*s of a ${e1}s estimate" "$out" ||
+    fail "case 7: depth 1's estimate is not ${e1}s from its subset's test count"
+grep -q "bisect depth 2: 11 filter(s) .* budget .*s of a ${e2}s estimate" "$out" ||
+    fail "case 7: depth 2's estimate is not ${e2}s from its subset's test count"
+
 echo "PASS: watchdog, heartbeat, decisive descent, per-test NOTEs, the"
-echo "PASS: clipped-level INCONCLUSIVE stop, and both kill-time phase reads"
+echo "PASS: clipped-level INCONCLUSIVE stop, both kill-time phase reads,"
+echo "PASS: and level estimates that follow the subset's own test count"

--- a/tests/scheme/tools/unit-chunk-watchdog-2560.sh
+++ b/tests/scheme/tools/unit-chunk-watchdog-2560.sh
@@ -15,17 +15,19 @@
 # (the timeout(1) convention) so the run fails loudly instead of just
 # quietly bleeding out at a CI cap.
 #
-# Both cases below drive that machinery with budgets small enough that the
-# initial test-binary compile itself "wedges": no real test hangs, and each
-# case is bounded by its budgets (~40s and ~75s). Which side of a bisection
-# level's own budget the machine lands on (cold compile vs warm objects)
-# varies by host, so every assertion accepts exactly the two outcomes the
-# script is allowed to print for it.
+# Every case below drives the script through a fake `zig` (KAAPPI_ZIG): a
+# shim that plays wedged or clean subsets in seconds, with real child
+# processes so the watchdog's process-tree snapshot has a tree to kill.
+# That makes each outcome deterministic -- the descent, the solo confirm,
+# the NOTE lines for tight-bound overruns, the INCONCLUSIVE stop for a
+# level the pot could only clip, and the unbudgeted heartbeat (which died
+# on an unbound variable under bash >= 4 before the fix) -- without ever
+# compiling the unit suite or contending for the Zig cache locks. The
+# real-zig path is what the riscv64 chunk steps run eight times per CI job.
 
 . "$(dirname "$0")/../shell-common.sh"
 
 skip_on_windows "the watchdog kills the zig process tree via pgrep, which MSYS lacks"
-skip_without_zig "the chunk script runs zig build"
 
 cd "$(dirname "$0")/../../.." || exit 1
 
@@ -33,6 +35,61 @@ fail() {
     echo "FAIL: $1" >&2
     exit 1
 }
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/kaappi-chunk-watchdog-XXXXXX")
+trap 'rm -rf "$work"' EXIT
+out="$work/out"
+
+# The fake `zig build test`: never compiles, decides from its arguments.
+#   wedge (hang with two children) iff, in order:
+#     - SHIM_WEDGE_ONCE is set and its stamp file is missing (first call), or
+#     - SHIM_HANG_FIRST is set and fewer than that many calls have hung, or
+#     - SHIM_WEDGE_FILTER is set and some -Dtest-filter= arg contains it;
+#   otherwise sleep SHIM_DELAY, print SHIM_TIMEOUT_NAME as a zig per-test
+#   timeout line (exercising the script's sed parser, spaces included),
+#   print a summary the script's floor check accepts, exit SHIM_EXIT.
+shim="$work/zig"
+cat > "$shim" <<'SHIM'
+#!/usr/bin/env bash
+set -u
+if [ -n "${SHIM_WEDGE_ONCE:-}" ] && [ ! -f "${SHIM_WEDGE_ONCE}" ]; then
+    : > "${SHIM_WEDGE_ONCE}"
+    sleep 9999 & sleep 9999 & wait
+fi
+if [ -n "${SHIM_HANG_FIRST:-}" ]; then
+    count=0
+    [ -f "${SHIM_HANG_FIRST}" ] && count=$(cat "${SHIM_HANG_FIRST}")
+    if [ "$count" -gt 0 ]; then
+        echo $((count - 1)) > "${SHIM_HANG_FIRST}"
+        sleep 9999 & sleep 9999 & wait
+    fi
+fi
+if [ -n "${SHIM_WEDGE_FILTER:-}" ]; then
+    for a in "$@"; do
+        case "$a" in
+            -Dtest-filter=*"$SHIM_WEDGE_FILTER"*) sleep 9999 & sleep 9999 & wait ;;
+        esac
+    done
+fi
+[ -n "${SHIM_DELAY:-}" ] && sleep "$SHIM_DELAY"
+if [ -n "${SHIM_TIMEOUT_NAME:-}" ]; then
+    printf "error: '%s' timed out after 90s\n" "$SHIM_TIMEOUT_NAME"
+fi
+printf '%s\n' \
+    "test success" \
+    "+- run test unit-tests 60 pass (60 total) 1s MaxRSS:1M" \
+    "+- run test thottam-tests 1 pass (1 total) 1s MaxRSS:1M"
+exit "${SHIM_EXIT:-0}"
+SHIM
+chmod +x "$shim"
+
+# Common knobs: the pinned KAAPPI_TEST_TIMEOUT guards against a caller's
+# run-all.sh KAAPPI_TEST_TIMEOUT (seconds, for Scheme tests) leaking into
+# the --test-timeout grammar (a Zig duration). The level-funding constants
+# are scaled down so a level's "full estimate" is seconds, not minutes.
+base_env="KAAPPI_ZIG=$shim KAAPPI_TEST_TIMEOUT=8m KAAPPI_BISECT_TEST_TIMEOUT=90s"
+base_env="$base_env KAAPPI_BISECT_LEVEL_BASE_SECS=2 KAAPPI_BISECT_LEVEL_PER_FILTER_SECS=1"
+base_env="$base_env KAAPPI_HEARTBEAT_SECS=2"
 
 # Structure: --list still derives the rest chunk's filters from the tree,
 # and an unknown chunk name is a usage error, not a silent success.
@@ -42,37 +99,66 @@ if bash tools/run-unit-test-chunk.sh --list bogus-chunk > /dev/null 2>&1; then
     fail "an unknown chunk name must exit 2"
 fi
 
-# Case 1: the wall budget fires and the bisection pot is too dry for even
-# one level. The kill must still be loud, streamed, and exit 124.
-out=$(mktemp)
-trap 'rm -f "$out" "$out2"' EXIT
-KAAPPI_CHUNK_BUDGET=12 KAAPPI_BISECT_BUDGET=20 KAAPPI_HEARTBEAT_SECS=3 \
-    bash tools/run-unit-test-chunk.sh rest > "$out" 2>&1
-status=$?
+# Case 1: NO wall budget (the header's primary invocation). The heartbeat
+# must fire on this path too -- before the budget_note fix it died on an
+# unbound variable under bash >= 4 and orphaned the zig tree it supervised
+# -- and a clean finish must still reach the floor-checked summary.
+rc=0
+# shellcheck disable=SC2086  # base_env is a deliberate VAR=val word list for env
+env $base_env SHIM_DELAY=8 bash tools/run-unit-test-chunk.sh rest > "$out" 2>&1 || rc=$?
+[ "$rc" -eq 0 ] || fail "case 1 (no budget): a clean unbudgeted run must exit 0 (got $rc)"
+grep -q "still running at" "$out" || fail "case 1: no heartbeat on the unbudgeted path"
+grep -q "== unit-test chunk 'rest': 60 tests (floor " "$out" ||
+    fail "case 1: no floor-checked summary line after a clean finish"
 
-[ "$status" -eq 124 ] || fail "case 1: wall-budget overrun must exit 124 (timeout(1) convention), got $status"
-grep -q "WALL BUDGET EXCEEDED" "$out" || fail "case 1: no streamed budget-exceeded line"
-grep -q "still running at" "$out" || fail "case 1: no heartbeat line survived the kill"
-grep -q "too shallow for depth 1" "$out" || fail "case 1: the dry pot was not reported as too shallow"
-grep -q "RESULT:" "$out" || fail "case 1: no summary verdict line"
+# Case 2: the descent. The shim wedges exactly when the subset contains
+# tests_printer, so every half holding it times out at its FULL estimate
+# (decisive), every other half completes, and the descent must end on the
+# single filter, confirmed by its solo run.
+rc=0
+# shellcheck disable=SC2086  # base_env is a deliberate VAR=val word list for env
+env $base_env KAAPPI_CHUNK_BUDGET=3 KAAPPI_BISECT_BUDGET=120 \
+    SHIM_WEDGE_FILTER="tests_printer.test." \
+    bash tools/run-unit-test-chunk.sh rest > "$out" 2>&1 || rc=$?
+[ "$rc" -eq 124 ] || fail "case 2 (descent): wall-budget overrun must exit 124 (got $rc)"
+grep -q "WALL BUDGET EXCEEDED" "$out" || fail "case 2: no streamed budget-exceeded line"
+grep -q "descending into this half" "$out" || fail "case 2: no decisive-timeout descent line"
+grep -q "LOCALISED AND CONFIRMED: filter 'tests_printer.test.'" "$out" ||
+    fail "case 2: the descent did not end confirmed on tests_printer"
+grep -q "zig build test -Dtest-filter=tests_printer.test." "$out" ||
+    fail "case 2: no reproduce command for the confirmed filter"
 
-# Case 2: enough pot for one bisection level (a level gets 3/5 of the pot
-# and needs >= 90s, so 180s is the smallest pot that starts one). A cold
-# cache cannot compile the subset in ~108s (level watchdog fires, descent
-# enters that half); a warm one runs the subset's tests (level finishes,
-# half is discarded). Both are correct; both must name the subset BEFORE
-# running it, and the level's outcome must be reported as a decision.
-out2=$(mktemp)
-KAAPPI_CHUNK_BUDGET=12 KAAPPI_BISECT_BUDGET=180 KAAPPI_HEARTBEAT_SECS=3 \
-    bash tools/run-unit-test-chunk.sh rest > "$out2" 2>&1
-status=$?
+# Case 3: the per-test reading. Only the FIRST invocation (the chunk run
+# itself) wedges; every level then completes while printing a zig per-test
+# timeout line with SPACES in the name, which must surface whole as a NOTE
+# and exactly once in the RESULT (the level and the full re-run both see
+# it; the collection dedups).
+rc=0
+# shellcheck disable=SC2086  # base_env is a deliberate VAR=val word list for env
+env $base_env KAAPPI_CHUNK_BUDGET=3 KAAPPI_BISECT_BUDGET=120 \
+    SHIM_WEDGE_ONCE="$work/once" SHIM_TIMEOUT_NAME="tests_fake.test.slow one" \
+    bash tools/run-unit-test-chunk.sh rest > "$out" 2>&1 || rc=$?
+[ "$rc" -eq 124 ] || fail "case 3 (per-test): wall-budget overrun must exit 124 (got $rc)"
+grep -q "NOTE: 'tests_fake.test.slow one' exceeded the tight 90s bound" "$out" ||
+    fail "case 3: no NOTE line carrying the whole space-containing name"
+[ "$(grep -c "^== RESULT: no level wedged; per-test suspect(s) named by the tight bound: 'tests_fake.test.slow one'$" "$out")" -eq 1 ] ||
+    fail "case 3: the RESULT must name the suspect exactly once"
 
-[ "$status" -eq 124 ] || fail "case 2: wall-budget overrun must exit 124, got $status"
-grep -Eq "bisect depth 1: [0-9]+ filter\\(s\\) [a-z_0-9.]+\.\.[a-z_0-9.]+, budget [0-9]+s" "$out2" ||
-    fail "case 2: no bisect level line naming its filter subset and its budget"
-grep -Eq "(did NOT finish in [0-9]+s -- the wedge reproduces inside this half|finished in [0-9]+s \\(zig exit [0-9]+\\) -- no process wedge here)" "$out2" ||
-    fail "case 2: the level's outcome was not reported as a bisection decision"
-grep -Eq "(bisect incomplete|RESULT:)" "$out2" ||
-    fail "case 2: neither an incomplete-descent suspects list nor a verdict line was printed"
+# Case 4: a level the pot can only clip. The chunk run and depth 1 both
+# hang (the counter file seeds two hangs), and the pot funds 10s of a 25s
+# estimate: the timeout must be reported INCONCLUSIVE and must NOT narrow
+# the descent.
+echo 2 > "$work/count"
+rc=0
+# shellcheck disable=SC2086  # base_env is a deliberate VAR=val word list for env
+env $base_env KAAPPI_CHUNK_BUDGET=3 KAAPPI_BISECT_BUDGET=10 \
+    SHIM_HANG_FIRST="$work/count" \
+    bash tools/run-unit-test-chunk.sh rest > "$out" 2>&1 || rc=$?
+[ "$rc" -eq 124 ] || fail "case 4 (clipped level): wall-budget overrun must exit 124 (got $rc)"
+grep -q "INCONCLUSIVE" "$out" || fail "case 4: a clipped-allowance timeout was not reported INCONCLUSIVE"
+grep -q "descending into this half" "$out" && fail "case 4: an inconclusive level must not descend"
+grep -q "RESULT: inconclusive -- the pot could not fund decisive levels" "$out" ||
+    fail "case 4: no pot-too-small verdict line"
 
-echo "PASS: watchdog fired loudly, bisection streamed its subsets, exit 124"
+echo "PASS: watchdog, heartbeat, decisive descent, per-test NOTEs, and the"
+echo "PASS: clipped-level INCONCLUSIVE stop all behave and are all streamed"

--- a/tests/scheme/tools/unit-chunk-watchdog-2560.sh
+++ b/tests/scheme/tools/unit-chunk-watchdog-2560.sh
@@ -49,25 +49,45 @@ out="$work/out"
 #   timeout line (exercising the script's sed parser, spaces included),
 #   print a summary the script's floor check accepts, exit SHIM_EXIT.
 shim="$work/zig"
+# A copy of sleep under the name `zig`: as a GRANDCHILD of the shim its
+# comm is "zig", which pins phase_of's compiling branch (the test binary
+# and the QEMU wrapper hold the same position with a different name).
+mkdir -p "$work/bin"
+cp "$(command -v sleep)" "$work/bin/zig"
+# macOS AMFI kills a copied system binary that carries no valid signature,
+# so re-sign the copy ad hoc; Linux and the BSDs enforce nothing here.
+if [ "$(uname -s)" = "Darwin" ]; then
+    codesign --force -s - "$work/bin/zig" > /dev/null 2>&1 || true
+fi
 cat > "$shim" <<'SHIM'
 #!/usr/bin/env bash
 set -u
+# hang_tree: hang with a GRANDCHILD whose executable name decides what
+# the script's phase_of reports -- `sleep` (default) reads as a spawned
+# test binary ("running tests"); the sleep copy named zig
+# (SHIM_WEDGE_STYLE=compile + SHIM_FAKE_ZIG) reads as the compiler.
+hang_tree() {
+    case "${SHIM_WEDGE_STYLE:-}" in
+        compile) bash -c '"$SHIM_FAKE_ZIG" 9999 & wait' ;;
+        *)       bash -c 'sleep 9999 & wait' ;;
+    esac
+}
 if [ -n "${SHIM_WEDGE_ONCE:-}" ] && [ ! -f "${SHIM_WEDGE_ONCE}" ]; then
     : > "${SHIM_WEDGE_ONCE}"
-    sleep 9999 & sleep 9999 & wait
+    hang_tree
 fi
 if [ -n "${SHIM_HANG_FIRST:-}" ]; then
     count=0
     [ -f "${SHIM_HANG_FIRST}" ] && count=$(cat "${SHIM_HANG_FIRST}")
     if [ "$count" -gt 0 ]; then
         echo $((count - 1)) > "${SHIM_HANG_FIRST}"
-        sleep 9999 & sleep 9999 & wait
+        hang_tree
     fi
 fi
 if [ -n "${SHIM_WEDGE_FILTER:-}" ]; then
     for a in "$@"; do
         case "$a" in
-            -Dtest-filter=*"$SHIM_WEDGE_FILTER"*) sleep 9999 & sleep 9999 & wait ;;
+            -Dtest-filter=*"$SHIM_WEDGE_FILTER"*) hang_tree ;;
         esac
     done
 fi
@@ -88,7 +108,7 @@ chmod +x "$shim"
 # the --test-timeout grammar (a Zig duration). The level-funding constants
 # are scaled down so a level's "full estimate" is seconds, not minutes.
 base_env="KAAPPI_ZIG=$shim KAAPPI_TEST_TIMEOUT=8m KAAPPI_BISECT_TEST_TIMEOUT=90s"
-base_env="$base_env KAAPPI_BISECT_LEVEL_BASE_SECS=2 KAAPPI_BISECT_LEVEL_PER_FILTER_SECS=1"
+base_env="$base_env KAAPPI_BISECT_LEVEL_BASE_SECS=2 KAAPPI_BISECT_LEVEL_PER_TEST_TENTHS=0"
 base_env="$base_env KAAPPI_HEARTBEAT_SECS=2"
 
 # Structure: --list still derives the rest chunk's filters from the tree,
@@ -152,6 +172,7 @@ echo 2 > "$work/count"
 rc=0
 # shellcheck disable=SC2086  # base_env is a deliberate VAR=val word list for env
 env $base_env KAAPPI_CHUNK_BUDGET=3 KAAPPI_BISECT_BUDGET=10 \
+    KAAPPI_BISECT_LEVEL_BASE_SECS=30 \
     SHIM_HANG_FIRST="$work/count" \
     bash tools/run-unit-test-chunk.sh rest > "$out" 2>&1 || rc=$?
 [ "$rc" -eq 124 ] || fail "case 4 (clipped level): wall-budget overrun must exit 124 (got $rc)"
@@ -160,5 +181,29 @@ grep -q "descending into this half" "$out" && fail "case 4: an inconclusive leve
 grep -q "RESULT: inconclusive -- the pot could not fund decisive levels" "$out" ||
     fail "case 4: no pot-too-small verdict line"
 
-echo "PASS: watchdog, heartbeat, decisive descent, per-test NOTEs, and the"
-echo "PASS: clipped-level INCONCLUSIVE stop all behave and are all streamed"
+# Case 5: the kill-time phase report, running-tests branch. The shim's
+# default hang_tree leaves a `sleep` grandchild, which phase_of must read
+# as a spawned test binary. A dry pot keeps the case to the kill itself.
+rc=0
+# shellcheck disable=SC2086  # base_env is a deliberate VAR=val word list for env
+env $base_env KAAPPI_CHUNK_BUDGET=3 KAAPPI_BISECT_BUDGET=0 \
+    SHIM_WEDGE_ONCE="$work/once5" \
+    bash tools/run-unit-test-chunk.sh rest > "$out" 2>&1 || rc=$?
+[ "$rc" -eq 124 ] || fail "case 5 (phase, tests): wall-budget overrun must exit 124 (got $rc)"
+grep -q "WALL BUDGET EXCEEDED after .*s (running tests)" "$out" ||
+    fail "case 5: a sleep grandchild must be reported as tests in flight"
+
+# Case 6: the compiling branch -- same shape, but the grandchild is the
+# sleep copy named zig, which phase_of must read as the compiler itself.
+rc=0
+# shellcheck disable=SC2086  # base_env is a deliberate VAR=val word list for env
+env $base_env KAAPPI_CHUNK_BUDGET=3 KAAPPI_BISECT_BUDGET=0 \
+    SHIM_WEDGE_ONCE="$work/once6" SHIM_WEDGE_STYLE=compile \
+    SHIM_FAKE_ZIG="$work/bin/zig" \
+    bash tools/run-unit-test-chunk.sh rest > "$out" 2>&1 || rc=$?
+[ "$rc" -eq 124 ] || fail "case 6 (phase, compile): wall-budget overrun must exit 124 (got $rc)"
+grep -q "WALL BUDGET EXCEEDED after .*s (compiling)" "$out" ||
+    fail "case 6: a zig-named grandchild must be reported as compiling"
+
+echo "PASS: watchdog, heartbeat, decisive descent, per-test NOTEs, the"
+echo "PASS: clipped-level INCONCLUSIVE stop, and both kill-time phase reads"

--- a/tools/run-unit-test-chunk.sh
+++ b/tools/run-unit-test-chunk.sh
@@ -280,8 +280,10 @@ for n in $names; do
     filters+=("-Dtest-filter=$n.test.")
     # The bisection's level estimates are per TEST (see the constants
     # above), so carry each file's declared-test count alongside its
-    # filter. grep -c prints 0 (and exits 1, which set -u does not mind)
-    # for a listed file with no named tests.
+    # filter. grep -c prints 0 and exits 1 for a listed file with no
+    # named tests; that status is harmless here because the command
+    # substitution feeding an array append discards it (set -e is what
+    # would mind, and this script does not set it).
     filter_tests+=("$(grep -c '^test "' "src/$n.zig" | tr -d ' ')")
 done
 

--- a/tools/run-unit-test-chunk.sh
+++ b/tools/run-unit-test-chunk.sh
@@ -4,6 +4,7 @@
 #     bash tools/run-unit-test-chunk.sh <process|concurrency|rest> [zig build args...]
 #     bash tools/run-unit-test-chunk.sh --list <chunk>      # print the filters, run nothing
 #     KAAPPI_TEST_TIMEOUT=90s bash tools/run-unit-test-chunk.sh <chunk>   # per-test bound
+#     KAAPPI_CHUNK_BUDGET=1320 bash tools/run-unit-test-chunk.sh <chunk>  # wall budget, seconds
 #
 # WHY THIS EXISTS. `riscv64-test` runs the whole unit suite under QEMU
 # user-mode as ONE `zig build test` step that prints nothing until it
@@ -26,15 +27,66 @@
 # go silent: a test that writes to fd 1 corrupts the IPC stream (the build
 # runner reads the stray bytes as a message header and waits for a body
 # that never comes), and the runner now gives up on that test too instead
-# of on the whole step. The chunks stay: the timeout localises to a test
-# only once the step is allowed to outlive it, so every step cap in the
-# workflow is sized as its healthy time plus this timeout plus margin.
+# of on the whole step.
 #
-# $KAAPPI_TEST_TIMEOUT overrides the bound (a Zig duration such as 8m or
-# 90s). The default is sized from the slowest chunk under QEMU: the fuzz
-# chunk's 20 tests (the fixed-seed generator gates among them) take about
-# 4.5m TOGETHER, so no single test is anywhere near 8m, and under emulation
-# a legitimately slow test must never be mistaken for a hang.
+# WHY THE PER-TEST NAME DID NOT SURVIVE CI KILLS (kaappi#2560). `zig build`
+# buffers its ENTIRE console output -- summaries and per-test timeout
+# messages alike -- until the process exits. Verified on Zig 0.16.0: piped
+# through `tee`, redirected to a file, or run under a pty, a test that
+# times out is killed and named at the moment the bound fires, yet zero
+# bytes leave `zig build` until it exits; SIGTERM does not flush the buffer
+# either. So on a step killed at its `timeout-minutes` cap, every name the
+# per-test bound had already recorded died inside the buffer -- which is
+# exactly the silent >24m kill of kaappi#2560, and it defeats #2491's
+# naming on every capped step, not just this chunk. The name survives only
+# when `zig build` exits on its own -- which is why the wall budget below
+# is sized to outlive one per-test bound: one hung test is still named by
+# zig itself, and it is only the second hang (or a wedge the runner cannot
+# see) that falls through to bisection.
+#
+# THE WALL BUDGET AND BISECTION. This script prints its own lines to the
+# live log as it goes (bash `echo` is unbuffered), so they survive any kill:
+# a heartbeat while the chunk runs, a loud line when the wall budget
+# expires, and one line per bisection level naming the filter subset in
+# flight. Bisection re-runs `zig build test` on halves of the chunk's
+# filter list with a TIGHT per-test bound (`KAAPPI_BISECT_TEST_TIMEOUT`,
+# default 90s -- bisection is localisation, not adjudication). A half that
+# cannot finish in its level budget holds a process-level wedge; the
+# descent follows those halves down to a single filter, confirmed by a
+# solo run. A half that finishes never exonerates slow TESTS -- the tight
+# bound kills those mid-level and zig flushes their names when the level
+# exits, which the script echoes as NOTE lines; if no level ever wedged,
+# the whole chunk is re-run under the tight bound (cache-hot: the same
+# filter set just compiled) so every per-test culprit is named in full
+# context. The last line before any kill therefore names the filter, the
+# narrowed subset, or the slow test -- the reopen criterion of #2488. Each
+# level costs at most one test-binary compile for its fresh filter set
+# (~1.5m cold on the CI host, cache-warm objects after phase 1), so levels
+# are binary-searched, never swept, and the whole phase runs inside
+# KAAPPI_BISECT_BUDGET (default 1080s): when the pot empties, the suspects
+# list is printed as-is and a human can re-run with a bigger pot.
+# Caveat, stated plainly: a wedge that is order- or load-dependent may
+# reproduce under none of these treatments; the log then says so instead
+# of guessing.
+#
+# Knobs (unset means the old behaviour -- no watchdog, no bisection):
+#   KAAPPI_TEST_TIMEOUT            per-test bound for the chunk run (Zig
+#                                  duration; default 8m, see below)
+#   KAAPPI_CHUNK_BUDGET            wall budget for the chunk run, SECONDS;
+#                                  0/unset disables the watchdog
+#   KAAPPI_BISECT_BUDGET           total bisection pot, SECONDS (default 1080)
+#   KAAPPI_BISECT_TEST_TIMEOUT     per-test bound during bisection levels
+#                                  (Zig duration; default 90s)
+#   KAAPPI_HEARTBEAT_SECS          heartbeat cadence, SECONDS (default 60)
+#
+# The chunk run exits 124 when the wall budget fired (the `timeout(1)`
+# convention), so CI fails loudly while the log carries the localisation.
+#
+# $KAAPPI_TEST_TIMEOUT's default is sized from the slowest chunk under
+# QEMU: the fuzz chunk's 20 tests (the fixed-seed generator gates among
+# them) take about 4.5m TOGETHER, so no single test is anywhere near 8m,
+# and under emulation a legitimately slow test must never be mistaken for
+# a hang.
 #
 # HOW THE CHUNKS ARE CUT. `-Dtest-filter` is a substring match on a test's
 # qualified name, `<file basename>.test.<title>` (build.zig; repeatable).
@@ -91,8 +143,8 @@
 # the thottam files, and only its own unnamed block in every other chunk.
 #
 # Works for any target: pass `-Dtarget=riscv64-linux` (or nothing, for the
-# host) after the chunk name. Exit status is `zig build test`'s, or 2 for a
-# misuse this script detected itself.
+# host) after the chunk name. Exit status is `zig build test`'s, 124 when
+# the wall budget fired, or 2 for a misuse this script detected itself.
 
 set -u
 set -o pipefail
@@ -119,9 +171,32 @@ TOOLING_FILES="cli cli_spec completions config check_lint tests_check doctor
 LISTED_FILES="$PROCESS_FILES $CONCURRENCY_FILES $IO_FILES $FUZZ_FILES $GC_FILES $NATIVE_FILES $TOOLING_FILES"
 CHUNK_NAMES="process|concurrency|io|fuzz|gc|native|tooling|rest"
 
+# Bisection level allowance, seconds: a fresh compile for the subset (~90s
+# on the CI host) + runtime under QEMU at ~35s per filter -- generously
+# over the ~15s/filter the `rest` chunk averages, so a CLEAN level is never
+# misread as wedged. Natively everything finishes far under this. A WEDGED
+# level burns its whole allowance (that is how it is recognised), so each
+# level is additionally capped at 3/5 of the remaining pot: the pot then
+# degrades geometrically down the descent instead of being consumed by the
+# first wedged level, and 90s (one cold compile, no tests) is the floor
+# below which a level cannot tell wedge from clean and is not started.
+BISECT_LEVEL_BASE_SECS=300
+BISECT_LEVEL_PER_FILTER_SECS=35
+BISECT_LEVEL_POT_SHARE_NUMERATOR=3
+BISECT_LEVEL_POT_SHARE_DENOMINATOR=5
+BISECT_LEVEL_MIN_SECS=90
+
 usage() {
     echo "usage: $0 [--list] <$CHUNK_NAMES> [zig build args...]" >&2
     exit 2
+}
+
+# fname <-Dtest-filter=NAME.test.>: the bare file name, for display and for
+# building the reproduce command (which re-adds the `.test.` anchor).
+fname() {
+    local s="$1"
+    s="${s#-Dtest-filter=}"
+    printf '%s' "${s%.test.}"
 }
 
 list_only=0
@@ -189,10 +264,230 @@ log="$(mktemp)"
 trap 'rm -f "$log"' EXIT
 
 test_timeout="${KAAPPI_TEST_TIMEOUT:-8m}"
+budget="${KAAPPI_CHUNK_BUDGET:-0}"
+bisect_pot="${KAAPPI_BISECT_BUDGET:-1080}"
+bisect_timeout="${KAAPPI_BISECT_TEST_TIMEOUT:-90s}"
+heartbeat_secs="${KAAPPI_HEARTBEAT_SECS:-60}"
 
-echo "== unit-test chunk '$chunk': ${#filters[@]} filter(s), per-test timeout $test_timeout, extra args: $*"
-zig build test "${filters[@]}" "$@" --test-timeout "$test_timeout" --summary all 2>&1 | tee "$log"
-status=${PIPESTATUS[0]}
+# kill_tree <pid> <signal>: signal pid and, best-effort, its descendants,
+# children first. `zig build`'s direct child is the cached build-runner
+# binary, whose child is the (possibly emulated) test binary; none of them
+# die with their parent on their own (verified: TERMing `zig build` leaves
+# the runner orphaned and burning CPU), so a watchdog kill must walk down.
+# pgrep -P exists on Linux, macOS and the BSDs; where it does not (MSYS),
+# the lone pid is signalled and the caller's own process group is the net.
+kill_tree() {
+    local pid="$1" sig="$2" child
+    if command -v pgrep > /dev/null 2>&1; then
+        for child in $(pgrep -P "$pid" 2>/dev/null); do
+            kill_tree "$child" "$sig"
+        done
+    fi
+    kill -"$sig" "$pid" 2> /dev/null || true
+}
+
+# run_supervised <budget-secs> <label> <zig args...>
+#
+# Runs `zig build test <args...> --summary all`, teeing its output to the
+# live log as it appears (in practice once, at exit -- see the header) and
+# to "$log", while printing a heartbeat every $heartbeat_secs and enforcing
+# the wall budget. The zig pid is tracked directly (output goes to a file
+# the script forwards, not through a pipeline, so `$!` is zig and killing it
+# orphans nothing but its own tree). Sets on return: zig_status,
+# watchdog_fired (1 = budget expired and the tree was killed), ran_secs.
+run_supervised() {
+    local budget="$1" label="$2"; shift 2
+    local start now next_beat sent size grace budget_note
+    : > "$log"
+    zig build test "$@" --summary all > "$log" 2>&1 &
+    zig_pid=$!
+    start=$(date +%s)
+    next_beat=$((start + heartbeat_secs))
+    sent=0
+    watchdog_fired=0
+    if [ "$budget" -gt 0 ]; then
+        budget_note=" of a ${budget}s budget"
+    fi
+    while kill -0 "$zig_pid" 2> /dev/null; do
+        sleep 5
+        now=$(date +%s)
+        size=$(wc -c < "$log" | tr -d ' ')
+        if [ "$size" -gt "$sent" ]; then
+            tail -c +$((sent + 1)) "$log"
+            sent=$size
+        fi
+        if [ "$now" -ge "$next_beat" ]; then
+            echo "== $label: still running at $((now - start))s${budget_note} (zig pid $zig_pid; zig buffers its output until exit, so silence here is normal)"
+            next_beat=$((now + heartbeat_secs))
+        fi
+        if [ "$budget" -gt 0 ] && [ $((now - start)) -ge "$budget" ]; then
+            watchdog_fired=1
+            echo "== $label: WALL BUDGET EXCEEDED after $((now - start))s -- killing the zig build (its buffered output dies with it)"
+            kill_tree "$zig_pid" TERM
+            grace=0
+            while [ "$grace" -lt 10 ] && kill -0 "$zig_pid" 2> /dev/null; do
+                sleep 1
+                grace=$((grace + 1))
+            done
+            kill_tree "$zig_pid" KILL
+            break
+        fi
+    done
+    wait "$zig_pid" 2> /dev/null
+    zig_status=$?
+    # Final drain: zig's whole buffered output lands in the file at exit.
+    size=$(wc -c < "$log" | tr -d ' ')
+    if [ "$size" -gt "$sent" ]; then
+        tail -c +$((sent + 1)) "$log"
+    fi
+    ran_secs=$(( $(date +%s) - start ))
+}
+
+# bisect_chunk <zig args...>: binary-search the filter list for the wedge,
+# spending at most $bisect_pot seconds in total. Prints one line per level
+# BEFORE running it, so a kill anywhere leaves the in-flight subset named.
+#
+# Three honest outcomes, because a wedge has three shapes:
+#   * a PROCESS-level wedge (emulation or runner stuck) also wedges every
+#     bisection level that contains it; the descent follows the wedged
+#     halves and ends on one filter, confirmed by a solo run;
+#   * PER-TEST hangs never wedge a level -- the tight per-test bound kills
+#     each one mid-level and the level completes -- so the descent cannot
+#     follow them; instead every name the tight bound flushes is echoed as
+#     a NOTE line, and if NO level ever wedged, the whole chunk is re-run
+#     under the tight bound (compile is cache-hot: same filter set as the
+#     phase that just ran) to name every per-test culprit in full context;
+#   * a wedge that reproduces under neither treatment is order- or
+#     load-dependent, and the log says so instead of guessing.
+bisect_chunk() {
+    local lo=0 hi=${#filters[@]} depth=0 mid n allow remaining now pot_share
+    local pot_start first last f i tn
+    local wedged_seen=0 full_rerun_wedged=0 bisect_slow_notes=""
+    pot_start=$(date +%s)
+    echo "== bisect: ${#filters[@]} filter(s), per-test timeout $bisect_timeout, total budget ${bisect_pot}s"
+    while [ $((hi - lo)) -gt 1 ]; do
+        depth=$((depth + 1))
+        now=$(date +%s)
+        remaining=$((bisect_pot - (now - pot_start)))
+        mid=$(((lo + hi) / 2))
+        n=$((mid - lo))
+        allow=$((BISECT_LEVEL_BASE_SECS + BISECT_LEVEL_PER_FILTER_SECS * n))
+        pot_share=$((remaining * BISECT_LEVEL_POT_SHARE_NUMERATOR / BISECT_LEVEL_POT_SHARE_DENOMINATOR))
+        [ "$allow" -gt "$pot_share" ] && allow=$pot_share
+        if [ "$allow" -lt "$BISECT_LEVEL_MIN_SECS" ]; then
+            echo "== bisect: remaining pot (${remaining}s) is too shallow for depth $depth (a level needs >= ${BISECT_LEVEL_MIN_SECS}s to tell wedged from clean)"
+            break
+        fi
+        first=$(fname "${filters[lo]}")
+        last=$(fname "${filters[mid - 1]}")
+        echo "== bisect depth $depth: $n filter(s) $first..$last, budget ${allow}s"
+        run_supervised "$allow" "bisect depth $depth ($first..$last)" "${filters[@]:lo:n}" "$@" --test-timeout "$bisect_timeout"
+        if [ "$watchdog_fired" = 1 ]; then
+            wedged_seen=1
+            echo "== bisect depth $depth: $first..$last did NOT finish in ${allow}s -- the wedge reproduces inside this half"
+            hi=$mid
+        else
+            echo "== bisect depth $depth: $first..$last finished in ${ran_secs}s (zig exit $zig_status) -- no process wedge here, discarding this half"
+            # A completed level can still carry the phase-1 culprit: a test
+            # that is merely SLOW (not wedged) survives phase 1's 8m bound
+            # long enough to blow the wall budget but not the tight one, and
+            # zig flushes its name when the level exits. Surface it.
+            # Whole lines, not word-split: a test TITLE can contain spaces
+            # ('synthetic wedge 2560'), and a shattered name localises
+            # nothing. Collected once per test, not once per sighting.
+            while IFS= read -r tn; do
+                [ -n "$tn" ] || continue
+                echo "== bisect depth $depth: NOTE: '$tn' exceeded the tight $bisect_timeout bound -- a phase-1 suspect"
+                case "$bisect_slow_notes" in
+                    *"'$tn'"*) ;;
+                    *) bisect_slow_notes="$bisect_slow_notes '$tn'" ;;
+                esac
+            done < <(sed -n "s/^error: '\([^']*\)' timed out after.*/\1/p" "$log")
+            lo=$mid
+        fi
+    done
+
+    now=$(date +%s)
+    remaining=$((bisect_pot - (now - pot_start)))
+
+    if [ "$wedged_seen" = 0 ]; then
+        # No level wedged, so the descent proves nothing about filters: the
+        # phase-1 overrun was per-test (hangs or slowness the runner can
+        # bound) or it does not reproduce at all. The tight-bound full
+        # re-run names the former; the log's honesty covers the latter.
+        if [ "$remaining" -ge "$BISECT_LEVEL_MIN_SECS" ]; then
+            echo "== bisect: no level wedged -- re-running the whole chunk under the tight $bisect_timeout bound (compile is cache-hot) to name per-test culprits in full context, budget ${remaining}s"
+            run_supervised "$remaining" "bisect full re-run" "${filters[@]}" "$@" --test-timeout "$bisect_timeout"
+            if [ "$watchdog_fired" = 1 ]; then
+                full_rerun_wedged=1
+                echo "== the full chunk wedged again under the tight bound without any level wedging first -- an order- or interaction-dependent wedge, not a single slow test"
+            else
+                echo "== the full re-run finished (zig exit $zig_status): any 'timed out after' name above is a phase-1 suspect"
+                while IFS= read -r tn; do
+                    [ -n "$tn" ] || continue
+                    case "$bisect_slow_notes" in
+                        *"'$tn'"*) ;;
+                        *) bisect_slow_notes="$bisect_slow_notes '$tn'" ;;
+                    esac
+                done < <(sed -n "s/^error: '\([^']*\)' timed out after.*/\1/p" "$log")
+            fi
+        else
+            echo "== bisect: budget pot too dry for the tight-bound full re-run"
+        fi
+        if [ "$full_rerun_wedged" = 1 ]; then
+            echo "== RESULT: the wedge reproduced only in the full chunk, never in any subset -- order- or interaction-dependent"
+        elif [ -n "$bisect_slow_notes" ]; then
+            echo "== RESULT: no process-level wedge reproduced; per-test suspect(s) named by the tight bound:$bisect_slow_notes"
+        else
+            echo "== RESULT: no wedge and no slow test reproduced under bisection -- the phase-1 overrun was order- or load-dependent"
+        fi
+        return 0
+    fi
+
+    if [ $((hi - lo)) -eq 1 ]; then
+        f=$(fname "${filters[lo]}")
+        if [ "$remaining" -ge "$BISECT_LEVEL_MIN_SECS" ]; then
+            allow=$((BISECT_LEVEL_BASE_SECS + BISECT_LEVEL_PER_FILTER_SECS))
+            [ "$allow" -gt "$remaining" ] && allow=$remaining
+            echo "== bisect: confirming the single suspect $f alone (budget ${allow}s)"
+            run_supervised "$allow" "bisect confirm ($f)" "${filters[lo]}" "$@" --test-timeout "$bisect_timeout"
+            if [ "$watchdog_fired" = 1 ]; then
+                echo "== LOCALISED AND CONFIRMED: filter '$f.test.' alone does not finish within its budget"
+            else
+                echo "== NARROWED BUT NOT CONFIRMED: '$f.test.' completed alone in ${ran_secs}s -- the wedge is order- or load-dependent; this is the last unexonerated filter"
+            fi
+        else
+            echo "== LOCALISED: filter '$f.test.' is the only suspect left (budget pot too dry to confirm it alone)"
+        fi
+        if [ -n "$bisect_slow_notes" ]; then
+            echo "== additionally, these tests exceeded the tight bound during the descent:$bisect_slow_notes"
+        fi
+        echo "== reproduce/narrow on any host with:"
+        echo "==   zig build test -Dtest-filter=$f.test. --test-timeout $bisect_timeout $*"
+    else
+        echo "== bisect incomplete: $((hi - lo)) suspect filter(s) remain:"
+        i=$lo
+        while [ "$i" -lt "$hi" ]; do
+            echo "==   $(fname "${filters[i]}")"
+            i=$((i + 1))
+        done
+        echo "== re-run the step with a larger KAAPPI_BISECT_BUDGET to finish the descent"
+    fi
+}
+
+budget_note="no wall budget (KAAPPI_CHUNK_BUDGET unset)"
+[ "$budget" -gt 0 ] && budget_note="wall budget ${budget}s"
+echo "== unit-test chunk '$chunk': ${#filters[@]} filter(s), per-test timeout $test_timeout, $budget_note, extra args: $*"
+run_supervised "$budget" "unit-test chunk '$chunk'" "${filters[@]}" "$@" --test-timeout "$test_timeout"
+status=$zig_status
+
+if [ "$watchdog_fired" = 1 ]; then
+    # The chunk did not finish inside its wall budget. zig's own summary --
+    # and any per-test name it had already collected -- is lost with its
+    # buffer, so localise with the script's own streamed lines instead.
+    bisect_chunk "$@"
+    exit 124
+fi
 [ "$status" = 0 ] || exit "$status"
 
 # `--summary all` prints one line per test binary, e.g.

--- a/tools/run-unit-test-chunk.sh
+++ b/tools/run-unit-test-chunk.sh
@@ -58,7 +58,8 @@
 # exits, which the script echoes as NOTE lines; if no level ever wedged,
 # the whole chunk is re-run under the tight bound (the same filter set as
 # the chunk run, so its compile is cached whenever that run got past
-# compiling) so every per-test culprit is named in full context. The last line before any kill therefore names the filter, the
+# compiling) so every per-test culprit is named in full context. The last
+# line before any kill therefore names the filter, the
 # narrowed subset, or the slow test -- the reopen criterion of #2488. Each
 # level costs at most one test-binary compile for its fresh filter set
 # (~1.5m cold on the CI host, cache-warm objects after phase 1), so levels
@@ -83,9 +84,11 @@
 #   KAAPPI_BISECT_BUDGET           total bisection pot, SECONDS (default 1080)
 #   KAAPPI_BISECT_TEST_TIMEOUT     per-test bound during bisection levels
 #                                  (Zig duration; default 90s)
-#   KAAPPI_BISECT_LEVEL_BASE_SECS  level-funding estimate base, SECONDS
-#                                  (default 120; see the constants below)
-#   KAAPPI_BISECT_LEVEL_PER_FILTER_SECS   ...and per-filter term (default 25)
+#   KAAPPI_BISECT_LEVEL_BASE_SECS        level-funding estimate base,
+#                                        SECONDS (default 120; see the
+#                                        constants below)
+#   KAAPPI_BISECT_LEVEL_PER_TEST_TENTHS  ...and per-TEST term, tenths of
+#                                        a second (default 12 = 1.2s/test)
 #   KAAPPI_HEARTBEAT_SECS          heartbeat cadence, SECONDS (default 60)
 #   KAAPPI_ZIG                     zig binary to drive (default `zig`); for
 #                                  the shim-driven regression test
@@ -183,22 +186,29 @@ LISTED_FILES="$PROCESS_FILES $CONCURRENCY_FILES $IO_FILES $FUZZ_FILES $GC_FILES 
 CHUNK_NAMES="process|concurrency|io|fuzz|gc|native|tooling|rest"
 
 # Bisection level funding, seconds. A level's ESTIMATE is the plausible
-# worst case for a CLEAN level of n filters under QEMU: a fresh compile for
-# the subset (~90s on the CI host) plus runtime at ~25s per filter (~2x the
-# ~12s/filter the #2560 numbers give for `rest`). A level run at its full
-# estimate therefore separates the outcomes: finishing exonerates its half,
-# and only not-finishing implicates it. The pot funds FULL estimates --
-# deliberately no fractional share, because a clipped level's TIMEOUT is
-# not evidence (a clean level can simply be slower than a clipped
-# allowance): an under-funded timeout is reported INCONCLUSIVE and never
-# narrows the descent, while an under-funded COMPLETION still exonerates
-# (finishing is finishing whatever the allowance was). Below MIN (BASE/3:
-# a fraction of even the compile) a level cannot decide anything and is
-# not started. Natively everything finishes far under the estimate; the
-# two constants are env-overridable for fast hosts and for the shim-driven
-# regression test.
+# worst case for a CLEAN level: a fresh compile for the subset (~90s on
+# the CI host) plus runtime per TEST in it. The term is per test, not per
+# filter, because the `rest` chunk's filters are skewed 2.4-4.7x in test
+# count (tests_ir carries 94 against a ~20-per-file average) and a
+# per-filter term underestimates the heavy windows enough to misread a
+# clean level as wedged -- worst at the solo confirm, which would print
+# LOCALISED AND CONFIRMED for a merely-heavy file. The default term is 12
+# tenths of a second (~2x the ~0.6s/test the #2560 numbers give for
+# `rest` under QEMU: 907 tests in ~9.5m after the ~1.5m compile). A level
+# run at its full estimate therefore separates the outcomes: finishing
+# exonerates its half, and only not-finishing implicates it. The pot
+# funds FULL estimates -- deliberately no fractional share, because a
+# clipped level's TIMEOUT is not evidence (a clean level can simply be
+# slower than a clipped allowance): an under-funded timeout is reported
+# INCONCLUSIVE and never narrows the descent, while an under-funded
+# COMPLETION still exonerates (finishing is finishing whatever the
+# allowance was). Below MIN (BASE/3: a fraction of even the compile) a
+# level cannot decide anything and is not started. Natively everything
+# finishes far under the estimate; the constants are env-overridable for
+# fast hosts and for the shim-driven regression test (which zeroes the
+# per-test term so an estimate is the base alone).
 BISECT_LEVEL_BASE_SECS="${KAAPPI_BISECT_LEVEL_BASE_SECS:-120}"
-BISECT_LEVEL_PER_FILTER_SECS="${KAAPPI_BISECT_LEVEL_PER_FILTER_SECS:-25}"
+BISECT_LEVEL_PER_TEST_TENTHS="${KAAPPI_BISECT_LEVEL_PER_TEST_TENTHS:-12}"
 BISECT_LEVEL_MIN_SECS=$((BISECT_LEVEL_BASE_SECS / 3))
 [ "$BISECT_LEVEL_MIN_SECS" -ge 1 ] || BISECT_LEVEL_MIN_SECS=1
 
@@ -265,7 +275,15 @@ case "$chunk" in
 esac
 
 filters=()
-for n in $names; do filters+=("-Dtest-filter=$n.test."); done
+filter_tests=()
+for n in $names; do
+    filters+=("-Dtest-filter=$n.test.")
+    # The bisection's level estimates are per TEST (see the constants
+    # above), so carry each file's declared-test count alongside its
+    # filter. grep -c prints 0 (and exits 1, which set -u does not mind)
+    # for a listed file with no named tests.
+    filter_tests+=("$(grep -c '^test "' "src/$n.zig" | tr -d ' ')")
+done
 
 if [ "$list_only" = 1 ]; then
     printf '%s\n' "${filters[@]}"
@@ -321,7 +339,14 @@ phase_of() {
     verdict=""
     for child in $(pgrep -P "$pid" 2>/dev/null); do
         for gc in $(pgrep -P "$child" 2>/dev/null); do
-            base="$(ps -o comm= -p "$gc" 2>/dev/null | awk '{print $1}')"
+            # Whole line, not the first word: macOS comm= is the full
+            # executable path, so a checkout under a directory with a
+            # space in its name would split to a non-zig first word and
+            # misclassify a compile as running tests. Linux comm= is the
+            # 15-char executable name, never a path; the basename is
+            # identity either way.
+            base=""
+            read -r base < <(ps -o comm= -p "$gc" 2>/dev/null)
             base="${base##*/}"
             if [ "$base" != "zig" ] && [ -n "$base" ]; then
                 echo "running tests"
@@ -431,7 +456,7 @@ run_supervised() {
 #     a timeout -- that is INCONCLUSIVE, not evidence -- though its
 #     completion still exonerates (finishing is finishing).
 bisect_chunk() {
-    local lo=0 hi=${#filters[@]} depth=0 mid n est allow remaining now
+    local lo=0 hi=${#filters[@]} depth=0 mid n est allow remaining now subset_tests
     local pot_start first last f i tn
     local wedged_seen=0 full_rerun_wedged=0 inconclusive_seen=0 bisect_slow_notes=""
     pot_start=$(date +%s)
@@ -442,7 +467,13 @@ bisect_chunk() {
         remaining=$((bisect_pot - (now - pot_start)))
         mid=$(((lo + hi) / 2))
         n=$((mid - lo))
-        est=$((BISECT_LEVEL_BASE_SECS + BISECT_LEVEL_PER_FILTER_SECS * n))
+        subset_tests=0
+        i=$lo
+        while [ "$i" -lt "$mid" ]; do
+            subset_tests=$((subset_tests + filter_tests[i]))
+            i=$((i + 1))
+        done
+        est=$((BISECT_LEVEL_BASE_SECS + (BISECT_LEVEL_PER_TEST_TENTHS * subset_tests) / 10))
         allow=$est
         [ "$allow" -gt "$remaining" ] && allow=$remaining
         if [ "$allow" -lt "$BISECT_LEVEL_MIN_SECS" ]; then
@@ -525,11 +556,12 @@ bisect_chunk() {
     if [ $((hi - lo)) -eq 1 ]; then
         f=$(fname "${filters[lo]}")
         if [ "$remaining" -ge "$BISECT_LEVEL_MIN_SECS" ]; then
-            allow=$((BISECT_LEVEL_BASE_SECS + BISECT_LEVEL_PER_FILTER_SECS))
+            est=$((BISECT_LEVEL_BASE_SECS + (BISECT_LEVEL_PER_TEST_TENTHS * filter_tests[lo]) / 10))
+            allow=$est
             [ "$allow" -gt "$remaining" ] && allow=$remaining
             echo "== bisect: confirming the single suspect $f alone (budget ${allow}s)"
             run_supervised "$allow" "bisect confirm ($f)" "${filters[lo]}" "$@" --test-timeout "$bisect_timeout"
-            if [ "$watchdog_fired" = 1 ] && [ "$allow" -ge $((BISECT_LEVEL_BASE_SECS + BISECT_LEVEL_PER_FILTER_SECS)) ]; then
+            if [ "$watchdog_fired" = 1 ] && [ "$allow" -ge "$est" ]; then
                 echo "== LOCALISED AND CONFIRMED: filter '$f.test.' alone did not finish at its full estimated allowance ($kill_phase at kill time)"
             elif [ "$watchdog_fired" = 1 ]; then
                 echo "== LOCALISED (unconfirmed): filter '$f.test.' did not finish its solo run, but on a clipped allowance -- a clean solo run can be slower than that"

--- a/tools/run-unit-test-chunk.sh
+++ b/tools/run-unit-test-chunk.sh
@@ -56,15 +56,21 @@
 # solo run. A half that finishes never exonerates slow TESTS -- the tight
 # bound kills those mid-level and zig flushes their names when the level
 # exits, which the script echoes as NOTE lines; if no level ever wedged,
-# the whole chunk is re-run under the tight bound (cache-hot: the same
-# filter set just compiled) so every per-test culprit is named in full
-# context. The last line before any kill therefore names the filter, the
+# the whole chunk is re-run under the tight bound (the same filter set as
+# the chunk run, so its compile is cached whenever that run got past
+# compiling) so every per-test culprit is named in full context. The last line before any kill therefore names the filter, the
 # narrowed subset, or the slow test -- the reopen criterion of #2488. Each
 # level costs at most one test-binary compile for its fresh filter set
 # (~1.5m cold on the CI host, cache-warm objects after phase 1), so levels
 # are binary-searched, never swept, and the whole phase runs inside
-# KAAPPI_BISECT_BUDGET (default 1080s): when the pot empties, the suspects
-# list is printed as-is and a human can re-run with a bigger pot.
+# KAAPPI_BISECT_BUDGET (default 1080s). The pot funds FULL level
+# estimates; a level whose allowance the pot could only clip is run anyway
+# but its timeout is reported INCONCLUSIVE and never narrows the descent
+# (its completion still exonerates). When the pot empties, the suspects
+# list is printed as-is and a human can re-run with a bigger pot. At the
+# kill itself the script also reports the tree's phase -- compiling vs
+# running tests, read from the process tree -- so every "did not finish"
+# line says what it was doing instead of asserting a wedge it cannot see.
 # Caveat, stated plainly: a wedge that is order- or load-dependent may
 # reproduce under none of these treatments; the log then says so instead
 # of guessing.
@@ -77,7 +83,12 @@
 #   KAAPPI_BISECT_BUDGET           total bisection pot, SECONDS (default 1080)
 #   KAAPPI_BISECT_TEST_TIMEOUT     per-test bound during bisection levels
 #                                  (Zig duration; default 90s)
+#   KAAPPI_BISECT_LEVEL_BASE_SECS  level-funding estimate base, SECONDS
+#                                  (default 120; see the constants below)
+#   KAAPPI_BISECT_LEVEL_PER_FILTER_SECS   ...and per-filter term (default 25)
 #   KAAPPI_HEARTBEAT_SECS          heartbeat cadence, SECONDS (default 60)
+#   KAAPPI_ZIG                     zig binary to drive (default `zig`); for
+#                                  the shim-driven regression test
 #
 # The chunk run exits 124 when the wall budget fired (the `timeout(1)`
 # convention), so CI fails loudly while the log carries the localisation.
@@ -171,20 +182,25 @@ TOOLING_FILES="cli cli_spec completions config check_lint tests_check doctor
 LISTED_FILES="$PROCESS_FILES $CONCURRENCY_FILES $IO_FILES $FUZZ_FILES $GC_FILES $NATIVE_FILES $TOOLING_FILES"
 CHUNK_NAMES="process|concurrency|io|fuzz|gc|native|tooling|rest"
 
-# Bisection level allowance, seconds: a fresh compile for the subset (~90s
-# on the CI host) + runtime under QEMU at ~35s per filter -- generously
-# over the ~15s/filter the `rest` chunk averages, so a CLEAN level is never
-# misread as wedged. Natively everything finishes far under this. A WEDGED
-# level burns its whole allowance (that is how it is recognised), so each
-# level is additionally capped at 3/5 of the remaining pot: the pot then
-# degrades geometrically down the descent instead of being consumed by the
-# first wedged level, and 90s (one cold compile, no tests) is the floor
-# below which a level cannot tell wedge from clean and is not started.
-BISECT_LEVEL_BASE_SECS=300
-BISECT_LEVEL_PER_FILTER_SECS=35
-BISECT_LEVEL_POT_SHARE_NUMERATOR=3
-BISECT_LEVEL_POT_SHARE_DENOMINATOR=5
-BISECT_LEVEL_MIN_SECS=90
+# Bisection level funding, seconds. A level's ESTIMATE is the plausible
+# worst case for a CLEAN level of n filters under QEMU: a fresh compile for
+# the subset (~90s on the CI host) plus runtime at ~25s per filter (~2x the
+# ~12s/filter the #2560 numbers give for `rest`). A level run at its full
+# estimate therefore separates the outcomes: finishing exonerates its half,
+# and only not-finishing implicates it. The pot funds FULL estimates --
+# deliberately no fractional share, because a clipped level's TIMEOUT is
+# not evidence (a clean level can simply be slower than a clipped
+# allowance): an under-funded timeout is reported INCONCLUSIVE and never
+# narrows the descent, while an under-funded COMPLETION still exonerates
+# (finishing is finishing whatever the allowance was). Below MIN (BASE/3:
+# a fraction of even the compile) a level cannot decide anything and is
+# not started. Natively everything finishes far under the estimate; the
+# two constants are env-overridable for fast hosts and for the shim-driven
+# regression test.
+BISECT_LEVEL_BASE_SECS="${KAAPPI_BISECT_LEVEL_BASE_SECS:-120}"
+BISECT_LEVEL_PER_FILTER_SECS="${KAAPPI_BISECT_LEVEL_PER_FILTER_SECS:-25}"
+BISECT_LEVEL_MIN_SECS=$((BISECT_LEVEL_BASE_SECS / 3))
+[ "$BISECT_LEVEL_MIN_SECS" -ge 1 ] || BISECT_LEVEL_MIN_SECS=1
 
 usage() {
     echo "usage: $0 [--list] <$CHUNK_NAMES> [zig build args...]" >&2
@@ -268,22 +284,57 @@ budget="${KAAPPI_CHUNK_BUDGET:-0}"
 bisect_pot="${KAAPPI_BISECT_BUDGET:-1080}"
 bisect_timeout="${KAAPPI_BISECT_TEST_TIMEOUT:-90s}"
 heartbeat_secs="${KAAPPI_HEARTBEAT_SECS:-60}"
+# The zig binary to drive. KAAPPI_ZIG exists so the regression test can
+# point the script at a shim that plays wedged/clean subsets in seconds;
+# everything else gets the real `zig` from PATH.
+zig_bin="${KAAPPI_ZIG:-zig}"
 
-# kill_tree <pid> <signal>: signal pid and, best-effort, its descendants,
-# children first. `zig build`'s direct child is the cached build-runner
-# binary, whose child is the (possibly emulated) test binary; none of them
-# die with their parent on their own (verified: TERMing `zig build` leaves
-# the runner orphaned and burning CPU), so a watchdog kill must walk down.
-# pgrep -P exists on Linux, macOS and the BSDs; where it does not (MSYS),
-# the lone pid is signalled and the caller's own process group is the net.
-kill_tree() {
-    local pid="$1" sig="$2" child
+# tree_pids <pid>: the pid and its descendants, deepest first. `zig
+# build`'s direct child is the cached build-runner binary, whose child is
+# the (possibly emulated) test binary; none of them die with their parent
+# on their own (verified: TERMing `zig build` leaves the runner orphaned
+# and burning CPU), so a watchdog kill must walk the whole tree -- and the
+# KILL escalation must walk a SNAPSHOT taken BEFORE the TERM: once the
+# parent exits, `pgrep -P` can no longer find the re-parented survivors,
+# and an escalation computed from the live tree signals nothing. pgrep -P
+# exists on Linux, macOS and the BSDs; where it does not (MSYS), only the
+# pid itself is captured and the caller's own process group is the net.
+tree_pids() {
+    local pid="$1" child
     if command -v pgrep > /dev/null 2>&1; then
         for child in $(pgrep -P "$pid" 2>/dev/null); do
-            kill_tree "$child" "$sig"
+            tree_pids "$child"
         done
     fi
-    kill -"$sig" "$pid" 2> /dev/null || true
+    printf '%s\n' "$pid"
+}
+
+# phase_of <zig-pid>: what the tree was doing when the budget fired --
+# "compiling" while a grandchild is the zig compiler itself, "running
+# tests" once a grandchild is a spawned test binary instead (under QEMU
+# that grandchild is the emulator wrapper, also not `zig`). zig prints
+# nothing (see the header), so the tree's shape is the only signal, and
+# the verdicts quote it as a heuristic, not a fact.
+phase_of() {
+    local pid="$1" child gc base verdict
+    command -v pgrep > /dev/null 2>&1 || { echo "unknown"; return; }
+    verdict=""
+    for child in $(pgrep -P "$pid" 2>/dev/null); do
+        for gc in $(pgrep -P "$child" 2>/dev/null); do
+            base="$(ps -o comm= -p "$gc" 2>/dev/null | awk '{print $1}')"
+            base="${base##*/}"
+            if [ "$base" != "zig" ] && [ -n "$base" ]; then
+                echo "running tests"
+                return
+            fi
+            verdict="compiling"
+        done
+    done
+    if [ -n "$verdict" ]; then
+        echo "$verdict"
+    else
+        echo "unknown"
+    fi
 }
 
 # run_supervised <budget-secs> <label> <zig args...>
@@ -297,9 +348,13 @@ kill_tree() {
 # watchdog_fired (1 = budget expired and the tree was killed), ran_secs.
 run_supervised() {
     local budget="$1" label="$2"; shift 2
-    local start now next_beat sent size grace budget_note
+    local start now next_beat sent size grace doomed p
+    # Empty by default: a heartbeat must expand it on the unbudgeted path
+    # too, and `local x` alone is UNSET under `set -u` on bash >= 4 (bash
+    # 3.2 leaves it set-but-empty, which is why macOS hid the bug).
+    local budget_note=""
     : > "$log"
-    zig build test "$@" --summary all > "$log" 2>&1 &
+    "$zig_bin" build test "$@" --summary all > "$log" 2>&1 &
     zig_pid=$!
     start=$(date +%s)
     next_beat=$((start + heartbeat_secs))
@@ -316,21 +371,32 @@ run_supervised() {
             tail -c +$((sent + 1)) "$log"
             sent=$size
         fi
-        if [ "$now" -ge "$next_beat" ]; then
-            echo "== $label: still running at $((now - start))s${budget_note} (zig pid $zig_pid; zig buffers its output until exit, so silence here is normal)"
-            next_beat=$((now + heartbeat_secs))
-        fi
-        if [ "$budget" -gt 0 ] && [ $((now - start)) -ge "$budget" ]; then
-            watchdog_fired=1
-            echo "== $label: WALL BUDGET EXCEEDED after $((now - start))s -- killing the zig build (its buffered output dies with it)"
-            kill_tree "$zig_pid" TERM
-            grace=0
-            while [ "$grace" -lt 10 ] && kill -0 "$zig_pid" 2> /dev/null; do
-                sleep 1
-                grace=$((grace + 1))
-            done
-            kill_tree "$zig_pid" KILL
-            break
+        # Re-check liveness after the sleep: a run that FINISHED during
+        # the poll interval must not be heartbeat-reported as running or
+        # watchdog-killed as overran, which a bare elapsed >= budget test
+        # would do whenever the budget is under the poll interval.
+        if kill -0 "$zig_pid" 2> /dev/null; then
+            if [ "$now" -ge "$next_beat" ]; then
+                echo "== $label: still running at $((now - start))s${budget_note} (zig pid $zig_pid; zig buffers its output until exit, so silence here is normal)"
+                next_beat=$((now + heartbeat_secs))
+            fi
+            if [ "$budget" -gt 0 ] && [ $((now - start)) -ge "$budget" ]; then
+                watchdog_fired=1
+                kill_phase=$(phase_of "$zig_pid")
+                doomed=$(tree_pids "$zig_pid")
+                echo "== $label: WALL BUDGET EXCEEDED after $((now - start))s ($kill_phase) -- killing the zig build tree (its buffered output dies with it)"
+                for p in $doomed; do kill -TERM "$p" 2> /dev/null || true; done
+                grace=0
+                while [ "$grace" -lt 10 ] && kill -0 "$zig_pid" 2> /dev/null; do
+                    sleep 1
+                    grace=$((grace + 1))
+                done
+                # KILL the SNAPSHOT, not the live tree: TERM may have
+                # already reaped zig itself, and survivors are unfindable
+                # afterwards.
+                for p in $doomed; do kill -KILL "$p" 2> /dev/null || true; done
+                break
+            fi
         fi
     done
     wait "$zig_pid" 2> /dev/null
@@ -347,7 +413,8 @@ run_supervised() {
 # spending at most $bisect_pot seconds in total. Prints one line per level
 # BEFORE running it, so a kill anywhere leaves the in-flight subset named.
 #
-# Three honest outcomes, because a wedge has three shapes:
+# Four honest outcomes, because a wedge has three shapes and the pot can
+# run out:
 #   * a PROCESS-level wedge (emulation or runner stuck) also wedges every
 #     bisection level that contains it; the descent follows the wedged
 #     halves and ends on one filter, confirmed by a solo run;
@@ -355,14 +422,18 @@ run_supervised() {
 #     each one mid-level and the level completes -- so the descent cannot
 #     follow them; instead every name the tight bound flushes is echoed as
 #     a NOTE line, and if NO level ever wedged, the whole chunk is re-run
-#     under the tight bound (compile is cache-hot: same filter set as the
-#     phase that just ran) to name every per-test culprit in full context;
+#     under the tight bound (same filter set as the chunk run, so its
+#     compile is cached whenever that run got past compiling) to name
+#     every per-test culprit in full context;
 #   * a wedge that reproduces under neither treatment is order- or
-#     load-dependent, and the log says so instead of guessing.
+#     load-dependent, and the log says so instead of guessing;
+#   * a level the pot could only fund below its estimate never narrows on
+#     a timeout -- that is INCONCLUSIVE, not evidence -- though its
+#     completion still exonerates (finishing is finishing).
 bisect_chunk() {
-    local lo=0 hi=${#filters[@]} depth=0 mid n allow remaining now pot_share
+    local lo=0 hi=${#filters[@]} depth=0 mid n est allow remaining now
     local pot_start first last f i tn
-    local wedged_seen=0 full_rerun_wedged=0 bisect_slow_notes=""
+    local wedged_seen=0 full_rerun_wedged=0 inconclusive_seen=0 bisect_slow_notes=""
     pot_start=$(date +%s)
     echo "== bisect: ${#filters[@]} filter(s), per-test timeout $bisect_timeout, total budget ${bisect_pot}s"
     while [ $((hi - lo)) -gt 1 ]; do
@@ -371,20 +442,25 @@ bisect_chunk() {
         remaining=$((bisect_pot - (now - pot_start)))
         mid=$(((lo + hi) / 2))
         n=$((mid - lo))
-        allow=$((BISECT_LEVEL_BASE_SECS + BISECT_LEVEL_PER_FILTER_SECS * n))
-        pot_share=$((remaining * BISECT_LEVEL_POT_SHARE_NUMERATOR / BISECT_LEVEL_POT_SHARE_DENOMINATOR))
-        [ "$allow" -gt "$pot_share" ] && allow=$pot_share
+        est=$((BISECT_LEVEL_BASE_SECS + BISECT_LEVEL_PER_FILTER_SECS * n))
+        allow=$est
+        [ "$allow" -gt "$remaining" ] && allow=$remaining
         if [ "$allow" -lt "$BISECT_LEVEL_MIN_SECS" ]; then
             echo "== bisect: remaining pot (${remaining}s) is too shallow for depth $depth (a level needs >= ${BISECT_LEVEL_MIN_SECS}s to tell wedged from clean)"
             break
         fi
         first=$(fname "${filters[lo]}")
         last=$(fname "${filters[mid - 1]}")
-        echo "== bisect depth $depth: $n filter(s) $first..$last, budget ${allow}s"
+        echo "== bisect depth $depth: $n filter(s) $first..$last, budget ${allow}s of a ${est}s estimate"
         run_supervised "$allow" "bisect depth $depth ($first..$last)" "${filters[@]:lo:n}" "$@" --test-timeout "$bisect_timeout"
         if [ "$watchdog_fired" = 1 ]; then
+            if [ "$allow" -lt "$est" ]; then
+                inconclusive_seen=1
+                echo "== bisect depth $depth: $first..$last did NOT finish in ${allow}s, but that allowance was clipped below the ${est}s estimate -- INCONCLUSIVE (a clean level of this size can be slower than a clipped allowance); not descending"
+                break
+            fi
             wedged_seen=1
-            echo "== bisect depth $depth: $first..$last did NOT finish in ${allow}s -- the wedge reproduces inside this half"
+            echo "== bisect depth $depth: $first..$last did NOT finish in ${allow}s at its full estimated allowance ($kill_phase at kill time) -- descending into this half"
             hi=$mid
         else
             echo "== bisect depth $depth: $first..$last finished in ${ran_secs}s (zig exit $zig_status) -- no process wedge here, discarding this half"
@@ -416,11 +492,11 @@ bisect_chunk() {
         # bound) or it does not reproduce at all. The tight-bound full
         # re-run names the former; the log's honesty covers the latter.
         if [ "$remaining" -ge "$BISECT_LEVEL_MIN_SECS" ]; then
-            echo "== bisect: no level wedged -- re-running the whole chunk under the tight $bisect_timeout bound (compile is cache-hot) to name per-test culprits in full context, budget ${remaining}s"
+            echo "== bisect: no level wedged -- re-running the whole chunk under the tight $bisect_timeout bound (same filter set as the chunk run; its compile is cached whenever that run got past compiling) to name per-test culprits in full context, budget ${remaining}s"
             run_supervised "$remaining" "bisect full re-run" "${filters[@]}" "$@" --test-timeout "$bisect_timeout"
             if [ "$watchdog_fired" = 1 ]; then
                 full_rerun_wedged=1
-                echo "== the full chunk wedged again under the tight bound without any level wedging first -- an order- or interaction-dependent wedge, not a single slow test"
+                echo "== the full chunk did not finish the re-run in ${ran_secs}s ($kill_phase at kill time) -- if the tests were in flight that is an order- or interaction-dependent wedge; if it was still compiling, the pot was simply too small to conclude anything"
             else
                 echo "== the full re-run finished (zig exit $zig_status): any 'timed out after' name above is a phase-1 suspect"
                 while IFS= read -r tn; do
@@ -435,11 +511,13 @@ bisect_chunk() {
             echo "== bisect: budget pot too dry for the tight-bound full re-run"
         fi
         if [ "$full_rerun_wedged" = 1 ]; then
-            echo "== RESULT: the wedge reproduced only in the full chunk, never in any subset -- order- or interaction-dependent"
+            echo "== RESULT: inconclusive -- the full-chunk re-run did not finish ($kill_phase); nothing is narrowed"
+        elif [ "$inconclusive_seen" = 1 ]; then
+            echo "== RESULT: inconclusive -- the pot could not fund decisive levels (see the INCONCLUSIVE line above); re-run with a larger KAAPPI_BISECT_BUDGET"
         elif [ -n "$bisect_slow_notes" ]; then
-            echo "== RESULT: no process-level wedge reproduced; per-test suspect(s) named by the tight bound:$bisect_slow_notes"
+            echo "== RESULT: no level wedged; per-test suspect(s) named by the tight bound:$bisect_slow_notes"
         else
-            echo "== RESULT: no wedge and no slow test reproduced under bisection -- the phase-1 overrun was order- or load-dependent"
+            echo "== RESULT: nothing reproduced under bisection -- the phase-1 overrun was order- or load-dependent, or slower than every budget here"
         fi
         return 0
     fi
@@ -451,8 +529,10 @@ bisect_chunk() {
             [ "$allow" -gt "$remaining" ] && allow=$remaining
             echo "== bisect: confirming the single suspect $f alone (budget ${allow}s)"
             run_supervised "$allow" "bisect confirm ($f)" "${filters[lo]}" "$@" --test-timeout "$bisect_timeout"
-            if [ "$watchdog_fired" = 1 ]; then
-                echo "== LOCALISED AND CONFIRMED: filter '$f.test.' alone does not finish within its budget"
+            if [ "$watchdog_fired" = 1 ] && [ "$allow" -ge $((BISECT_LEVEL_BASE_SECS + BISECT_LEVEL_PER_FILTER_SECS)) ]; then
+                echo "== LOCALISED AND CONFIRMED: filter '$f.test.' alone did not finish at its full estimated allowance ($kill_phase at kill time)"
+            elif [ "$watchdog_fired" = 1 ]; then
+                echo "== LOCALISED (unconfirmed): filter '$f.test.' did not finish its solo run, but on a clipped allowance -- a clean solo run can be slower than that"
             else
                 echo "== NARROWED BUT NOT CONFIRMED: '$f.test.' completed alone in ${ran_secs}s -- the wedge is order- or load-dependent; this is the last unexonerated filter"
             fi


### PR DESCRIPTION
Fixes #2560.

## The finding first

The issue's "one to answer first" question is answered, and the answer changes the fix: **`zig build` buffers its entire console output until the process exits.** Verified on Zig 0.16.0 with a synthetic hanging test: piped through `tee`, redirected to a file, or run under a pty, a test that overruns `--test-timeout` is killed and named the moment the bound fires — yet zero bytes leave `zig build` until it exits, and SIGTERM does not flush the buffer either.

So a step killed at its `timeout-minutes` cap takes the buffer — names included — with it. That is exactly the silent `>24m` kill of #2560, and it means #2491's naming was defeated on *every* capped step, not just this chunk. It also means the capped runs tell us nothing about which reading of the issue held: the name may have existed inside the buffer and died there.

## What this does

Since zig's own output cannot be made to survive, `tools/run-unit-test-chunk.sh` now carries the localisation itself, in its own unbuffered `echo` lines (which survive any kill):

- **Heartbeat** every 60s while a run is in flight, noting that zig's silence in between is normal.
- **Wall budget** (`KAAPPI_CHUNK_BUDGET`, seconds, per chunk step in ci.yml), sized to outlive one per-test bound (healthy + 8m + ~2m) so a *single* hung test is still named by zig at its own exit — only a second hang, or a wedge the runner cannot see, falls through. On expiry the script kills the zig process tree (children first, TERM then grace then KILL — the build runner orphans its test binary otherwise) and bisects.
- **Bisection** over the chunk's filter list under a tight 90s per-test bound, one streamed line per level naming the subset in flight *before* it runs. Each level is capped at 3/5 of the remaining pot so the descent degrades geometrically instead of being consumed by the first wedged level. Three honest outcomes:
  - a process-level wedge wedges every level containing it → descent ends on **one filter, confirmed by a solo run** (validated end-to-end locally with a real hanging test: `LOCALISED AND CONFIRMED: filter 'tests_fuzz.test.' …` plus a ready-to-paste reproduce command);
  - per-test hangs/slow tests never wedge a level (the tight bound kills them mid-level) → every name the bound flushes is echoed as a **NOTE line**, and if no level wedged, the whole chunk is re-run **cache-hot** under the tight bound to name every per-test culprit in full context — this covers the issue's "whole chunk 2.4x slower" reading;
  - nothing reproduces → the log says *that*, instead of guessing.
- The step exits **124** (the `timeout(1)` convention) when the budget fired, so the run fails loudly rather than just bleeding out at a CI cap.

## CI arithmetic (the issue's third ask)

Each riscv64 chunk step now sets its `KAAPPI_CHUNK_BUDGET` from its slowest observed healthy time (the #2560 spread for `rest`: 9m46s–11m32s) + the 8m bound + ~2m margin, and its `timeout-minutes` is re-derived as budget + an 18m bisection pot + 2m slop, with the arithmetic spelled out in the workflow. The job cap moves 55 → 80 to let a wedge in *any* chunk localise fully, and `rest` now runs **first**: it is the chunk that has wedged (both #2488 recurrences and both #2560 kills), so a wedge fails fast with the most headroom instead of burning ~36m of healthy chunks first. Healthy runs are unchanged — no budget is exceeded, one compile per chunk, same output and exit statuses.

## Test

New `tests/scheme/tools/` shell suite (wired into `run-all.sh`) drives the machinery with budgets small enough that the compile itself "wedges": asserts the streamed budget-exceeded line, a surviving heartbeat, a bisection level naming its subset, the level's decision line, the dry-pot verdict, and exit 124 — on both cold-cache and warm-cache outcomes of the level. `skip_on_windows`/`skip_without_zig` per the shell-common conventions.

## Not touched

s390x/ppc64le still run the whole suite in one `--test-timeout 8m` step and share the buffering vulnerability; they have not wedged yet, and converting them is out of scope here.