### PR TITLE
Normalise Alt+Shift+letter on the Windows console so slurp/barf/raise fire

### DIFF
--- a/vendor/isocline/PATCHES.md
+++ b/vendor/isocline/PATCHES.md
@@ -124,8 +124,12 @@ printable that Shift transformed (`chr >= 0x20 && chr != 0x7f`), drop
 encoded in the glyph, so this loses nothing and makes both platforms agree. It
 lives in the `#if defined(_WIN32)` console branch only, not the shared
 `modify_code` in `tty.c`, so it cannot affect the POSIX/xterm decode. The
-unshifted upstream Alt bindings (`alt-d`/`alt-m`/`alt-f`/`alt-b`) never carry a
-SHIFT bit and are unaffected.
+change is strictly parity-restoring: it activates no new bindings. The unshifted
+upstream Alt bindings (`alt-d`/`alt-m`/`alt-f`/`alt-b`) never carry a SHIFT bit
+and are unaffected, and their *shifted* variants remain unbound on both
+platforms — the arms match the lowercase glyph (`WITH_ALT('d')`) while a shifted
+key delivers the uppercase one, so alt-shift-D → `'D' | KEY_MOD_ALT` matches
+nothing here just as `ESC D` matches nothing on a POSIX tty.
 
 Found by code reading; end-to-end confirmation requires a real Alt+Shift key
 event on a Windows console.

--- a/vendor/isocline/PATCHES.md
+++ b/vendor/isocline/PATCHES.md
@@ -50,7 +50,7 @@ asking for 1000 gets 1000.
 ## Patch 3 — structural s-expression editing
 
 **Files:** `include/isocline.h`, `src/env.h`, `src/isocline.c`,
-`src/editline.c`, `src/editline_help.c`
+`src/editline.c`, `src/editline_help.c`, `src/tty.c`
 
 Upstream has no structural editing — no way to move a paren rather than a
 character. The patch adds four keys and one callback:
@@ -92,6 +92,43 @@ The commands and keybindings come from [bestline](https://github.com/jart/bestli
 (BSD-2-Clause) by way of kaappi#2216. The code does not: bestline's `raise` is
 an empty stub, its `rotate` rotates the kill ring rather than a form, and its
 barf and slurp count parens with no awareness of strings or comments.
+
+### Windows: normalise Alt+Shift+letter (kaappi#2564)
+
+**File:** `src/tty.c` (`tty_waitc_console`, the `_WIN32` key path).
+
+Three of the four bindings above are *shifted* letters (alt-shift-S/B/R); only
+alt-y is unshifted. On the Windows console those three could never fire while
+alt-y worked, because the shifted and unshifted Alt paths deliver different
+codes:
+
+- **POSIX tty:** the terminal applies Shift before sending `ESC S`, so the ALT
+  path in `tty_esc.c` yields `'S' | KEY_MOD_ALT` — no SHIFT bit.
+- **Windows console:** `ReadConsoleInputW` delivers Alt+Shift+S as one
+  `KEY_EVENT_RECORD` whose `dwControlKeyState` carries both `LEFT_ALT_PRESSED`
+  and `SHIFT_PRESSED`, with `uChar.UnicodeChar` already the *shifted* glyph
+  (`'S'`). `tty_waitc_console` therefore builds `mods =
+  KEY_MOD_ALT | KEY_MOD_SHIFT` and pushes `ESC [ 83 ; 4 u`, which decodes back
+  to `'S' | KEY_MOD_ALT | KEY_MOD_SHIFT`.
+
+The dispatch arms in `editline.c` compare against `WITH_ALT('S')` (=
+`'S' | KEY_MOD_ALT`), which has no SHIFT bit, so no `case` matched and the
+keystroke was silently dropped (`debug_msg("edit: ignore code")`, nothing in a
+non-debug build). alt-y carries no SHIFT bit, so it matched `WITH_ALT('y')` and
+rotate worked — which is why the bug was slurp/barf/raise-only.
+
+The fix normalises the Windows path to what the POSIX ESC path produces: in the
+"regular character" arm, when `KEY_MOD_ALT` is set and the char is already a
+printable that Shift transformed (`chr >= 0x20 && chr != 0x7f`), drop
+`KEY_MOD_SHIFT` before `tty_cpush_csi_unicode`. The shift information is already
+encoded in the glyph, so this loses nothing and makes both platforms agree. It
+lives in the `#if defined(_WIN32)` console branch only, not the shared
+`modify_code` in `tty.c`, so it cannot affect the POSIX/xterm decode. The
+unshifted upstream Alt bindings (`alt-d`/`alt-m`/`alt-f`/`alt-b`) never carry a
+SHIFT bit and are unaffected.
+
+Found by code reading; end-to-end confirmation requires a real Alt+Shift key
+event on a Windows console.
 
 ## Patch 4 — don't discard buffered input when leaving/entering raw mode
 

--- a/vendor/isocline/src/tty.c
+++ b/vendor/isocline/src/tty.c
@@ -941,6 +941,20 @@ static void tty_waitc_console(tty_t* tty, long timeout_ms)
 		}
     // regular character
     else {
+      // KAAPPI PATCH 3: see vendor/isocline/PATCHES.md — normalise Alt+Shift+letter.
+      // The Windows console reports Alt+Shift+S as one event carrying both
+      // LEFT_ALT_PRESSED and SHIFT_PRESSED with uChar already the *shifted*
+      // glyph ('S'), so `mods` becomes KEY_MOD_ALT|KEY_MOD_SHIFT. A POSIX tty
+      // applies Shift before sending `ESC S`, so its ALT path yields 'S'|ALT
+      // with no SHIFT bit — and the editor's structural-edit arms compare
+      // against WITH_ALT('S') (= 'S'|KEY_MOD_ALT), which has no SHIFT bit.
+      // Without this the shifted bindings (alt-shift-S/B/R) never match any
+      // case and are silently dropped, while the unshifted alt-y works
+      // (kaappi#2564). When Alt is held and the char is already a printable
+      // that Shift transformed, drop KEY_MOD_SHIFT so the two paths agree.
+      if ((mods & KEY_MOD_ALT) != 0 && chr >= 0x20 && chr != 0x7f) {
+        mods &= ~(code_t)KEY_MOD_SHIFT;
+      }
       tty_cpush_csi_unicode(tty,mods,chr);
 			return;
     }


### PR DESCRIPTION
## Summary

On the Windows console, the three *shifted* structural-editing bindings —
alt-shift-S (slurp), alt-shift-B (barf), alt-shift-R (raise) — could never
fire, while the unshifted alt-y (rotate) worked.

`tty_waitc_console` (the `_WIN32` key path) delivers Alt+Shift+S as one
`KEY_EVENT_RECORD` whose `dwControlKeyState` carries `LEFT_ALT_PRESSED |
SHIFT_PRESSED` with `uChar.UnicodeChar` already the shifted glyph (`'S'`). It
builds `mods = KEY_MOD_ALT | KEY_MOD_SHIFT`, so the keystroke decodes back to
`'S' | KEY_MOD_ALT | KEY_MOD_SHIFT`. The dispatch arms in `editline.c` compare
against `WITH_ALT('S')` (= `'S' | KEY_MOD_ALT`), which carries no SHIFT bit, so
no `case` matched and the keystroke was silently dropped. alt-y carries no SHIFT
bit and matched `WITH_ALT('y')`, which is why only the shifted keys broke.

On a POSIX tty the terminal applies Shift before sending `ESC S`, so its ALT
path yields `'S' | ALT` with no SHIFT bit — which is why this is Windows-only
and the pty smoke test (skipped on Windows) never saw it.

## Fix

Normalise the Windows path to what the POSIX ESC path produces: in the
regular-character arm of `tty_waitc_console`, when `KEY_MOD_ALT` is set and the
char is already a printable that Shift transformed (`chr >= 0x20 && chr !=
0x7f`), drop `KEY_MOD_SHIFT` before `tty_cpush_csi_unicode`. The shift
information is already encoded in the glyph, so this loses nothing.

The change lives entirely inside the `#if defined(_WIN32)` console branch — not
the shared `modify_code` — so it cannot affect the POSIX/xterm decode. It is
documented as a sub-note of KAAPPI PATCH 3 in `vendor/isocline/PATCHES.md`, and
carries a `KAAPPI PATCH 3` marker at the fix site.

## Verification and its limits

- Cross-compiles cleanly for **both** Windows targets (`zig build
  -Dtarget=x86_64-windows` and `-Dtarget=aarch64-windows`) — the only builds
  that actually compile this `_WIN32`-only code.
- Host `zig build` and `zig build test` pass: unit-tests 2008 pass / 21 skip
  (2029 total), thottam-tests 88 pass.

This is a **code-reading finding**, not yet reproduced on a real console. No
host-runnable automated regression guard is feasible: `tty_waitc_console` is
`_WIN32`-only (not compiled off-Windows), and exercising it needs a real
Alt+Shift key event that an SSH script cannot inject. Rather than add a hollow
test, the invariant is captured in a clear code comment at the fix site and in
PATCHES.md. **Final confirmation requires a real Alt+Shift keypress on a Windows
console** (win11 ARM64 VM).

Closes #2564
