### PR TITLE
Treat REPL ESC as a sticky Meta prefix so alt-<key> bindings are reachable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -453,7 +453,7 @@ It holds a whole form in one buffer, which is why `repl.zig` no longer joins
 continuation lines: `ic_readline` returns a finished expression, newlines
 included, and every line of it stays editable until submit.
 
-**The copy is patched** — six changes, each marked `KAAPPI PATCH` in the
+**The copy is patched** — seven changes, each marked `KAAPPI PATCH` in the
 source and documented in `vendor/isocline/PATCHES.md`: an input-completeness
 callback (upstream's Enter always submits), a configurable history size
 (upstream caps at 200), structural s-expression editing — slurp, barf,
@@ -461,9 +461,11 @@ raise, rotate, whose transforms live in `src/repl_sexp.zig` (`docs/dev/repl.md`)
 — `TCSADRAIN` instead of `TCSAFLUSH` around raw-mode transitions, so a
 multi-line paste that submits partway through doesn't get its still-unread
 tail silently discarded (kaappi#2226), click-to-reposition mouse support
-(kaappi#2264), and `FD_CLOEXEC` on the history/debug files so spawned
-children inherit only stdio (kaappi#2423). Re-apply all six when updating;
-`grep -rn 'KAAPPI PATCH' vendor/isocline/` finds every site.
+(kaappi#2264), `FD_CLOEXEC` on the history/debug files so spawned
+children inherit only stdio (kaappi#2423), and `ESC` as a sticky Meta prefix
+so alt-<key> bindings work without a Meta-configured terminal — at the cost
+of a lone `ESC` no longer clearing input (kaappi#2562). Re-apply all seven
+when updating; `grep -rn 'KAAPPI PATCH' vendor/isocline/` finds every site.
 
 ## Package manager (thottam)
 

--- a/docs/dev/repl.md
+++ b/docs/dev/repl.md
@@ -55,7 +55,7 @@ cursor:
 
 They are listed under F1 too, and only when the callback is set. Each is
 reached by pressing `ESC` then the character. Since patch 7 (kaappi#2562) `ESC`
-is a sticky Meta prefix with no timeout, so `ESC` then `S` composes to
+is a sticky Meta prefix with no timeout, so `ESC` then `shift-S` composes to
 `alt-shift-S` on *every* terminal, whether or not it sends Option as Meta — no
 "Use Option as Meta key" setting is needed. The deliberate cost is that a lone
 `ESC` no longer clears the input; `ctrl-u` and `ctrl-c` still do.

--- a/docs/dev/repl.md
+++ b/docs/dev/repl.md
@@ -54,9 +54,11 @@ cursor:
 | alt+y | rotate | `(if a\| b c)` → `(if b c a\|)` |
 
 They are listed under F1 too, and only when the callback is set. Each is
-`ESC` followed by the character, so a terminal that does not send Option as
-Meta (macOS Terminal.app, unless "Use Option as Meta key" is on) will not
-deliver them.
+reached by pressing `ESC` then the character. Since patch 7 (kaappi#2562) `ESC`
+is a sticky Meta prefix with no timeout, so `ESC` then `S` composes to
+`alt-shift-S` on *every* terminal, whether or not it sends Option as Meta — no
+"Use Option as Meta key" setting is needed. The deliberate cost is that a lone
+`ESC` no longer clears the input; `ctrl-u` and `ctrl-c` still do.
 
 `src/repl_sexp.zig` holds the transforms — pure functions over
 `(buffer, byte cursor)`, so they unit-test without a terminal. The keys and the

--- a/tests/scheme/smoke/repl-structural-editing-2216.sh
+++ b/tests/scheme/smoke/repl-structural-editing-2216.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # kaappi#2216: structural s-expression editing at the REPL.
+# kaappi#2562: ESC is a sticky Meta prefix so those bindings are reachable
+#              without a Meta-configured terminal.
 #
 # The transforms themselves are unit-tested in `src/repl_sexp.zig`. What this
 # covers is the half that lives in C and cannot be reached from Zig: isocline's
@@ -11,6 +13,12 @@
 # key, submits, and asserts on what the *evaluator* printed. That keeps the
 # check independent of how the editor redraws the line: the only way to print
 # `(1 2)` from `(list 1 2 3)` is for barf to have moved the paren.
+#
+# The final case is the #2562 regression: it sends a lone ESC, waits far longer
+# than the old ESC-compose window, then sends `S`. With the sticky-Meta prefix
+# (KAAPPI PATCH 7) that composes to alt-S (slurp); before the fix the lone ESC
+# ran `edit_delete_all` and wiped the whole form, and `S` was left as an
+# undefined variable.
 
 set -eu
 
@@ -173,6 +181,35 @@ for typed, lefts, key, expect, reject in CASES:
     if not ok or (reject is not None and reject in produced):
         failures.append((key, expect, produced))
 
+# kaappi#2562: ESC as a sticky Meta prefix, driven the way a Mac user actually
+# reaches these keys — press Escape, then the letter. The pause below is far
+# longer than the ESC-compose window this fix removed (200 ms on macOS, 100 ms
+# elsewhere), so it exercises the *no-timeout* prefix specifically. Before the
+# fix the lone ESC deleted the whole form and `S` evaluated as an undefined
+# variable; with it, ESC+S composes to alt-S = slurp. Same form/cursor as the
+# slurp case above so the only variable is how the key is delivered.
+esc_label = b'\x1b <pause> S'
+mark = len(buf)
+send(b'(list 1 2) 3')
+if not wait_for(b'(list 1 2) 3', mark, 20):
+    failures.append((esc_label, b'(list 1 2) 3', seen(mark)))
+else:
+    for _ in range(3):
+        send(b'\x02')          # ctrl-b: cursor to just after the `2`
+    idle(0.3)
+    send(b'\x1b')              # lone ESC — the sticky Meta prefix, no timeout
+    time.sleep(0.4)            # longer than the removed ESC-compose window
+    send(b'S')                 # composes to alt-S = slurp
+    idle(0.3)
+    send(b'\r')
+    ok = wait_for(b'\n(1 2 3)\n', mark, 20)
+    idle()
+    produced = seen(mark)
+    # Without the fix the form is gone and `S` is undefined; guard both the
+    # positive result and that no wipe-then-error snuck through.
+    if not ok or b'undefined variable' in produced:
+        failures.append((esc_label, b'(1 2 3)', produced))
+
 send(b',quit\r')
 while pump(1.0):
     pass
@@ -193,7 +230,7 @@ status=$?
 set -e
 
 case $status in
-    0)  echo "PASS: barf, slurp, raise and rotate all edit the buffer"; exit 0 ;;
+    0)  echo "PASS: barf, slurp, raise, rotate edit the buffer; ESC is a sticky Meta prefix"; exit 0 ;;
     77) echo "SKIP: no usable pty for the REPL here"; exit 77 ;;
     *)  echo "FAIL: structural editing did not take effect"; exit 1 ;;
 esac

--- a/vendor/isocline/PATCHES.md
+++ b/vendor/isocline/PATCHES.md
@@ -4,7 +4,7 @@ Vendored from <https://github.com/daanx/isocline> at commit
 `8d6dc1ef95b1b46711e66eb23d39d4467a0fcdac` (2026-04-23, v1.1.0), MIT licensed —
 see `LICENSE`.
 
-**This is a patched copy.** Six changes diverge from upstream. Each is marked
+**This is a patched copy.** Seven changes diverge from upstream. Each is marked
 in the source with a `KAAPPI PATCH <n>` comment pointing here. When updating
 isocline, re-apply them; `grep -rn 'KAAPPI PATCH' vendor/isocline/` finds every
 site.
@@ -270,6 +270,58 @@ is a bigger diff to re-apply than a post-open `fcntl`.) The wasm32-wasi build
 never compiles isocline (`use_isocline = !is_wasm_target` in `build.zig`), so
 no WASI guard is needed. Fixes kaappi#2423; found by the KEP-0022 CLOEXEC
 audit (kaappi#2414).
+
+## Patch 7 — ESC is a sticky Meta prefix (reach alt-<key> without a Meta terminal)
+
+**Files:** `src/tty.c`, `src/editline.c`
+
+The four structural-editing keys from Patch 3 (`alt-shift-S` slurp,
+`alt-shift-B` barf, `alt-shift-R` raise, `alt-y` rotate) and the upstream
+`alt-<key>` bindings are only reachable when the terminal sends Option/Alt as
+Meta, i.e. as `ESC <char>`. **No default macOS terminal does that** —
+Terminal.app, iTerm2, kitty, Alacritty and Ghostty all insert the *composed*
+character instead. So out of the box on the primary dev platform the documented
+keys did not run; they inserted a stray glyph (`Í`, `¥`, …), and the natural
+readline habit — press Escape, then the letter — ran `edit_delete_all` and
+**wiped the whole form** (kaappi#2562). The four structural keys have no
+ctrl/arrow alternative, so the feature was simply unreachable.
+
+The fix makes `ESC` a **sticky Meta prefix**, exactly like readline / zsh /
+Emacs: `ESC` followed by any key is that key with Alt, with **no timeout**.
+
+Two sites:
+
+1. **`src/tty.c` (`tty_read_timeout`)** — the interactive ESC decode now calls
+   `tty_read_esc(tty, -1, ...)` instead of passing `tty->esc_initial_timeout`.
+   The `-1` makes the read of the byte *after* ESC block indefinitely (see
+   `tty_readc_noblock`: `timeout_ms < 0` is a plain blocking read). A genuine
+   terminal escape sequence (arrows, mouse) still arrives as one burst and
+   decodes immediately; only a lone ESC keypress waits — for the key the user
+   is about to press — and composes it as alt-<key> at the `alt:` label in
+   `tty_esc.c`. That path (`key_unicode(peek) | KEY_MOD_ALT`) is upstream's and
+   is unchanged.
+
+2. **`src/tty.c` (`tty_new`)** — the `esc_initial_timeout` field is now one
+   platform-independent value (100ms). The old `#if defined(__APPLE__)` bump to
+   200ms carried the comment "apple use ESC+<key> for alt-<key>", which was only
+   true once a user had configured their terminal to send Option as Meta. With
+   the sticky prefix the interactive decode ignores this field entirely, so the
+   platform distinction has no rationale left. The field still bounds the
+   terminal query-response readers (`tty_read_esc_response`,
+   `tty_read_dsr_response` from Patch 5), which use `2*esc_initial_timeout`.
+
+3. **`src/editline.c`** — the lone `KEY_ESC` arm no longer runs
+   `edit_delete_all`. With the sticky prefix a lone ESC from an interactive
+   keypress never reaches the edit loop (the decoder blocks for the next key),
+   so this arm now only fires if the input stream ends right after an ESC byte;
+   deleting the buffer there was the kaappi#2562 data-loss path. The
+   empty-input `break` is kept.
+
+**Cost, and it is deliberate:** a lone Escape no longer clears the input.
+`ctrl-u` (delete-to-start) and `ctrl-c` (cancel) still do. This is upstream
+isocline behaviour we override, which is why it is a patch; it is also the
+convention every other line editor on macOS already follows, and it turns the
+old destructive "Escape then S" into the slurp the user meant.
 
 ## Deliberately not patched
 

--- a/vendor/isocline/PATCHES.md
+++ b/vendor/isocline/PATCHES.md
@@ -273,7 +273,7 @@ audit (kaappi#2414).
 
 ## Patch 7 — ESC is a sticky Meta prefix (reach alt-<key> without a Meta terminal)
 
-**Files:** `src/tty.c`, `src/editline.c`
+**Files:** `src/tty.c`, `src/editline.c`, `src/editline_help.c`
 
 The four structural-editing keys from Patch 3 (`alt-shift-S` slurp,
 `alt-shift-B` barf, `alt-shift-R` raise, `alt-y` rotate) and the upstream
@@ -309,6 +309,12 @@ Two sites:
    platform distinction has no rationale left. The field still bounds the
    terminal query-response readers (`tty_read_esc_response`,
    `tty_read_dsr_response` from Patch 5), which use `2*esc_initial_timeout`.
+   Note that the field — and therefore the `initial_delay_ms` parameter of the
+   public `ic_set_tty_esc_delay` setter (`isocline.h` → `tty_set_esc_delay`) —
+   now bounds *only* those query-response readers; it no longer affects
+   interactive ESC compose at all. Kaappi never calls the setter, so there is no
+   functional impact, but an embedder or a future upstream merge would otherwise
+   puzzle over why the knob does nothing.
 
 3. **`src/editline.c`** — the lone `KEY_ESC` arm no longer runs
    `edit_delete_all`. With the sticky prefix a lone ESC from an interactive
@@ -322,6 +328,17 @@ Two sites:
 isocline behaviour we override, which is why it is a patch; it is also the
 convention every other line editor on macOS already follows, and it turns the
 old destructive "Escape then S" into the slurp the user meant.
+
+**One race, on record:** a signal while the prefix is pending drops the prefix.
+`tty_readc_blocking` swallows `EINTR` (e.g. SIGWINCH on a resize) and returns
+false, so `tty_read_esc` returns `KEY_ESC`, the edit loop handles the resize,
+and the user's pending sticky prefix is silently abandoned — their next key
+arrives un-prefixed. Upstream had the identical race inside its 100–200ms
+window; the no-timeout window makes it marginally more likely, but the
+consequence is trivial (press ESC again), and the old code's failure mode in
+this exact race was *wiping the input*, so this is strictly an improvement. No
+code change; recorded here so "my ESC-S sometimes types a plain S after a
+resize" is explicable.
 
 ## Deliberately not patched
 

--- a/vendor/isocline/src/editline.c
+++ b/vendor/isocline/src/editline.c
@@ -1033,9 +1033,15 @@ static char* edit_line( ic_env_t* env, const char* prompt_text )
       break; // STOP event quits with NULL
     }
     else if (c == KEY_ESC) {
+      // KAAPPI PATCH 7: ESC is a sticky Meta prefix now (see PATCHES.md and
+      // kaappi#2562). The decoder in tty_read_timeout blocks for the next key
+      // and composes it as alt-<key>, so a lone ESC from an interactive
+      // keypress no longer reaches here — this arm only fires if the input
+      // stream ends right after an ESC byte. Do NOT edit_delete_all: that was
+      // the data-loss path (Escape-then-letter wiped the whole form on macOS,
+      // where Option is not Meta). ctrl-u / ctrl-c still clear the input.
       if (eb.pos == 0 && editor_pos_is_at_end(&eb)) break;  // ESC on empty input returns with empty input
-      edit_delete_all(env,&eb);      // otherwise delete the current input
-      // edit_delete_line(env,&eb);  // otherwise delete the current line
+      // otherwise: ignore. (Upstream, and Kaappi before #2562, ran edit_delete_all here.)
     }
     else if (c == KEY_BELL /* ^G */ || c == KEY_CTRL_C) {
       edit_delete_all(env,&eb);

--- a/vendor/isocline/src/editline_help.c
+++ b/vendor/isocline/src/editline_help.c
@@ -52,7 +52,7 @@ static const char* help[] = {
   "^u",         "delete to the start of the current line",
   "^k",         "delete to the end of the current line",
   // KAAPPI PATCH 7: esc is a sticky Meta prefix now, not delete-input (see PATCHES.md)
-  "esc",        "Meta prefix for alt-<key>, or done with empty input",
+  "esc",        "Meta prefix for alt-<key>",
   "","",
 
   "", "Editing:",

--- a/vendor/isocline/src/editline_help.c
+++ b/vendor/isocline/src/editline_help.c
@@ -51,7 +51,8 @@ static const char* help[] = {
   "alt-d",      "delete to the end of the current word",
   "^u",         "delete to the start of the current line",
   "^k",         "delete to the end of the current line",
-  "esc",        "delete the current input, or done with empty input",
+  // KAAPPI PATCH 7: esc is a sticky Meta prefix now, not delete-input (see PATCHES.md)
+  "esc",        "Meta prefix for alt-<key>, or done with empty input",
   "","",
 
   "", "Editing:",
@@ -126,7 +127,8 @@ static const char* help_initial =
   "         │        ┌───────┼──────┐        │    ctrl-r   : search history\n"
   "         ▼        ▼       ▼      ▼        ▼    tab      : complete word\n"
   "  prompt> [ansi-darkgray]it's the quintessential language[/]     shift-tab: insert new line\n"
-  "         ▲        ▲              ▲        ▲    esc      : delete input, done\n"
+  // KAAPPI PATCH 7: esc is a sticky Meta prefix now (see PATCHES.md)
+  "         ▲        ▲              ▲        ▲    esc      : alt-<key> prefix\n"
   "         │        └──────────────┘        │    ctrl-z   : undo\n"
   "         │   alt-backsp        alt-d      │\n"
   //"       │                │               │\n"

--- a/vendor/isocline/src/tty.c
+++ b/vendor/isocline/src/tty.c
@@ -164,7 +164,15 @@ ic_private bool tty_read_timeout(tty_t* tty, long timeout_ms, code_t* code)
 
   if (c == KEY_ESC) {
     // escape sequence?
-    *code = tty_read_esc(tty, tty->esc_initial_timeout, tty->esc_timeout);
+    // KAAPPI PATCH 7: ESC is a sticky Meta prefix (see PATCHES.md) — pass -1 so
+    // the first byte after ESC is read with NO timeout. A real escape sequence
+    // (arrow keys, mouse) still arrives as a burst and decodes immediately; a
+    // lone ESC keypress now waits indefinitely for the next key and composes it
+    // as alt-<key>, which is the only way to reach the alt-<key> structural
+    // bindings on a default macOS terminal (kaappi#2562). Upstream passed
+    // tty->esc_initial_timeout here, which required the terminal to send Option
+    // as Meta within a short window — no default Mac terminal does.
+    *code = tty_read_esc(tty, -1, tty->esc_timeout);
   }
   else if (c <= 0x7F) {
     // ascii
@@ -488,11 +496,14 @@ ic_private tty_t* tty_new(alloc_t* mem, int fd_in)
   tty_t* tty = mem_zalloc_tp(mem, tty_t);
   tty->mem = mem;
   tty->fd_in = (fd_in < 0 ? STDIN_FILENO : fd_in);
-  #if defined(__APPLE__)
-  tty->esc_initial_timeout = 200;  // apple use ESC+<key> for alt-<key>
-  #else
+  // KAAPPI PATCH 7: one platform-independent value. The interactive ESC decode
+  // no longer consults this field (tty_read_timeout passes -1 for a blocking,
+  // no-timeout sticky Meta prefix — see PATCHES.md and kaappi#2562), so the old
+  // __APPLE__ bump to 200ms "apple use ESC+<key> for alt-<key>" no longer has a
+  // rationale. The field now only bounds the terminal query-response readers
+  // (tty_read_esc_response / tty_read_dsr_response, both 2*this = 200ms), which
+  // are round-trips to the terminal, not user typing.
   tty->esc_initial_timeout = 100;
-  #endif
   tty->esc_timeout = 10;
   if (!(isatty(tty->fd_in) && tty_init_raw(tty) && tty_init_utf8(tty))) {
     tty_free(tty);


### PR DESCRIPTION
## Problem

The four structural-editing keys from #2216 — alt-shift-S (slurp),
alt-shift-B (barf), alt-shift-R (raise), alt-y (rotate) — are bound as
`ESC <char>` (Meta). But no default macOS terminal sends Option/Alt as Meta:
Terminal.app, iTerm2, kitty, Alacritty and Ghostty all insert the *composed*
character instead. So out of the box on the primary dev platform these keys
never ran — they inserted a stray glyph (`Í`, `¥`, …), and the natural readline
habit (press Escape, then the letter) ran `edit_delete_all` and **wiped the
whole form**. That is data loss, and the four structural keys have no ctrl/arrow
alternative, so the feature was simply unreachable.

## Fix

This implements option 1 from the issue (the author's recommendation): treat
`ESC` as a **sticky Meta prefix**, exactly like readline / zsh / Emacs. `ESC`
followed by any key becomes that key with Alt, with **no timeout**. A genuine
terminal escape sequence (arrows, mouse) still arrives as one burst and decodes
immediately; only a lone ESC waits — for the key the user is about to press —
and composes it as alt-<key>.

Three sites in the vendored isocline copy:

- `src/tty.c` (`tty_read_timeout`): the interactive ESC decode now reads the
  byte after ESC with a blocking (`-1`) read instead of `esc_initial_timeout`.
- `src/tty.c` (`tty_new`): `esc_initial_timeout` is unified to one
  platform-independent value; the old `__APPLE__` 200ms bump lost its rationale
  (it only helped a terminal already configured to send Option as Meta). The
  field now only bounds the terminal query-response readers.
- `src/editline.c`: the lone `KEY_ESC` arm no longer runs `edit_delete_all` —
  that was the data-loss path.

## Behaviour change (deliberate)

**A lone Escape no longer clears the input.** `ctrl-u` (delete-to-start) and
`ctrl-c` (cancel) still do. This is the convention every other line editor on
macOS already follows, and it turns the old destructive "Escape then S" into
the slurp the user meant.

This is a change to the vendored isocline library, so it is a **new
`vendor/isocline/PATCHES.md` entry (Patch 7)**, with a `KAAPPI PATCH 7` marker
at each changed site.

## Testing

`tests/scheme/smoke/repl-structural-editing-2216.sh` gains a case that drives
the keys the new way under a pty: a lone ESC, a pause far longer than the removed
compose window, then `S` — which now composes to slurp. Verified it fails
without the fix (form wiped, `S` undefined) and passes with it. `zig build test`
passes; the full smoke test passes.

Closes #2562
