### PR TITLE
Give the ubuntu ReleaseFast CI leg a 40-minute timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,8 +265,18 @@ jobs:
             optimize: ReleaseSafe
             timeout: 50
             test_args: -Dtest-strip=true
+          # ReleaseFast was the last leg still on the 30-min default, and the
+          # suite outgrew it the same way Debug and macOS did above: healthy
+          # runs crept to 20-28 min (28 on 2026-09-08), then a slow runner
+          # cancelled it at 30:00 twice on 2026-09-09 -- once on main, once on
+          # PR #2566 -- every suite green, killed mid "Differential tiers" on
+          # wall clock alone. 40 matches the Debug leg and leaves ~12 min over
+          # the worst healthy run while still catching a real hang. Include-only
+          # key, so it merges into this os+optimize combination without renaming
+          # the required check (see the naming note above).
           - os: ubuntu-latest
             optimize: ReleaseFast
+            timeout: 40
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## What

The `test` matrix in `.github/workflows/ci.yml` defaults each leg to a 30-minute cap (`matrix.timeout || 30`), overridden per leg when the suite outgrows it — ubuntu **Debug** is at 40 and **macOS ReleaseSafe** at 50 for exactly this reason. The ubuntu **ReleaseFast** leg was the last one still on the default, and it has grown into it.

## Why now

Recent `test (ubuntu-latest, ReleaseFast)` durations:

| Date | Duration | Result |
|---|---|---|
| 2026-09-08 | 21–28 min | pass |
| 2026-09-09 (main) | 30:00 | **cancelled** |
| 2026-09-09 (PR #2566) | 30:19 | **cancelled** |

Both cancellations had every Scheme suite green and were killed mid **"Differential tiers"** on wall clock alone — no assertion failed, no hang. The cap has stopped being a hang-bound and started cancelling healthy runs, the precise failure mode the matrix's own timeout comment warns against.

## The change

Add an include-only `timeout: 40` to the existing ReleaseFast entry — same value as the Debug leg, ~12 minutes of headroom over the worst healthy run (28 min) while still catching a real hang.

`timeout` is an include-only key that merges into the existing `os`+`optimize` combination, and the job `name:` is pinned to just os+optimize, so the required check `test (ubuntu-latest, ReleaseFast)` is **not** renamed (the file comment documents how a rename bricked a required check in PR #1728).

No test: CI-config-only change; validated with `yaml.safe_load`.