### PR TITLE
Raise the default test-leg CI timeout from 30 to 40 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,19 @@ jobs:
     # avoid. Bumped to 40 to restore real headroom, same fix as the
     # macOS/PR #1635 recurrence -- and then to 50 when the suite outgrew 40
     # too (see the per-leg comment in the matrix below).
-    timeout-minutes: ${{ matrix.timeout || 30 }}
+    #
+    # The default itself outgrew 30 the same way. By 2026-09-09 every leg
+    # that hit the cap had been given an explicit override (macOS/Debug 50,
+    # ReleaseFast 40), leaving only the two ubuntu ReleaseSafe legs on the
+    # bare default -- and both reached the wall: ubuntu-latest was cancelled
+    # at 30:27 (build 3, unit tests 3, Scheme suites killed at the 30:00 mark
+    # with every suite green) while ubuntu-24.04-arm squeaked through at
+    # 27:27. So the default is no longer a hang-bound either; raised to 40 to
+    # give the remaining default legs the same ~13-min headroom over a ~27-min
+    # healthy run. The check name is pinned to os+optimize (see the naming
+    # note above) and never included matrix.timeout, so the default number
+    # has never affected a required check's name -- changing it here is safe.
+    timeout-minutes: ${{ matrix.timeout || 40 }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Every test leg that outgrew the 30-min cap this cycle was given an explicit per-leg override — macOS and Debug at 50, ReleaseFast at 40 (#2567, #2568) — which left the two ubuntu **ReleaseSafe** legs as the only ones still on the bare default. Both have now reached the wall:

- **ubuntu-latest** — cancelled at **30:27** (build 3 min, unit tests 3 min, Scheme suites killed at the 30:00 mark with every suite green — wall clock, not a hang; observed on #2566).
- **ubuntu-24.04-arm** — squeaked through at **27:27**, so it's next in line.

The default is no longer a realistic hang-bound. Raise it to 40, matching the ReleaseFast override and giving the remaining default legs the same ~13-min headroom over a ~27-min healthy run.

The check name is pinned to `os+optimize` and never included `matrix.timeout`, so the default number has never affected a required check's name — **changing it renames nothing** (the PR #1728 rename footgun does not apply here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)