### PR TITLE
Name the structural-editing keys per platform and by their esc prefix

### DIFF
--- a/src/repl_commands.zig
+++ b/src/repl_commands.zig
@@ -311,10 +311,12 @@ pub fn handleCommand(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []cons
             \\  ,condition <id> <expr>  Set breakpoint condition
             \\
             \\ -- Structural editing (moves a paren, not a character):
-            \\  alt-shift-S       Slurp: pull the next datum into the form
-            \\  alt-shift-B       Barf: push the last datum out of the form
-            \\  alt-shift-R       Raise: replace the form with the datum at point
-            \\  alt-y             Rotate the form's arguments
+            \\   Press esc, then the key. On macOS "alt" is the Option key,
+            \\   which sends this directly only if the terminal is set to.
+            \\  esc shift-S       Slurp: pull the next datum into the form
+            \\  esc shift-B       Barf: push the last datum out of the form
+            \\  esc shift-R       Raise: replace the form with the datum at point
+            \\  esc y             Rotate the form's arguments
             \\  F1                All editor keys
             \\
             \\ -- System:

--- a/src/repl_commands.zig
+++ b/src/repl_commands.zig
@@ -312,7 +312,8 @@ pub fn handleCommand(vm: *vm_mod.VM, allocator: std.mem.Allocator, input: []cons
             \\
             \\ -- Structural editing (moves a paren, not a character):
             \\   Press esc, then the key. On macOS "alt" is the Option key,
-            \\   which sends this directly only if the terminal is set to.
+            \\   which sends the esc prefix directly only if the terminal is
+            \\   configured to do so.
             \\  esc shift-S       Slurp: pull the next datum into the form
             \\  esc shift-B       Barf: push the last datum out of the form
             \\  esc shift-R       Raise: replace the form with the datum at point

--- a/vendor/isocline/PATCHES.md
+++ b/vendor/isocline/PATCHES.md
@@ -368,9 +368,9 @@ Two sites:
    assuming a Meta terminal. The `esc` entry reads "Meta prefix for alt-<key>",
    the overview diagram legend reads "esc : alt-<key> prefix", and the overview
    header spells the mechanism out — alt-<key> means esc then <key>, and on
-   macOS "alt" is the Option key, which sends this directly only if the terminal
-   is set to. That one note covers every `alt-` binding in both the main table
-   and the structural-editing table. Before it, F1, `,help`
+   macOS "alt" is the Option key, which sends the esc prefix directly only if
+   the terminal is configured to do so. That note covers every `alt-` binding
+   in both the main table and the structural-editing table. Before it, F1, `,help`
    (`src/repl_commands.zig`) and the site REPL guide all named the keys "alt"
    with no hint that a default Mac inserts a glyph instead; only the developer
    doc `docs/dev/repl.md` said so (kaappi#2563).

--- a/vendor/isocline/PATCHES.md
+++ b/vendor/isocline/PATCHES.md
@@ -364,6 +364,17 @@ Two sites:
    deleting the buffer there was the kaappi#2562 data-loss path. The
    empty-input `break` is kept.
 
+4. **`src/editline_help.c`** — the F1 help describes the prefix rather than
+   assuming a Meta terminal. The `esc` entry reads "Meta prefix for alt-<key>",
+   the overview diagram legend reads "esc : alt-<key> prefix", and the overview
+   header spells the mechanism out — alt-<key> means esc then <key>, and on
+   macOS "alt" is the Option key, which sends this directly only if the terminal
+   is set to. That one note covers every `alt-` binding in both the main table
+   and the structural-editing table. Before it, F1, `,help`
+   (`src/repl_commands.zig`) and the site REPL guide all named the keys "alt"
+   with no hint that a default Mac inserts a glyph instead; only the developer
+   doc `docs/dev/repl.md` said so (kaappi#2563).
+
 **Cost, and it is deliberate:** a lone Escape no longer clears the input.
 `ctrl-u` (delete-to-start) and `ctrl-c` (cancel) still do. This is upstream
 isocline behaviour we override, which is why it is a patch; it is also the

--- a/vendor/isocline/src/editline_help.c
+++ b/vendor/isocline/src/editline_help.c
@@ -112,7 +112,11 @@ static const char* help_initial =
   "This is free software; you can redistribute it and/or\n"
   "modify it under the terms of the MIT License.\n"
   "See <[url]https://github.com/daanx/isocline[/url]> for further information.\n"
-  "We use ^<key> as a shorthand for ctrl-<key>.\n"
+  "We use ^<key> as a shorthand for ctrl-<key>, and alt-<key> means\n"
+  // KAAPPI PATCH 7: name the Meta prefix per platform, since esc reaches
+  // every alt- binding on every terminal now (see PATCHES.md, kaappi#2563).
+  "esc then <key> (on macOS \"alt\" is the Option key, which sends this\n"
+  "directly only if the terminal is set to).\n"
   "\n"
   "Overview:\n"
   "\n[ansi-lightgray]"

--- a/vendor/isocline/src/editline_help.c
+++ b/vendor/isocline/src/editline_help.c
@@ -115,8 +115,8 @@ static const char* help_initial =
   "We use ^<key> as a shorthand for ctrl-<key>, and alt-<key> means\n"
   // KAAPPI PATCH 7: name the Meta prefix per platform, since esc reaches
   // every alt- binding on every terminal now (see PATCHES.md, kaappi#2563).
-  "esc then <key> (on macOS \"alt\" is the Option key, which sends this\n"
-  "directly only if the terminal is set to).\n"
+  "esc then <key> (on macOS \"alt\" is the Option key, which sends the\n"
+  "esc prefix directly only if the terminal is configured to do so).\n"
   "\n"
   "Overview:\n"
   "\n[ansi-lightgray]"


### PR DESCRIPTION
## Summary

Three user-facing surfaces called the REPL structural-editing keys "alt"
(`alt-shift-S`, `Alt+Shift+S`). On macOS there is no Alt key — the key is
Option, and a default Mac terminal does not send Option as Meta, so a user
following any of these pressed Option-Shift-S, got a stray glyph inserted into
their form, and had only the *developer* doc to explain why (kaappi#2563).

Since kaappi#2562 the bindings are reachable on **every** terminal by pressing
`esc` then the key, with no terminal configuration. This PR names them that way.

## Changes (this repo)

- **`,help`** (`src/repl_commands.zig`) now lists `esc shift-S` / `esc y` and
  states the rule next to the table: on macOS "alt" is Option, which sends this
  directly only if the terminal is set to.
- **F1 editor-key list** (`vendor/isocline/src/editline_help.c`) — the overview
  header spells out that `alt-<key>` means `esc` then `<key>` (Option on macOS).
  One note covers every `alt-` binding in both the main table and the
  structural-editing table.
- **`vendor/isocline/PATCHES.md`** gains a fourth site under patch 7 recording
  the help-text wording.

The site REPL guide (`kaappi.github.io/docs/guide/repl.md`) is updated in a
companion PR in the kaappi.github.io repo.

## Verification

- `zig build` clean; `zig fmt --check` clean.
- `tests/scheme/smoke/repl-structural-editing-2216.sh` passes.
- Over a pty, `,help` and F1 render the new wording; the structural keys still
  slurp/barf/raise/rotate via `esc` then the key.

Docs-only string changes (no behavior change), so no new regression test; the
existing structural-editing smoke test already exercises the keys.

Closes #2563

🤖 Generated with [Claude Code](https://claude.com/claude-code)