### PR TITLE
Remove the last two org-membership references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ the essentials: how to get involved, building, testing, and submitting changes.
 ## How to get involved
 
 See [kaappi/community's CONTRIBUTING.md](https://github.com/kaappi/community/blob/main/CONTRIBUTING.md)
-for how to join the conversation, request org access, and the typical path
-for a new contributor. The rest of this document covers this repo's
+for how to join the conversation, what a PR needs before it merges, and the
+typical path for a new contributor. The rest of this document covers this repo's
 build/test/PR workflow specifically.
 
 ---

--- a/docs/dev/github-issues.md
+++ b/docs/dev/github-issues.md
@@ -1,9 +1,9 @@
 # GitHub Issues
 
 How the issue tracker is labeled and triaged. Two neighbouring documents own
-the rest: [`CONTRIBUTING.md`](../../CONTRIBUTING.md) covers *who* may file
-(org members) and the PR path, and `.github/ISSUE_TEMPLATE/` covers *what* a
-report must contain. This document covers the label taxonomy, the priority
+the rest: [`CONTRIBUTING.md`](../../CONTRIBUTING.md) covers the PR path and
+the review rules (anyone may file), and the issue forms under
+`.github/ISSUE_TEMPLATE/` cover *what* a report must contain. This document covers the label taxonomy, the priority
 rubric, and the triage invariant — the parts a maintainer has to apply by
 judgement rather than by template.
 


### PR DESCRIPTION
Follow-up to #2571: two sentences still described the old collaborators-only gate (CONTRIBUTING.md's pointer to "request org access", and `docs/dev/github-issues.md` saying only org members may file). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)